### PR TITLE
Simplify global logger setup

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/database"
 	"github.com/banzaicloud/pipeline/helm"
 	"github.com/banzaicloud/pipeline/model"
@@ -21,17 +21,13 @@ import (
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	resourceHelper "k8s.io/kubernetes/pkg/api/v1/resource"
-	"math"
 )
-
-var log *logrus.Logger
 
 const (
 	awsLabelMaster = "node-role.kubernetes.io/master"
@@ -51,11 +47,6 @@ const (
 	zeroCPU    = "0 CPU"
 	zeroMemory = "0 B"
 )
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 //ParseField is to restrict other query TODO investigate to just pass the hasmap
 func ParseField(c *gin.Context) map[string]interface{} {

--- a/api/log.go
+++ b/api/log.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -20,17 +20,9 @@ import (
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/kubicorn/kubicorn/pkg/logger"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 //CommonCluster interface for clusters
 type CommonCluster interface {

--- a/cluster/log.go
+++ b/cluster/log.go
@@ -1,0 +1,12 @@
+package cluster
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/cluster/supported/base.go
+++ b/cluster/supported/base.go
@@ -1,18 +1,9 @@
 package supported
 
 import (
-	"github.com/banzaicloud/pipeline/config"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // CloudInfoProvider interface for cloud supports
 type CloudInfoProvider interface {

--- a/cluster/supported/log.go
+++ b/cluster/supported/log.go
@@ -1,0 +1,12 @@
+package supported
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/database/database.go
+++ b/database/database.go
@@ -4,9 +4,7 @@ import (
 	"sync"
 
 	"github.com/banzaicloud/bank-vaults/database"
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/jinzhu/gorm"
-	"github.com/sirupsen/logrus"
 	// blank import is used here for simplicity
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	"github.com/spf13/viper"
@@ -14,12 +12,6 @@ import (
 
 var dbOnce sync.Once
 var db *gorm.DB
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 func initDatabase() {
 	dbName := viper.GetString("database.dbname")

--- a/database/log.go
+++ b/database/log.go
@@ -1,0 +1,12 @@
+package database
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/dns/externaldns.go
+++ b/dns/externaldns.go
@@ -9,12 +9,9 @@ import (
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
-
-var log *logrus.Logger
 
 var once sync.Once
 var errCreate error
@@ -36,11 +33,6 @@ var mux sync.RWMutex
 type DnsEventsSubscription struct {
 	Id     uuid.UUID
 	Events <-chan interface{}
-}
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
 }
 
 // DnsServiceClient contains the operations for managing domains in a Dns Service

--- a/dns/log.go
+++ b/dns/log.go
@@ -1,0 +1,12 @@
+package dns
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -13,13 +13,12 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig"
-	"github.com/banzaicloud/pipeline/config"
 	helm2 "github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm"
@@ -27,7 +26,6 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
 	"k8s.io/helm/pkg/repo"
-	"time"
 )
 
 // DefaultNamespace default namespace
@@ -37,8 +35,6 @@ const DefaultNamespace = "default"
 const SystemNamespace = "kube-system"
 
 const versionAll = "all"
-
-var log *logrus.Logger
 
 // ErrRepoNotFound describe an error if helm repository not found
 var ErrRepoNotFound = errors.New("helm repository not found!")
@@ -51,11 +47,6 @@ type DeploymentNotFoundError struct {
 
 func (e *DeploymentNotFoundError) Error() string {
 	return fmt.Sprintf("deployment not found: %s", e.HelmError)
-}
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
 }
 
 // DownloadFile download file/unzip and untar and store it in memory

--- a/helm/log.go
+++ b/helm/log.go
@@ -1,0 +1,12 @@
+package helm
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/kubernetes/crd.go
+++ b/kubernetes/crd.go
@@ -1,21 +1,15 @@
 package kubernetes
 
 import (
-	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"fmt"
-	"github.com/banzaicloud/pipeline/config"
+
+	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-var log *logrus.Logger
-
-func init() {
-	log = config.Logger()
-}
 
 //GetK8sClientConfig creates a Kubernetes client config
 //This is a duplicate from Helm

--- a/kubernetes/log.go
+++ b/kubernetes/log.go
@@ -1,0 +1,12 @@
+package kubernetes
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/model/defaults/base.go
+++ b/model/defaults/base.go
@@ -4,16 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/database"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	oracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
-
-var log *logrus.Logger
 
 // cluster profile table names
 const (
@@ -30,11 +26,6 @@ const (
 const (
 	DefaultNodeName = "pool1"
 )
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // SetDefaultValues saves the default cluster profile into the database if not exists yet
 func SetDefaultValues() error {

--- a/model/defaults/log.go
+++ b/model/defaults/log.go
@@ -1,0 +1,12 @@
+package defaults
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/notify/log.go
+++ b/notify/log.go
@@ -1,0 +1,12 @@
+package notify
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/notify/slack.go
+++ b/notify/slack.go
@@ -3,8 +3,6 @@ package notify
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/banzaicloud/pipeline/config"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -18,12 +16,6 @@ type Slack struct {
 	IconEmoji string `json:"iconemoji"`
 	IconUrl   string `json:"iconurl"`
 	Channel   string `json:"channel"`
-}
-
-var log *logrus.Logger
-
-func init() {
-	log = config.Logger()
 }
 
 //SlackNotify is pushing to Slack

--- a/objectstore/common.go
+++ b/objectstore/common.go
@@ -2,7 +2,6 @@ package objectstore
 
 import (
 	"github.com/banzaicloud/pipeline/auth"
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/database"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -10,15 +9,7 @@ import (
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/jinzhu/gorm"
-	"github.com/sirupsen/logrus"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // ManagedBucketNotFoundError signals that managed bucket was not found in database.
 type ManagedBucketNotFoundError struct {

--- a/objectstore/log.go
+++ b/objectstore/log.go
@@ -1,0 +1,12 @@
+package objectstore
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/pkg/cluster/eks/action/actions.go
+++ b/pkg/cluster/eks/action/actions.go
@@ -16,26 +16,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/model"
 	pkgEks "github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 )
 
-var log *logrus.Logger
-
 const awsNoUpdatesError = "No updates are to be performed."
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
-
-// --
 
 // EksClusterCreateUpdateContext describes the properties of an EKS cluster creation
 type EksClusterCreateUpdateContext struct {
@@ -672,7 +661,6 @@ func (action *UploadSSHKeyAction) ExecuteAction(input interface{}) (output inter
 	action.context.SSHKey = secret.NewSSHKeyPair(action.sshSecret)
 	ec2srv := ec2.New(action.context.Session)
 	importKeyPairInput := &ec2.ImportKeyPairInput{
-
 		// A unique name for the key pair.
 		// KeyName is a required field
 		KeyName: aws.String(action.context.SSHKeyName),

--- a/pkg/cluster/eks/action/log.go
+++ b/pkg/cluster/eks/action/log.go
@@ -1,0 +1,12 @@
+package action
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/pkg/cluster/eks/log.go
+++ b/pkg/cluster/eks/log.go
@@ -1,0 +1,12 @@
+package eks
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/pkg/cluster/eks/templates.go
+++ b/pkg/cluster/eks/templates.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 
 	"github.com/banzaicloud/pipeline/config"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -15,13 +14,6 @@ const (
 	eksVPCTemplateName      = "amazon-eks-vpc-cf.yaml"
 	eksNodePoolTemplateName = "amazon-eks-nodepool-cf.yaml"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // getEksCloudFormationTemplate returns CloudFormation template with given name
 func getEksCloudFormationTemplate(name string) (string, error) {

--- a/pkg/providers/oracle/model/log.go
+++ b/pkg/providers/oracle/model/log.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/pkg/providers/oracle/model/profile.go
+++ b/pkg/providers/oracle/model/profile.go
@@ -3,7 +3,6 @@ package model
 import (
 	"time"
 
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/database"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/amazon"
@@ -11,15 +10,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/google"
 	oracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/cluster"
-	"github.com/sirupsen/logrus"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // SQL table names
 const (

--- a/pkg/providers/oracle/oci/oci.go
+++ b/pkg/providers/oracle/oci/oci.go
@@ -11,7 +11,7 @@ import (
 // OCI is for managing OCI API calls
 type OCI struct {
 	config          common.ConfigurationProvider
-	logger          *logrus.Logger
+	logger          logrus.FieldLogger
 	credential      *Credential
 	Tenancy         identity.Tenancy
 	CompartmentOCID string
@@ -68,13 +68,13 @@ func (oci *OCI) ChangeRegion(regionName string) (err error) {
 }
 
 // SetLogger sets a logrus logger
-func (oci *OCI) SetLogger(logger *logrus.Logger) {
+func (oci *OCI) SetLogger(logger logrus.FieldLogger) {
 
 	oci.logger = logger
 }
 
 // GetLogger gets the previously set logrus logger
-func (oci *OCI) GetLogger() *logrus.Logger {
+func (oci *OCI) GetLogger() logrus.FieldLogger {
 
 	return oci.logger
 }

--- a/secret/log.go
+++ b/secret/log.go
@@ -1,0 +1,12 @@
+package secret
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log logrus.FieldLogger
+
+func init() {
+	log = config.Logger()
+}

--- a/secret/store.go
+++ b/secret/store.go
@@ -11,19 +11,15 @@ import (
 
 	"github.com/banzaicloud/bank-vaults/pkg/tls"
 	"github.com/banzaicloud/bank-vaults/vault"
-	"github.com/banzaicloud/pipeline/config"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
-
-var log *logrus.Logger
 
 // Store object that wraps up vault logical store
 var Store *secretStore
@@ -32,7 +28,6 @@ var Store *secretStore
 var ErrSecretNotExists = fmt.Errorf("There's no secret with this ID")
 
 func init() {
-	log = config.Logger()
 	Store = newVaultSecretStore()
 }
 

--- a/secret/verify/aws.go
+++ b/secret/verify/aws.go
@@ -5,18 +5,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/banzaicloud/pipeline/config"
 	pkgAmazon "github.com/banzaicloud/pipeline/pkg/cluster/amazon"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/sirupsen/logrus"
 )
-
-var log *logrus.Logger
-
-// Simple init for logging
-func init() {
-	log = config.Logger()
-}
 
 // awsVerify for validation AWS credentials
 type awsVerify struct {

--- a/secret/verify/log.go
+++ b/secret/verify/log.go
@@ -1,0 +1,14 @@
+package verify
+
+import (
+	"github.com/banzaicloud/pipeline/config"
+	"github.com/sirupsen/logrus"
+)
+
+// Note: this should be FieldLogger instead.
+// Debug mode should be split to a separate config.
+var log *logrus.Logger
+
+func init() {
+	log = config.Logger()
+}

--- a/utils/revocable_action.go
+++ b/utils/revocable_action.go
@@ -74,11 +74,11 @@ func (ctx *ActionCallContext) executeContextAction() (interface{}, error) {
 
 // ActionExecutor executes Actions
 type ActionExecutor struct {
-	log *logrus.Logger
+	log logrus.FieldLogger
 }
 
 // NewActionExecutor creates a new ActionExecutor
-func NewActionExecutor(log *logrus.Logger) *ActionExecutor {
+func NewActionExecutor(log logrus.FieldLogger) *ActionExecutor {
 	return &ActionExecutor{
 		log: log,
 	}


### PR DESCRIPTION
This PR tries to simplify or at least make the global logger setup consistent across the repository.

It adds:

- a log.go file with the same setup to each package where the logger is needed (which could become a standard)
- uses logrus.FieldLogger interface instead of *logrus.Logger (where possible) (so that the parent logger itself can be a *logrus.Entry with some base context)

This move also makes it easier to change how we do logging globally if we decide to, but it's heavily opinionated, so feel free to reject if you think it's too big change.