### PR TITLE
Add TLS snippet to a auth client example

### DIFF
--- a/client/examples/auth/main.go
+++ b/client/examples/auth/main.go
@@ -4,13 +4,30 @@ import (
 	"context"
 	"os"
 
-	"github.com/banzaicloud/pipeline/client"
 	"github.com/antihax/optional"
+	"github.com/banzaicloud/pipeline/client"
 )
 
 // First you have to create a Pipeline Bearer token and put it into the TOKEN env variable.
 func main() {
+
+	// // Load Root CA cert example
+	// CACert := []byte{}
+
+	// caCertPool := x509.NewCertPool()
+	// caCertPool.AppendCertsFromPEM([]byte(CACert))
+
+	// clientTLSConfig := &tls.Config{
+	// 	RootCAs: caCertPool,
+	// }
+	// clientTLSConfig.BuildNameToCertificate()
+	// transport := &http.Transport{TLSClientConfig: clientTLSConfig}
+	// httpClient := &http.Client{Transport: transport}
+
+	// Create a new configuration with a custom root certificate pool
 	config := client.NewConfiguration()
+	// config.HTTPClient = httpClient
+
 	ctx := context.WithValue(context.Background(), client.ContextAccessToken, os.Getenv("TOKEN"))
 	pipeline := client.NewAPIClient(config)
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -67,7 +67,7 @@ func init() {
 	viper.SetDefault("database.dbname", "pipelinedb")
 	viper.SetDefault("audit.enabled", true)
 	viper.SetDefault("audit.headers", []string{"secretId"})
-	viper.SetDefault("audit.skippaths", []string{"/auth/github/callback"})
+	viper.SetDefault("audit.skippaths", []string{"/auth/github/callback", "/pipeline/api"})
 	viper.SetDefault("tls.validity", "8760h") // 1 year
 
 	viper.SetDefault("dns.domain", "banzaicloud.io")


### PR DESCRIPTION
Also skip auditing the unauthenticated meta endpoint, because that is used in the Kubernetes health check, thus called in every 10 seconds.