### PR TITLE
Make registration possible via Github Access Tokens

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -160,6 +160,7 @@ func Init() {
 	tokenStore = NewVaultTokenStore("pipeline")
 }
 
+// Install the whole OAuth and JWT Token based auth/authz mechanism to the specified Gin Engine.
 func Install(engine *gin.Engine) {
 	authHandler := gin.WrapH(Auth.NewServeMux())
 


### PR DESCRIPTION
Also it is possible now to request Pipeline API tokens via Github Tokens
The auth installation is now more libraryfied

Usage (with HTTPie):
```bash
http http://localhost:9090/auth/github/callback?access_token=$GITHUB_TOKEN
http POST http://localhost:9090/auth/tokens?access_token=$GITHUB_TOKEN
```