### PR TITLE
Cluster instance decorated with properties from the DB when retrievin…

### DIFF
--- a/cloud/gke.go
+++ b/cloud/gke.go
@@ -621,7 +621,7 @@ func deleteCluster(cc *GKECluster, c *gin.Context) bool {
 	return true
 }
 
-//GetAzureK8SConfig retrieves kubeconfig for Azure AKS
+//GetGoogleK8SConfig retrieves kubeconfig for GKE
 func GetGoogleK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) {
 	banzaiUtils.LogInfo(banzaiConstants.TagFetchClusterConfig, "Start loading google k8s config")
 
@@ -630,9 +630,6 @@ func GetGoogleK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) {
 		return
 	}
 
-	// set google props
-	banzaiUtils.LogInfo(banzaiConstants.TagFetchClusterConfig, "Load Google props from database")
-	database.SelectFirstWhere(&cs.Google, banzaiSimpleTypes.GoogleClusterSimple{ClusterSimpleId: cs.ID})
 	config, err := getGoogleKubernetesConfig(cs)
 	if err != nil {
 		// something went wrong
@@ -664,6 +661,9 @@ func GetGoogleK8SConfig(cs *banzaiSimpleTypes.ClusterSimple, c *gin.Context) {
 }
 
 func getGoogleKubernetesConfig(cs *banzaiSimpleTypes.ClusterSimple) ([]byte, *banzaiTypes.BanzaiResponse) {
+
+	banzaiUtils.LogInfo(banzaiConstants.TagFetchClusterConfig, "Load Google props from database")
+	database.SelectFirstWhere(&cs.Google, banzaiSimpleTypes.GoogleClusterSimple{ClusterSimpleId: cs.ID})
 
 	banzaiUtils.LogInfo(banzaiConstants.TagFetchClusterConfig, "Get Google Service Client")
 	svc, err := GetGoogleServiceClient()


### PR DESCRIPTION
…g GKE cluster config

Cluster instance decorated with properties from the database before retrieving K8S config from the GKE when retrieving tiller status. (This was only done in case of config retrieval request)