### PR TITLE
Add go import rules to idea config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test.txt
 !/.idea/runConfigurations/
 !/.idea/modules.xml
 !/.idea/*.iml
+!/.idea/go.imports.xml

--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoImports">
+    <option name="groupStdlibImports" value="true" />
+    <option name="importSorting" value="GOFMT" />
+    <option name="moveAllImportsInOneDeclaration" value="true" />
+    <option name="moveAllStdlibImportsInOneGroup" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
This PR makes idea to format go imports.

Example:

```go
import (
	"bytes"
	"errors"
	"fmt"

	"localPackage"

	"golang.org/x/tools/cmd/gotype"

	"appengine"

	"github.com/dlsniper/go-metrics"
)
```

Rules:

- one import block
- stdlib imports are grouped