### PR TITLE
openapi: Fix number -> integer issues

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,9 +33,9 @@ Class | Method | HTTP request | Description
 *ApplicationsApi* | [**CreateApplication**](docs/ApplicationsApi.md#createapplication) | **Post** /api/v1/orgs/{orgId}/applications | Create new application based on catalog
 *ApplicationsApi* | [**GetApplication**](docs/ApplicationsApi.md#getapplication) | **Get** /api/v1/orgs/{orgId}/applications/{appId} | Get application details
 *ApplicationsApi* | [**ListApplications**](docs/ApplicationsApi.md#listapplications) | **Get** /api/v1/orgs/{orgId}/applications | List application catalogs
-*AuthApi* | [**DeleteToken**](docs/AuthApi.md#deletetoken) | **Delete** /auth/tokens/{tokenId} | Delete an API token
-*AuthApi* | [**GenerateToken**](docs/AuthApi.md#generatetoken) | **Post** /auth/tokens | Generate token
-*AuthApi* | [**GetTokens**](docs/AuthApi.md#gettokens) | **Get** /auth/tokens | List all API tokens
+*AuthApi* | [**CreateToken**](docs/AuthApi.md#createtoken) | **Post** /api/v1/tokens | Create token
+*AuthApi* | [**DeleteToken**](docs/AuthApi.md#deletetoken) | **Delete** /api/v1/tokens/{tokenId} | Delete an API token
+*AuthApi* | [**ListTokens**](docs/AuthApi.md#listtokens) | **Get** /api/v1/tokens | List all API tokens
 *CatalogsApi* | [**GetCatalogDetail**](docs/CatalogsApi.md#getcatalogdetail) | **Get** /api/v1/orgs/{orgId}/catalogs/{name} | Get catalog details
 *CatalogsApi* | [**ListCatalogs**](docs/CatalogsApi.md#listcatalogs) | **Get** /api/v1/orgs/{orgId}/catalogs | List catalogs
 *ClustersApi* | [**ClusterPostHooks**](docs/ClustersApi.md#clusterposthooks) | **Put** /api/v1/orgs/{orgId}/clusters/{id}/posthooks | Run posthook functions

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -1808,10 +1808,10 @@ paths:
       summary: Delete cluster profiles
       tags:
       - profiles
-  /auth/tokens:
+  /api/v1/tokens:
     get:
       description: List all API tokens
-      operationId: GetTokens
+      operationId: ListTokens
       responses:
         200:
           content:
@@ -1839,8 +1839,8 @@ paths:
       tags:
       - auth
     post:
-      description: Generate token
-      operationId: GenerateToken
+      description: Create token
+      operationId: CreateToken
       requestBody:
         content:
           application/json:
@@ -1853,7 +1853,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenCreateResponse'
-          description: Token generated successfully
+          description: Token created successfully
         401:
           content:
             application/json:
@@ -1868,10 +1868,10 @@ paths:
           description: Internal server error
       security:
       - bearerAuth: []
-      summary: Generate token
+      summary: Create token
       tags:
       - auth
-  /auth/tokens/{tokenId}:
+  /api/v1/tokens/{tokenId}:
     delete:
       description: Delete an API token
       operationId: DeleteToken
@@ -3459,7 +3459,8 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
           format: int32
@@ -3490,7 +3491,8 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
           format: int32
@@ -3519,7 +3521,8 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
           format: int32
@@ -3689,13 +3692,16 @@ components:
           type: boolean
         count:
           example: 2
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
       type: object
     UpdateAzureProperties:
       properties:
@@ -5020,7 +5026,8 @@ components:
           type: string
         id:
           example: 1
-          type: number
+          format: int32
+          type: integer
         nodePools:
           $ref: '#/components/schemas/GetClusterStatusResponse_nodePools'
       type: object
@@ -5036,13 +5043,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         image:
           example: ami-16bfeb6f
           type: string
@@ -5053,13 +5063,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         instanceType:
           example: Standard_D4_v2
           type: string
@@ -5070,13 +5083,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         instanceType:
           example: n1-standard-1
           type: string
@@ -5289,13 +5305,16 @@ components:
           type: boolean
         count:
           example: 2
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
     UpdateAzureProperties_azure_nodePools:
       properties:
         pool1:
@@ -5314,13 +5333,16 @@ components:
           type: boolean
         count:
           example: 2
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         instanceType:
           example: n1-standard-2
           type: string
@@ -5872,13 +5894,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         image:
           example: ami-06d1667f
           type: string
@@ -5898,13 +5923,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         instanceType:
           example: Standard_D2_v2
           type: string
@@ -5925,13 +5953,16 @@ components:
           type: boolean
         count:
           example: 1
-          type: number
+          format: int32
+          type: integer
         minCount:
           example: 1
-          type: number
+          format: int32
+          type: integer
         maxCount:
           example: 2
-          type: number
+          format: int32
+          type: integer
         instanceType:
           example: n1-standard-1
           type: string

--- a/client/api_auth.go
+++ b/client/api_auth.go
@@ -27,99 +27,13 @@ var (
 type AuthApiService service
 
 /* 
-AuthApiService Delete an API token
-Delete an API token
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param tokenId Token identification
-*/
-func (a *AuthApiService) DeleteToken(ctx context.Context, tokenId string) (*http.Response, error) {
-	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
-	)
-
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/auth/tokens/{tokenId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"tokenId"+"}", fmt.Sprintf("%v", tokenId), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
-	if localVarHttpContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHttpContentType
-	}
-
-	// to determine the Accept header
-	localVarHttpHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
-	if localVarHttpHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
-	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	localVarHttpResponse, err := a.client.callAPI(r)
-	if err != nil || localVarHttpResponse == nil {
-		return localVarHttpResponse, err
-	}
-
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
-	localVarHttpResponse.Body.Close()
-	if err != nil {
-		return localVarHttpResponse, err
-	}
-
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body: localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 401 {
-			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
-				return localVarHttpResponse, newErr
-		}
-		if localVarHttpResponse.StatusCode == 500 {
-			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
-				return localVarHttpResponse, newErr
-		}
-		return localVarHttpResponse, newErr
-	}
-
-	return localVarHttpResponse, nil
-}
-
-/* 
-AuthApiService Generate token
-Generate token
+AuthApiService Create token
+Create token
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param tokenCreateRequest
 @return TokenCreateResponse
 */
-func (a *AuthApiService) GenerateToken(ctx context.Context, tokenCreateRequest TokenCreateRequest) (TokenCreateResponse, *http.Response, error) {
+func (a *AuthApiService) CreateToken(ctx context.Context, tokenCreateRequest TokenCreateRequest) (TokenCreateResponse, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -129,7 +43,7 @@ func (a *AuthApiService) GenerateToken(ctx context.Context, tokenCreateRequest T
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/auth/tokens"
+	localVarPath := a.client.cfg.BasePath + "/api/v1/tokens"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -220,12 +134,98 @@ func (a *AuthApiService) GenerateToken(ctx context.Context, tokenCreateRequest T
 }
 
 /* 
+AuthApiService Delete an API token
+Delete an API token
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param tokenId Token identification
+*/
+func (a *AuthApiService) DeleteToken(ctx context.Context, tokenId string) (*http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Delete")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/v1/tokens/{tokenId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"tokenId"+"}", fmt.Sprintf("%v", tokenId), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body: localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 401 {
+			var v Unauthorized
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 500 {
+			var v BaseError500
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarHttpResponse, newErr
+				}
+				newErr.model = v
+				return localVarHttpResponse, newErr
+		}
+		return localVarHttpResponse, newErr
+	}
+
+	return localVarHttpResponse, nil
+}
+
+/* 
 AuthApiService List all API tokens
 List all API tokens
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 @return []TokenListResponseItem
 */
-func (a *AuthApiService) GetTokens(ctx context.Context) ([]TokenListResponseItem, *http.Response, error) {
+func (a *AuthApiService) ListTokens(ctx context.Context) ([]TokenListResponseItem, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -235,7 +235,7 @@ func (a *AuthApiService) GetTokens(ctx context.Context) ([]TokenListResponseItem
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/auth/tokens"
+	localVarPath := a.client.cfg.BasePath + "/api/v1/tokens"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/client/docs/AuthApi.md
+++ b/client/docs/AuthApi.md
@@ -4,10 +4,38 @@ All URIs are relative to *http://localhost:9090*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**DeleteToken**](AuthApi.md#DeleteToken) | **Delete** /auth/tokens/{tokenId} | Delete an API token
-[**GenerateToken**](AuthApi.md#GenerateToken) | **Post** /auth/tokens | Generate token
-[**GetTokens**](AuthApi.md#GetTokens) | **Get** /auth/tokens | List all API tokens
+[**CreateToken**](AuthApi.md#CreateToken) | **Post** /api/v1/tokens | Create token
+[**DeleteToken**](AuthApi.md#DeleteToken) | **Delete** /api/v1/tokens/{tokenId} | Delete an API token
+[**ListTokens**](AuthApi.md#ListTokens) | **Get** /api/v1/tokens | List all API tokens
 
+
+# **CreateToken**
+> TokenCreateResponse CreateToken(ctx, tokenCreateRequest)
+Create token
+
+Create token
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **tokenCreateRequest** | [**TokenCreateRequest**](TokenCreateRequest.md)|  | 
+
+### Return type
+
+[**TokenCreateResponse**](TokenCreateResponse.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **DeleteToken**
 > DeleteToken(ctx, tokenId)
@@ -37,36 +65,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **GenerateToken**
-> TokenCreateResponse GenerateToken(ctx, tokenCreateRequest)
-Generate token
-
-Generate token
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-  **tokenCreateRequest** | [**TokenCreateRequest**](TokenCreateRequest.md)|  | 
-
-### Return type
-
-[**TokenCreateResponse**](TokenCreateResponse.md)
-
-### Authorization
-
-[bearerAuth](../README.md#bearerAuth)
-
-### HTTP request headers
-
- - **Content-Type**: application/json
- - **Accept**: application/json
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **GetTokens**
-> []TokenListResponseItem GetTokens(ctx, )
+# **ListTokens**
+> []TokenListResponseItem ListTokens(ctx, )
 List all API tokens
 
 List all API tokens

--- a/client/docs/ClusterProfileAmazonAmazonNodePoolsPool1.md
+++ b/client/docs/ClusterProfileAmazonAmazonNodePoolsPool1.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 **InstanceType** | **string** |  | [optional] 
 **SpotPrice** | **string** |  | [optional] 
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **Image** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/ClusterProfileAzureAzureNodePoolsPool1.md
+++ b/client/docs/ClusterProfileAzureAzureNodePoolsPool1.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/ClusterProfileGoogleGoogleNodePoolsPool1.md
+++ b/client/docs/ClusterProfileGoogleGoogleNodePoolsPool1.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | [optional] 
 **ServiceAccount** | **string** |  | [optional] 
 

--- a/client/docs/GetClusterStatusResponse.md
+++ b/client/docs/GetClusterStatusResponse.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | [optional] 
 **Cloud** | **string** |  | [optional] 
 **Location** | **string** |  | [optional] 
-**Id** | **float32** |  | [optional] 
+**Id** | **int32** |  | [optional] 
 **NodePools** | [**GetClusterStatusResponseNodePools**](GetClusterStatusResponse_nodePools.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/NodePoolStatusAmazon.md
+++ b/client/docs/NodePoolStatusAmazon.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 **InstanceType** | **string** |  | [optional] 
 **SpotPrice** | **string** |  | [optional] 
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **Image** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/NodePoolStatusAzure.md
+++ b/client/docs/NodePoolStatusAzure.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/NodePoolStatusGoogle.md
+++ b/client/docs/NodePoolStatusGoogle.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/NodePoolsAmazon.md
+++ b/client/docs/NodePoolsAmazon.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **InstanceType** | **string** |  | 
 **SpotPrice** | **string** |  | 
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
 **MinCount** | **int32** |  | 
 **MaxCount** | **int32** |  | 
 **Image** | **string** |  | [optional] 

--- a/client/docs/NodePoolsAzure.md
+++ b/client/docs/NodePoolsAzure.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | 
+**Count** | **int32** |  | 
 **MinCount** | **int32** |  | [optional] 
 **MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | 

--- a/client/docs/NodePoolsGoogle.md
+++ b/client/docs/NodePoolsGoogle.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | 
+**Count** | **int32** |  | 
 **MinCount** | **int32** |  | [optional] 
 **MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | 

--- a/client/docs/UpdateAzurePropertiesAzureNodePoolsPool1.md
+++ b/client/docs/UpdateAzurePropertiesAzureNodePoolsPool1.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/docs/UpdateGooglePropertiesNodePoolsPool1.md
+++ b/client/docs/UpdateGooglePropertiesNodePoolsPool1.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/docs/UpdateNodePoolsAmazon.md
+++ b/client/docs/UpdateNodePoolsAmazon.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Autoscaling** | **bool** |  | [optional] 
-**Count** | **float32** |  | [optional] 
-**MinCount** | **float32** |  | [optional] 
-**MaxCount** | **float32** |  | [optional] 
+**Count** | **int32** |  | [optional] 
+**MinCount** | **int32** |  | [optional] 
+**MaxCount** | **int32** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/examples/auth/main.go
+++ b/client/examples/auth/main.go
@@ -13,8 +13,9 @@ func main() {
 	ctx := context.WithValue(context.Background(), client.ContextAccessToken, os.Getenv("TOKEN"))
 	pipeline := client.NewAPIClient(config)
 
+	// Create a new token for a virtual user
 	tokenRequest := client.TokenCreateRequest{Name: "drone token", VirtualUser: "banzaicloud/pipeline"}
-	tokenResponse, _, err := pipeline.AuthApi.GenerateToken(ctx, tokenRequest)
+	tokenResponse, _, err := pipeline.AuthApi.CreateToken(ctx, tokenRequest)
 
 	if err != nil {
 		panic(err)

--- a/client/model_cluster_profile_amazon_amazon_node_pools_pool1.go
+++ b/client/model_cluster_profile_amazon_amazon_node_pools_pool1.go
@@ -14,8 +14,8 @@ type ClusterProfileAmazonAmazonNodePoolsPool1 struct {
 	InstanceType string `json:"instanceType,omitempty"`
 	SpotPrice string `json:"spotPrice,omitempty"`
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	Image string `json:"image,omitempty"`
 }

--- a/client/model_cluster_profile_azure_azure_node_pools_pool1.go
+++ b/client/model_cluster_profile_azure_azure_node_pools_pool1.go
@@ -12,8 +12,8 @@ package client
 
 type ClusterProfileAzureAzureNodePoolsPool1 struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_cluster_profile_google_google_node_pools_pool1.go
+++ b/client/model_cluster_profile_google_google_node_pools_pool1.go
@@ -12,9 +12,9 @@ package client
 
 type ClusterProfileGoogleGoogleNodePoolsPool1 struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 }

--- a/client/model_get_cluster_status_response.go
+++ b/client/model_get_cluster_status_response.go
@@ -16,6 +16,6 @@ type GetClusterStatusResponse struct {
 	Name string `json:"name,omitempty"`
 	Cloud string `json:"cloud,omitempty"`
 	Location string `json:"location,omitempty"`
-	Id float32 `json:"id,omitempty"`
+	Id int32 `json:"id,omitempty"`
 	NodePools GetClusterStatusResponseNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_node_pool_status_amazon.go
+++ b/client/model_node_pool_status_amazon.go
@@ -14,8 +14,8 @@ type NodePoolStatusAmazon struct {
 	InstanceType string `json:"instanceType,omitempty"`
 	SpotPrice string `json:"spot_price,omitempty"`
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	Image string `json:"image,omitempty"`
 }

--- a/client/model_node_pool_status_azure.go
+++ b/client/model_node_pool_status_azure.go
@@ -12,8 +12,8 @@ package client
 
 type NodePoolStatusAzure struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_node_pool_status_google.go
+++ b/client/model_node_pool_status_google.go
@@ -12,8 +12,8 @@ package client
 
 type NodePoolStatusGoogle struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_node_pools_amazon.go
+++ b/client/model_node_pools_amazon.go
@@ -14,7 +14,7 @@ type NodePoolsAmazon struct {
 	InstanceType string `json:"instanceType"`
 	SpotPrice string `json:"spotPrice"`
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
+	Count int32 `json:"count,omitempty"`
 	MinCount int32 `json:"minCount"`
 	MaxCount int32 `json:"maxCount"`
 	Image string `json:"image,omitempty"`

--- a/client/model_node_pools_azure.go
+++ b/client/model_node_pools_azure.go
@@ -12,7 +12,7 @@ package client
 
 type NodePoolsAzure struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count"`
+	Count int32 `json:"count"`
 	MinCount int32 `json:"minCount,omitempty"`
 	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType"`

--- a/client/model_node_pools_google.go
+++ b/client/model_node_pools_google.go
@@ -12,7 +12,7 @@ package client
 
 type NodePoolsGoogle struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count"`
+	Count int32 `json:"count"`
 	MinCount int32 `json:"minCount,omitempty"`
 	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType"`

--- a/client/model_update_azure_properties_azure_node_pools_pool1.go
+++ b/client/model_update_azure_properties_azure_node_pools_pool1.go
@@ -12,7 +12,7 @@ package client
 
 type UpdateAzurePropertiesAzureNodePoolsPool1 struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 }

--- a/client/model_update_google_properties_node_pools_pool1.go
+++ b/client/model_update_google_properties_node_pools_pool1.go
@@ -12,8 +12,8 @@ package client
 
 type UpdateGooglePropertiesNodePoolsPool1 struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_update_node_pools_amazon.go
+++ b/client/model_update_node_pools_amazon.go
@@ -12,7 +12,7 @@ package client
 
 type UpdateNodePoolsAmazon struct {
 	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count float32 `json:"count,omitempty"`
-	MinCount float32 `json:"minCount,omitempty"`
-	MaxCount float32 `json:"maxCount,omitempty"`
+	Count int32 `json:"count,omitempty"`
+	MinCount int32 `json:"minCount,omitempty"`
+	MaxCount int32 `json:"maxCount,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -1655,14 +1655,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/BaseError_500'
 
-  /auth/tokens:
+  /api/v1/tokens:
     get:
       security:
         - bearerAuth: []
       tags:
         - auth
       summary: List all API tokens
-      operationId: GetTokens
+      operationId: ListTokens
       description: List all API tokens
       responses:
         '200':
@@ -1690,9 +1690,9 @@ paths:
           - bearerAuth: []
       tags:
         - auth
-      summary: Generate token
-      operationId: GenerateToken
-      description: Generate token
+      summary: Create token
+      operationId: CreateToken
+      description: Create token
       requestBody:
         required: true
         content:
@@ -1701,7 +1701,7 @@ paths:
               $ref: '#/components/schemas/TokenCreateRequest'
       responses:
         '200':
-          description: Token generated successfully
+          description: Token created successfully
           content:
             application/json:
               schema:
@@ -1719,7 +1719,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BaseError_500'
 
-  /auth/tokens/{tokenId}:
+  /api/v1/tokens/{tokenId}:
     delete:
       security:
           - bearerAuth: []
@@ -3114,7 +3114,7 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
           type: integer
@@ -3160,7 +3160,7 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
           type: integer
@@ -3211,7 +3211,7 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
           type: integer
@@ -3377,13 +3377,13 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 2
         minCount:
-          type: number
+          type: integer
           example: 1
         maxCount:
-          type: number
+          type: integer
           example: 2
 
     UpdateAzureProperties:
@@ -3404,13 +3404,13 @@ components:
                       type: boolean
                       example: true
                     count:
-                      type: number
+                      type: integer
                       example: 2
                     minCount:
-                      type: number
+                      type: integer
                       example: 1
                     maxCount:
-                      type: number
+                      type: integer
                       example: 2
 
     UpdateGoogleProperties:
@@ -3431,13 +3431,13 @@ components:
                   type: boolean
                   example: true
                 count:
-                  type: number
+                  type: integer
                   example: 2
                 minCount:
-                  type: number
+                  type: integer
                   example: 1
                 maxCount:
-                  type: number
+                  type: integer
                   example: 2
                 instanceType:
                   type: string
@@ -4162,13 +4162,13 @@ components:
                       type: boolean
                       example: true
                     count:
-                      type: number
+                      type: integer
                       example: 1
                     minCount:
-                      type: number
+                      type: integer
                       example: 1
                     maxCount:
-                      type: number
+                      type: integer
                       example: 2
                     image:
                       type: string
@@ -4193,13 +4193,13 @@ components:
                       type: boolean
                       example: true
                     count:
-                      type: number
+                      type: integer
                       example: 1
                     minCount:
-                      type: number
+                      type: integer
                       example: 1
                     maxCount:
-                      type: number
+                      type: integer
                       example: 2
                     instanceType:
                       type: string
@@ -4230,13 +4230,13 @@ components:
                       type: boolean
                       example: true
                     count:
-                      type: number
+                      type: integer
                       example: 1
                     minCount:
-                      type: number
+                      type: integer
                       example: 1
                     maxCount:
-                      type: number
+                      type: integer
                       example: 2
                     instanceType:
                       type: string
@@ -4904,7 +4904,7 @@ components:
           type: string
           example: "us-central1-a"
         id:
-          type: number
+          type: integer
           example: 1
         nodePools:
           type: object
@@ -4932,13 +4932,13 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
-          type: number
+          type: integer
           example: 1
         maxCount:
-          type: number
+          type: integer
           example: 2
         image:
           type: string
@@ -4951,13 +4951,13 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
-          type: number
+          type: integer
           example: 1
         maxCount:
-          type: number
+          type: integer
           example: 2
         instanceType:
           type: string
@@ -4970,13 +4970,13 @@ components:
           type: boolean
           example: true
         count:
-          type: number
+          type: integer
           example: 1
         minCount:
-          type: number
+          type: integer
           example: 1
         maxCount:
-          type: number
+          type: integer
           example: 2
         instanceType:
           type: string


### PR DESCRIPTION
We used `type: number` in most of the cases when an `integer` would have been more appropriate, otherwise, the generated code will container `float32` types.