### PR TITLE
Fix cluster delete, delete cluster when tiller is not available

### DIFF
--- a/main.go
+++ b/main.go
@@ -458,13 +458,9 @@ func DeleteCluster(c *gin.Context) {
 		err = deleteAllDeployment(config)
 		if err != nil {
 			banzaiUtils.LogError(banzaiConstants.TagDeleteCluster, "Error during deleting all deployments #", err.Error())
-			cloud.SetResponseBodyJson(c, http.StatusInternalServerError, gin.H{
-				cloud.JsonKeyStatus:  http.StatusInternalServerError,
-				cloud.JsonKeyMessage: err,
-			})
-			return
+		} else {
+			banzaiUtils.LogInfo(banzaiConstants.TagDeleteCluster, "Deployments successfully deleted")
 		}
-		banzaiUtils.LogInfo(banzaiConstants.TagDeleteCluster, "Deployments successfully deleted")
 	}
 	if cloud.DeleteCluster(cl, c) {
 		// cluster delete success, delete from db


### PR DESCRIPTION
Without this fix, if the cluster create succeeded but the tiller install failed, the delete cluster returns 500 with could not find tiller. This fix allows to delete cluster even if tiller is not installed.