### PR TITLE
Remove Check build config

### DIFF
--- a/.idea/runConfigurations/Check.xml
+++ b/.idea/runConfigurations/Check.xml
@@ -1,6 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Check" type="CompoundRunConfigurationType" factoryName="Compound Run Configuration">
-    <toRun type="GoTestRunConfiguration" name="Tests" />
-    <method />
-  </configuration>
-</component>


### PR DESCRIPTION
I propose that we remove this config from the repo. It causes more problem than it helps. It can easily be added back to the local workspace.