### PR TITLE
Fix alreadyExists error handling on GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION = 0.1.0
 GITREV = $(shell git rev-parse --short HEAD)
 
 build: ## Builds binary package
-	go build  -ldflags "-X main.Version=$(VERSION) -X main.GitRev=$(GITREV)" .
+	go build -v -ldflags "-X main.Version=$(VERSION) -X main.GitRev=$(GITREV)" .
 
 build-ci:
 	CGO_ENABLED=0 GOOS=linux go build .

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -218,12 +218,16 @@ func (g *GKECluster) CreateCluster() error {
 		// TODO status code !?
 		return errors.New(be.Message)
 	}
-	log.Infof("Cluster %s create is called for project %s and zone %s. Status Code %v", cc.Name, cc.ProjectID, cc.Zone, createCall.HTTPStatusCode)
 
-	log.Info("Waiting for cluster...")
+	if createCall != nil {
+		log.Infof("Cluster %s create is called for project %s and zone %s. Status Code %v", cc.Name, cc.ProjectID, cc.Zone)
+		log.Info("Waiting for cluster...")
 
-	if err := waitForOperation(svc, g.modelCluster.Location, projectId, createCall.Name); err != nil {
-		return err
+		if err := waitForOperation(svc, g.modelCluster.Location, projectId, createCall.Name); err != nil {
+			return err
+		}
+	} else {
+		log.Info("Cluster %s already exists.", g.modelCluster.Name)
 	}
 
 	gkeCluster, err := getClusterGoogle(svc, cc)


### PR DESCRIPTION
Fixes: 
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1effb67]

goroutine 11322 [running]:
github.com/banzaicloud/pipeline/cluster.(*GKECluster).CreateCluster(0xc420766aa0, 0x0, 0x0)
	/go/src/github.com/banzaicloud/pipeline/cluster/gke.go:224 +0x657
github.com/banzaicloud/pipeline/api.postCreateCluster(0x2c70fe0, 0xc420766aa0, 0x0, 0x0, 0x0, 0x0, 0xc422057490)
	/go/src/github.com/banzaicloud/pipeline/api/cluster.go:317 +0x77
created by github.com/banzaicloud/pipeline/api.CreateCluster
	/go/src/github.com/banzaicloud/pipeline/api/cluster.go:293 +0xf69```