### PR TITLE
Dynamic database secrets

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -136,7 +136,7 @@ func Init() {
 		},
 	})
 	if viper.GetBool("drone.enabled") {
-		Auth.UserStorer = BanzaiUserStorer{signingKeyBase32: signingKeyBase32, droneDB: initDroneDatabase()}
+		Auth.UserStorer = BanzaiUserStorer{signingKeyBase32: signingKeyBase32, droneDB: initDroneDB()}
 	} else {
 		Auth.UserStorer = BanzaiUserStorer{signingKeyBase32: signingKeyBase32, droneDB: nil}
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/banzaicloud/bank-vaults/database"
+	"github.com/banzaicloud/pipeline/model"
 	"github.com/jinzhu/copier"
 	"github.com/jinzhu/gorm"
 	// blank import is used here for sql driver inclusion
@@ -96,22 +96,6 @@ func (bus BanzaiUserStorer) createUserInDroneDB(user *User, githubAccessToken st
 	return bus.droneDB.Create(&droneUser).Error
 }
 
-func initDroneDatabase() *gorm.DB {
-	host := viper.GetString("database.host")
-	port := viper.GetString("database.port")
-	role := viper.GetString("database.role")
-
-	dataSource, err := database.DynamicSecretDataSource("mysql", role+"@tcp("+host+":"+port+")/drone?charset=utf8&parseTime=True&loc=Local")
-	if err != nil {
-		log.Error("Database dyanimc secret acquisition failed")
-		panic(err.Error())
-	}
-	db, err := gorm.Open("mysql", dataSource)
-	if err != nil {
-		log.Error("Database connection failed")
-		panic(err.Error())
-	}
-	db.LogMode(true)
-
-	return db
+func initDroneDB() *gorm.DB {
+	return model.ConnectDB("drone")
 }

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -10,6 +10,7 @@ dialect = "mysql"
 host = "localhost"
 port = 3306
 user = "sparky"
+role = "pipeline"
 password = "sparky123"
 dbname = "sparky"
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -38,7 +38,8 @@ func init() {
 	viper.SetDefault("database.dialect", "mysql")
 	viper.SetDefault("database.port", 3306)
 	viper.SetDefault("database.host", "localhost")
-	viper.SetDefault("database.role", "pipeline")
+	viper.SetDefault("database.user", "kellyslater")
+	viper.SetDefault("database.password", "pipemaster123!")
 	viper.SetDefault("database.dbname", "pipelinedb")
 
 	ReleaseName := os.Getenv("KUBERNETES_RELEASE_NAME")

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -38,8 +38,7 @@ func init() {
 	viper.SetDefault("database.dialect", "mysql")
 	viper.SetDefault("database.port", 3306)
 	viper.SetDefault("database.host", "localhost")
-	viper.SetDefault("database.user", "kellyslater")
-	viper.SetDefault("database.password", "pipemaster123!")
+	viper.SetDefault("database.role", "pipeline")
 	viper.SetDefault("database.dbname", "pipelinedb")
 
 	ReleaseName := os.Getenv("KUBERNETES_RELEASE_NAME")

--- a/db-init.sql
+++ b/db-init.sql
@@ -1,1 +1,2 @@
 CREATE DATABASE IF NOT EXISTS drone;
+GRANT ALL PRIVILEGES ON drone.* TO 'sparky'@'%';

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -80,4 +80,3 @@ services:
     environment:
       DRONE_SERVER: drone-server:9000
       DRONE_SECRET: "s3cr3t"
-

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -31,6 +31,20 @@ services:
     volumes:
       - $HOME:/home/vault
 
+  vault-configurer:
+    image: vault
+    depends_on:
+      - vault
+      - db
+    restart: on-failure
+    command:
+      - /bin/vault-enable-database.sh
+    environment:
+      VAULT_ADDR: http://vault:8200
+    volumes:
+      - $HOME:/root
+      - ./vault-enable-database.sh:/bin/vault-enable-database.sh
+
   drone-server:
     image: banzaicloud/drone:0.3.0
     restart: always

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 339cf68aab54c66342ed15ab7659458647e61635ed2f18a44cfb0849c07ee06f
-updated: 2018-03-10T14:41:17.265028+01:00
+hash: af32a9e96fc7354814150360bbe2cce551e2ffa2e8c50566c8cc73278deb44a0
+updated: 2018-03-10T15:51:47.352629+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -65,6 +65,7 @@ imports:
 - name: github.com/banzaicloud/bank-vaults
   version: 1211922aa2951c40474e663ca0e57f4436077cc9
   subpackages:
+  - database
   - vault
 - name: github.com/banzaicloud/banzai-types
   version: e86d61906327b2a3583c417d944fca87bcf093aa

--- a/glide.yaml
+++ b/glide.yaml
@@ -288,3 +288,4 @@ import:
 - package: github.com/banzaicloud/bank-vaults
   subpackages:
   - vault
+  - database

--- a/vault-enable-database.sh
+++ b/vault-enable-database.sh
@@ -9,10 +9,10 @@ set -euo pipefail
 vault write database/config/my-mysql-database \
     plugin_name=mysql-database-plugin \
     connection_url="root:example@tcp(db:3306)/" \
-    allowed_roles="my-role"
+    allowed_roles="pipeline"
 
-vault write database/roles/my-role \
+vault write database/roles/pipeline \
     db_name=my-mysql-database \
-    creation_statements="GRANT ALL ON *.* TO '{{name}}'@'localhost' IDENTIFIED BY '{{password}}';" \
+    creation_statements="GRANT ALL ON *.* TO '{{name}}'@'%' IDENTIFIED BY '{{password}}';" \
     default_ttl="10m" \
     max_ttl="24h"

--- a/vault-enable-database.sh
+++ b/vault-enable-database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script demonstrates how to setup Vault in the docker-compose local environment
+# This script showcases how to setup Vault in the docker-compose local environment
 
 vault secrets enable database
 

--- a/vault-enable-database.sh
+++ b/vault-enable-database.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script demonstrates how to setup Vault in the docker-compose local environment
+
+vault secrets enable database
+
+set -euo pipefail
+
+vault write database/config/my-mysql-database \
+    plugin_name=mysql-database-plugin \
+    connection_url="root:example@tcp(db:3306)/" \
+    allowed_roles="my-role"
+
+vault write database/roles/my-role \
+    db_name=my-mysql-database \
+    creation_statements="GRANT ALL ON *.* TO '{{name}}'@'localhost' IDENTIFIED BY '{{password}}';" \
+    default_ttl="10m" \
+    max_ttl="24h"

--- a/vendor/github.com/banzaicloud/bank-vaults/database/database.go
+++ b/vendor/github.com/banzaicloud/bank-vaults/database/database.go
@@ -1,0 +1,67 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/banzaicloud/bank-vaults/vault"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
+)
+
+// DynamicSecretDataSource creates a SQL data source but instead of passing username:password
+// in the connection source, one just has to pass in a Vault role name:
+//     ds, err := DynamicSecretDataSource("mysql", "my-role@localhost:3306/dbname?parseTime=True")
+//
+// MySQL (github.com/go-sql-driver/mysql) and PostgreSQL URI is supported.
+//
+// The underlying Vault client will make sure that the credential is renewed when it
+// is close to the time of expiry.
+func DynamicSecretDataSource(dialect string, source string) (dynamicSecretDataSource string, err error) {
+
+	postgresql := false
+	if strings.HasPrefix(source, "postgresql://") {
+		source = strings.TrimPrefix(source, "postgresql://")
+		postgresql = true
+	}
+
+	sourceParts := strings.Split(source, "@")
+	if len(sourceParts) != 2 {
+		err = errors.New("invalid database source")
+		return "", err
+	}
+
+	vaultRole := sourceParts[0]
+	vaultCredsEndpoint := "database/creds/" + vaultRole
+
+	vaultClient, err := vault.NewClient(vaultRole)
+
+	if err != nil {
+		err = errors.Wrap(err, "failed to establish vault connection")
+		return "", err
+	}
+
+	secret, err := vaultClient.Vault().Logical().Read(vaultCredsEndpoint)
+	if err != nil {
+		err = errors.Wrap(err, "failed to read db credentials")
+		return "", err
+	}
+
+	if secret == nil {
+		err = errors.New("failed to find '" + vaultCredsEndpoint + "' secret in vault")
+		return "", err
+	}
+
+	secretRenewer, err := vaultClient.Vault().NewRenewer(&vaultapi.RenewerInput{Secret: secret})
+	go secretRenewer.Renew()
+
+	username := secret.Data["username"].(string)
+	password := secret.Data["password"].(string)
+
+	dynamicSecretDataSource = fmt.Sprintf("%s:%s@%s", username, password, sourceParts[1])
+	if postgresql {
+		dynamicSecretDataSource = "postgresql://" + source
+	}
+
+	return dynamicSecretDataSource, nil
+}


### PR DESCRIPTION
This needs some changes in the helm charts to be able to use it on the supported cloud providers, but currently, it is turned on if one defines the
```toml
[database]
role = "pipeline"
```
It is possible to use it locally, otherwise, it falls back to the good old static password based connection.