### PR TITLE
Audit configurability

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -32,7 +32,6 @@ func (*closeableBuffer) Close() error {
 // AuditEvent holds all information related to a user interaction
 type AuditEvent struct {
 	Time       time.Time
-	Latency    time.Duration
 	ClientIP   string
 	UserAgent  string
 	Path       string
@@ -82,14 +81,8 @@ func LogWriter(notloggedPaths ...string) gin.HandlerFunc {
 		rawBody := bodyBuffer.Bytes()
 		c.Request.Body = bodyBuffer
 
-		// Process request
-		c.Next()
-
 		// Log only when path is not being skipped
 		if _, ok := skip[path]; !ok {
-			// Stop timer
-			end := time.Now()
-			latency := end.Sub(start)
 
 			// Filter out sensitive data from body
 			var body string
@@ -134,7 +127,6 @@ func LogWriter(notloggedPaths ...string) gin.HandlerFunc {
 
 			event := AuditEvent{
 				Time:       start,
-				Latency:    latency,
 				ClientIP:   clientIP,
 				UserAgent:  userAgent,
 				UserID:     userID,

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -55,6 +55,7 @@ func init() {
 	viper.SetDefault("database.user", "kellyslater")
 	viper.SetDefault("database.password", "pipemaster123!")
 	viper.SetDefault("database.dbname", "pipelinedb")
+	viper.SetDefault("audit.enabled", true)
 
 	ReleaseName := os.Getenv("KUBERNETES_RELEASE_NAME")
 	if ReleaseName == "" {

--- a/main.go
+++ b/main.go
@@ -104,7 +104,10 @@ func main() {
 	router.Use(gin.LoggerWithWriter(gin.DefaultWriter, "/auth/tokens", "/auth/github/callback"))
 	router.Use(gin.Recovery())
 	router.Use(cors.New(config.GetCORS()))
-	router.Use(audit.LogWriter())
+	if viper.GetBool("audit.enabled") {
+		log.Infoln("Audit enabled, installing Gin audit middleware")
+		router.Use(audit.LogWriter())
+	}
 
 	auth.Install(router)
 


### PR DESCRIPTION
Fixes #563 

Also block event if the audit couldn't happen, as it is a hard requirement of auditing, but was missed out in the previous PR.