### PR TITLE
Revert until dep prune is fixed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,0 @@
-theme: jekyll-theme-minimal
-# title: Pipeline
-logo: /docs/images/banzai cloud logo-ikon.png
-google_analytics: UA-109213883-1


### PR DESCRIPTION
We have this [dep](https://github.com/golang/dep/issues/1820) issue with non-go files while prune-ing (dep ensure actually). This triggers the page build failures we wanted to address with #452