### PR TITLE
Update default gke master/node version

### DIFF
--- a/model/defaults/gke.go
+++ b/model/defaults/gke.go
@@ -15,8 +15,8 @@ type GKEProfile struct {
 	Location         string `gorm:"default:'us-central1-a'"`
 	NodeInstanceType string `gorm:"default:'n1-standard-1'"`
 	NodeCount        int    `gorm:"default:1"`
-	NodeVersion      string `gorm:"default:'1.8.7-gke.1'"`
-	MasterVersion    string `gorm:"default:'1.8.7-gke.1'"`
+	NodeVersion      string `gorm:"default:'1.8.8-gke.0'"`
+	MasterVersion    string `gorm:"default:'1.8.8-gke.0'"`
 	ServiceAccount   string
 }
 


### PR DESCRIPTION
`1.8.7-gke.1` master version is no longer supported by Google. Current default cluster version is `1.8.8-gke.0`.