### PR TITLE
Fix azure autoscaler (add missing cluster name)

### DIFF
--- a/cluster/autoscale.go
+++ b/cluster/autoscale.go
@@ -173,6 +173,9 @@ func createAutoscalingForAzure(cluster CommonCluster, groups []nodeGroup) *autos
 			"expander": expanderStrategy,
 		},
 		Rbac: rbac{Create: true},
+		AutoDiscovery: map[string]string{
+			"clusterName": cluster.GetName(),
+		},
 		Azure: azureInfo{
 			ClientID:          clusterSecret.Values[pkgSecret.AzureClientId],
 			ClientSecret:      clusterSecret.Values[pkgSecret.AzureClientSecret],


### PR DESCRIPTION
Wild guess based on the error message