### PR TITLE
Cluster proxy endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -815,6 +815,12 @@
   version = "1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mxk/go-flowrate"
+  packages = ["flowrate"]
+  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
+
+[[projects]]
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
@@ -1436,6 +1442,7 @@
     "pkg/util/json",
     "pkg/util/mergepatch",
     "pkg/util/net",
+    "pkg/util/proxy",
     "pkg/util/rand",
     "pkg/util/remotecommand",
     "pkg/util/runtime",
@@ -1834,6 +1841,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a573079560209435d3dc1387663974bf6d7238e8f39b2da84fc08dec02bc231b"
+  inputs-digest = "415a5603d27a0ee30586cbc11085a8a690b1b7270a5b60fd60af555f297329ed"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
@@ -583,6 +586,9 @@ func postDeleteCluster(commonCluster cluster.CommonCluster, force bool) error {
 		return err
 	}
 
+	// delete from proxy from kubeProxyCache if any
+	kubeProxyCache.Delete(GetGlobalClusterID(commonCluster))
+
 	// Asyncron update prometheus
 	go cluster.UpdatePrometheus()
 
@@ -1158,4 +1164,49 @@ func InstallSecretsToCluster(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, secretSources)
+}
+
+var kubeProxyCache sync.Map
+
+// GetGlobalClusterID generates an universally unique ID for a cluster within the Pipeline
+func GetGlobalClusterID(cluster cluster.CommonCluster) string {
+	return fmt.Sprint(cluster.GetOrganizationId(), "-", cluster.GetID())
+}
+
+// ProxyToCluster sets up a proxy and forwards all requests to the cluster's API server.
+func ProxyToCluster(c *gin.Context) {
+
+	commonCluster, ok := GetCommonClusterFromRequest(c)
+	if !ok {
+		return
+	}
+
+	clusterKey := GetGlobalClusterID(commonCluster)
+
+	kubeProxy, found := kubeProxyCache.Load(clusterKey)
+	if !found {
+		var err error
+
+		apiProxyPrefix := strings.TrimSuffix(c.Request.URL.Path, c.Param("path"))
+
+		kubeProxy, err = cluster.NewProxy(apiProxyPrefix, nil, commonCluster, 1*time.Minute)
+
+		if err != nil {
+			if err != nil {
+				log.Errorf("Error proxying to cluster [%d]: %s", commonCluster.GetID(), err.Error())
+				c.AbortWithStatusJSON(http.StatusInternalServerError, pkgCommon.ErrorResponse{
+					Code:    http.StatusInternalServerError,
+					Message: "Error proxying to cluster",
+					Error:   err.Error(),
+				})
+				return
+			}
+		}
+
+		kubeProxy, _ = kubeProxyCache.LoadOrStore(clusterKey, kubeProxy)
+	}
+
+	kubeProxyHandler := kubeProxy.(gin.HandlerFunc)
+
+	kubeProxyHandler(c)
 }

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -37,7 +37,7 @@ type AuditEvent struct {
 	ClientIP   string    `gorm:"size:45"`
 	UserAgent  string
 	Path       string `gorm:"size:8000"`
-	Method     string `gorm:"size:6"`
+	Method     string `gorm:"size:7"`
 	UserID     uint
 	StatusCode int
 	Body       *string `gorm:"type:json"`

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"syscall"
-
 	"time"
 
 	"github.com/banzaicloud/pipeline/auth"

--- a/cluster/proxy.go
+++ b/cluster/proxy.go
@@ -1,0 +1,229 @@
+package cluster
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/banzaicloud/pipeline/helm"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/glog"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+const (
+	// DefaultHostAcceptRE is the default value for which hosts to accept.
+	DefaultHostAcceptRE = "^localhost$,^127\\.0\\.0\\.1$,^\\[::1\\]$"
+	// DefaultPathAcceptRE is the default path to accept.
+	DefaultPathAcceptRE = "^.*"
+	// DefaultPathRejectRE is the default set of paths to reject.
+	DefaultPathRejectRE = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
+	// DefaultMethodRejectRE is the set of HTTP methods to reject by default.
+	DefaultMethodRejectRE = "^$"
+)
+
+var (
+	// ReverseProxyFlushInterval is the frequency to flush the reverse proxy.
+	// Only matters for long poll connections like the one used to watch. With an
+	// interval of 0 the reverse proxy will buffer content sent on any connection
+	// with transfer-encoding=chunked.
+	// TODO: Flush after each chunk so the client doesn't suffer a 100ms latency per
+	// watch event.
+	ReverseProxyFlushInterval = 100 * time.Millisecond
+)
+
+// FilterServer rejects requests which don't match one of the specified regular expressions
+type FilterServer struct {
+	// Only paths that match this regexp will be accepted
+	AcceptPaths []*regexp.Regexp
+	// Paths that match this regexp will be rejected, even if they match the above
+	RejectPaths []*regexp.Regexp
+	// Hosts are required to match this list of regexp
+	AcceptHosts []*regexp.Regexp
+	// Methods that match this regexp are rejected
+	RejectMethods []*regexp.Regexp
+	// The delegate to call to handle accepted requests.
+	delegate http.Handler
+}
+
+// MakeRegexpArray splits a comma separated list of regexps into an array of Regexp objects.
+func MakeRegexpArray(str string) ([]*regexp.Regexp, error) {
+	parts := strings.Split(str, ",")
+	result := make([]*regexp.Regexp, len(parts))
+	for ix := range parts {
+		re, err := regexp.Compile(parts[ix])
+		if err != nil {
+			return nil, err
+		}
+		result[ix] = re
+	}
+	return result, nil
+}
+
+// MakeRegexpArrayOrDie creates an array of regular expression objects from a string or exits.
+func MakeRegexpArrayOrDie(str string) []*regexp.Regexp {
+	result, err := MakeRegexpArray(str)
+	if err != nil {
+		glog.Fatalf("Error compiling re: %v", err)
+	}
+	return result
+}
+
+func matchesRegexp(str string, regexps []*regexp.Regexp) bool {
+	for _, re := range regexps {
+		if re.MatchString(str) {
+			glog.V(6).Infof("%v matched %s", str, re)
+			return true
+		}
+	}
+	return false
+}
+
+func (f *FilterServer) accept(method, path, host string) bool {
+	if matchesRegexp(path, f.RejectPaths) {
+		return false
+	}
+	if matchesRegexp(method, f.RejectMethods) {
+		return false
+	}
+	if matchesRegexp(path, f.AcceptPaths) && matchesRegexp(host, f.AcceptHosts) {
+		return true
+	}
+	return false
+}
+
+// HandlerFor makes a shallow copy of f which passes its requests along to the
+// new delegate.
+func (f *FilterServer) HandlerFor(delegate http.Handler) *FilterServer {
+	f2 := *f
+	f2.delegate = delegate
+	return &f2
+}
+
+// Get host from a host header value like "localhost" or "localhost:8080"
+func extractHost(header string) (host string) {
+	host, _, err := net.SplitHostPort(header)
+	if err != nil {
+		host = header
+	}
+	return host
+}
+
+func (f *FilterServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	host := extractHost(req.Host)
+	if f.accept(req.Method, req.URL.Path, host) {
+		glog.V(3).Infof("Filter accepting %v %v %v", req.Method, req.URL.Path, host)
+		f.delegate.ServeHTTP(rw, req)
+		return
+	}
+	glog.V(3).Infof("Filter rejecting %v %v %v", req.Method, req.URL.Path, host)
+	rw.WriteHeader(http.StatusForbidden)
+	rw.Write([]byte("<h3>Unauthorized</h3>"))
+}
+
+// Server is a http.Handler which proxies Kubernetes APIs to remote API server.
+type Server struct {
+	handler http.Handler
+}
+
+type responder struct{}
+
+func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	glog.Errorf("Error while proxying request: %v", err)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+// makeUpgradeTransport creates a transport that explicitly bypasses HTTP2 support
+// for proxy connections that must upgrade.
+func makeUpgradeTransport(config *rest.Config, keepalive time.Duration) (proxy.UpgradeRequestRoundTripper, error) {
+	transportConfig, err := config.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+	rt := utilnet.SetOldTransportDefaults(&http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: keepalive,
+		}).DialContext,
+	})
+
+	upgrader, err := transport.HTTPWrappersForConfig(transportConfig, proxy.MirrorRequest)
+	if err != nil {
+		return nil, err
+	}
+	return proxy.NewUpgradeRequestRoundTripper(rt, upgrader), nil
+}
+
+// NewProxy creates and installs a new Kubernetes API Server Proxy.
+// 'filter', if non-nil, protects requests to the api only.
+func NewProxy(apiProxyPrefix string, filter *FilterServer, cluster CommonCluster, keepalive time.Duration) (gin.HandlerFunc, error) {
+
+	kubeConfig, err := cluster.GetK8sConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := helm.GetK8sClientConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	host := cfg.Host
+	if !strings.HasSuffix(host, "/") {
+		host = host + "/"
+	}
+	target, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+
+	responder := &responder{}
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	upgradeTransport, err := makeUpgradeTransport(cfg, keepalive)
+	if err != nil {
+		return nil, err
+	}
+	proxy := proxy.NewUpgradeAwareHandler(target, transport, false, false, responder)
+	proxy.UpgradeTransport = upgradeTransport
+	proxy.UseRequestLocation = true
+
+	proxyServer := http.Handler(proxy)
+	if filter != nil {
+		proxyServer = filter.HandlerFor(proxyServer)
+	}
+
+	proxyServer = stripLeaveSlash(apiProxyPrefix, proxyServer)
+
+	return gin.WrapH(proxyServer), nil
+}
+
+// like http.StripPrefix, but always leaves an initial slash. (so that our
+// regexps will work.)
+func stripLeaveSlash(prefix string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		p := strings.TrimPrefix(req.URL.Path, prefix)
+		if len(p) >= len(req.URL.Path) {
+			http.NotFound(w, req)
+			return
+		}
+		if len(p) > 0 && p[:1] != "/" {
+			p = "/" + p
+		}
+		req.URL.Path = p
+		h.ServeHTTP(w, req)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -180,6 +180,7 @@ func main() {
 			orgs.PUT("/:orgid/clusters/:id", api.UpdateCluster)
 			orgs.PUT("/:orgid/clusters/:id/posthooks", api.ReRunPostHooks)
 			orgs.POST("/:orgid/clusters/:id/secrets", api.InstallSecretsToCluster)
+			orgs.Any("/:orgid/clusters/:id/proxy/*path", api.ProxyToCluster)
 			orgs.DELETE("/:orgid/clusters/:id", api.DeleteCluster)
 			orgs.HEAD("/:orgid/clusters/:id", api.ClusterHEAD)
 			orgs.GET("/:orgid/clusters/:id/config", api.GetClusterConfig)

--- a/vendor/github.com/mxk/go-flowrate/LICENSE
+++ b/vendor/github.com/mxk/go-flowrate/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+ * Neither the name of the go-flowrate project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/mxk/go-flowrate/flowrate/flowrate.go
+++ b/vendor/github.com/mxk/go-flowrate/flowrate/flowrate.go
@@ -1,0 +1,267 @@
+//
+// Written by Maxim Khitrov (November 2012)
+//
+
+// Package flowrate provides the tools for monitoring and limiting the flow rate
+// of an arbitrary data stream.
+package flowrate
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// Monitor monitors and limits the transfer rate of a data stream.
+type Monitor struct {
+	mu      sync.Mutex    // Mutex guarding access to all internal fields
+	active  bool          // Flag indicating an active transfer
+	start   time.Duration // Transfer start time (clock() value)
+	bytes   int64         // Total number of bytes transferred
+	samples int64         // Total number of samples taken
+
+	rSample float64 // Most recent transfer rate sample (bytes per second)
+	rEMA    float64 // Exponential moving average of rSample
+	rPeak   float64 // Peak transfer rate (max of all rSamples)
+	rWindow float64 // rEMA window (seconds)
+
+	sBytes int64         // Number of bytes transferred since sLast
+	sLast  time.Duration // Most recent sample time (stop time when inactive)
+	sRate  time.Duration // Sampling rate
+
+	tBytes int64         // Number of bytes expected in the current transfer
+	tLast  time.Duration // Time of the most recent transfer of at least 1 byte
+}
+
+// New creates a new flow control monitor. Instantaneous transfer rate is
+// measured and updated for each sampleRate interval. windowSize determines the
+// weight of each sample in the exponential moving average (EMA) calculation.
+// The exact formulas are:
+//
+// 	sampleTime = currentTime - prevSampleTime
+// 	sampleRate = byteCount / sampleTime
+// 	weight     = 1 - exp(-sampleTime/windowSize)
+// 	newRate    = weight*sampleRate + (1-weight)*oldRate
+//
+// The default values for sampleRate and windowSize (if <= 0) are 100ms and 1s,
+// respectively.
+func New(sampleRate, windowSize time.Duration) *Monitor {
+	if sampleRate = clockRound(sampleRate); sampleRate <= 0 {
+		sampleRate = 5 * clockRate
+	}
+	if windowSize <= 0 {
+		windowSize = 1 * time.Second
+	}
+	now := clock()
+	return &Monitor{
+		active:  true,
+		start:   now,
+		rWindow: windowSize.Seconds(),
+		sLast:   now,
+		sRate:   sampleRate,
+		tLast:   now,
+	}
+}
+
+// Update records the transfer of n bytes and returns n. It should be called
+// after each Read/Write operation, even if n is 0.
+func (m *Monitor) Update(n int) int {
+	m.mu.Lock()
+	m.update(n)
+	m.mu.Unlock()
+	return n
+}
+
+// IO is a convenience method intended to wrap io.Reader and io.Writer method
+// execution. It calls m.Update(n) and then returns (n, err) unmodified.
+func (m *Monitor) IO(n int, err error) (int, error) {
+	return m.Update(n), err
+}
+
+// Done marks the transfer as finished and prevents any further updates or
+// limiting. Instantaneous and current transfer rates drop to 0. Update, IO, and
+// Limit methods become NOOPs. It returns the total number of bytes transferred.
+func (m *Monitor) Done() int64 {
+	m.mu.Lock()
+	if now := m.update(0); m.sBytes > 0 {
+		m.reset(now)
+	}
+	m.active = false
+	m.tLast = 0
+	n := m.bytes
+	m.mu.Unlock()
+	return n
+}
+
+// timeRemLimit is the maximum Status.TimeRem value.
+const timeRemLimit = 999*time.Hour + 59*time.Minute + 59*time.Second
+
+// Status represents the current Monitor status. All transfer rates are in bytes
+// per second rounded to the nearest byte.
+type Status struct {
+	Active   bool          // Flag indicating an active transfer
+	Start    time.Time     // Transfer start time
+	Duration time.Duration // Time period covered by the statistics
+	Idle     time.Duration // Time since the last transfer of at least 1 byte
+	Bytes    int64         // Total number of bytes transferred
+	Samples  int64         // Total number of samples taken
+	InstRate int64         // Instantaneous transfer rate
+	CurRate  int64         // Current transfer rate (EMA of InstRate)
+	AvgRate  int64         // Average transfer rate (Bytes / Duration)
+	PeakRate int64         // Maximum instantaneous transfer rate
+	BytesRem int64         // Number of bytes remaining in the transfer
+	TimeRem  time.Duration // Estimated time to completion
+	Progress Percent       // Overall transfer progress
+}
+
+// Status returns current transfer status information. The returned value
+// becomes static after a call to Done.
+func (m *Monitor) Status() Status {
+	m.mu.Lock()
+	now := m.update(0)
+	s := Status{
+		Active:   m.active,
+		Start:    clockToTime(m.start),
+		Duration: m.sLast - m.start,
+		Idle:     now - m.tLast,
+		Bytes:    m.bytes,
+		Samples:  m.samples,
+		PeakRate: round(m.rPeak),
+		BytesRem: m.tBytes - m.bytes,
+		Progress: percentOf(float64(m.bytes), float64(m.tBytes)),
+	}
+	if s.BytesRem < 0 {
+		s.BytesRem = 0
+	}
+	if s.Duration > 0 {
+		rAvg := float64(s.Bytes) / s.Duration.Seconds()
+		s.AvgRate = round(rAvg)
+		if s.Active {
+			s.InstRate = round(m.rSample)
+			s.CurRate = round(m.rEMA)
+			if s.BytesRem > 0 {
+				if tRate := 0.8*m.rEMA + 0.2*rAvg; tRate > 0 {
+					ns := float64(s.BytesRem) / tRate * 1e9
+					if ns > float64(timeRemLimit) {
+						ns = float64(timeRemLimit)
+					}
+					s.TimeRem = clockRound(time.Duration(ns))
+				}
+			}
+		}
+	}
+	m.mu.Unlock()
+	return s
+}
+
+// Limit restricts the instantaneous (per-sample) data flow to rate bytes per
+// second. It returns the maximum number of bytes (0 <= n <= want) that may be
+// transferred immediately without exceeding the limit. If block == true, the
+// call blocks until n > 0. want is returned unmodified if want < 1, rate < 1,
+// or the transfer is inactive (after a call to Done).
+//
+// At least one byte is always allowed to be transferred in any given sampling
+// period. Thus, if the sampling rate is 100ms, the lowest achievable flow rate
+// is 10 bytes per second.
+//
+// For usage examples, see the implementation of Reader and Writer in io.go.
+func (m *Monitor) Limit(want int, rate int64, block bool) (n int) {
+	if want < 1 || rate < 1 {
+		return want
+	}
+	m.mu.Lock()
+
+	// Determine the maximum number of bytes that can be sent in one sample
+	limit := round(float64(rate) * m.sRate.Seconds())
+	if limit <= 0 {
+		limit = 1
+	}
+
+	// If block == true, wait until m.sBytes < limit
+	if now := m.update(0); block {
+		for m.sBytes >= limit && m.active {
+			now = m.waitNextSample(now)
+		}
+	}
+
+	// Make limit <= want (unlimited if the transfer is no longer active)
+	if limit -= m.sBytes; limit > int64(want) || !m.active {
+		limit = int64(want)
+	}
+	m.mu.Unlock()
+
+	if limit < 0 {
+		limit = 0
+	}
+	return int(limit)
+}
+
+// SetTransferSize specifies the total size of the data transfer, which allows
+// the Monitor to calculate the overall progress and time to completion.
+func (m *Monitor) SetTransferSize(bytes int64) {
+	if bytes < 0 {
+		bytes = 0
+	}
+	m.mu.Lock()
+	m.tBytes = bytes
+	m.mu.Unlock()
+}
+
+// update accumulates the transferred byte count for the current sample until
+// clock() - m.sLast >= m.sRate. The monitor status is updated once the current
+// sample is done.
+func (m *Monitor) update(n int) (now time.Duration) {
+	if !m.active {
+		return
+	}
+	if now = clock(); n > 0 {
+		m.tLast = now
+	}
+	m.sBytes += int64(n)
+	if sTime := now - m.sLast; sTime >= m.sRate {
+		t := sTime.Seconds()
+		if m.rSample = float64(m.sBytes) / t; m.rSample > m.rPeak {
+			m.rPeak = m.rSample
+		}
+
+		// Exponential moving average using a method similar to *nix load
+		// average calculation. Longer sampling periods carry greater weight.
+		if m.samples > 0 {
+			w := math.Exp(-t / m.rWindow)
+			m.rEMA = m.rSample + w*(m.rEMA-m.rSample)
+		} else {
+			m.rEMA = m.rSample
+		}
+		m.reset(now)
+	}
+	return
+}
+
+// reset clears the current sample state in preparation for the next sample.
+func (m *Monitor) reset(sampleTime time.Duration) {
+	m.bytes += m.sBytes
+	m.samples++
+	m.sBytes = 0
+	m.sLast = sampleTime
+}
+
+// waitNextSample sleeps for the remainder of the current sample. The lock is
+// released and reacquired during the actual sleep period, so it's possible for
+// the transfer to be inactive when this method returns.
+func (m *Monitor) waitNextSample(now time.Duration) time.Duration {
+	const minWait = 5 * time.Millisecond
+	current := m.sLast
+
+	// sleep until the last sample time changes (ideally, just one iteration)
+	for m.sLast == current && m.active {
+		d := current + m.sRate - now
+		m.mu.Unlock()
+		if d < minWait {
+			d = minWait
+		}
+		time.Sleep(d)
+		m.mu.Lock()
+		now = m.update(0)
+	}
+	return now
+}

--- a/vendor/github.com/mxk/go-flowrate/flowrate/io.go
+++ b/vendor/github.com/mxk/go-flowrate/flowrate/io.go
@@ -1,0 +1,133 @@
+//
+// Written by Maxim Khitrov (November 2012)
+//
+
+package flowrate
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrLimit is returned by the Writer when a non-blocking write is short due to
+// the transfer rate limit.
+var ErrLimit = errors.New("flowrate: flow rate limit exceeded")
+
+// Limiter is implemented by the Reader and Writer to provide a consistent
+// interface for monitoring and controlling data transfer.
+type Limiter interface {
+	Done() int64
+	Status() Status
+	SetTransferSize(bytes int64)
+	SetLimit(new int64) (old int64)
+	SetBlocking(new bool) (old bool)
+}
+
+// Reader implements io.ReadCloser with a restriction on the rate of data
+// transfer.
+type Reader struct {
+	io.Reader // Data source
+	*Monitor  // Flow control monitor
+
+	limit int64 // Rate limit in bytes per second (unlimited when <= 0)
+	block bool  // What to do when no new bytes can be read due to the limit
+}
+
+// NewReader restricts all Read operations on r to limit bytes per second.
+func NewReader(r io.Reader, limit int64) *Reader {
+	return &Reader{r, New(0, 0), limit, true}
+}
+
+// Read reads up to len(p) bytes into p without exceeding the current transfer
+// rate limit. It returns (0, nil) immediately if r is non-blocking and no new
+// bytes can be read at this time.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	p = p[:r.Limit(len(p), r.limit, r.block)]
+	if len(p) > 0 {
+		n, err = r.IO(r.Reader.Read(p))
+	}
+	return
+}
+
+// SetLimit changes the transfer rate limit to new bytes per second and returns
+// the previous setting.
+func (r *Reader) SetLimit(new int64) (old int64) {
+	old, r.limit = r.limit, new
+	return
+}
+
+// SetBlocking changes the blocking behavior and returns the previous setting. A
+// Read call on a non-blocking reader returns immediately if no additional bytes
+// may be read at this time due to the rate limit.
+func (r *Reader) SetBlocking(new bool) (old bool) {
+	old, r.block = r.block, new
+	return
+}
+
+// Close closes the underlying reader if it implements the io.Closer interface.
+func (r *Reader) Close() error {
+	defer r.Done()
+	if c, ok := r.Reader.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// Writer implements io.WriteCloser with a restriction on the rate of data
+// transfer.
+type Writer struct {
+	io.Writer // Data destination
+	*Monitor  // Flow control monitor
+
+	limit int64 // Rate limit in bytes per second (unlimited when <= 0)
+	block bool  // What to do when no new bytes can be written due to the limit
+}
+
+// NewWriter restricts all Write operations on w to limit bytes per second. The
+// transfer rate and the default blocking behavior (true) can be changed
+// directly on the returned *Writer.
+func NewWriter(w io.Writer, limit int64) *Writer {
+	return &Writer{w, New(0, 0), limit, true}
+}
+
+// Write writes len(p) bytes from p to the underlying data stream without
+// exceeding the current transfer rate limit. It returns (n, ErrLimit) if w is
+// non-blocking and no additional bytes can be written at this time.
+func (w *Writer) Write(p []byte) (n int, err error) {
+	var c int
+	for len(p) > 0 && err == nil {
+		s := p[:w.Limit(len(p), w.limit, w.block)]
+		if len(s) > 0 {
+			c, err = w.IO(w.Writer.Write(s))
+		} else {
+			return n, ErrLimit
+		}
+		p = p[c:]
+		n += c
+	}
+	return
+}
+
+// SetLimit changes the transfer rate limit to new bytes per second and returns
+// the previous setting.
+func (w *Writer) SetLimit(new int64) (old int64) {
+	old, w.limit = w.limit, new
+	return
+}
+
+// SetBlocking changes the blocking behavior and returns the previous setting. A
+// Write call on a non-blocking writer returns as soon as no additional bytes
+// may be written at this time due to the rate limit.
+func (w *Writer) SetBlocking(new bool) (old bool) {
+	old, w.block = w.block, new
+	return
+}
+
+// Close closes the underlying writer if it implements the io.Closer interface.
+func (w *Writer) Close() error {
+	defer w.Done()
+	if c, ok := w.Writer.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/vendor/github.com/mxk/go-flowrate/flowrate/util.go
+++ b/vendor/github.com/mxk/go-flowrate/flowrate/util.go
@@ -1,0 +1,67 @@
+//
+// Written by Maxim Khitrov (November 2012)
+//
+
+package flowrate
+
+import (
+	"math"
+	"strconv"
+	"time"
+)
+
+// clockRate is the resolution and precision of clock().
+const clockRate = 20 * time.Millisecond
+
+// czero is the process start time rounded down to the nearest clockRate
+// increment.
+var czero = time.Duration(time.Now().UnixNano()) / clockRate * clockRate
+
+// clock returns a low resolution timestamp relative to the process start time.
+func clock() time.Duration {
+	return time.Duration(time.Now().UnixNano())/clockRate*clockRate - czero
+}
+
+// clockToTime converts a clock() timestamp to an absolute time.Time value.
+func clockToTime(c time.Duration) time.Time {
+	return time.Unix(0, int64(czero+c))
+}
+
+// clockRound returns d rounded to the nearest clockRate increment.
+func clockRound(d time.Duration) time.Duration {
+	return (d + clockRate>>1) / clockRate * clockRate
+}
+
+// round returns x rounded to the nearest int64 (non-negative values only).
+func round(x float64) int64 {
+	if _, frac := math.Modf(x); frac >= 0.5 {
+		return int64(math.Ceil(x))
+	}
+	return int64(math.Floor(x))
+}
+
+// Percent represents a percentage in increments of 1/1000th of a percent.
+type Percent uint32
+
+// percentOf calculates what percent of the total is x.
+func percentOf(x, total float64) Percent {
+	if x < 0 || total <= 0 {
+		return 0
+	} else if p := round(x / total * 1e5); p <= math.MaxUint32 {
+		return Percent(p)
+	}
+	return Percent(math.MaxUint32)
+}
+
+func (p Percent) Float() float64 {
+	return float64(p) * 1e-3
+}
+
+func (p Percent) String() string {
+	var buf [12]byte
+	b := strconv.AppendUint(buf[:0], uint64(p)/1000, 10)
+	n := len(b)
+	b = strconv.AppendUint(b, 1000+uint64(p)%1000, 10)
+	b[n] = '.'
+	return string(append(b, '%'))
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/proxy/dial.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/proxy/dial.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/golang/glog"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/third_party/forked/golang/netutil"
+)
+
+func DialURL(url *url.URL, transport http.RoundTripper) (net.Conn, error) {
+	dialAddr := netutil.CanonicalAddr(url)
+
+	dialer, err := utilnet.DialerFor(transport)
+	if err != nil {
+		glog.V(5).Infof("Unable to unwrap transport %T to get dialer: %v", transport, err)
+	}
+
+	switch url.Scheme {
+	case "http":
+		if dialer != nil {
+			return dialer("tcp", dialAddr)
+		}
+		return net.Dial("tcp", dialAddr)
+	case "https":
+		// Get the tls config from the transport if we recognize it
+		var tlsConfig *tls.Config
+		var tlsConn *tls.Conn
+		var err error
+		tlsConfig, err = utilnet.TLSClientConfig(transport)
+		if err != nil {
+			glog.V(5).Infof("Unable to unwrap transport %T to get at TLS config: %v", transport, err)
+		}
+
+		if dialer != nil {
+			// We have a dialer; use it to open the connection, then
+			// create a tls client using the connection.
+			netConn, err := dialer("tcp", dialAddr)
+			if err != nil {
+				return nil, err
+			}
+			if tlsConfig == nil {
+				// tls.Client requires non-nil config
+				glog.Warningf("using custom dialer with no TLSClientConfig. Defaulting to InsecureSkipVerify")
+				// tls.Handshake() requires ServerName or InsecureSkipVerify
+				tlsConfig = &tls.Config{
+					InsecureSkipVerify: true,
+				}
+			} else if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
+				// tls.Handshake() requires ServerName or InsecureSkipVerify
+				// infer the ServerName from the hostname we're connecting to.
+				inferredHost := dialAddr
+				if host, _, err := net.SplitHostPort(dialAddr); err == nil {
+					inferredHost = host
+				}
+				// Make a copy to avoid polluting the provided config
+				tlsConfigCopy := tlsConfig.Clone()
+				tlsConfigCopy.ServerName = inferredHost
+				tlsConfig = tlsConfigCopy
+			}
+			tlsConn = tls.Client(netConn, tlsConfig)
+			if err := tlsConn.Handshake(); err != nil {
+				netConn.Close()
+				return nil, err
+			}
+
+		} else {
+			// Dial
+			tlsConn, err = tls.Dial("tcp", dialAddr, tlsConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Return if we were configured to skip validation
+		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
+			return tlsConn, nil
+		}
+
+		// Verify
+		host, _, _ := net.SplitHostPort(dialAddr)
+		if tlsConfig != nil && len(tlsConfig.ServerName) > 0 {
+			host = tlsConfig.ServerName
+		}
+		if err := tlsConn.VerifyHostname(host); err != nil {
+			tlsConn.Close()
+			return nil, err
+		}
+
+		return tlsConn, nil
+	default:
+		return nil, fmt.Errorf("Unknown scheme: %s", url.Scheme)
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/proxy/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/proxy/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package proxy provides transport and upgrade support for proxies.
+package proxy // import "k8s.io/apimachinery/pkg/util/proxy"

--- a/vendor/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// atomsToAttrs states which attributes of which tags require URL substitution.
+// Sources: http://www.w3.org/TR/REC-html40/index/attributes.html
+//          http://www.w3.org/html/wg/drafts/html/master/index.html#attributes-1
+var atomsToAttrs = map[atom.Atom]sets.String{
+	atom.A:          sets.NewString("href"),
+	atom.Applet:     sets.NewString("codebase"),
+	atom.Area:       sets.NewString("href"),
+	atom.Audio:      sets.NewString("src"),
+	atom.Base:       sets.NewString("href"),
+	atom.Blockquote: sets.NewString("cite"),
+	atom.Body:       sets.NewString("background"),
+	atom.Button:     sets.NewString("formaction"),
+	atom.Command:    sets.NewString("icon"),
+	atom.Del:        sets.NewString("cite"),
+	atom.Embed:      sets.NewString("src"),
+	atom.Form:       sets.NewString("action"),
+	atom.Frame:      sets.NewString("longdesc", "src"),
+	atom.Head:       sets.NewString("profile"),
+	atom.Html:       sets.NewString("manifest"),
+	atom.Iframe:     sets.NewString("longdesc", "src"),
+	atom.Img:        sets.NewString("longdesc", "src", "usemap"),
+	atom.Input:      sets.NewString("src", "usemap", "formaction"),
+	atom.Ins:        sets.NewString("cite"),
+	atom.Link:       sets.NewString("href"),
+	atom.Object:     sets.NewString("classid", "codebase", "data", "usemap"),
+	atom.Q:          sets.NewString("cite"),
+	atom.Script:     sets.NewString("src"),
+	atom.Source:     sets.NewString("src"),
+	atom.Video:      sets.NewString("poster", "src"),
+
+	// TODO: css URLs hidden in style elements.
+}
+
+// Transport is a transport for text/html content that replaces URLs in html
+// content with the prefix of the proxy server
+type Transport struct {
+	Scheme      string
+	Host        string
+	PathPrepend string
+
+	http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add reverse proxy headers.
+	forwardedURI := path.Join(t.PathPrepend, req.URL.Path)
+	if strings.HasSuffix(req.URL.Path, "/") {
+		forwardedURI = forwardedURI + "/"
+	}
+	req.Header.Set("X-Forwarded-Uri", forwardedURI)
+	if len(t.Host) > 0 {
+		req.Header.Set("X-Forwarded-Host", t.Host)
+	}
+	if len(t.Scheme) > 0 {
+		req.Header.Set("X-Forwarded-Proto", t.Scheme)
+	}
+
+	rt := t.RoundTripper
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		message := fmt.Sprintf("Error: '%s'\nTrying to reach: '%v'", err.Error(), req.URL.String())
+		resp = &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       ioutil.NopCloser(strings.NewReader(message)),
+		}
+		return resp, nil
+	}
+
+	if redirect := resp.Header.Get("Location"); redirect != "" {
+		resp.Header.Set("Location", t.rewriteURL(redirect, req.URL, req.Host))
+		return resp, nil
+	}
+
+	cType := resp.Header.Get("Content-Type")
+	cType = strings.TrimSpace(strings.SplitN(cType, ";", 2)[0])
+	if cType != "text/html" {
+		// Do nothing, simply pass through
+		return resp, nil
+	}
+
+	return t.rewriteResponse(req, resp)
+}
+
+var _ = net.RoundTripperWrapper(&Transport{})
+
+func (rt *Transport) WrappedRoundTripper() http.RoundTripper {
+	return rt.RoundTripper
+}
+
+// rewriteURL rewrites a single URL to go through the proxy, if the URL refers
+// to the same host as sourceURL, which is the page on which the target URL
+// occurred, or if the URL matches the sourceRequestHost. If any error occurs (e.g.
+// parsing), it returns targetURL.
+func (t *Transport) rewriteURL(targetURL string, sourceURL *url.URL, sourceRequestHost string) string {
+	url, err := url.Parse(targetURL)
+	if err != nil {
+		return targetURL
+	}
+
+	// Example:
+	//      When API server processes a proxy request to a service (e.g. /api/v1/namespace/foo/service/bar/proxy/),
+	//      the sourceURL.Host (i.e. req.URL.Host) is the endpoint IP address of the service. The
+	//      sourceRequestHost (i.e. req.Host) is the Host header that specifies the host on which the
+	//      URL is sought, which can be different from sourceURL.Host. For example, if user sends the
+	//      request through "kubectl proxy" locally (i.e. localhost:8001/api/v1/namespace/foo/service/bar/proxy/),
+	//      sourceRequestHost is "localhost:8001".
+	//
+	//      If the service's response URL contains non-empty host, and url.Host is equal to either sourceURL.Host
+	//      or sourceRequestHost, we should not consider the returned URL to be a completely different host.
+	//      It's the API server's responsibility to rewrite a same-host-and-absolute-path URL and append the
+	//      necessary URL prefix (i.e. /api/v1/namespace/foo/service/bar/proxy/).
+	isDifferentHost := url.Host != "" && url.Host != sourceURL.Host && url.Host != sourceRequestHost
+	isRelative := !strings.HasPrefix(url.Path, "/")
+	if isDifferentHost || isRelative {
+		return targetURL
+	}
+
+	// Do not rewrite scheme and host if the Transport has empty scheme and host
+	// when targetURL already contains the sourceRequestHost
+	if !(url.Host == sourceRequestHost && t.Scheme == "" && t.Host == "") {
+		url.Scheme = t.Scheme
+		url.Host = t.Host
+	}
+
+	origPath := url.Path
+	// Do not rewrite URL if the sourceURL already contains the necessary prefix.
+	if strings.HasPrefix(url.Path, t.PathPrepend) {
+		return url.String()
+	}
+	url.Path = path.Join(t.PathPrepend, url.Path)
+	if strings.HasSuffix(origPath, "/") {
+		// Add back the trailing slash, which was stripped by path.Join().
+		url.Path += "/"
+	}
+
+	return url.String()
+}
+
+// rewriteHTML scans the HTML for tags with url-valued attributes, and updates
+// those values with the urlRewriter function. The updated HTML is output to the
+// writer.
+func rewriteHTML(reader io.Reader, writer io.Writer, urlRewriter func(string) string) error {
+	// Note: This assumes the content is UTF-8.
+	tokenizer := html.NewTokenizer(reader)
+
+	var err error
+	for err == nil {
+		tokenType := tokenizer.Next()
+		switch tokenType {
+		case html.ErrorToken:
+			err = tokenizer.Err()
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if urlAttrs, ok := atomsToAttrs[token.DataAtom]; ok {
+				for i, attr := range token.Attr {
+					if urlAttrs.Has(attr.Key) {
+						token.Attr[i].Val = urlRewriter(attr.Val)
+					}
+				}
+			}
+			_, err = writer.Write([]byte(token.String()))
+		default:
+			_, err = writer.Write(tokenizer.Raw())
+		}
+	}
+	if err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+// rewriteResponse modifies an HTML response by updating absolute links referring
+// to the original host to instead refer to the proxy transport.
+func (t *Transport) rewriteResponse(req *http.Request, resp *http.Response) (*http.Response, error) {
+	origBody := resp.Body
+	defer origBody.Close()
+
+	newContent := &bytes.Buffer{}
+	var reader io.Reader = origBody
+	var writer io.Writer = newContent
+	encoding := resp.Header.Get("Content-Encoding")
+	switch encoding {
+	case "gzip":
+		var err error
+		reader, err = gzip.NewReader(reader)
+		if err != nil {
+			return nil, fmt.Errorf("errorf making gzip reader: %v", err)
+		}
+		gzw := gzip.NewWriter(writer)
+		defer gzw.Close()
+		writer = gzw
+	// TODO: support flate, other encodings.
+	case "":
+		// This is fine
+	default:
+		// Some encoding we don't understand-- don't try to parse this
+		glog.Errorf("Proxy encountered encoding %v for text/html; can't understand this so not fixing links.", encoding)
+		return resp, nil
+	}
+
+	urlRewriter := func(targetUrl string) string {
+		return t.rewriteURL(targetUrl, req.URL, req.Host)
+	}
+	err := rewriteHTML(reader, writer, urlRewriter)
+	if err != nil {
+		glog.Errorf("Failed to rewrite URLs: %v", err)
+		return resp, err
+	}
+
+	resp.Body = ioutil.NopCloser(newContent)
+	// Update header node with new content-length
+	// TODO: Remove any hash/signature headers here?
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = int64(newContent.Len())
+
+	return resp, err
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/golang/glog"
+	"github.com/mxk/go-flowrate/flowrate"
+)
+
+// UpgradeRequestRoundTripper provides an additional method to decorate a request
+// with any authentication or other protocol level information prior to performing
+// an upgrade on the server. Any response will be handled by the intercepting
+// proxy.
+type UpgradeRequestRoundTripper interface {
+	http.RoundTripper
+	// WrapRequest takes a valid HTTP request and returns a suitably altered version
+	// of request with any HTTP level values required to complete the request half of
+	// an upgrade on the server. It does not get a chance to see the response and
+	// should bypass any request side logic that expects to see the response.
+	WrapRequest(*http.Request) (*http.Request, error)
+}
+
+// UpgradeAwareHandler is a handler for proxy requests that may require an upgrade
+type UpgradeAwareHandler struct {
+	// UpgradeRequired will reject non-upgrade connections if true.
+	UpgradeRequired bool
+	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
+	// for upgrade requests unless UseRequestLocationOnUpgrade is true.
+	Location *url.URL
+	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
+	Transport http.RoundTripper
+	// UpgradeTransport, if specified, will be used as the backend transport when upgrade requests are provided.
+	// This allows clients to disable HTTP/2.
+	UpgradeTransport UpgradeRequestRoundTripper
+	// WrapTransport indicates whether the provided Transport should be wrapped with default proxy transport behavior (URL rewriting, X-Forwarded-* header setting)
+	WrapTransport bool
+	// InterceptRedirects determines whether the proxy should sniff backend responses for redirects,
+	// following them as necessary.
+	InterceptRedirects bool
+	// UseRequestLocation will use the incoming request URL when talking to the backend server.
+	UseRequestLocation bool
+	// FlushInterval controls how often the standard HTTP proxy will flush content from the upstream.
+	FlushInterval time.Duration
+	// MaxBytesPerSec controls the maximum rate for an upstream connection. No rate is imposed if the value is zero.
+	MaxBytesPerSec int64
+	// Responder is passed errors that occur while setting up proxying.
+	Responder ErrorResponder
+}
+
+const defaultFlushInterval = 200 * time.Millisecond
+
+// ErrorResponder abstracts error reporting to the proxy handler to remove the need to hardcode a particular
+// error format.
+type ErrorResponder interface {
+	Error(w http.ResponseWriter, req *http.Request, err error)
+}
+
+// SimpleErrorResponder is the legacy implementation of ErrorResponder for callers that only
+// service a single request/response per proxy.
+type SimpleErrorResponder interface {
+	Error(err error)
+}
+
+func NewErrorResponder(r SimpleErrorResponder) ErrorResponder {
+	return simpleResponder{r}
+}
+
+type simpleResponder struct {
+	responder SimpleErrorResponder
+}
+
+func (r simpleResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	r.responder.Error(err)
+}
+
+// upgradeRequestRoundTripper implements proxy.UpgradeRequestRoundTripper.
+type upgradeRequestRoundTripper struct {
+	http.RoundTripper
+	upgrader http.RoundTripper
+}
+
+var (
+	_ UpgradeRequestRoundTripper  = &upgradeRequestRoundTripper{}
+	_ utilnet.RoundTripperWrapper = &upgradeRequestRoundTripper{}
+)
+
+// WrappedRoundTripper returns the round tripper that a caller would use.
+func (rt *upgradeRequestRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.RoundTripper
+}
+
+// WriteToRequest calls the nested upgrader and then copies the returned request
+// fields onto the passed request.
+func (rt *upgradeRequestRoundTripper) WrapRequest(req *http.Request) (*http.Request, error) {
+	resp, err := rt.upgrader.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Request, nil
+}
+
+// onewayRoundTripper captures the provided request - which is assumed to have
+// been modified by other round trippers - and then returns a fake response.
+type onewayRoundTripper struct{}
+
+// RoundTrip returns a simple 200 OK response that captures the provided request.
+func (onewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		Request:    req,
+	}, nil
+}
+
+// MirrorRequest is a round tripper that can be called to get back the calling request as
+// the core round tripper in a chain.
+var MirrorRequest http.RoundTripper = onewayRoundTripper{}
+
+// NewUpgradeRequestRoundTripper takes two round trippers - one for the underlying TCP connection, and
+// one that is able to write headers to an HTTP request. The request rt is used to set the request headers
+// and that is written to the underlying connection rt.
+func NewUpgradeRequestRoundTripper(connection, request http.RoundTripper) UpgradeRequestRoundTripper {
+	return &upgradeRequestRoundTripper{
+		RoundTripper: connection,
+		upgrader:     request,
+	}
+}
+
+// normalizeLocation returns the result of parsing the full URL, with scheme set to http if missing
+func normalizeLocation(location *url.URL) *url.URL {
+	normalized, _ := url.Parse(location.String())
+	if len(normalized.Scheme) == 0 {
+		normalized.Scheme = "http"
+	}
+	return normalized
+}
+
+// NewUpgradeAwareHandler creates a new proxy handler with a default flush interval. Responder is required for returning
+// errors to the caller.
+func NewUpgradeAwareHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool, responder ErrorResponder) *UpgradeAwareHandler {
+	return &UpgradeAwareHandler{
+		Location:        normalizeLocation(location),
+		Transport:       transport,
+		WrapTransport:   wrapTransport,
+		UpgradeRequired: upgradeRequired,
+		FlushInterval:   defaultFlushInterval,
+		Responder:       responder,
+	}
+}
+
+// ServeHTTP handles the proxy request
+func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if h.tryUpgrade(w, req) {
+		return
+	}
+	if h.UpgradeRequired {
+		h.Responder.Error(w, req, errors.NewBadRequest("Upgrade request required"))
+		return
+	}
+
+	loc := *h.Location
+	loc.RawQuery = req.URL.RawQuery
+
+	// If original request URL ended in '/', append a '/' at the end of the
+	// of the proxy URL
+	if !strings.HasSuffix(loc.Path, "/") && strings.HasSuffix(req.URL.Path, "/") {
+		loc.Path += "/"
+	}
+
+	// From pkg/genericapiserver/endpoints/handlers/proxy.go#ServeHTTP:
+	// Redirect requests with an empty path to a location that ends with a '/'
+	// This is essentially a hack for http://issue.k8s.io/4958.
+	// Note: Keep this code after tryUpgrade to not break that flow.
+	if len(loc.Path) == 0 {
+		var queryPart string
+		if len(req.URL.RawQuery) > 0 {
+			queryPart = "?" + req.URL.RawQuery
+		}
+		w.Header().Set("Location", req.URL.Path+"/"+queryPart)
+		w.WriteHeader(http.StatusMovedPermanently)
+		return
+	}
+
+	if h.Transport == nil || h.WrapTransport {
+		h.Transport = h.defaultProxyTransport(req.URL, h.Transport)
+	}
+
+	// WithContext creates a shallow clone of the request with the new context.
+	newReq := req.WithContext(context.Background())
+	newReq.Header = utilnet.CloneHeader(req.Header)
+	if !h.UseRequestLocation {
+		newReq.URL = &loc
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
+	proxy.Transport = h.Transport
+	proxy.FlushInterval = h.FlushInterval
+	proxy.ServeHTTP(w, newReq)
+}
+
+// tryUpgrade returns true if the request was handled.
+func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Request) bool {
+	if !httpstream.IsUpgradeRequest(req) {
+		glog.V(6).Infof("Request was not an upgrade")
+		return false
+	}
+
+	var (
+		backendConn net.Conn
+		rawResponse []byte
+		err         error
+	)
+
+	location := *h.Location
+	if h.UseRequestLocation {
+		location = *req.URL
+		location.Scheme = h.Location.Scheme
+		location.Host = h.Location.Host
+	}
+
+	clone := utilnet.CloneRequest(req)
+	// Only append X-Forwarded-For in the upgrade path, since httputil.NewSingleHostReverseProxy
+	// handles this in the non-upgrade path.
+	utilnet.AppendForwardedForHeader(clone)
+	if h.InterceptRedirects {
+		glog.V(6).Infof("Connecting to backend proxy (intercepting redirects) %s\n  Headers: %v", &location, clone.Header)
+		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade))
+	} else {
+		glog.V(6).Infof("Connecting to backend proxy (direct dial) %s\n  Headers: %v", &location, clone.Header)
+		clone.URL = &location
+		backendConn, err = h.DialForUpgrade(clone)
+	}
+	if err != nil {
+		glog.V(6).Infof("Proxy connection error: %v", err)
+		h.Responder.Error(w, req, err)
+		return true
+	}
+	defer backendConn.Close()
+
+	// Once the connection is hijacked, the ErrorResponder will no longer work, so
+	// hijacking should be the last step in the upgrade.
+	requestHijacker, ok := w.(http.Hijacker)
+	if !ok {
+		glog.V(6).Infof("Unable to hijack response writer: %T", w)
+		h.Responder.Error(w, req, fmt.Errorf("request connection cannot be hijacked: %T", w))
+		return true
+	}
+	requestHijackedConn, _, err := requestHijacker.Hijack()
+	if err != nil {
+		glog.V(6).Infof("Unable to hijack response: %v", err)
+		h.Responder.Error(w, req, fmt.Errorf("error hijacking connection: %v", err))
+		return true
+	}
+	defer requestHijackedConn.Close()
+
+	// Forward raw response bytes back to client.
+	if len(rawResponse) > 0 {
+		glog.V(6).Infof("Writing %d bytes to hijacked connection", len(rawResponse))
+		if _, err = requestHijackedConn.Write(rawResponse); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error proxying response from backend to client: %v", err))
+		}
+	}
+
+	// Proxy the connection.
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		var writer io.WriteCloser
+		if h.MaxBytesPerSec > 0 {
+			writer = flowrate.NewWriter(backendConn, h.MaxBytesPerSec)
+		} else {
+			writer = backendConn
+		}
+		_, err := io.Copy(writer, requestHijackedConn)
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			glog.Errorf("Error proxying data from client to backend: %v", err)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		var reader io.ReadCloser
+		if h.MaxBytesPerSec > 0 {
+			reader = flowrate.NewReader(backendConn, h.MaxBytesPerSec)
+		} else {
+			reader = backendConn
+		}
+		_, err := io.Copy(requestHijackedConn, reader)
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			glog.Errorf("Error proxying data from backend to client: %v", err)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	return true
+}
+
+func (h *UpgradeAwareHandler) Dial(req *http.Request) (net.Conn, error) {
+	return dial(req, h.Transport)
+}
+
+func (h *UpgradeAwareHandler) DialForUpgrade(req *http.Request) (net.Conn, error) {
+	if h.UpgradeTransport == nil {
+		return dial(req, h.Transport)
+	}
+	updatedReq, err := h.UpgradeTransport.WrapRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return dial(updatedReq, h.UpgradeTransport)
+}
+
+// dial dials the backend at req.URL and writes req to it.
+func dial(req *http.Request, transport http.RoundTripper) (net.Conn, error) {
+	conn, err := DialURL(req.URL, transport)
+	if err != nil {
+		return nil, fmt.Errorf("error dialing backend: %v", err)
+	}
+
+	if err = req.Write(conn); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("error sending request: %v", err)
+	}
+
+	return conn, err
+}
+
+var _ utilnet.Dialer = &UpgradeAwareHandler{}
+
+func (h *UpgradeAwareHandler) defaultProxyTransport(url *url.URL, internalTransport http.RoundTripper) http.RoundTripper {
+	scheme := url.Scheme
+	host := url.Host
+	suffix := h.Location.Path
+	if strings.HasSuffix(url.Path, "/") && !strings.HasSuffix(suffix, "/") {
+		suffix += "/"
+	}
+	pathPrepend := strings.TrimSuffix(url.Path, suffix)
+	rewritingTransport := &Transport{
+		Scheme:       scheme,
+		Host:         host,
+		PathPrepend:  pathPrepend,
+		RoundTripper: internalTransport,
+	}
+	return &corsRemovingTransport{
+		RoundTripper: rewritingTransport,
+	}
+}
+
+// corsRemovingTransport is a wrapper for an internal transport. It removes CORS headers
+// from the internal response.
+// Implements pkg/util/net.RoundTripperWrapper
+type corsRemovingTransport struct {
+	http.RoundTripper
+}
+
+var _ = utilnet.RoundTripperWrapper(&corsRemovingTransport{})
+
+func (rt *corsRemovingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	removeCORSHeaders(resp)
+	return resp, nil
+}
+
+func (rt *corsRemovingTransport) WrappedRoundTripper() http.RoundTripper {
+	return rt.RoundTripper
+}
+
+// removeCORSHeaders strip CORS headers sent from the backend
+// This should be called on all responses before returning
+func removeCORSHeaders(resp *http.Response) {
+	resp.Header.Del("Access-Control-Allow-Credentials")
+	resp.Header.Del("Access-Control-Allow-Headers")
+	resp.Header.Del("Access-Control-Allow-Methods")
+	resp.Header.Del("Access-Control-Allow-Origin")
+}


### PR DESCRIPTION
This endpoint lets you proxy into a provisioned Kubernetes cluster's API server through Pipeline (thus authenticated via our auth mechanism).

A possible use case is for example proxy the Kubernetes Dashboard through Pipeline:
http://localhost:9090/pipeline/api/v1/orgs/2/clusters/61/proxy/api/v1/namespaces/kube-system/services/https:dashboard-kubernetes-dashboard:/proxy