### PR TITLE
Cluster Creation status reordering

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -285,12 +285,6 @@ func postCreateCluster(commonCluster cluster.CommonCluster, postHooks []cluster.
 		return err
 	}
 
-	err = commonCluster.UpdateStatus(pkgCluster.Running, pkgCluster.RunningMessage)
-	if err != nil {
-		log.Errorf("Error during updating cluster status: %s", err.Error())
-		return err
-	}
-
 	// Apply PostHooks
 	// These are hardcoded posthooks maybe we will want a bit more dynamic
 	postHookFunctions := cluster.BasePostHookFunctions
@@ -299,7 +293,12 @@ func postCreateCluster(commonCluster cluster.CommonCluster, postHooks []cluster.
 		postHookFunctions = append(postHookFunctions, postHooks...)
 	}
 
-	cluster.RunPostHooks(postHookFunctions, commonCluster)
+	err = cluster.RunPostHooks(postHookFunctions, commonCluster)
+
+	if err != nil {
+		log.Errorf("Error during running cluster posthooks: %s", err.Error())
+		return err
+	}
 
 	return nil
 }

--- a/api/helm.go
+++ b/api/helm.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/helm"
 	pkgCommmon "github.com/banzaicloud/pipeline/pkg/common"
@@ -12,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/repo"
-	"net/http"
-	"time"
 )
 
 // ChartQuery describes a query to get available helm chart's list
@@ -237,7 +238,7 @@ func GetTillerStatus(c *gin.Context) {
 			Message: message,
 			Error:   err.Error(),
 		})
-		log.Error(message)
+		log.Errorln(message, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, pkgHelm.StatusResponse{


### PR DESCRIPTION
Cluster becomes `RUNNING` after:
- it is created on the cloud provider
- all post hooks have finished without errors

If the post hooks fail, the remaining posthooks aren't executed, and the state becomes ERROR. With the already existing rerun posthooks API call a user or an automation can trigger the post hook run again and promote the cluster into `RUNNING` state (healthy).

---

Also, there was a race condition during the cluster config downloading. The `getConfig` call shouldn't change the database, because the `StoreKubeConfig` posthook function also changes it, and there could be a state where none of those methods could finish correctly (and we end up without any configuration).

---

Fixes: #711 