### PR TITLE
Synchronize Drone repositories on register

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -304,12 +304,12 @@ func (sessionStorer *BanzaiSessionStorer) Update(w http.ResponseWriter, req *htt
 		return fmt.Errorf("Can't get current user")
 	}
 	droneClaims := &DroneClaims{Claims: claims, Type: DroneSessionCookieType, Text: currentUser.Login}
-	tokenToken, err := sessionStorer.SignedTokenWithDrone(droneClaims)
+	droneToken, err := sessionStorer.SignedTokenWithDrone(droneClaims)
 	if err != nil {
 		log.Info(req.RemoteAddr, err.Error())
 		return err
 	}
-	SetCookie(w, req, DroneSessionCookie, tokenToken)
+	SetCookie(w, req, DroneSessionCookie, droneToken)
 	return nil
 }
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -24,6 +24,7 @@ func init() {
 
 	// Set defaults TODO expand defaults
 	viper.SetDefault("drone.enabled", false)
+	viper.SetDefault("drone.url", "http://localhost:8000")
 	viper.SetDefault("helm.retryAttempt", 30)
 	viper.SetDefault("helm.retrySleepSeconds", 15)
 	viper.SetDefault("helm.stableRepositoryURL", "https://kubernetes-charts.storage.googleapis.com")


### PR DESCRIPTION
This PR adds a logic to user registration to trigger Drone user repository synchronization, so when a users logs in at the first time his/her repos will be there on the Drone UI.