### PR TITLE
Add lint and check compound build config to idea

### DIFF
--- a/.idea/runConfigurations/Check.xml
+++ b/.idea/runConfigurations/Check.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Check" type="CompoundRunConfigurationType" factoryName="Compound Run Configuration">
+    <toRun type="GoTestRunConfiguration" name="Tests" />
+    <toRun type="MAKEFILE_TARGET_RUN_CONFIGURATION" name="Lint" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Lint.xml
+++ b/.idea/runConfigurations/Lint.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lint" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="lint" workingDirectory="" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
This PR adds a Lint build config for running the linter and a Check compound config for running both tests and the linter. Comes handy right before committing code.