### PR TITLE
Make goreportcard happy by go fmt-ing the client package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ generate-client:
 	-i /local/docs/openapi/pipeline.yaml \
 	-g go \
 	-o /local/client
+	go fmt ./client
 
 ineffassign: install-ineffassign
 	ineffassign ${GOFILES_NOVENDOR}

--- a/client/api_applications.go
+++ b/client/api_applications.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type ApplicationsApiService service
 
-/* 
+/*
 ApplicationsApiService Create new application based on catalog
 Create new application based on Catalog definition s
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -36,10 +36,10 @@ Create new application based on Catalog definition s
 */
 func (a *ApplicationsApiService) CreateApplication(ctx context.Context, orgId int32, createApplicationRequest CreateApplicationRequest) (map[string]interface{}, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue map[string]interface{}
 	)
 
@@ -88,26 +88,26 @@ func (a *ApplicationsApiService) CreateApplication(ctx context.Context, orgId in
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 201 {
 			var v map[string]interface{}
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -115,7 +115,7 @@ func (a *ApplicationsApiService) CreateApplication(ctx context.Context, orgId in
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ApplicationsApiService Get application details
 Get application details with deployments
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -125,10 +125,10 @@ Get application details with deployments
 */
 func (a *ApplicationsApiService) GetApplication(ctx context.Context, orgId int32, appId int32) (ApplicationDetailsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ApplicationDetailsResponse
 	)
 
@@ -176,26 +176,26 @@ func (a *ApplicationsApiService) GetApplication(ctx context.Context, orgId int32
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ApplicationDetailsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -203,7 +203,7 @@ func (a *ApplicationsApiService) GetApplication(ctx context.Context, orgId int32
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ApplicationsApiService List application catalogs
 List all available application for lunch
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -212,10 +212,10 @@ List all available application for lunch
 */
 func (a *ApplicationsApiService) ListApplications(ctx context.Context, orgId int32) (ApplicationListResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ApplicationListResponse
 	)
 
@@ -262,26 +262,26 @@ func (a *ApplicationsApiService) ListApplications(ctx context.Context, orgId int
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ApplicationListResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_auth.go
+++ b/client/api_auth.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type AuthApiService service
 
-/* 
+/*
 AuthApiService Create token
 Create token
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -35,10 +35,10 @@ Create token
 */
 func (a *AuthApiService) CreateToken(ctx context.Context, tokenCreateRequest TokenCreateRequest) (TokenCreateResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue TokenCreateResponse
 	)
 
@@ -86,46 +86,46 @@ func (a *AuthApiService) CreateToken(ctx context.Context, tokenCreateRequest Tok
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v TokenCreateResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -133,7 +133,7 @@ func (a *AuthApiService) CreateToken(ctx context.Context, tokenCreateRequest Tok
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 AuthApiService Delete an API token
 Delete an API token
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -190,28 +190,28 @@ func (a *AuthApiService) DeleteToken(ctx context.Context, tokenId string) (*http
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -219,7 +219,7 @@ func (a *AuthApiService) DeleteToken(ctx context.Context, tokenId string) (*http
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 AuthApiService List all API tokens
 List all API tokens
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -227,10 +227,10 @@ List all API tokens
 */
 func (a *AuthApiService) ListTokens(ctx context.Context) ([]TokenListResponseItem, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []TokenListResponseItem
 	)
 
@@ -276,46 +276,46 @@ func (a *AuthApiService) ListTokens(ctx context.Context) ([]TokenListResponseIte
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []TokenListResponseItem
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_catalogs.go
+++ b/client/api_catalogs.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type CatalogsApiService service
 
-/* 
+/*
 CatalogsApiService Get catalog details
 Get details about specific catalog
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -36,10 +36,10 @@ Get details about specific catalog
 */
 func (a *CatalogsApiService) GetCatalogDetail(ctx context.Context, orgId int32, name string) (CatalogDetailsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CatalogDetailsResponse
 	)
 
@@ -87,36 +87,36 @@ func (a *CatalogsApiService) GetCatalogDetail(ctx context.Context, orgId int32, 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v CatalogDetailsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v CatalogNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -124,7 +124,7 @@ func (a *CatalogsApiService) GetCatalogDetail(ctx context.Context, orgId int32, 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 CatalogsApiService List catalogs
 List all available catalogs
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -133,10 +133,10 @@ List all available catalogs
 */
 func (a *CatalogsApiService) ListCatalogs(ctx context.Context, orgId int32) (ListCatalogResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListCatalogResponse
 	)
 
@@ -183,26 +183,26 @@ func (a *CatalogsApiService) ListCatalogs(ctx context.Context, orgId int32) (Lis
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListCatalogResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -210,7 +210,7 @@ func (a *CatalogsApiService) ListCatalogs(ctx context.Context, orgId int32) (Lis
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 CatalogsApiService Update repository for catalog
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orgId Organization identification
@@ -266,7 +266,7 @@ func (a *CatalogsApiService) UpdateCatalogs(ctx context.Context, orgId int32) (*
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr

--- a/client/api_clusters.go
+++ b/client/api_clusters.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type ClustersApiService service
 
-/* 
+/*
 ClustersApiService Run posthook functions
 Run posthook functions
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -88,7 +88,7 @@ func (a *ClustersApiService) ClusterPostHooks(ctx context.Context, orgId int32, 
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr
@@ -97,7 +97,7 @@ func (a *ClustersApiService) ClusterPostHooks(ctx context.Context, orgId int32, 
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Create cluster
 Create a new K8S cluster in the cloud
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -107,10 +107,10 @@ Create a new K8S cluster in the cloud
 */
 func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, createApplicationRequest CreateApplicationRequest) (CreateClusterResponse202, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CreateClusterResponse202
 	)
 
@@ -159,46 +159,46 @@ func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, cre
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v CreateClusterResponse202
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v CreateClusterResponse400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -206,7 +206,7 @@ func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, cre
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Delete cluster
 Deleting a K8S cluster
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -216,10 +216,10 @@ Deleting a K8S cluster
 */
 func (a *ClustersApiService) DeleteCluster(ctx context.Context, orgId int32, id int32) (ClusterDelete200, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ClusterDelete200
 	)
 
@@ -267,66 +267,66 @@ func (a *ClustersApiService) DeleteCluster(ctx context.Context, orgId int32, id 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v ClusterDelete200
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -334,7 +334,7 @@ func (a *ClustersApiService) DeleteCluster(ctx context.Context, orgId int32, id 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Get API endpoint
 Get API endpoint
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -344,10 +344,10 @@ Get API endpoint
 */
 func (a *ClustersApiService) GetAPIEndpoint(ctx context.Context, orgId int32, id int32) (string, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue string
 	)
 
@@ -395,56 +395,56 @@ func (a *ClustersApiService) GetAPIEndpoint(ctx context.Context, orgId int32, id
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -452,7 +452,7 @@ func (a *ClustersApiService) GetAPIEndpoint(ctx context.Context, orgId int32, id
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Get cluster status
 Getting cluster status
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -462,10 +462,10 @@ Getting cluster status
 */
 func (a *ClustersApiService) GetCluster(ctx context.Context, orgId int32, id int32) (GetClusterStatusResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue GetClusterStatusResponse
 	)
 
@@ -513,56 +513,56 @@ func (a *ClustersApiService) GetCluster(ctx context.Context, orgId int32, id int
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v GetClusterStatusResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -570,7 +570,7 @@ func (a *ClustersApiService) GetCluster(ctx context.Context, orgId int32, id int
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Get a cluster config
 Getting a K8S cluster config file
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -580,10 +580,10 @@ Getting a K8S cluster config file
 */
 func (a *ClustersApiService) GetClusterConfig(ctx context.Context, orgId int32, id int32) (string, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue string
 	)
 
@@ -631,56 +631,56 @@ func (a *ClustersApiService) GetClusterConfig(ctx context.Context, orgId int32, 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -688,7 +688,7 @@ func (a *ClustersApiService) GetClusterConfig(ctx context.Context, orgId int32, 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Get cluster status
 Getting the K8S cluster status
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -747,7 +747,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, orgId int32, 
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr
@@ -756,7 +756,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, orgId int32, 
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Initialize Helm
 Initialize helm in the cluster
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -767,10 +767,10 @@ Initialize helm in the cluster
 */
 func (a *ClustersApiService) HelmInit(ctx context.Context, orgId int32, id int32, helmInitRequest HelmInitRequest) (HelmInitResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmInitResponse
 	)
 
@@ -820,56 +820,56 @@ func (a *ClustersApiService) HelmInit(ctx context.Context, orgId int32, id int32
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 201 {
 			var v HelmInitResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -877,7 +877,7 @@ func (a *ClustersApiService) HelmInit(ctx context.Context, orgId int32, id int32
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Install secrets into cluster
 Install secrets into cluster
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -888,10 +888,10 @@ Install secrets into cluster
 */
 func (a *ClustersApiService) InstallSecrets(ctx context.Context, orgId int32, id int32, installSecretsRequest InstallSecretsRequest) ([]InstallSecretsResponseItem, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []InstallSecretsResponseItem
 	)
 
@@ -941,56 +941,56 @@ func (a *ClustersApiService) InstallSecrets(ctx context.Context, orgId int32, id
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []InstallSecretsResponseItem
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -998,7 +998,7 @@ func (a *ClustersApiService) InstallSecrets(ctx context.Context, orgId int32, id
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService List clusters
 Listing all the K8S clusters from the cloud
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1007,10 +1007,10 @@ Listing all the K8S clusters from the cloud
 */
 func (a *ClustersApiService) ListClusters(ctx context.Context, orgId int32) ([]GetClusterStatusResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []GetClusterStatusResponse
 	)
 
@@ -1057,46 +1057,46 @@ func (a *ClustersApiService) ListClusters(ctx context.Context, orgId int32) ([]G
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []GetClusterStatusResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -1104,7 +1104,7 @@ func (a *ClustersApiService) ListClusters(ctx context.Context, orgId int32) ([]G
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService List service public endpoints
 List service public endpoints
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1114,10 +1114,10 @@ List service public endpoints
 */
 func (a *ClustersApiService) ListEndpoints(ctx context.Context, orgId int32, id int32) (ListEndpointsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListEndpointsResponse
 	)
 
@@ -1165,66 +1165,66 @@ func (a *ClustersApiService) ListEndpoints(ctx context.Context, orgId int32, id 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListEndpointsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -1232,7 +1232,7 @@ func (a *ClustersApiService) ListEndpoints(ctx context.Context, orgId int32, id 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService List cluser nodes
 List cluser nodes
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1242,10 +1242,10 @@ List cluser nodes
 */
 func (a *ClustersApiService) ListNodes(ctx context.Context, orgId int32, id int32) (ListNodesResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListNodesResponse
 	)
 
@@ -1293,66 +1293,66 @@ func (a *ClustersApiService) ListNodes(ctx context.Context, orgId int32, id int3
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListNodesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -1360,7 +1360,7 @@ func (a *ClustersApiService) ListNodes(ctx context.Context, orgId int32, id int3
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Update cluster
 Updating an existing K8S cluster
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1422,38 +1422,38 @@ func (a *ClustersApiService) UpdateCluster(ctx context.Context, orgId int32, id 
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -1461,7 +1461,7 @@ func (a *ClustersApiService) UpdateCluster(ctx context.Context, orgId int32, id 
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 ClustersApiService Update monitoring
 Update monitoring
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1471,10 +1471,10 @@ Update monitoring
 */
 func (a *ClustersApiService) UpdateMonitoring(ctx context.Context, orgId int32, id int32) (string, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue string
 	)
 
@@ -1522,26 +1522,26 @@ func (a *ClustersApiService) UpdateMonitoring(ctx context.Context, orgId int32, 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_common.go
+++ b/client/api_common.go
@@ -25,7 +25,7 @@ var (
 
 type CommonApiService service
 
-/* 
+/*
 CommonApiService List Pipeline API endpoints
 Listing Pipeline API endpoint
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -33,10 +33,10 @@ Listing Pipeline API endpoint
 */
 func (a *CommonApiService) ListEndpoints(ctx context.Context) ([]string, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []string
 	)
 
@@ -82,26 +82,26 @@ func (a *CommonApiService) ListEndpoints(ctx context.Context) ([]string, *http.R
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []string
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_deployment.go
+++ b/client/api_deployment.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type DeploymentApiService service
 
-/* 
+/*
 DeploymentApiService Delete deployment
 Deleting a Helm deployment
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -37,10 +37,10 @@ Deleting a Helm deployment
 */
 func (a *DeploymentApiService) DeleteDeployment(ctx context.Context, orgId int32, id int32, name string) (DeleteDeploymentResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue DeleteDeploymentResponse
 	)
 
@@ -89,56 +89,56 @@ func (a *DeploymentApiService) DeleteDeployment(ctx context.Context, orgId int32
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v DeleteDeploymentResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -146,7 +146,7 @@ func (a *DeploymentApiService) DeleteDeployment(ctx context.Context, orgId int32
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 DeploymentApiService Check deployment status
 Checking the status of a deployment through the Helm client API
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -207,7 +207,7 @@ func (a *DeploymentApiService) HelmDeploymentStatus(ctx context.Context, orgId i
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr
@@ -216,7 +216,7 @@ func (a *DeploymentApiService) HelmDeploymentStatus(ctx context.Context, orgId i
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 DeploymentApiService Update deployment
 Updating a Helm deployment
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -277,7 +277,7 @@ func (a *DeploymentApiService) UpdateDeployment(ctx context.Context, orgId int32
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr

--- a/client/api_deployments.go
+++ b/client/api_deployments.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type DeploymentsApiService service
 
-/* 
+/*
 DeploymentsApiService Create a Helm deployment
 Creating a Helm deployment
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -37,10 +37,10 @@ Creating a Helm deployment
 */
 func (a *DeploymentsApiService) CreateDeployment(ctx context.Context, orgId int32, id int32, createDeploymentRequest CreateDeploymentRequest) (CreateDeploymentResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CreateDeploymentResponse
 	)
 
@@ -90,56 +90,56 @@ func (a *DeploymentsApiService) CreateDeployment(ctx context.Context, orgId int3
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 201 {
 			var v CreateDeploymentResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -147,7 +147,7 @@ func (a *DeploymentsApiService) CreateDeployment(ctx context.Context, orgId int3
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 DeploymentsApiService Get tiller status
 Checking if tiller ready to accept deployments
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -206,7 +206,7 @@ func (a *DeploymentsApiService) GetTillerStatus(ctx context.Context, orgId int32
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr
@@ -215,7 +215,7 @@ func (a *DeploymentsApiService) GetTillerStatus(ctx context.Context, orgId int32
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 DeploymentsApiService List deployments
 Listing Helm deployments
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -225,10 +225,10 @@ Listing Helm deployments
 */
 func (a *DeploymentsApiService) ListDeployments(ctx context.Context, orgId int32, id int32) (ListDeploymentsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListDeploymentsResponse
 	)
 
@@ -276,56 +276,56 @@ func (a *DeploymentsApiService) ListDeployments(ctx context.Context, orgId int32
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListDeploymentsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_helm.go
+++ b/client/api_helm.go
@@ -12,12 +12,12 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
-	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -27,7 +27,7 @@ var (
 
 type HelmApiService service
 
-/* 
+/*
 HelmApiService Chart details
 Get helm chart details
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -39,10 +39,10 @@ Get helm chart details
 */
 func (a *HelmApiService) HelmChartDetails(ctx context.Context, orgId int32, repoName string, chartName string, chartVersion string) (HelmChartDetailsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmChartDetailsResponse
 	)
 
@@ -92,56 +92,56 @@ func (a *HelmApiService) HelmChartDetails(ctx context.Context, orgId int32, repo
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmChartDetailsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ChartNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -149,7 +149,7 @@ func (a *HelmApiService) HelmChartDetails(ctx context.Context, orgId int32, repo
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService Chart List
 Get available Helm chart&#39;s list
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -162,17 +162,17 @@ Get available Helm chart&#39;s list
 */
 
 type HelmChartListOpts struct {
-    Name optional.String
-    Repo optional.String
-    Version optional.String
+	Name    optional.String
+	Repo    optional.String
+	Version optional.String
 }
 
 func (a *HelmApiService) HelmChartList(ctx context.Context, orgId int32, localVarOptionals *HelmChartListOpts) (HelmChartsListResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmChartsListResponse
 	)
 
@@ -228,56 +228,56 @@ func (a *HelmApiService) HelmChartList(ctx context.Context, orgId int32, localVa
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmChartsListResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -285,7 +285,7 @@ func (a *HelmApiService) HelmChartList(ctx context.Context, orgId int32, localVa
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService List repositories
 Listing Helm repositories in the cluster
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -294,10 +294,10 @@ Listing Helm repositories in the cluster
 */
 func (a *HelmApiService) HelmInit(ctx context.Context, orgId int32) (HelmReposListResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmReposListResponse
 	)
 
@@ -344,56 +344,56 @@ func (a *HelmApiService) HelmInit(ctx context.Context, orgId int32) (HelmReposLi
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmReposListResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -401,7 +401,7 @@ func (a *HelmApiService) HelmInit(ctx context.Context, orgId int32) (HelmReposLi
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService Add Repo
 Add new Helm repository
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -411,10 +411,10 @@ Add new Helm repository
 */
 func (a *HelmApiService) HelmReposAdd(ctx context.Context, orgId int32, helmReposAddRequest HelmReposAddRequest) (HelmReposAddResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmReposAddResponse
 	)
 
@@ -463,56 +463,56 @@ func (a *HelmApiService) HelmReposAdd(ctx context.Context, orgId int32, helmRepo
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmReposAddResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -520,7 +520,7 @@ func (a *HelmApiService) HelmReposAdd(ctx context.Context, orgId int32, helmRepo
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService Delete Repo
 Delete  Helm repository
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -530,10 +530,10 @@ Delete  Helm repository
 */
 func (a *HelmApiService) HelmReposDelete(ctx context.Context, orgId int32, repoName string) (HelmReposDeleteResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmReposDeleteResponse
 	)
 
@@ -581,56 +581,56 @@ func (a *HelmApiService) HelmReposDelete(ctx context.Context, orgId int32, repoN
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmReposDeleteResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -638,7 +638,7 @@ func (a *HelmApiService) HelmReposDelete(ctx context.Context, orgId int32, repoN
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService Modify Repo
 Modify Helm repository
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -649,10 +649,10 @@ Modify Helm repository
 */
 func (a *HelmApiService) HelmReposModify(ctx context.Context, orgId int32, repoName string, helmReposModifyRequest HelmReposModifyRequest) (HelmReposUpdateResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Put")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmReposUpdateResponse
 	)
 
@@ -702,56 +702,56 @@ func (a *HelmApiService) HelmReposModify(ctx context.Context, orgId int32, repoN
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmReposUpdateResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v map[string]interface{}
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -759,7 +759,7 @@ func (a *HelmApiService) HelmReposModify(ctx context.Context, orgId int32, repoN
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 HelmApiService Update Repo
 Modify Helm repository
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -769,10 +769,10 @@ Modify Helm repository
 */
 func (a *HelmApiService) HelmReposUpdate(ctx context.Context, orgId int32, repoName string) (HelmReposUpdateResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Put")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue HelmReposUpdateResponse
 	)
 
@@ -820,56 +820,56 @@ func (a *HelmApiService) HelmReposUpdate(ctx context.Context, orgId int32, repoN
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v HelmReposUpdateResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v map[string]interface{}
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_info.go
+++ b/client/api_info.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type InfoApiService service
 
-/* 
+/*
 InfoApiService Get all amazon config
 Get all amazon config
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -39,10 +39,10 @@ Get all amazon config
 */
 func (a *InfoApiService) GetAmazonConfig(ctx context.Context, orgId int32, secretId string, fields string, tags string, location string) (AmazonConfigResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue AmazonConfigResponse
 	)
 
@@ -93,46 +93,46 @@ func (a *InfoApiService) GetAmazonConfig(ctx context.Context, orgId int32, secre
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v AmazonConfigResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -140,7 +140,7 @@ func (a *InfoApiService) GetAmazonConfig(ctx context.Context, orgId int32, secre
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 InfoApiService Get all azure config
 Get all azure config
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -152,10 +152,10 @@ Get all azure config
 */
 func (a *InfoApiService) GetAzureConfig(ctx context.Context, orgId int32, secretId string, fields string, location string) (AzureConfigResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue AzureConfigResponse
 	)
 
@@ -205,46 +205,46 @@ func (a *InfoApiService) GetAzureConfig(ctx context.Context, orgId int32, secret
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v AzureConfigResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -252,7 +252,7 @@ func (a *InfoApiService) GetAzureConfig(ctx context.Context, orgId int32, secret
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 InfoApiService Get all google config
 Get all google config
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -264,10 +264,10 @@ Get all google config
 */
 func (a *InfoApiService) GetGoogleConfig(ctx context.Context, orgId int32, secretId string, fields string, location string) (GoogleConfigResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue GoogleConfigResponse
 	)
 
@@ -317,46 +317,46 @@ func (a *InfoApiService) GetGoogleConfig(ctx context.Context, orgId int32, secre
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v GoogleConfigResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -364,7 +364,7 @@ func (a *InfoApiService) GetGoogleConfig(ctx context.Context, orgId int32, secre
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 InfoApiService Get supported cloud types
 Get supported cloud types
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -373,10 +373,10 @@ Get supported cloud types
 */
 func (a *InfoApiService) GetSupportedClouds(ctx context.Context, orgId int32) (SupportedCloudsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue SupportedCloudsResponse
 	)
 
@@ -423,36 +423,36 @@ func (a *InfoApiService) GetSupportedClouds(ctx context.Context, orgId int32) (S
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v SupportedCloudsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_organizations.go
+++ b/client/api_organizations.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type OrganizationsApiService service
 
-/* 
+/*
 OrganizationsApiService Create organization
 Creating organization
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -35,10 +35,10 @@ Creating organization
 */
 func (a *OrganizationsApiService) CreateOrg(ctx context.Context, body Body) (OrganizationCreateResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue OrganizationCreateResponse
 	)
 
@@ -86,56 +86,56 @@ func (a *OrganizationsApiService) CreateOrg(ctx context.Context, body Body) (Org
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v OrganizationCreateResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -143,7 +143,7 @@ func (a *OrganizationsApiService) CreateOrg(ctx context.Context, body Body) (Org
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 OrganizationsApiService Get organization
 Getting organization
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -152,10 +152,10 @@ Getting organization
 */
 func (a *OrganizationsApiService) GetOrg(ctx context.Context, orgId int32) (OrganizationListItemResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue OrganizationListItemResponse
 	)
 
@@ -202,56 +202,56 @@ func (a *OrganizationsApiService) GetOrg(ctx context.Context, orgId int32) (Orga
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v OrganizationListItemResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v OrganizationNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -259,7 +259,7 @@ func (a *OrganizationsApiService) GetOrg(ctx context.Context, orgId int32) (Orga
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 OrganizationsApiService List organizations
 Listing organizations
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -267,10 +267,10 @@ Listing organizations
 */
 func (a *OrganizationsApiService) ListOrgs(ctx context.Context) ([]OrganizationListItemResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []OrganizationListItemResponse
 	)
 
@@ -316,46 +316,46 @@ func (a *OrganizationsApiService) ListOrgs(ctx context.Context) ([]OrganizationL
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []OrganizationListItemResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_profiles.go
+++ b/client/api_profiles.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type ProfilesApiService service
 
-/* 
+/*
 ProfilesApiService Add cluster profiles
 Add cluster profile
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -86,28 +86,28 @@ func (a *ProfilesApiService) AddProfiles(ctx context.Context, orgId int32, addCl
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -115,7 +115,7 @@ func (a *ProfilesApiService) AddProfiles(ctx context.Context, orgId int32, addCl
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 ProfilesApiService Delete cluster profiles
 Delete cluster profiles by cloud type and name
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -176,48 +176,48 @@ func (a *ProfilesApiService) DeleteProfiles(ctx context.Context, orgId int32, ty
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterProfileNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -225,7 +225,7 @@ func (a *ProfilesApiService) DeleteProfiles(ctx context.Context, orgId int32, ty
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 ProfilesApiService List cluster profiles
 Listing cluster profiles by cloud type
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -235,10 +235,10 @@ Listing cluster profiles by cloud type
 */
 func (a *ProfilesApiService) ListProfiles(ctx context.Context, orgId int32, type_ string) (ProfileListResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ProfileListResponse
 	)
 
@@ -286,46 +286,46 @@ func (a *ProfilesApiService) ListProfiles(ctx context.Context, orgId int32, type
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ProfileListResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -333,7 +333,7 @@ func (a *ProfilesApiService) ListProfiles(ctx context.Context, orgId int32, type
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 ProfilesApiService Update cluster profiles
 Update an existing cluster profile
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -393,48 +393,48 @@ func (a *ProfilesApiService) UpdateProfiles(ctx context.Context, orgId int32, ad
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v ClusterProfileNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}

--- a/client/api_secrets.go
+++ b/client/api_secrets.go
@@ -12,12 +12,12 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
-	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -27,7 +27,7 @@ var (
 
 type SecretsApiService service
 
-/* 
+/*
 SecretsApiService Add secrets
 Adding secrets
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -39,15 +39,15 @@ Adding secrets
 */
 
 type AddSecretsOpts struct {
-    Validate optional.Bool
+	Validate optional.Bool
 }
 
 func (a *SecretsApiService) AddSecrets(ctx context.Context, orgId int32, createSecretRequest CreateSecretRequest, localVarOptionals *AddSecretsOpts) (CreateSecretResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CreateSecretResponse
 	)
 
@@ -99,56 +99,56 @@ func (a *SecretsApiService) AddSecrets(ctx context.Context, orgId int32, createS
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 201 {
 			var v CreateSecretResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -156,7 +156,7 @@ func (a *SecretsApiService) AddSecrets(ctx context.Context, orgId int32, createS
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService List allowed secret types
 List allowed secret types and their required keys
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -164,10 +164,10 @@ List allowed secret types and their required keys
 */
 func (a *SecretsApiService) AllowedSecretsTypes(ctx context.Context) (AllowedSecretTypesResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue AllowedSecretTypesResponse
 	)
 
@@ -213,36 +213,36 @@ func (a *SecretsApiService) AllowedSecretsTypes(ctx context.Context) (AllowedSec
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v AllowedSecretTypesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -250,7 +250,7 @@ func (a *SecretsApiService) AllowedSecretsTypes(ctx context.Context) (AllowedSec
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService List required keys
 List required keys in the given secret type
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -259,10 +259,10 @@ List required keys in the given secret type
 */
 func (a *SecretsApiService) AllowedSecretsTypesKeys(ctx context.Context, type_ string) (AllowedSecretTypeResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue AllowedSecretTypeResponse
 	)
 
@@ -309,46 +309,46 @@ func (a *SecretsApiService) AllowedSecretsTypesKeys(ctx context.Context, type_ s
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v AllowedSecretTypeResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -356,7 +356,7 @@ func (a *SecretsApiService) AllowedSecretsTypesKeys(ctx context.Context, type_ s
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService Delete secrets
 Deleting secrets
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -415,38 +415,38 @@ func (a *SecretsApiService) DeleteSecrets(ctx context.Context, orgId int32, secr
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v SecretsNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -454,7 +454,7 @@ func (a *SecretsApiService) DeleteSecrets(ctx context.Context, orgId int32, secr
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService Get secret
 Get secret
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -464,10 +464,10 @@ Get secret
 */
 func (a *SecretsApiService) GetSecret(ctx context.Context, orgId int32, secretId string) (SecretItem, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue SecretItem
 	)
 
@@ -515,66 +515,66 @@ func (a *SecretsApiService) GetSecret(ctx context.Context, orgId int32, secretId
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v SecretItem
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v SecretsNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -582,7 +582,7 @@ func (a *SecretsApiService) GetSecret(ctx context.Context, orgId int32, secretId
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService List secrets
 Listing secrets
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -595,17 +595,17 @@ Listing secrets
 */
 
 type GetSecretsOpts struct {
-    Type_ optional.String
-    Tag optional.String
-    Values optional.Bool
+	Type_  optional.String
+	Tag    optional.String
+	Values optional.Bool
 }
 
 func (a *SecretsApiService) GetSecrets(ctx context.Context, orgId int32, localVarOptionals *GetSecretsOpts) ([]SecretItem, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []SecretItem
 	)
 
@@ -661,46 +661,46 @@ func (a *SecretsApiService) GetSecrets(ctx context.Context, orgId int32, localVa
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []SecretItem
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -708,7 +708,7 @@ func (a *SecretsApiService) GetSecrets(ctx context.Context, orgId int32, localVa
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService Update secrets
 Update secrets
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -721,15 +721,15 @@ Update secrets
 */
 
 type UpdateSecretsOpts struct {
-    Validate optional.Bool
+	Validate optional.Bool
 }
 
 func (a *SecretsApiService) UpdateSecrets(ctx context.Context, orgId int32, secretId string, createSecretRequest CreateSecretRequest, localVarOptionals *UpdateSecretsOpts) (CreateSecretResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Put")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CreateSecretResponse
 	)
 
@@ -782,76 +782,76 @@ func (a *SecretsApiService) UpdateSecrets(ctx context.Context, orgId int32, secr
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v CreateSecretResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 409 {
 			var v Conflict
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -859,7 +859,7 @@ func (a *SecretsApiService) UpdateSecrets(ctx context.Context, orgId int32, secr
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 SecretsApiService Validate secret
 Validate secret
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -918,48 +918,48 @@ func (a *SecretsApiService) ValidateSecret(ctx context.Context, orgId int32, sec
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 404 {
 			var v SecretsNotFound
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}

--- a/client/api_storage.go
+++ b/client/api_storage.go
@@ -12,12 +12,12 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
-	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -27,7 +27,7 @@ var (
 
 type StorageApiService service
 
-/* 
+/*
 StorageApiService Creates a new object store bucket with the given params
 Creates a new object store bucket on the Cloud provider referenced by the given secret. The credentials for creating the bucket is taken from the provided secret.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -37,10 +37,10 @@ Creates a new object store bucket on the Cloud provider referenced by the given 
 */
 func (a *StorageApiService) CreateObjectStoreBucket(ctx context.Context, orgId int32, createObjectStoreBucketRequest CreateObjectStoreBucketRequest) (CreateObjectStoreBucketResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue CreateObjectStoreBucketResponse
 	)
 
@@ -89,56 +89,56 @@ func (a *StorageApiService) CreateObjectStoreBucket(ctx context.Context, orgId i
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v CreateObjectStoreBucketResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -146,7 +146,7 @@ func (a *StorageApiService) CreateObjectStoreBucket(ctx context.Context, orgId i
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 StorageApiService Deletes the object store bucket with the given name
 Deletes the object store bucket identified by the given name. The credentials for deleting the bucket is taken from the provided secret.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -160,8 +160,8 @@ Deletes the object store bucket identified by the given name. The credentials fo
 */
 
 type DeleteObjectStoreBucketOpts struct {
-    ResourceGroup optional.String
-    StorageAccount optional.String
+	ResourceGroup  optional.String
+	StorageAccount optional.String
 }
 
 func (a *StorageApiService) DeleteObjectStoreBucket(ctx context.Context, orgId int32, name int32, secretId string, cloudType string, localVarOptionals *DeleteObjectStoreBucketOpts) (*http.Response, error) {
@@ -224,38 +224,38 @@ func (a *StorageApiService) DeleteObjectStoreBucket(ctx context.Context, orgId i
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarHttpResponse, newErr
 		}
 		return localVarHttpResponse, newErr
 	}
@@ -263,7 +263,7 @@ func (a *StorageApiService) DeleteObjectStoreBucket(ctx context.Context, orgId i
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 StorageApiService Get object store bucket status
 Retrieves the status of the object store bucket given its name
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -277,8 +277,8 @@ Retrieves the status of the object store bucket given its name
 */
 
 type GetObjectStoreBucketStatusOpts struct {
-    ResourceGroup optional.String
-    StorageAccount optional.String
+	ResourceGroup  optional.String
+	StorageAccount optional.String
 }
 
 func (a *StorageApiService) GetObjectStoreBucketStatus(ctx context.Context, orgId int32, name int32, secretId string, cloudType string, localVarOptionals *GetObjectStoreBucketStatusOpts) (*http.Response, error) {
@@ -341,7 +341,7 @@ func (a *StorageApiService) GetObjectStoreBucketStatus(ctx context.Context, orgI
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		return localVarHttpResponse, newErr
@@ -350,7 +350,7 @@ func (a *StorageApiService) GetObjectStoreBucketStatus(ctx context.Context, orgI
 	return localVarHttpResponse, nil
 }
 
-/* 
+/*
 StorageApiService List object storage buckets
 List object store buckets accessible by the credentials referenced by the given secret.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -363,15 +363,15 @@ List object store buckets accessible by the credentials referenced by the given 
 */
 
 type ListObjectStoreBucketsOpts struct {
-    Location optional.String
+	Location optional.String
 }
 
 func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId int32, secretId string, cloudType string, localVarOptionals *ListObjectStoreBucketsOpts) (ListStorageBucketsResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListStorageBucketsResponse
 	)
 
@@ -423,56 +423,56 @@ func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId in
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListStorageBucketsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v BaseError400
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 401 {
 			var v Unauthorized
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v BaseError500
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/api_users.go
+++ b/client/api_users.go
@@ -12,11 +12,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -26,7 +26,7 @@ var (
 
 type UsersApiService service
 
-/* 
+/*
 UsersApiService Get user
 Getting user
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -36,10 +36,10 @@ Getting user
 */
 func (a *UsersApiService) GetUsers(ctx context.Context, orgId int32, userId int32) (User, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue User
 	)
 
@@ -87,26 +87,26 @@ func (a *UsersApiService) GetUsers(ctx context.Context, orgId int32, userId int3
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v User
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
@@ -114,7 +114,7 @@ func (a *UsersApiService) GetUsers(ctx context.Context, orgId int32, userId int3
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* 
+/*
 UsersApiService List users
 Listing users
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -123,10 +123,10 @@ Listing users
 */
 func (a *UsersApiService) ListUsers(ctx context.Context, orgId int32) (ListUserResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ListUserResponse
 	)
 
@@ -173,26 +173,26 @@ func (a *UsersApiService) ListUsers(ctx context.Context, orgId int32) (ListUserR
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericOpenAPIError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ListUserResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -340,17 +340,17 @@ func (c *APIClient) prepareRequest(
 }
 
 func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
-		if strings.Contains(contentType, "application/xml") {
-			if err = xml.Unmarshal(b, v); err != nil {
-				return err
-			}
-			return nil
-		} else if strings.Contains(contentType, "application/json") {
-			if err = json.Unmarshal(b, v); err != nil {
-				return err
-			}
-			return nil
+	if strings.Contains(contentType, "application/xml") {
+		if err = xml.Unmarshal(b, v); err != nil {
+			return err
 		}
+		return nil
+	} else if strings.Contains(contentType, "application/json") {
+		if err = json.Unmarshal(b, v); err != nil {
+			return err
+		}
+		return nil
+	}
 	return errors.New("undefined response type")
 }
 

--- a/client/model_add_cluster_profile_amazon_amazon.go
+++ b/client/model_add_cluster_profile_amazon_amazon.go
@@ -11,6 +11,6 @@
 package client
 
 type AddClusterProfileAmazonAmazon struct {
-	Master CreateAmazonPropertiesAmazonMaster `json:"master,omitempty"`
+	Master    CreateAmazonPropertiesAmazonMaster     `json:"master,omitempty"`
 	NodePools AddClusterProfileAmazonAmazonNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_add_cluster_profile_amazon_amazon_node_pools_pool1.go
+++ b/client/model_add_cluster_profile_amazon_amazon_node_pools_pool1.go
@@ -11,9 +11,9 @@
 package client
 
 type AddClusterProfileAmazonAmazonNodePoolsPool1 struct {
-	SpotPrice string `json:"spotPrice,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
-	Image string `json:"image,omitempty"`
+	SpotPrice    string `json:"spotPrice,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
+	Image        string `json:"image,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_add_cluster_profile_azure_azure.go
+++ b/client/model_add_cluster_profile_azure_azure.go
@@ -11,6 +11,6 @@
 package client
 
 type AddClusterProfileAzureAzure struct {
-	NodePools AddClusterProfileAzureAzureNodePools `json:"nodePools,omitempty"`
-	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+	NodePools         AddClusterProfileAzureAzureNodePools `json:"nodePools,omitempty"`
+	KubernetesVersion string                               `json:"kubernetesVersion,omitempty"`
 }

--- a/client/model_add_cluster_profile_azure_azure_node_pools_pool1.go
+++ b/client/model_add_cluster_profile_azure_azure_node_pools_pool1.go
@@ -11,6 +11,6 @@
 package client
 
 type AddClusterProfileAzureAzureNodePoolsPool1 struct {
-	Count int32 `json:"count,omitempty"`
+	Count        int32  `json:"count,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_add_cluster_profile_google_google.go
+++ b/client/model_add_cluster_profile_google_google.go
@@ -11,7 +11,7 @@
 package client
 
 type AddClusterProfileGoogleGoogle struct {
-	Master CreateGooglePropertiesGoogleMaster `json:"master,omitempty"`
-	NodeVersion string `json:"nodeVersion,omitempty"`
-	NodePools AddClusterProfileGoogleGoogleNodePools `json:"nodePools,omitempty"`
+	Master      CreateGooglePropertiesGoogleMaster     `json:"master,omitempty"`
+	NodeVersion string                                 `json:"nodeVersion,omitempty"`
+	NodePools   AddClusterProfileGoogleGoogleNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_add_cluster_profile_google_google_node_pools_pool1.go
+++ b/client/model_add_cluster_profile_google_google_node_pools_pool1.go
@@ -11,7 +11,7 @@
 package client
 
 type AddClusterProfileGoogleGoogleNodePoolsPool1 struct {
-	Count int32 `json:"count,omitempty"`
+	Count          int32  `json:"count,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	InstanceType string `json:"instanceType,omitempty"`
+	InstanceType   string `json:"instanceType,omitempty"`
 }

--- a/client/model_add_cluster_profile_request.go
+++ b/client/model_add_cluster_profile_request.go
@@ -11,8 +11,8 @@
 package client
 
 type AddClusterProfileRequest struct {
-	Name string `json:"name,omitempty"`
-	Location string `json:"location,omitempty"`
-	Cloud string `json:"cloud,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Location   string                 `json:"location,omitempty"`
+	Cloud      string                 `json:"cloud,omitempty"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }

--- a/client/model_allowed_secret_type_response.go
+++ b/client/model_allowed_secret_type_response.go
@@ -11,6 +11,6 @@
 package client
 
 type AllowedSecretTypeResponse struct {
-	Fields []AllowedSecretTypeResponseFields `json:"fields,omitempty"`
-	Sourcing string `json:"sourcing,omitempty"`
+	Fields   []AllowedSecretTypeResponseFields `json:"fields,omitempty"`
+	Sourcing string                            `json:"sourcing,omitempty"`
 }

--- a/client/model_allowed_secret_type_response_fields.go
+++ b/client/model_allowed_secret_type_response_fields.go
@@ -11,7 +11,7 @@
 package client
 
 type AllowedSecretTypeResponseFields struct {
-	Name string `json:"name,omitempty"`
-	Required bool `json:"required,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Required    bool   `json:"required,omitempty"`
 	Description string `json:"description,omitempty"`
 }

--- a/client/model_allowed_secret_types_response.go
+++ b/client/model_allowed_secret_types_response.go
@@ -11,13 +11,13 @@
 package client
 
 type AllowedSecretTypesResponse struct {
-	Amazon AllowedSecretTypeResponse `json:"amazon,omitempty"`
-	Azure AllowedSecretTypeResponse `json:"azure,omitempty"`
-	Google AllowedSecretTypeResponse `json:"google,omitempty"`
+	Amazon     AllowedSecretTypeResponse `json:"amazon,omitempty"`
+	Azure      AllowedSecretTypeResponse `json:"azure,omitempty"`
+	Google     AllowedSecretTypeResponse `json:"google,omitempty"`
 	Kubernetes AllowedSecretTypeResponse `json:"kubernetes,omitempty"`
-	Generic AllowedSecretTypeResponse `json:"generic,omitempty"`
-	Fn AllowedSecretTypeResponse `json:"fn,omitempty"`
-	Password AllowedSecretTypeResponse `json:"password,omitempty"`
-	Tls AllowedSecretTypeResponse `json:"tls,omitempty"`
-	Ssh AllowedSecretTypeResponse `json:"ssh,omitempty"`
+	Generic    AllowedSecretTypeResponse `json:"generic,omitempty"`
+	Fn         AllowedSecretTypeResponse `json:"fn,omitempty"`
+	Password   AllowedSecretTypeResponse `json:"password,omitempty"`
+	Tls        AllowedSecretTypeResponse `json:"tls,omitempty"`
+	Ssh        AllowedSecretTypeResponse `json:"ssh,omitempty"`
 }

--- a/client/model_amazon_config_response.go
+++ b/client/model_amazon_config_response.go
@@ -11,9 +11,9 @@
 package client
 
 type AmazonConfigResponse struct {
-	Type string `json:"type,omitempty"`
-	NameRegexp string `json:"nameRegexp,omitempty"`
-	Locations string `json:"locations,omitempty"`
-	Image AmazonConfigResponseImage `json:"image,omitempty"`
+	Type         string                           `json:"type,omitempty"`
+	NameRegexp   string                           `json:"nameRegexp,omitempty"`
+	Locations    string                           `json:"locations,omitempty"`
+	Image        AmazonConfigResponseImage        `json:"image,omitempty"`
 	InstanceType AmazonConfigResponseInstanceType `json:"instanceType,omitempty"`
 }

--- a/client/model_application_deployment_item.go
+++ b/client/model_application_deployment_item.go
@@ -11,13 +11,13 @@
 package client
 
 type ApplicationDeploymentItem struct {
-	Id int32 `json:"id,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
-	Name string `json:"name,omitempty"`
-	Chart string `json:"chart,omitempty"`
-	ReleaseName string `json:"releaseName,omitempty"`
-	Status string `json:"status,omitempty"`
-	Message string `json:"message,omitempty"`
-	ApplicationId int32 `json:"applicationId,omitempty"`
+	Id            int32  `json:"id,omitempty"`
+	CreatedAt     string `json:"createdAt,omitempty"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Chart         string `json:"chart,omitempty"`
+	ReleaseName   string `json:"releaseName,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Message       string `json:"message,omitempty"`
+	ApplicationId int32  `json:"applicationId,omitempty"`
 }

--- a/client/model_application_details_response.go
+++ b/client/model_application_details_response.go
@@ -11,15 +11,15 @@
 package client
 
 type ApplicationDetailsResponse struct {
-	Name string `json:"name,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
-	CatalogName string `json:"catalogName,omitempty"`
-	Description string `json:"description,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	OrganizationId int32 `json:"organizationId,omitempty"`
-	ClusterName string `json:"cluster_name,omitempty"`
-	ClusterId int32 `json:"cluster_id,omitempty"`
-	Readme string `json:"readme,omitempty"`
-	Deployments []ApplicationDeploymentItem `json:"deployments,omitempty"`
+	Name           string                      `json:"name,omitempty"`
+	CreatedAt      string                      `json:"createdAt,omitempty"`
+	UpdatedAt      string                      `json:"updatedAt,omitempty"`
+	CatalogName    string                      `json:"catalogName,omitempty"`
+	Description    string                      `json:"description,omitempty"`
+	Icon           string                      `json:"icon,omitempty"`
+	OrganizationId int32                       `json:"organizationId,omitempty"`
+	ClusterName    string                      `json:"cluster_name,omitempty"`
+	ClusterId      int32                       `json:"cluster_id,omitempty"`
+	Readme         string                      `json:"readme,omitempty"`
+	Deployments    []ApplicationDeploymentItem `json:"deployments,omitempty"`
 }

--- a/client/model_application_list_item.go
+++ b/client/model_application_list_item.go
@@ -11,14 +11,14 @@
 package client
 
 type ApplicationListItem struct {
-	Id int32 `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
-	ClusterName string `json:"clusterName,omitempty"`
-	ClusterId int32 `json:"clusterId,omitempty"`
-	Status string `json:"status,omitempty"`
-	CatalogName string `json:"catalogName,omitempty"`
-	Icon string `json:"icon,omitempty"`
+	Id            int32  `json:"id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	CreatedAt     string `json:"createdAt,omitempty"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
+	ClusterName   string `json:"clusterName,omitempty"`
+	ClusterId     int32  `json:"clusterId,omitempty"`
+	Status        string `json:"status,omitempty"`
+	CatalogName   string `json:"catalogName,omitempty"`
+	Icon          string `json:"icon,omitempty"`
 	StatusMessage string `json:"statusMessage,omitempty"`
 }

--- a/client/model_azure_blob_storage_props.go
+++ b/client/model_azure_blob_storage_props.go
@@ -11,6 +11,6 @@
 package client
 
 type AzureBlobStorageProps struct {
-	ResourceGroup string `json:"resourceGroup"`
+	ResourceGroup  string `json:"resourceGroup"`
 	StorageAccount string `json:"storageAccount"`
 }

--- a/client/model_azure_config_response.go
+++ b/client/model_azure_config_response.go
@@ -11,9 +11,9 @@
 package client
 
 type AzureConfigResponse struct {
-	Type string `json:"type,omitempty"`
-	NameRegexp string `json:"nameRegexp,omitempty"`
-	Locations string `json:"locations,omitempty"`
-	InstanceType AzureConfigResponseInstanceType `json:"instanceType,omitempty"`
-	KubernetesVersions []string `json:"kubernetes_versions,omitempty"`
+	Type               string                          `json:"type,omitempty"`
+	NameRegexp         string                          `json:"nameRegexp,omitempty"`
+	Locations          string                          `json:"locations,omitempty"`
+	InstanceType       AzureConfigResponseInstanceType `json:"instanceType,omitempty"`
+	KubernetesVersions []string                        `json:"kubernetes_versions,omitempty"`
 }

--- a/client/model_base_error_400.go
+++ b/client/model_base_error_400.go
@@ -11,7 +11,7 @@
 package client
 
 type BaseError400 struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_base_error_500.go
+++ b/client/model_base_error_500.go
@@ -11,7 +11,7 @@
 package client
 
 type BaseError500 struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_bucket_info.go
+++ b/client/model_bucket_info.go
@@ -11,7 +11,7 @@
 package client
 
 type BucketInfo struct {
-	Name string `json:"name"`
-	Managed bool `json:"managed"`
-	Azure AzureBlobStorageProps `json:"azure,omitempty"`
+	Name    string                `json:"name"`
+	Managed bool                  `json:"managed"`
+	Azure   AzureBlobStorageProps `json:"azure,omitempty"`
 }

--- a/client/model_catalog_chart_info.go
+++ b/client/model_catalog_chart_info.go
@@ -11,9 +11,9 @@
 package client
 
 type CatalogChartInfo struct {
-	Name string `json:"name,omitempty"`
+	Name        string                      `json:"name,omitempty"`
 	Annotations CatalogChartInfoAnnotations `json:"annotations,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	Description string `json:"description,omitempty"`
-	Keywords []string `json:"keywords,omitempty"`
+	Icon        string                      `json:"icon,omitempty"`
+	Description string                      `json:"description,omitempty"`
+	Keywords    []string                    `json:"keywords,omitempty"`
 }

--- a/client/model_catalog_chart_info_annotations.go
+++ b/client/model_catalog_chart_info_annotations.go
@@ -11,6 +11,6 @@
 package client
 
 type CatalogChartInfoAnnotations struct {
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
 	LongDescription string `json:"longDescription,omitempty"`
 }

--- a/client/model_catalog_details_response.go
+++ b/client/model_catalog_details_response.go
@@ -13,6 +13,6 @@ package client
 type CatalogDetailsResponse struct {
 	Chart CatalogChartInfo `json:"chart,omitempty"`
 	// Catalog Readme.md in base64 encoded string
-	Readme string `json:"readme,omitempty"`
+	Readme    string                          `json:"readme,omitempty"`
 	Spotguide CatalogDetailsResponseSpotguide `json:"spotguide,omitempty"`
 }

--- a/client/model_catalog_details_response_spotguide.go
+++ b/client/model_catalog_details_response_spotguide.go
@@ -11,6 +11,6 @@
 package client
 
 type CatalogDetailsResponseSpotguide struct {
-	Resources RequestedResources `json:"resources,omitempty"`
-	Options []map[string]interface{} `json:"options,omitempty"`
+	Resources RequestedResources       `json:"resources,omitempty"`
+	Options   []map[string]interface{} `json:"options,omitempty"`
 }

--- a/client/model_catalog_not_found.go
+++ b/client/model_catalog_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type CatalogNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_catalog_options_monitor.go
+++ b/client/model_catalog_options_monitor.go
@@ -11,10 +11,10 @@
 package client
 
 type CatalogOptionsMonitor struct {
-	Name string `json:"name,omitempty"`
-	Type bool `json:"type,omitempty"`
-	Info string `json:"info,omitempty"`
-	Default bool `json:"default,omitempty"`
-	Readonly bool `json:"readonly,omitempty"`
-	Key string `json:"key,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     bool   `json:"type,omitempty"`
+	Info     string `json:"info,omitempty"`
+	Default  bool   `json:"default,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+	Key      string `json:"key,omitempty"`
 }

--- a/client/model_catalog_options_mysql_database_name.go
+++ b/client/model_catalog_options_mysql_database_name.go
@@ -11,11 +11,11 @@
 package client
 
 type CatalogOptionsMysqlDatabaseName struct {
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	Info string `json:"info,omitempty"`
-	Default string `json:"default,omitempty"`
-	Readonly bool `json:"readonly,omitempty"`
-	Enabled bool `json:"enabled,omitempty"`
-	Key string `json:"key,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Info     string `json:"info,omitempty"`
+	Default  string `json:"default,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+	Enabled  bool   `json:"enabled,omitempty"`
+	Key      string `json:"key,omitempty"`
 }

--- a/client/model_catalog_options_mysql_database_size.go
+++ b/client/model_catalog_options_mysql_database_size.go
@@ -11,11 +11,11 @@
 package client
 
 type CatalogOptionsMysqlDatabaseSize struct {
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	Info string `json:"info,omitempty"`
-	Default int32 `json:"default,omitempty"`
-	Readonly bool `json:"readonly,omitempty"`
-	Enabled bool `json:"enabled,omitempty"`
-	Key string `json:"key,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Info     string `json:"info,omitempty"`
+	Default  int32  `json:"default,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+	Enabled  bool   `json:"enabled,omitempty"`
+	Key      string `json:"key,omitempty"`
 }

--- a/client/model_catalog_options_mysql_version.go
+++ b/client/model_catalog_options_mysql_version.go
@@ -11,10 +11,10 @@
 package client
 
 type CatalogOptionsMysqlVersion struct {
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	Info string `json:"info,omitempty"`
-	Default string `json:"default,omitempty"`
-	Readonly bool `json:"readonly,omitempty"`
-	Key string `json:"key,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Info     string `json:"info,omitempty"`
+	Default  string `json:"default,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+	Key      string `json:"key,omitempty"`
 }

--- a/client/model_chart_not_found.go
+++ b/client/model_chart_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type ChartNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_cluster_delete_200.go
+++ b/client/model_cluster_delete_200.go
@@ -11,7 +11,7 @@
 package client
 
 type ClusterDelete200 struct {
-	Status int32 `json:"status,omitempty"`
-	Name string `json:"name,omitempty"`
-	Id int32 `json:"id,omitempty"`
+	Status int32  `json:"status,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Id     int32  `json:"id,omitempty"`
 }

--- a/client/model_cluster_not_found.go
+++ b/client/model_cluster_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type ClusterNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_cluster_profile_amazon_amazon.go
+++ b/client/model_cluster_profile_amazon_amazon.go
@@ -11,6 +11,6 @@
 package client
 
 type ClusterProfileAmazonAmazon struct {
-	Master CreateAmazonPropertiesAmazonMaster `json:"master,omitempty"`
+	Master    CreateAmazonPropertiesAmazonMaster  `json:"master,omitempty"`
 	NodePools ClusterProfileAmazonAmazonNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_cluster_profile_amazon_amazon_node_pools_pool1.go
+++ b/client/model_cluster_profile_amazon_amazon_node_pools_pool1.go
@@ -12,10 +12,10 @@ package client
 
 type ClusterProfileAmazonAmazonNodePoolsPool1 struct {
 	InstanceType string `json:"instanceType,omitempty"`
-	SpotPrice string `json:"spotPrice,omitempty"`
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
-	Image string `json:"image,omitempty"`
+	SpotPrice    string `json:"spotPrice,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
+	Image        string `json:"image,omitempty"`
 }

--- a/client/model_cluster_profile_azure_azure.go
+++ b/client/model_cluster_profile_azure_azure.go
@@ -11,6 +11,6 @@
 package client
 
 type ClusterProfileAzureAzure struct {
-	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
-	NodePools ClusterProfileAzureAzureNodePools `json:"nodePools,omitempty"`
+	KubernetesVersion string                            `json:"kubernetesVersion,omitempty"`
+	NodePools         ClusterProfileAzureAzureNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_cluster_profile_azure_azure_node_pools_pool1.go
+++ b/client/model_cluster_profile_azure_azure_node_pools_pool1.go
@@ -11,9 +11,9 @@
 package client
 
 type ClusterProfileAzureAzureNodePoolsPool1 struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_cluster_profile_google_google.go
+++ b/client/model_cluster_profile_google_google.go
@@ -11,7 +11,7 @@
 package client
 
 type ClusterProfileGoogleGoogle struct {
-	Master CreateGooglePropertiesGoogleMaster `json:"master,omitempty"`
-	NodeVersion string `json:"nodeVersion,omitempty"`
-	NodePools ClusterProfileGoogleGoogleNodePools `json:"nodePools,omitempty"`
+	Master      CreateGooglePropertiesGoogleMaster  `json:"master,omitempty"`
+	NodeVersion string                              `json:"nodeVersion,omitempty"`
+	NodePools   ClusterProfileGoogleGoogleNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_cluster_profile_google_google_node_pools_pool1.go
+++ b/client/model_cluster_profile_google_google_node_pools_pool1.go
@@ -11,10 +11,10 @@
 package client
 
 type ClusterProfileGoogleGoogleNodePoolsPool1 struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
-	InstanceType string `json:"instanceType,omitempty"`
+	Autoscaling    bool   `json:"autoscaling,omitempty"`
+	Count          int32  `json:"count,omitempty"`
+	MinCount       int32  `json:"minCount,omitempty"`
+	MaxCount       int32  `json:"maxCount,omitempty"`
+	InstanceType   string `json:"instanceType,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 }

--- a/client/model_cluster_profile_not_found.go
+++ b/client/model_cluster_profile_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type ClusterProfileNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_conflict.go
+++ b/client/model_conflict.go
@@ -11,7 +11,7 @@
 package client
 
 type Conflict struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_create_amazon_properties_amazon.go
+++ b/client/model_create_amazon_properties_amazon.go
@@ -11,6 +11,6 @@
 package client
 
 type CreateAmazonPropertiesAmazon struct {
-	Master CreateAmazonPropertiesAmazonMaster `json:"master,omitempty"`
+	Master    CreateAmazonPropertiesAmazonMaster    `json:"master,omitempty"`
 	NodePools CreateAmazonPropertiesAmazonNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_create_amazon_properties_amazon_master.go
+++ b/client/model_create_amazon_properties_amazon_master.go
@@ -12,5 +12,5 @@ package client
 
 type CreateAmazonPropertiesAmazonMaster struct {
 	InstanceType string `json:"instanceType,omitempty"`
-	Image string `json:"image,omitempty"`
+	Image        string `json:"image,omitempty"`
 }

--- a/client/model_create_application_request.go
+++ b/client/model_create_application_request.go
@@ -11,8 +11,8 @@
 package client
 
 type CreateApplicationRequest struct {
-	Name string `json:"name,omitempty"`
-	CatalogName string `json:"catalogName,omitempty"`
-	ClusterId int32 `json:"clusterId,omitempty"`
-	Cluster CreateClusterRequest `json:"cluster,omitempty"`
+	Name        string               `json:"name,omitempty"`
+	CatalogName string               `json:"catalogName,omitempty"`
+	ClusterId   int32                `json:"clusterId,omitempty"`
+	Cluster     CreateClusterRequest `json:"cluster,omitempty"`
 }

--- a/client/model_create_azure_object_store_bucket_properties.go
+++ b/client/model_create_azure_object_store_bucket_properties.go
@@ -12,6 +12,6 @@ package client
 
 type CreateAzureObjectStoreBucketProperties struct {
 	StorageAccount string `json:"storageAccount"`
-	Location string `json:"location"`
-	ResourceGroup string `json:"resourceGroup"`
+	Location       string `json:"location"`
+	ResourceGroup  string `json:"resourceGroup"`
 }

--- a/client/model_create_azure_properties_azure.go
+++ b/client/model_create_azure_properties_azure.go
@@ -11,7 +11,7 @@
 package client
 
 type CreateAzurePropertiesAzure struct {
-	ResourceGroup string `json:"resourceGroup,omitempty"`
-	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
-	NodePools CreateAzurePropertiesAzureNodePools `json:"nodePools,omitempty"`
+	ResourceGroup     string                              `json:"resourceGroup,omitempty"`
+	KubernetesVersion string                              `json:"kubernetesVersion,omitempty"`
+	NodePools         CreateAzurePropertiesAzureNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_create_cluster_request.go
+++ b/client/model_create_cluster_request.go
@@ -11,10 +11,10 @@
 package client
 
 type CreateClusterRequest struct {
-	Name string `json:"name"`
-	Location string `json:"location"`
-	Cloud string `json:"cloud"`
-	SecretId string `json:"secretId"`
-	PostHooks []string `json:"postHooks,omitempty"`
+	Name       string                 `json:"name"`
+	Location   string                 `json:"location"`
+	Cloud      string                 `json:"cloud"`
+	SecretId   string                 `json:"secretId"`
+	PostHooks  []string               `json:"postHooks,omitempty"`
 	Properties map[string]interface{} `json:"properties"`
 }

--- a/client/model_create_cluster_response_202.go
+++ b/client/model_create_cluster_response_202.go
@@ -12,5 +12,5 @@ package client
 
 type CreateClusterResponse202 struct {
 	Name string `json:"name,omitempty"`
-	Id int32 `json:"id,omitempty"`
+	Id   int32  `json:"id,omitempty"`
 }

--- a/client/model_create_cluster_response_400.go
+++ b/client/model_create_cluster_response_400.go
@@ -11,7 +11,7 @@
 package client
 
 type CreateClusterResponse400 struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_create_deployment_request.go
+++ b/client/model_create_deployment_request.go
@@ -11,8 +11,8 @@
 package client
 
 type CreateDeploymentRequest struct {
-	Name string `json:"name"`
-	Releasename string `json:"releasename,omitempty"`
-	Version string `json:"version,omitempty"`
-	Values map[string]interface{} `json:"values,omitempty"`
+	Name        string                 `json:"name"`
+	Releasename string                 `json:"releasename,omitempty"`
+	Version     string                 `json:"version,omitempty"`
+	Values      map[string]interface{} `json:"values,omitempty"`
 }

--- a/client/model_create_deployment_response.go
+++ b/client/model_create_deployment_response.go
@@ -12,5 +12,5 @@ package client
 
 type CreateDeploymentResponse struct {
 	ReleaseName string `json:"release_name,omitempty"`
-	Notes string `json:"notes,omitempty"`
+	Notes       string `json:"notes,omitempty"`
 }

--- a/client/model_create_google_properties_google.go
+++ b/client/model_create_google_properties_google.go
@@ -11,7 +11,7 @@
 package client
 
 type CreateGooglePropertiesGoogle struct {
-	Master CreateGooglePropertiesGoogleMaster `json:"master,omitempty"`
-	NodeVersion string `json:"nodeVersion,omitempty"`
-	NodePools CreateGooglePropertiesGoogleNodePools `json:"nodePools,omitempty"`
+	Master      CreateGooglePropertiesGoogleMaster    `json:"master,omitempty"`
+	NodeVersion string                                `json:"nodeVersion,omitempty"`
+	NodePools   CreateGooglePropertiesGoogleNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_create_object_store_bucket_request.go
+++ b/client/model_create_object_store_bucket_request.go
@@ -11,7 +11,7 @@
 package client
 
 type CreateObjectStoreBucketRequest struct {
-	SecretId string `json:"secretId"`
-	Name string `json:"name"`
+	SecretId   string                 `json:"secretId"`
+	Name       string                 `json:"name"`
 	Properties map[string]interface{} `json:"properties"`
 }

--- a/client/model_create_secret_request.go
+++ b/client/model_create_secret_request.go
@@ -11,9 +11,9 @@
 package client
 
 type CreateSecretRequest struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Tags []string `json:"tags,omitempty"`
-	Version int32 `json:"version,omitempty"`
-	Values map[string]interface{} `json:"values"`
+	Name    string                 `json:"name"`
+	Type    string                 `json:"type"`
+	Tags    []string               `json:"tags,omitempty"`
+	Version int32                  `json:"version,omitempty"`
+	Values  map[string]interface{} `json:"values"`
 }

--- a/client/model_create_secret_response.go
+++ b/client/model_create_secret_response.go
@@ -11,8 +11,8 @@
 package client
 
 type CreateSecretResponse struct {
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	Id string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Id    string `json:"id,omitempty"`
 	Error string `json:"error,omitempty"`
 }

--- a/client/model_delete_deployment_response.go
+++ b/client/model_delete_deployment_response.go
@@ -11,7 +11,7 @@
 package client
 
 type DeleteDeploymentResponse struct {
-	Status int32 `json:"status,omitempty"`
+	Status  int32  `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name    string `json:"name,omitempty"`
 }

--- a/client/model_endpoint_item.go
+++ b/client/model_endpoint_item.go
@@ -11,7 +11,7 @@
 package client
 
 type EndpointItem struct {
-	Name string `json:"name,omitempty"`
-	Host string `json:"host,omitempty"`
+	Name string    `json:"name,omitempty"`
+	Host string    `json:"host,omitempty"`
 	Urls []UrlItem `json:"urls,omitempty"`
 }

--- a/client/model_get_cluster_status_response.go
+++ b/client/model_get_cluster_status_response.go
@@ -11,11 +11,11 @@
 package client
 
 type GetClusterStatusResponse struct {
-	Status string `json:"status,omitempty"`
-	StatusMessage string `json:"status_message,omitempty"`
-	Name string `json:"name,omitempty"`
-	Cloud string `json:"cloud,omitempty"`
-	Location string `json:"location,omitempty"`
-	Id int32 `json:"id,omitempty"`
-	NodePools GetClusterStatusResponseNodePools `json:"nodePools,omitempty"`
+	Status        string                            `json:"status,omitempty"`
+	StatusMessage string                            `json:"status_message,omitempty"`
+	Name          string                            `json:"name,omitempty"`
+	Cloud         string                            `json:"cloud,omitempty"`
+	Location      string                            `json:"location,omitempty"`
+	Id            int32                             `json:"id,omitempty"`
+	NodePools     GetClusterStatusResponseNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_google_config_response.go
+++ b/client/model_google_config_response.go
@@ -11,9 +11,9 @@
 package client
 
 type GoogleConfigResponse struct {
-	Type string `json:"type,omitempty"`
-	NameRegexp string `json:"nameRegexp,omitempty"`
-	Locations string `json:"locations,omitempty"`
-	InstanceType GoogleConfigResponseInstanceType `json:"instanceType,omitempty"`
+	Type               string                                 `json:"type,omitempty"`
+	NameRegexp         string                                 `json:"nameRegexp,omitempty"`
+	Locations          string                                 `json:"locations,omitempty"`
+	InstanceType       GoogleConfigResponseInstanceType       `json:"instanceType,omitempty"`
 	KubernetesVersions GoogleConfigResponseKubernetesVersions `json:"kubernetes_versions,omitempty"`
 }

--- a/client/model_google_config_response_kubernetes_versions.go
+++ b/client/model_google_config_response_kubernetes_versions.go
@@ -11,9 +11,9 @@
 package client
 
 type GoogleConfigResponseKubernetesVersions struct {
-	DefaultClusterVersion string `json:"defaultClusterVersion,omitempty"`
-	DefaultImageType string `json:"defaultImageType,omitempty"`
-	ValidImageTypes []string `json:"validImageTypes,omitempty"`
-	ValidMasterVersions []string `json:"validMasterVersions,omitempty"`
-	ValidNodeVersions []string `json:"validNodeVersions,omitempty"`
+	DefaultClusterVersion string   `json:"defaultClusterVersion,omitempty"`
+	DefaultImageType      string   `json:"defaultImageType,omitempty"`
+	ValidImageTypes       []string `json:"validImageTypes,omitempty"`
+	ValidMasterVersions   []string `json:"validMasterVersions,omitempty"`
+	ValidNodeVersions     []string `json:"validNodeVersions,omitempty"`
 }

--- a/client/model_helm_chart_details_response.go
+++ b/client/model_helm_chart_details_response.go
@@ -11,7 +11,7 @@
 package client
 
 type HelmChartDetailsResponse struct {
-	Chart HelmChartDetailsResponseChart `json:"chart,omitempty"`
-	Values string `json:"values,omitempty"`
-	Readme string `json:"readme,omitempty"`
+	Chart  HelmChartDetailsResponseChart `json:"chart,omitempty"`
+	Values string                        `json:"values,omitempty"`
+	Readme string                        `json:"readme,omitempty"`
 }

--- a/client/model_helm_chart_details_response_chart.go
+++ b/client/model_helm_chart_details_response_chart.go
@@ -11,19 +11,19 @@
 package client
 
 type HelmChartDetailsResponseChart struct {
-	Name string `json:"name,omitempty"`
-	Home string `json:"home,omitempty"`
-	Sources []string `json:"sources,omitempty"`
-	Version string `json:"version,omitempty"`
-	Description string `json:"description,omitempty"`
-	Keywords []string `json:"keywords,omitempty"`
+	Name        string                                     `json:"name,omitempty"`
+	Home        string                                     `json:"home,omitempty"`
+	Sources     []string                                   `json:"sources,omitempty"`
+	Version     string                                     `json:"version,omitempty"`
+	Description string                                     `json:"description,omitempty"`
+	Keywords    []string                                   `json:"keywords,omitempty"`
 	Maintainers []HelmChartDetailsResponseChartMaintainers `json:"maintainers,omitempty"`
-	Engine string `json:"engine,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	AppVersion string `json:"appVersion,omitempty"`
-	ApiVersion string `json:"apiVersion,omitempty"`
-	Deprecated bool `json:"deprecated,omitempty"`
-	Urls []string `json:"urls,omitempty"`
-	Created string `json:"created,omitempty"`
-	Digest string `json:"digest,omitempty"`
+	Engine      string                                     `json:"engine,omitempty"`
+	Icon        string                                     `json:"icon,omitempty"`
+	AppVersion  string                                     `json:"appVersion,omitempty"`
+	ApiVersion  string                                     `json:"apiVersion,omitempty"`
+	Deprecated  bool                                       `json:"deprecated,omitempty"`
+	Urls        []string                                   `json:"urls,omitempty"`
+	Created     string                                     `json:"created,omitempty"`
+	Digest      string                                     `json:"digest,omitempty"`
 }

--- a/client/model_helm_chart_details_response_chart_maintainers.go
+++ b/client/model_helm_chart_details_response_chart_maintainers.go
@@ -11,6 +11,6 @@
 package client
 
 type HelmChartDetailsResponseChartMaintainers struct {
-	Name string `json:"name,omitempty"`
+	Name  string `json:"name,omitempty"`
 	Email string `json:"email,omitempty"`
 }

--- a/client/model_helm_charts_list_response_inner.go
+++ b/client/model_helm_charts_list_response_inner.go
@@ -11,6 +11,6 @@
 package client
 
 type HelmChartsListResponseInner struct {
-	Name string `json:"name,omitempty"`
+	Name   string                     `json:"name,omitempty"`
 	Charts [][]map[string]interface{} `json:"charts,omitempty"`
 }

--- a/client/model_helm_init_request.go
+++ b/client/model_helm_init_request.go
@@ -11,11 +11,11 @@
 package client
 
 type HelmInitRequest struct {
-	KubeContext string `json:"kube_context,omitempty"`
-	Namespace string `json:"namespace"`
-	Upgrade bool `json:"upgrade,omitempty"`
+	KubeContext    string `json:"kube_context,omitempty"`
+	Namespace      string `json:"namespace"`
+	Upgrade        bool   `json:"upgrade,omitempty"`
 	ServiceAccount string `json:"service_account"`
-	CanaryImage bool `json:"canary_image,omitempty"`
-	TillerImage string `json:"tiller_image,omitempty"`
-	HistoryMax int32 `json:"history_max,omitempty"`
+	CanaryImage    bool   `json:"canary_image,omitempty"`
+	TillerImage    string `json:"tiller_image,omitempty"`
+	HistoryMax     int32  `json:"history_max,omitempty"`
 }

--- a/client/model_helm_init_response.go
+++ b/client/model_helm_init_response.go
@@ -11,6 +11,6 @@
 package client
 
 type HelmInitResponse struct {
-	Status int32 `json:"status,omitempty"`
+	Status  int32  `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
 }

--- a/client/model_helm_repos_add_request.go
+++ b/client/model_helm_repos_add_request.go
@@ -11,9 +11,9 @@
 package client
 
 type HelmReposAddRequest struct {
-	Name string `json:"name"`
-	Url string `json:"url"`
+	Name     string `json:"name"`
+	Url      string `json:"url"`
 	CertFile string `json:"certFile,omitempty"`
-	KeyFile string `json:"keyFile,omitempty"`
-	CaFile string `json:"caFile,omitempty"`
+	KeyFile  string `json:"keyFile,omitempty"`
+	CaFile   string `json:"caFile,omitempty"`
 }

--- a/client/model_helm_repos_add_response.go
+++ b/client/model_helm_repos_add_response.go
@@ -11,7 +11,7 @@
 package client
 
 type HelmReposAddResponse struct {
-	Status int32 `json:"status,omitempty"`
+	Status  int32  `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name    string `json:"name,omitempty"`
 }

--- a/client/model_helm_repos_delete_response.go
+++ b/client/model_helm_repos_delete_response.go
@@ -11,7 +11,7 @@
 package client
 
 type HelmReposDeleteResponse struct {
-	Status int32 `json:"status,omitempty"`
+	Status  int32  `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name    string `json:"name,omitempty"`
 }

--- a/client/model_helm_repos_list_response_inner.go
+++ b/client/model_helm_repos_list_response_inner.go
@@ -11,10 +11,10 @@
 package client
 
 type HelmReposListResponseInner struct {
-	Name string `json:"name,omitempty"`
-	Cache string `json:"cache,omitempty"`
-	Url string `json:"url,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Cache    string `json:"cache,omitempty"`
+	Url      string `json:"url,omitempty"`
 	CertFile string `json:"certFile,omitempty"`
-	KeyFile string `json:"keyFile,omitempty"`
-	CaFile string `json:"caFile,omitempty"`
+	KeyFile  string `json:"keyFile,omitempty"`
+	CaFile   string `json:"caFile,omitempty"`
 }

--- a/client/model_helm_repos_modify_request.go
+++ b/client/model_helm_repos_modify_request.go
@@ -11,9 +11,9 @@
 package client
 
 type HelmReposModifyRequest struct {
-	Name string `json:"name,omitempty"`
-	Url string `json:"url,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Url      string `json:"url,omitempty"`
 	CertFile string `json:"certFile,omitempty"`
-	KeyFile string `json:"keyFile,omitempty"`
-	CaFile string `json:"caFile,omitempty"`
+	KeyFile  string `json:"keyFile,omitempty"`
+	CaFile   string `json:"caFile,omitempty"`
 }

--- a/client/model_helm_repos_update_response.go
+++ b/client/model_helm_repos_update_response.go
@@ -11,7 +11,7 @@
 package client
 
 type HelmReposUpdateResponse struct {
-	Status int32 `json:"status,omitempty"`
+	Status  int32  `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name    string `json:"name,omitempty"`
 }

--- a/client/model_install_secrets_request.go
+++ b/client/model_install_secrets_request.go
@@ -11,6 +11,6 @@
 package client
 
 type InstallSecretsRequest struct {
-	Namespace string `json:"namespace"`
-	Query InstallSecretsRequestQuery `json:"query,omitempty"`
+	Namespace string                     `json:"namespace"`
+	Query     InstallSecretsRequestQuery `json:"query,omitempty"`
 }

--- a/client/model_install_secrets_request_query.go
+++ b/client/model_install_secrets_request_query.go
@@ -12,5 +12,5 @@ package client
 
 type InstallSecretsRequestQuery struct {
 	Type string `json:"type,omitempty"`
-	Tag string `json:"tag,omitempty"`
+	Tag  string `json:"tag,omitempty"`
 }

--- a/client/model_install_secrets_response_item.go
+++ b/client/model_install_secrets_response_item.go
@@ -11,6 +11,6 @@
 package client
 
 type InstallSecretsResponseItem struct {
-	Name string `json:"name"`
+	Name     string `json:"name"`
 	Sourcing string `json:"sourcing"`
 }

--- a/client/model_list_catalog_item1.go
+++ b/client/model_list_catalog_item1.go
@@ -11,9 +11,9 @@
 package client
 
 type ListCatalogItem1 struct {
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	Version string `json:"version,omitempty"`
+	Icon        string `json:"icon,omitempty"`
+	Version     string `json:"version,omitempty"`
 }

--- a/client/model_list_catalog_item2.go
+++ b/client/model_list_catalog_item2.go
@@ -11,9 +11,9 @@
 package client
 
 type ListCatalogItem2 struct {
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	Version string `json:"version,omitempty"`
+	Icon        string `json:"icon,omitempty"`
+	Version     string `json:"version,omitempty"`
 }

--- a/client/model_list_deployments_response_inner.go
+++ b/client/model_list_deployments_response_inner.go
@@ -11,9 +11,9 @@
 package client
 
 type ListDeploymentsResponseInner struct {
-	Name string `json:"name,omitempty"`
-	Chart string `json:"chart,omitempty"`
-	Version int32 `json:"version,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Chart   string `json:"chart,omitempty"`
+	Version int32  `json:"version,omitempty"`
 	Updated string `json:"updated,omitempty"`
-	Status string `json:"status,omitempty"`
+	Status  string `json:"status,omitempty"`
 }

--- a/client/model_list_nodes_response.go
+++ b/client/model_list_nodes_response.go
@@ -12,5 +12,5 @@ package client
 
 type ListNodesResponse struct {
 	Metadata ListNodesResponseMetadata `json:"metadata,omitempty"`
-	Items []NodeItem `json:"items,omitempty"`
+	Items    []NodeItem                `json:"items,omitempty"`
 }

--- a/client/model_list_nodes_response_metadata.go
+++ b/client/model_list_nodes_response_metadata.go
@@ -11,6 +11,6 @@
 package client
 
 type ListNodesResponseMetadata struct {
-	SelfLink string `json:"selfLink,omitempty"`
+	SelfLink        string `json:"selfLink,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }

--- a/client/model_node_item.go
+++ b/client/model_node_item.go
@@ -12,6 +12,6 @@ package client
 
 type NodeItem struct {
 	Metadata NodeItemMetadata `json:"metadata,omitempty"`
-	Spec NodeItemSpec `json:"spec,omitempty"`
-	Status NodeItemStatus `json:"status,omitempty"`
+	Spec     NodeItemSpec     `json:"spec,omitempty"`
+	Status   NodeItemStatus   `json:"status,omitempty"`
 }

--- a/client/model_node_item_metadata.go
+++ b/client/model_node_item_metadata.go
@@ -11,11 +11,11 @@
 package client
 
 type NodeItemMetadata struct {
-	Name string `json:"name,omitempty"`
-	SelfLink string `json:"selfLink,omitempty"`
-	Uid string `json:"uid,omitempty"`
-	ResourceVersion string `json:"resourceVersion,omitempty"`
-	CreationTimestamp string `json:"creationTimestamp,omitempty"`
-	Labels NodeItemMetadataLabels `json:"labels,omitempty"`
-	Annotations NodeItemMetadataAnnotations `json:"annotations,omitempty"`
+	Name              string                      `json:"name,omitempty"`
+	SelfLink          string                      `json:"selfLink,omitempty"`
+	Uid               string                      `json:"uid,omitempty"`
+	ResourceVersion   string                      `json:"resourceVersion,omitempty"`
+	CreationTimestamp string                      `json:"creationTimestamp,omitempty"`
+	Labels            NodeItemMetadataLabels      `json:"labels,omitempty"`
+	Annotations       NodeItemMetadataAnnotations `json:"annotations,omitempty"`
 }

--- a/client/model_node_item_metadata_annotations.go
+++ b/client/model_node_item_metadata_annotations.go
@@ -11,6 +11,6 @@
 package client
 
 type NodeItemMetadataAnnotations struct {
-	NodeAlphaKubernetesIottl string `json:"node.alpha.kubernetes.io/ttl,omitempty"`
+	NodeAlphaKubernetesIottl                         string `json:"node.alpha.kubernetes.io/ttl,omitempty"`
 	VolumesKubernetesIocontrollerManagedAttachDetach string `json:"volumes.kubernetes.io/controller-managed-attach-detach,omitempty"`
 }

--- a/client/model_node_item_metadata_labels.go
+++ b/client/model_node_item_metadata_labels.go
@@ -11,12 +11,12 @@
 package client
 
 type NodeItemMetadataLabels struct {
-	BetaKubernetesIoarch string `json:"beta.kubernetes.io/arch,omitempty"`
-	BetaKubernetesIofluentdDsReady string `json:"beta.kubernetes.io/fluentd-ds-ready,omitempty"`
-	BetaKubernetesIoinstanceType string `json:"beta.kubernetes.io/instance-type,omitempty"`
-	BetaKubernetesIoos string `json:"beta.kubernetes.io/os,omitempty"`
-	CloudGoogleComgkeNodepool string `json:"cloud.google.com/gke-nodepool,omitempty"`
+	BetaKubernetesIoarch                string `json:"beta.kubernetes.io/arch,omitempty"`
+	BetaKubernetesIofluentdDsReady      string `json:"beta.kubernetes.io/fluentd-ds-ready,omitempty"`
+	BetaKubernetesIoinstanceType        string `json:"beta.kubernetes.io/instance-type,omitempty"`
+	BetaKubernetesIoos                  string `json:"beta.kubernetes.io/os,omitempty"`
+	CloudGoogleComgkeNodepool           string `json:"cloud.google.com/gke-nodepool,omitempty"`
 	FailureDomainBetaKubernetesIoregion string `json:"failure-domain.beta.kubernetes.io/region,omitempty"`
-	FailureDomainBetaKubernetesIozone string `json:"failure-domain.beta.kubernetes.io/zone,omitempty"`
-	KubernetesIohostname string `json:"kubernetes.io/hostname,omitempty"`
+	FailureDomainBetaKubernetesIozone   string `json:"failure-domain.beta.kubernetes.io/zone,omitempty"`
+	KubernetesIohostname                string `json:"kubernetes.io/hostname,omitempty"`
 }

--- a/client/model_node_item_spec.go
+++ b/client/model_node_item_spec.go
@@ -11,7 +11,7 @@
 package client
 
 type NodeItemSpec struct {
-	PodCIDR string `json:"podCIDR,omitempty"`
+	PodCIDR    string `json:"podCIDR,omitempty"`
 	ExternalID string `json:"externalID,omitempty"`
 	ProviderID string `json:"providerID,omitempty"`
 }

--- a/client/model_node_item_status.go
+++ b/client/model_node_item_status.go
@@ -11,11 +11,11 @@
 package client
 
 type NodeItemStatus struct {
-	Capacity NodeItemStatusCapacity `json:"capacity,omitempty"`
-	Allocatable NodeItemStatusAllocatable `json:"allocatable,omitempty"`
-	Conditions []NodeItemStatusConditions `json:"conditions,omitempty"`
-	Addresses []NodeItemStatusAddresses `json:"addresses,omitempty"`
+	Capacity        NodeItemStatusCapacity        `json:"capacity,omitempty"`
+	Allocatable     NodeItemStatusAllocatable     `json:"allocatable,omitempty"`
+	Conditions      []NodeItemStatusConditions    `json:"conditions,omitempty"`
+	Addresses       []NodeItemStatusAddresses     `json:"addresses,omitempty"`
 	DaemonEndpoints NodeItemStatusDaemonEndpoints `json:"daemonEndpoints,omitempty"`
-	NodeInfo NodeItemStatusNodeInfo `json:"nodeInfo,omitempty"`
-	Images []NodeItemStatusImages `json:"images,omitempty"`
+	NodeInfo        NodeItemStatusNodeInfo        `json:"nodeInfo,omitempty"`
+	Images          []NodeItemStatusImages        `json:"images,omitempty"`
 }

--- a/client/model_node_item_status_addresses.go
+++ b/client/model_node_item_status_addresses.go
@@ -11,6 +11,6 @@
 package client
 
 type NodeItemStatusAddresses struct {
-	Type string `json:"type,omitempty"`
+	Type    string `json:"type,omitempty"`
 	Address string `json:"address,omitempty"`
 }

--- a/client/model_node_item_status_allocatable.go
+++ b/client/model_node_item_status_allocatable.go
@@ -11,7 +11,7 @@
 package client
 
 type NodeItemStatusAllocatable struct {
-	Cpu string `json:"cpu,omitempty"`
+	Cpu    string `json:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty"`
-	Pods string `json:"pods,omitempty"`
+	Pods   string `json:"pods,omitempty"`
 }

--- a/client/model_node_item_status_capacity.go
+++ b/client/model_node_item_status_capacity.go
@@ -11,7 +11,7 @@
 package client
 
 type NodeItemStatusCapacity struct {
-	Cpu string `json:"cpu,omitempty"`
+	Cpu    string `json:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty"`
-	Pods string `json:"pods,omitempty"`
+	Pods   string `json:"pods,omitempty"`
 }

--- a/client/model_node_item_status_conditions.go
+++ b/client/model_node_item_status_conditions.go
@@ -11,10 +11,10 @@
 package client
 
 type NodeItemStatusConditions struct {
-	Type string `json:"type,omitempty"`
-	Status string `json:"status,omitempty"`
-	LastHeartbeatTime string `json:"lastHeartbeatTime,omitempty"`
+	Type               string `json:"type,omitempty"`
+	Status             string `json:"status,omitempty"`
+	LastHeartbeatTime  string `json:"lastHeartbeatTime,omitempty"`
 	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
-	Reason string `json:"reason,omitempty"`
-	Message string `json:"message,omitempty"`
+	Reason             string `json:"reason,omitempty"`
+	Message            string `json:"message,omitempty"`
 }

--- a/client/model_node_item_status_images.go
+++ b/client/model_node_item_status_images.go
@@ -11,6 +11,6 @@
 package client
 
 type NodeItemStatusImages struct {
-	Name []string `json:"name,omitempty"`
-	SizeBytes int32 `json:"sizeBytes,omitempty"`
+	Name      []string `json:"name,omitempty"`
+	SizeBytes int32    `json:"sizeBytes,omitempty"`
 }

--- a/client/model_node_item_status_node_info.go
+++ b/client/model_node_item_status_node_info.go
@@ -11,14 +11,14 @@
 package client
 
 type NodeItemStatusNodeInfo struct {
-	MachineID string `json:"machineID,omitempty"`
-	SystemUUID string `json:"systemUUID,omitempty"`
-	BootID string `json:"bootID,omitempty"`
-	KernelVersion string `json:"kernelVersion,omitempty"`
-	OsImage string `json:"osImage,omitempty"`
+	MachineID               string `json:"machineID,omitempty"`
+	SystemUUID              string `json:"systemUUID,omitempty"`
+	BootID                  string `json:"bootID,omitempty"`
+	KernelVersion           string `json:"kernelVersion,omitempty"`
+	OsImage                 string `json:"osImage,omitempty"`
 	ContainerRuntimeVersion string `json:"containerRuntimeVersion,omitempty"`
-	KubeletVersion string `json:"kubeletVersion,omitempty"`
-	KubeProxyVersion string `json:"kubeProxyVersion,omitempty"`
-	OperatingSystem string `json:"operatingSystem,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
+	KubeletVersion          string `json:"kubeletVersion,omitempty"`
+	KubeProxyVersion        string `json:"kubeProxyVersion,omitempty"`
+	OperatingSystem         string `json:"operatingSystem,omitempty"`
+	Architecture            string `json:"architecture,omitempty"`
 }

--- a/client/model_node_pool_status_amazon.go
+++ b/client/model_node_pool_status_amazon.go
@@ -12,10 +12,10 @@ package client
 
 type NodePoolStatusAmazon struct {
 	InstanceType string `json:"instanceType,omitempty"`
-	SpotPrice string `json:"spot_price,omitempty"`
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
-	Image string `json:"image,omitempty"`
+	SpotPrice    string `json:"spot_price,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
+	Image        string `json:"image,omitempty"`
 }

--- a/client/model_node_pool_status_azure.go
+++ b/client/model_node_pool_status_azure.go
@@ -11,9 +11,9 @@
 package client
 
 type NodePoolStatusAzure struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_node_pool_status_google.go
+++ b/client/model_node_pool_status_google.go
@@ -11,9 +11,9 @@
 package client
 
 type NodePoolStatusGoogle struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_node_pools_amazon.go
+++ b/client/model_node_pools_amazon.go
@@ -12,10 +12,10 @@ package client
 
 type NodePoolsAmazon struct {
 	InstanceType string `json:"instanceType"`
-	SpotPrice string `json:"spotPrice"`
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount"`
-	MaxCount int32 `json:"maxCount"`
-	Image string `json:"image,omitempty"`
+	SpotPrice    string `json:"spotPrice"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount"`
+	MaxCount     int32  `json:"maxCount"`
+	Image        string `json:"image,omitempty"`
 }

--- a/client/model_node_pools_azure.go
+++ b/client/model_node_pools_azure.go
@@ -11,9 +11,9 @@
 package client
 
 type NodePoolsAzure struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType"`
 }

--- a/client/model_node_pools_google.go
+++ b/client/model_node_pools_google.go
@@ -11,9 +11,9 @@
 package client
 
 type NodePoolsGoogle struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType"`
 }

--- a/client/model_organization_create_response.go
+++ b/client/model_organization_create_response.go
@@ -11,9 +11,9 @@
 package client
 
 type OrganizationCreateResponse struct {
-	Id int32 `json:"id,omitempty"`
+	Id        int32  `json:"id,omitempty"`
 	CreatedAt string `json:"createdAt,omitempty"`
 	UpdatedAt string `json:"updatedAt,omitempty"`
-	Name string `json:"name,omitempty"`
-	Users []User `json:"users,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Users     []User `json:"users,omitempty"`
 }

--- a/client/model_organization_list_item_response.go
+++ b/client/model_organization_list_item_response.go
@@ -11,8 +11,8 @@
 package client
 
 type OrganizationListItemResponse struct {
-	Id int32 `json:"id,omitempty"`
+	Id        int32  `json:"id,omitempty"`
 	CreatedAt string `json:"createdAt,omitempty"`
 	UpdatedAt string `json:"updatedAt,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name      string `json:"name,omitempty"`
 }

--- a/client/model_organization_not_found.go
+++ b/client/model_organization_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type OrganizationNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_profile_list_response.go
+++ b/client/model_profile_list_response.go
@@ -11,8 +11,8 @@
 package client
 
 type ProfileListResponse struct {
-	Name string `json:"name,omitempty"`
-	Location string `json:"location,omitempty"`
-	Cloud string `json:"cloud,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Location   string                 `json:"location,omitempty"`
+	Cloud      string                 `json:"cloud,omitempty"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }

--- a/client/model_repo_not_found.go
+++ b/client/model_repo_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type RepoNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_requested_resources.go
+++ b/client/model_requested_resources.go
@@ -14,7 +14,7 @@ type RequestedResources struct {
 	// Total CPU requested for the cluster
 	SumCpu int32 `json:"sumCpu,omitempty"`
 	// Total memory requested for the cluster (GB)
-	SumMem int32 `json:"sumMem,omitempty"`
+	SumMem  int32    `json:"sumMem,omitempty"`
 	Filters []string `json:"filters,omitempty"`
 	// If true, recommended instance types will have a similar size
 	SameSize bool `json:"sameSize,omitempty"`

--- a/client/model_secret_item.go
+++ b/client/model_secret_item.go
@@ -9,17 +9,18 @@
  */
 
 package client
+
 import (
 	"time"
 )
 
 type SecretItem struct {
-	Id string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	Version int32 `json:"version,omitempty"`
-	UpdatedAt time.Time `json:"updatedAt,omitempty"`
-	UpdatedBy string `json:"updatedBy,omitempty"`
-	Tags []string `json:"tags,omitempty"`
-	Values map[string]interface{} `json:"values,omitempty"`
+	Id        string                 `json:"id,omitempty"`
+	Name      string                 `json:"name,omitempty"`
+	Type      string                 `json:"type,omitempty"`
+	Version   int32                  `json:"version,omitempty"`
+	UpdatedAt time.Time              `json:"updatedAt,omitempty"`
+	UpdatedBy string                 `json:"updatedBy,omitempty"`
+	Tags      []string               `json:"tags,omitempty"`
+	Values    map[string]interface{} `json:"values,omitempty"`
 }

--- a/client/model_secret_key_value_amazon.go
+++ b/client/model_secret_key_value_amazon.go
@@ -11,6 +11,6 @@
 package client
 
 type SecretKeyValueAmazon struct {
-	AWS_ACCESS_KEY_ID string `json:"AWS_ACCESS_KEY_ID"`
+	AWS_ACCESS_KEY_ID     string `json:"AWS_ACCESS_KEY_ID"`
 	AWS_SECRET_ACCESS_KEY string `json:"AWS_SECRET_ACCESS_KEY"`
 }

--- a/client/model_secret_key_value_azure.go
+++ b/client/model_secret_key_value_azure.go
@@ -11,8 +11,8 @@
 package client
 
 type SecretKeyValueAzure struct {
-	AZURE_CLIENT_ID string `json:"AZURE_CLIENT_ID"`
-	AZURE_CLIENT_SECRET string `json:"AZURE_CLIENT_SECRET"`
-	AZURE_TENANT_ID string `json:"AZURE_TENANT_ID"`
+	AZURE_CLIENT_ID       string `json:"AZURE_CLIENT_ID"`
+	AZURE_CLIENT_SECRET   string `json:"AZURE_CLIENT_SECRET"`
+	AZURE_TENANT_ID       string `json:"AZURE_TENANT_ID"`
 	AZURE_SUBSCRIPTION_ID string `json:"AZURE_SUBSCRIPTION_ID"`
 }

--- a/client/model_secret_key_value_google.go
+++ b/client/model_secret_key_value_google.go
@@ -11,14 +11,14 @@
 package client
 
 type SecretKeyValueGoogle struct {
-	Type string `json:"type"`
-	ProjectId string `json:"project_id"`
-	PrivateKeyId string `json:"private_key_id"`
-	PrivateKey string `json:"private_key"`
-	ClientEmail string `json:"client_email"`
-	ClientId string `json:"client_id"`
-	AuthUri string `json:"auth_uri"`
-	TokenUri string `json:"token_uri"`
+	Type                    string `json:"type"`
+	ProjectId               string `json:"project_id"`
+	PrivateKeyId            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	AuthUri                 string `json:"auth_uri"`
+	TokenUri                string `json:"token_uri"`
 	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
-	ClientX509CertUrl string `json:"client_x509_cert_url"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
 }

--- a/client/model_secret_key_value_tls.go
+++ b/client/model_secret_key_value_tls.go
@@ -11,12 +11,12 @@
 package client
 
 type SecretKeyValueTls struct {
-	Hosts string `json:"hosts"`
-	Validity string `json:"validity,omitempty"`
-	CaCert string `json:"caCert,omitempty"`
-	CaKey string `json:"caKey,omitempty"`
+	Hosts      string `json:"hosts"`
+	Validity   string `json:"validity,omitempty"`
+	CaCert     string `json:"caCert,omitempty"`
+	CaKey      string `json:"caKey,omitempty"`
 	ServerCert string `json:"serverCert,omitempty"`
-	ServerKey string `json:"serverKey,omitempty"`
+	ServerKey  string `json:"serverKey,omitempty"`
 	ClientCert string `json:"clientCert,omitempty"`
-	ClientKey string `json:"clientKey,omitempty"`
+	ClientKey  string `json:"clientKey,omitempty"`
 }

--- a/client/model_secrets_not_found.go
+++ b/client/model_secrets_not_found.go
@@ -11,7 +11,7 @@
 package client
 
 type SecretsNotFound struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_supported_cloud_item.go
+++ b/client/model_supported_cloud_item.go
@@ -12,5 +12,5 @@ package client
 
 type SupportedCloudItem struct {
 	Name string `json:"name,omitempty"`
-	Key string `json:"key,omitempty"`
+	Key  string `json:"key,omitempty"`
 }

--- a/client/model_token_create_request.go
+++ b/client/model_token_create_request.go
@@ -11,6 +11,6 @@
 package client
 
 type TokenCreateRequest struct {
-	Name string `json:"name"`
+	Name        string `json:"name"`
 	VirtualUser string `json:"virtualUser,omitempty"`
 }

--- a/client/model_token_create_response.go
+++ b/client/model_token_create_response.go
@@ -11,7 +11,7 @@
 package client
 
 type TokenCreateResponse struct {
-	Id string `json:"id"`
+	Id    string `json:"id"`
 	Token string `json:"token"`
-	Name string `json:"name"`
+	Name  string `json:"name"`
 }

--- a/client/model_token_list_response_item.go
+++ b/client/model_token_list_response_item.go
@@ -11,7 +11,7 @@
 package client
 
 type TokenListResponseItem struct {
-	Id string `json:"id"`
+	Id        string `json:"id"`
 	CreatedAt string `json:"createdAt"`
-	Name string `json:"name"`
+	Name      string `json:"name"`
 }

--- a/client/model_unauthorized.go
+++ b/client/model_unauthorized.go
@@ -11,7 +11,7 @@
 package client
 
 type Unauthorized struct {
-	Code int32 `json:"code,omitempty"`
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
-	Error string `json:"error,omitempty"`
+	Error   string `json:"error,omitempty"`
 }

--- a/client/model_update_azure_properties_azure_node_pools_pool1.go
+++ b/client/model_update_azure_properties_azure_node_pools_pool1.go
@@ -11,8 +11,8 @@
 package client
 
 type UpdateAzurePropertiesAzureNodePoolsPool1 struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling bool  `json:"autoscaling,omitempty"`
+	Count       int32 `json:"count,omitempty"`
+	MinCount    int32 `json:"minCount,omitempty"`
+	MaxCount    int32 `json:"maxCount,omitempty"`
 }

--- a/client/model_update_cluster_request.go
+++ b/client/model_update_cluster_request.go
@@ -11,6 +11,6 @@
 package client
 
 type UpdateClusterRequest struct {
-	Cloud string `json:"cloud"`
+	Cloud      string                 `json:"cloud"`
 	Properties map[string]interface{} `json:"properties"`
 }

--- a/client/model_update_google_properties.go
+++ b/client/model_update_google_properties.go
@@ -11,6 +11,6 @@
 package client
 
 type UpdateGoogleProperties struct {
-	Master UpdateGooglePropertiesMaster `json:"master,omitempty"`
+	Master    UpdateGooglePropertiesMaster    `json:"master,omitempty"`
 	NodePools UpdateGooglePropertiesNodePools `json:"nodePools,omitempty"`
 }

--- a/client/model_update_google_properties_node_pools_pool1.go
+++ b/client/model_update_google_properties_node_pools_pool1.go
@@ -11,9 +11,9 @@
 package client
 
 type UpdateGooglePropertiesNodePoolsPool1 struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool   `json:"autoscaling,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	MinCount     int32  `json:"minCount,omitempty"`
+	MaxCount     int32  `json:"maxCount,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }

--- a/client/model_update_node_pools_amazon.go
+++ b/client/model_update_node_pools_amazon.go
@@ -11,8 +11,8 @@
 package client
 
 type UpdateNodePoolsAmazon struct {
-	Autoscaling bool `json:"autoscaling,omitempty"`
-	Count int32 `json:"count,omitempty"`
-	MinCount int32 `json:"minCount,omitempty"`
-	MaxCount int32 `json:"maxCount,omitempty"`
+	Autoscaling bool  `json:"autoscaling,omitempty"`
+	Count       int32 `json:"count,omitempty"`
+	MinCount    int32 `json:"minCount,omitempty"`
+	MaxCount    int32 `json:"maxCount,omitempty"`
 }

--- a/client/model_url_item.go
+++ b/client/model_url_item.go
@@ -12,5 +12,5 @@ package client
 
 type UrlItem struct {
 	Servicename string `json:"servicename,omitempty"`
-	Url string `json:"url,omitempty"`
+	Url         string `json:"url,omitempty"`
 }

--- a/client/model_user.go
+++ b/client/model_user.go
@@ -11,12 +11,12 @@
 package client
 
 type User struct {
-	Id int32 `json:"id,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
-	Name string `json:"name,omitempty"`
-	Email string `json:"email,omitempty"`
-	Login string `json:"login,omitempty"`
-	Image string `json:"image,omitempty"`
+	Id            int32                  `json:"id,omitempty"`
+	CreatedAt     string                 `json:"createdAt,omitempty"`
+	UpdatedAt     string                 `json:"updatedAt,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	Email         string                 `json:"email,omitempty"`
+	Login         string                 `json:"login,omitempty"`
+	Image         string                 `json:"image,omitempty"`
 	Organizations map[string]interface{} `json:"organizations,omitempty"`
 }


### PR DESCRIPTION
We jumped back a few positions on the reportcard, because the generated client code wasn't formatted.