### PR TITLE
Fix: existig route53 secret not injected into clusters created after …

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -431,7 +431,6 @@ func RegisterDomainPostHook(input interface{}) error {
 		}
 	} else {
 		log.Infof("Domain '%s' already registered", domain)
-		return nil
 	}
 
 	_, err = InstallOrUpdateSecrets(


### PR DESCRIPTION
…the first cluster in the organization