### PR TITLE
Fix allowed/secrets authz in Casbin

### DIFF
--- a/auth/authz.go
+++ b/auth/authz.go
@@ -86,6 +86,7 @@ func (a *BearerAuthorizer) RequirePermission(c *gin.Context) {
 
 func addDefaultPolicies() {
 	basePath := viper.GetString("pipeline.basepath")
+	enforcer.AddPolicy("default", basePath+"/api/v1/allowed/secrets", "*")
 	enforcer.AddPolicy("default", basePath+"/api/v1/allowed/secrets/*", "*")
 	enforcer.AddPolicy("default", basePath+"/api/v1/orgs", "*")
 	enforcer.AddPolicy("default", basePath+"/api/v1/token", "*")


### PR DESCRIPTION
This fix is needed to allow all logged in users to list allowed secret types.