### PR TITLE
Reimplemented the deployment status call using the specialized intern…

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+
 	"github.com/Masterminds/sprig"
+	"github.com/banzaicloud/banzai-types/utils"
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
-	"github.com/banzaicloud/banzai-types/utils"
+	"net/http"
 )
 
 //ListDeployments lists Helm deployments
@@ -158,6 +161,30 @@ func DeleteDeployment(releaseName string, kubeConfig []byte) error {
 
 //GetDeployment - N/A
 func GetDeployment() {
+
+}
+
+// Retrieves the status of the passed in release name.
+// returns with an error if the release is not found or another error occurs
+// in case of error the status is filled with information to classify the error cause
+func GetDeploymentStatus(releaseName string, kubeConfig []byte) (string, error) {
+	defer tearDown()
+
+	helmClient, err := GetHelmClient(kubeConfig)
+
+	if err != nil {
+		// internal server error
+		return fmt.Sprint(http.StatusInternalServerError), errors.Wrap(err, "couldn't get the helm client")
+	}
+
+	releaseStatusResponse, err := helmClient.ReleaseStatus(releaseName)
+
+	if err != nil {
+		// the release cannot be found
+		return fmt.Sprint(http.StatusNotFound), errors.Wrap(err, "couldn't get the release status")
+	}
+
+	return releaseStatusResponse.Info.Status.GetCode().String(), nil
 
 }
 

--- a/main.go
+++ b/main.go
@@ -945,6 +945,7 @@ func HelmDeploymentStatus(c *gin.Context) {
 	// todo error handling - design it, refine it, refactor it
 
 	name := c.Param("name")
+	banzaiUtils.LogInfof("HelmDeploymentStatus", "Retrieving status for deployment: %s", name)
 
 	cloudCluster, err := cloud.GetClusterFromDB(c)
 	helmDeploymentStatusErrorResponse(c, errors.Wrap(err, "couldn't get the cluster from db"))
@@ -956,6 +957,7 @@ func HelmDeploymentStatus(c *gin.Context) {
 
 	if err != nil {
 
+		banzaiUtils.LogError("HelmDeploymentStatus", err.Error())
 		// convert the status code back - this is specific to the underlying call!
 		code, _ := strconv.Atoi(status)
 
@@ -968,6 +970,7 @@ func HelmDeploymentStatus(c *gin.Context) {
 	}
 
 	if status != "" {
+		banzaiUtils.LogInfof("HelmDeploymentStatus", "Deployment status: %s", status)
 		cloud.SetResponseBodyJson(c, http.StatusOK, gin.H{
 			cloud.JsonKeyStatus:  http.StatusOK,
 			cloud.JsonKeyMessage: "Deployment status: " + status,
@@ -977,7 +980,9 @@ func HelmDeploymentStatus(c *gin.Context) {
 }
 
 func helmDeploymentStatusErrorResponse(c *gin.Context, err error) {
+
 	if err != nil {
+		banzaiUtils.LogError("HelmDeploymentStatus", err.Error())
 		cloud.SetResponseBodyJson(c, http.StatusInternalServerError, gin.H{
 			cloud.JsonKeyStatus:  http.StatusInternalServerError,
 			cloud.JsonKeyMessage: err.Error(),


### PR DESCRIPTION
…al api call
This PR fixes the behaviour of the rest calls of the form:

```
HEAD /api/v1/clusters/2/deployments/dep_name HTTP/1.1
```
The implementation uses a the specialized internal api call.
HTTP response codes fixed to be consistent with the behaviour (further refinements based on deployment statuses may be required)