### PR TITLE
Reduce Docker context to the bare minimum

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+bin/
+client/
+docs/
+orgs/
+vendor/


### PR DESCRIPTION
This reduces the build context sent to Docker from multi-hundred megabytes to 1.6MB.