### PR TITLE
Fix: pass kubeconfig to CreateDeployment instead of path to kubeconfig [PIP-26]

### DIFF
--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -503,7 +503,7 @@ func DeleteAmazonCluster(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) bo
 
 }
 
-func getAmazonKubernetesConfig(existing *cluster.Cluster) (string, error) {
+func getAmazonKubernetesConfig(existing *cluster.Cluster) ([]byte, error) {
 	user := existing.SSH.User
 	pubKeyPath := expand(existing.SSH.PublicKeyPath)
 	privKeyPath := strings.Replace(pubKeyPath, ".pub", "", 1)
@@ -523,12 +523,12 @@ func getAmazonKubernetesConfig(existing *cluster.Cluster) (string, error) {
 	pemBytes, err := ioutil.ReadFile(privKeyPath)
 	if err != nil {
 
-		return "", err
+		return nil , err
 	}
 
 	signer, err := getSigner(pemBytes)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	auths := []ssh.AuthMethod{
@@ -540,24 +540,24 @@ func getAmazonKubernetesConfig(existing *cluster.Cluster) (string, error) {
 
 	conn, err := ssh.Dial("tcp", address, sshConfig)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer conn.Close()
 	c, err := sftp.NewClient(conn)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer c.Close()
 	r, err := c.Open(remotePath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer r.Close()
-	bytes, err := ioutil.ReadAll(r)
+	config, err := ioutil.ReadAll(r)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(bytes), nil
+	return config, nil
 }
 
 func getAmazonK8SEndpoint(cl *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string, error) {

--- a/cloud/base.go
+++ b/cloud/base.go
@@ -208,13 +208,13 @@ func GetK8SEndpoint(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string
 	}
 }
 
-func GetK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string, error) {
+func GetK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) ([]byte, error) {
 
 	const LOGTAG = "GetK8sConfig"
 
 	if cs == nil {
 		banzaiUtils.LogInfo(LOGTAG, "<nil> cluster")
-		return "", errors.New("<nil> cluster")
+		return nil, errors.New("<nil> cluster")
 	}
 	clusterType := cs.Cloud
 	banzaiUtils.LogInfo(LOGTAG, "Cluster type is ", clusterType)
@@ -224,7 +224,7 @@ func GetK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string, 
 		cloudCluster, err := GetClusterWithDbCluster(cs, c)
 		if err != nil {
 			banzaiUtils.LogInfo(LOGTAG, "Error during getting aws cluster")
-			return "", errors.New("error happened during getting aws cluster")
+			return nil, errors.New("error happened during getting aws cluster")
 		} else {
 			banzaiUtils.LogInfo(LOGTAG, "Get aws cluster succeeded")
 		}
@@ -234,7 +234,7 @@ func GetK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string, 
 				JsonKeyStatus:  http.StatusInternalServerError,
 				JsonKeyMessage: err,
 			})
-			return "", err
+			return nil, err
 		}
 		return config, nil
 
@@ -248,14 +248,14 @@ func GetK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) (string, 
 				JsonKeyStatus: err.StatusCode,
 				JsonKeyData:   err.Message,
 			})
-			return "", errors.New("error happened during getting K8S config")
+			return nil, errors.New("error happened during getting K8S config")
 		} else {
 			banzaiUtils.LogInfo(LOGTAG, "Kubernetes Config retrieve succeeded!")
 			config, _ := base64.StdEncoding.DecodeString(b64config.Properties.KubeConfig)
-			return string(config), nil
+			return config, nil
 		}
 	default:
 		SendNotSupportedCloudResponse(c, LOGTAG)
-		return "", errors.New("error happened during getting K8S config")
+		return nil, errors.New("error happened during getting K8S config")
 	}
 }

--- a/cloud/utils.go
+++ b/cloud/utils.go
@@ -93,7 +93,7 @@ func GetConfig(existing *cluster.Cluster, localDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, err = f.WriteString(conf)
+	_, err = f.Write(conf)
 	if err != nil {
 		return "", err
 	}

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -15,7 +15,7 @@ import (
 )
 
 //ListDeployments lists Helm deployments
-func ListDeployments(filter *string, kubeConfig string) (*rls.ListReleasesResponse, error) {
+func ListDeployments(filter *string, kubeConfig []byte) (*rls.ListReleasesResponse, error) {
 	defer tearDown()
 	hClient, err := getHelmClient(kubeConfig)
 	// TODO doc the options here
@@ -43,7 +43,7 @@ func ListDeployments(filter *string, kubeConfig string) (*rls.ListReleasesRespon
 }
 
 //UpgradeDeployment upgrades a Helm deployment
-func UpgradeDeployment(deploymentName, chartName string, values map[string]interface{}, kubeConfig string) (string, error) {
+func UpgradeDeployment(deploymentName, chartName string, values map[string]interface{}, kubeConfig []byte) (string, error) {
 	//Base maps for values
 	base := map[string]interface{}{}
 	//this is only to parse x=y format
@@ -95,7 +95,7 @@ func UpgradeDeployment(deploymentName, chartName string, values map[string]inter
 }
 
 //CreateDeployment creates a Helm deployment
-func CreateDeployment(chartName string, releaseName string, valueOverrides []byte, kubeConfig string) (*rls.InstallReleaseResponse, error) {
+func CreateDeployment(chartName string, releaseName string, valueOverrides []byte, kubeConfig []byte) (*rls.InstallReleaseResponse, error) {
 	defer tearDown()
 	chartRequested, err := chartutil.Load(chartName)
 	if err != nil {
@@ -133,7 +133,7 @@ func CreateDeployment(chartName string, releaseName string, valueOverrides []byt
 }
 
 //DeleteDeployment deletes a Helm deployment
-func DeleteDeployment(releaseName string, kubeConfig string) error {
+func DeleteDeployment(releaseName string, kubeConfig []byte) error {
 	defer tearDown()
 	hClient, err := getHelmClient(kubeConfig)
 	if err != nil {

--- a/helm/kubernetes.go
+++ b/helm/kubernetes.go
@@ -21,13 +21,13 @@ import (
 
 var tillerTunnel *kube.Tunnel
 
-func getHelmClient(kubeConfig string) (*helm.Client, error) {
+func getHelmClient(kubeConfig []byte) (*helm.Client, error) {
 	var config *rest.Config
 	var err error
 
 	//TODO Beatify this do not use string for kubeConfig
-	if kubeConfig != "" {
-		apiconfig, _ :=clientcmd.Load([]byte(kubeConfig))
+	if len(kubeConfig) > 0 {
+		apiconfig, _ :=clientcmd.Load(kubeConfig)
 		clientConfig := clientcmd.NewDefaultClientConfig(*apiconfig, &clientcmd.ConfigOverrides{})
 		config, err = clientConfig.ClientConfig()
 	} else {


### PR DESCRIPTION
Assuming that kubeconfig can be stored in various places (db, key value store, file) pass the config content to methods that need kubernetes config instead of the path the file that caches the config