### PR TITLE
Support creating/upgrading a deployment from chart with specific version

### DIFF
--- a/api/helm.go
+++ b/api/helm.go
@@ -57,6 +57,7 @@ func CreateDeployment(c *gin.Context) {
 		return
 	}
 	release, err := helm.CreateDeployment(parsedRequest.deploymentName,
+		parsedRequest.deploymentVersion,
 		parsedRequest.namespace,
 		parsedRequest.deploymentReleaseName,
 		parsedRequest.values,
@@ -310,7 +311,7 @@ func UpgradeDeployment(c *gin.Context) {
 	}
 
 	release, err := helm.UpgradeDeployment(name,
-		parsedRequest.deploymentName, parsedRequest.values,
+		parsedRequest.deploymentName, parsedRequest.deploymentVersion, parsedRequest.values,
 		parsedRequest.reuseValues, parsedRequest.kubeConfig, helm.GenerateHelmRepoEnv(parsedRequest.organizationName))
 	if err != nil {
 		log.Errorf("Error during upgrading deployment. %s", err.Error())
@@ -362,6 +363,7 @@ func DeleteDeployment(c *gin.Context) {
 
 type parsedDeploymentRequest struct {
 	deploymentName        string
+	deploymentVersion     string
 	deploymentReleaseName string
 	reuseValues           bool
 	namespace             string
@@ -395,6 +397,7 @@ func parseCreateUpdateDeploymentRequest(c *gin.Context) (*parsedDeploymentReques
 	log.Debugf("Parsing chart %s with version %s and release name %s", deployment.Name, deployment.Version, deployment.ReleaseName)
 
 	pdr.deploymentName = deployment.Name
+	pdr.deploymentVersion = deployment.Version
 	pdr.deploymentReleaseName = deployment.ReleaseName
 	pdr.reuseValues = deployment.ReUseValues
 	pdr.namespace = deployment.Namespace

--- a/application/applications.go
+++ b/application/applications.go
@@ -226,7 +226,7 @@ func CreateApplicationDeployment(env helm_env.EnvSettings, am *model.Application
 		return err
 	}
 	if !ok {
-		resp, err := helm.CreateDeployment(chart, helm.DefaultNamespace, releaseName, values, kubeConfig, env)
+		resp, err := helm.CreateDeployment(chart, "", helm.DefaultNamespace, releaseName, values, kubeConfig, env)
 		if err != nil {
 			deployment.Update(model.Deployment{Status: FAILED, Message: err.Error()})
 			return err
@@ -322,7 +322,7 @@ func EnsureChart(env helm_env.EnvSettings, dep pkgCatalog.ApplicationDependency,
 	// TODO this is a workaround to not implement repository handling
 	chart := catalog.CatalogRepository + "/" + dep.Chart.Name
 
-	resp, err := helm.CreateDeployment(chart, dep.Namespace, releaseName, nil, kubeConfig, env)
+	resp, err := helm.CreateDeployment(chart, "", dep.Namespace, releaseName, nil, kubeConfig, env)
 	if err != nil {
 		return "", err
 	}

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -4446,10 +4446,14 @@ components:
         name: banzaicloud-stable/drone
         namespace: default
         reuseValues: true
-        version: 1
+        version: 0.1.0
       properties:
         name:
           example: banzaicloud-stable/drone
+          type: string
+        version:
+          description: Version of the deployment. If not specified, the latest version is used.
+          example: 0.1.0
           type: string
         namespace:
           example: default
@@ -4460,10 +4464,6 @@ components:
         reuseValues:
           example: true
           type: boolean
-        version:
-          example: 1
-          format: int32
-          type: integer
         values:
           additionalProperties: true
           description: current values of the deployment

--- a/client/docs/CreateUpdateDeploymentRequest.md
+++ b/client/docs/CreateUpdateDeploymentRequest.md
@@ -4,10 +4,10 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | 
+**Version** | **string** | Version of the deployment. If not specified, the latest version is used. | [optional] 
 **Namespace** | **string** |  | [optional] 
 **ReleaseName** | **string** |  | [optional] 
 **ReuseValues** | **bool** |  | [optional] 
-**Version** | **int32** |  | [optional] 
 **Values** | [**map[string]interface{}**](map[string]interface{}.md) | current values of the deployment | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/model_create_update_deployment_request.go
+++ b/client/model_create_update_deployment_request.go
@@ -11,11 +11,12 @@
 package client
 
 type CreateUpdateDeploymentRequest struct {
-	Name        string `json:"name"`
+	Name string `json:"name"`
+	// Version of the deployment. If not specified, the latest version is used.
+	Version     string `json:"version,omitempty"`
 	Namespace   string `json:"namespace,omitempty"`
 	ReleaseName string `json:"releaseName,omitempty"`
 	ReuseValues bool   `json:"reuseValues,omitempty"`
-	Version     int32  `json:"version,omitempty"`
 	// current values of the deployment
 	Values map[string]interface{} `json:"values,omitempty"`
 }

--- a/cluster/autoscale.go
+++ b/cluster/autoscale.go
@@ -239,9 +239,9 @@ func deployAutoscalerChart(cluster CommonCluster, nodeGroups []nodeGroup, kubeCo
 	}
 	switch action {
 	case install:
-		_, err = helm.CreateDeployment(autoScalerChart, helm.SystemNamespace, releaseName, yamlValues, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+		_, err = helm.CreateDeployment(autoScalerChart, "", helm.SystemNamespace, releaseName, yamlValues, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
 	case upgrade:
-		_, err = helm.UpgradeDeployment(releaseName, autoScalerChart, yamlValues, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+		_, err = helm.UpgradeDeployment(releaseName, autoScalerChart, "", yamlValues, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
 	default:
 		return err
 	}

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -259,7 +259,7 @@ func installDeployment(cluster CommonCluster, namespace string, deploymentName s
 		}
 	}
 
-	_, err = helm.CreateDeployment(deploymentName, namespace, releaseName, values, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+	_, err = helm.CreateDeployment(deploymentName, "", namespace, releaseName, values, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
 	if err != nil {
 		log.Errorf("Deploying '%s' failed due to: %s", deploymentName, err.Error())
 		return err

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -4104,6 +4104,10 @@ components:
         name:
           type: string
           example: "banzaicloud-stable/drone"
+        version:
+          type: string
+          example: "0.1.0"
+          description: "Version of the deployment. If not specified, the latest version is used."
         namespace:
           type: string
           example: "default"
@@ -4113,9 +4117,6 @@ components:
         reuseValues:
           type: boolean
           example: "true"
-        version:
-          type: integer
-          example: 1
         values:
           type: object
           additionalProperties: true

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -151,17 +151,17 @@ func ListDeployments(filter *string, kubeConfig []byte) (*rls.ListReleasesRespon
 }
 
 //UpgradeDeployment upgrades a Helm deployment
-func UpgradeDeployment(releaseName, chartName string, values []byte, reuseValues bool, kubeConfig []byte, env helm_env.EnvSettings) (*rls.UpdateReleaseResponse, error) {
+func UpgradeDeployment(releaseName, chartName, chartVersion string, values []byte, reuseValues bool, kubeConfig []byte, env helm_env.EnvSettings) (*rls.UpdateReleaseResponse, error) {
 	//Map chartName as
-	log.Infof("Deploying chart=%q, release name=%q", chartName, releaseName)
-	downloadedChartPath, err := DownloadChartFromRepo(chartName, env)
+	log.Infof("Deploying chart=%q, version=%q release name=%q", chartName, chartVersion, releaseName)
+	downloadedChartPath, err := DownloadChartFromRepo(chartName, chartVersion, env)
 	if err != nil {
 		return nil, err
 	}
 
 	chartRequested, err := chartutil.Load(downloadedChartPath)
 	if err != nil {
-		return nil, fmt.Errorf("Error loading chart: %v", err)
+		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
 	if req, err := chartutil.LoadRequirements(chartRequested); err == nil {
 		if err := checkDependencies(chartRequested, req); err != nil {
@@ -190,10 +190,10 @@ func UpgradeDeployment(releaseName, chartName string, values []byte, reuseValues
 }
 
 //CreateDeployment creates a Helm deployment in chosen namespace
-func CreateDeployment(chartName string, namespace string, releaseName string, valueOverrides []byte, kubeConfig []byte, env helm_env.EnvSettings) (*rls.InstallReleaseResponse, error) {
+func CreateDeployment(chartName string, chartVersion, namespace string, releaseName string, valueOverrides []byte, kubeConfig []byte, env helm_env.EnvSettings) (*rls.InstallReleaseResponse, error) {
 
-	log.Infof("Deploying chart=%q, release name=%q", chartName, releaseName)
-	downloadedChartPath, err := DownloadChartFromRepo(chartName, env)
+	log.Infof("Deploying chart=%q, version=%q release name=%q", chartName, chartVersion, releaseName)
+	downloadedChartPath, err := DownloadChartFromRepo(chartName, chartVersion, env)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func CreateDeployment(chartName string, namespace string, releaseName string, va
 
 	chartRequested, err := chartutil.Load(downloadedChartPath)
 	if err != nil {
-		return nil, fmt.Errorf("Error loading chart: %v", err)
+		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
 	if req, err := chartutil.LoadRequirements(chartRequested); err == nil {
 		if err := checkDependencies(chartRequested, req); err != nil {

--- a/helm/install.go
+++ b/helm/install.go
@@ -180,7 +180,7 @@ func GenerateHelmRepoEnv(orgName string) (env helm_env.EnvSettings) {
 }
 
 // DownloadChartFromRepo download a given chart
-func DownloadChartFromRepo(name string, env helm_env.EnvSettings) (string, error) {
+func DownloadChartFromRepo(name, version string, env helm_env.EnvSettings) (string, error) {
 	dl := downloader.ChartDownloader{
 		HelmHome: env.Home,
 		Getters:  getter.All(env),
@@ -190,18 +190,18 @@ func DownloadChartFromRepo(name string, env helm_env.EnvSettings) (string, error
 		os.MkdirAll(env.Home.Archive(), 0744)
 	}
 
-	log.Infof("Downloading helm chart '%s' to '%s'", name, env.Home.Archive())
-	filename, _, err := dl.DownloadTo(name, "", env.Home.Archive())
+	log.Infof("Downloading helm chart %q, version %q to %q", name, version, env.Home.Archive())
+	filename, _, err := dl.DownloadTo(name, version, env.Home.Archive())
 	if err == nil {
 		lname, err := filepath.Abs(filename)
 		if err != nil {
 			return filename, errors.Wrapf(err, "Could not create absolute path from %s", filename)
 		}
-		log.Debugf("Fetched helm chart '%s' to '%s'", name, filename)
+		log.Debugf("Fetched helm chart %q, version %q to %q", name, version, filename)
 		return lname, nil
 	}
 
-	return filename, errors.Wrapf(err, "Failed to download %q", name)
+	return filename, errors.Wrapf(err, "Failed to download chart %q, version %q", name, version)
 }
 
 // InstallHelmClient Installs helm client on a given path

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -90,8 +90,8 @@ type CreateUpdateDeploymentResponse struct {
 // CreateUpdateDeploymentRequest describes a Helm deployment
 type CreateUpdateDeploymentRequest struct {
 	Name        string                 `json:"name" binding:"required"`
+	Version     string                 `json:"version,omitempty"`
 	ReleaseName string                 `json:"releaseName"`
-	Version     int32                  `json:"version"`
 	ReUseValues bool                   `json:"reuseValues"`
 	Namespace   string                 `json:"namespace"`
 	Values      map[string]interface{} `json:"values,omitempty"`


### PR DESCRIPTION
We need support creating a deployment from given version of a chart beside lates version. This is to allow to create deployments from any available chart version.

In case of upgrade this will allow upgrading a deployment to a new chart version or downgrading to an older chart version.