### PR TITLE
Fix cors.AllowOrigin* config parsing

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -155,7 +155,7 @@ func GetCORS() cors.Config {
 	if !config.AllowAllOrigins {
 		allowOriginsRegexp := viper.GetString("cors.AllowOriginsRegexp")
 		if allowOriginsRegexp != "" {
-			originsRegexp, err := regexp.Compile(allowOriginsRegexp)
+			originsRegexp, err := regexp.Compile(fmt.Sprintf("^(%s)$", allowOriginsRegexp))
 			if err == nil {
 				config.AllowOriginFunc = func(origin string) bool {
 					return originsRegexp.Match([]byte(origin))

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -161,8 +161,8 @@ func GetCORS() cors.Config {
 					return originsRegexp.Match([]byte(origin))
 				}
 			}
-		} else if len(viper.GetStringSlice("cors.AllowOrigins")) > 0 {
-			config.AllowOrigins = viper.GetStringSlice("cors.AllowOrigins")
+		} else if allowOrigins := viper.GetStringSlice("cors.AllowOrigins"); len(allowOrigins) > 0 {
+			config.AllowOrigins = allowOrigins
 		}
 	}
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -161,9 +161,9 @@ func GetCORS() cors.Config {
 					return originsRegexp.Match([]byte(origin))
 				}
 			}
+		} else if len(viper.GetStringSlice("cors.AllowOrigins")) > 0 {
+			config.AllowOrigins = viper.GetStringSlice("cors.AllowOrigins")
 		}
-	} else if len(viper.GetStringSlice("cors.AllowOrigins")) > 0 {
-		config.AllowOrigins = viper.GetStringSlice("cors.AllowOrigins")
 	}
 
 	config.AllowMethods = viper.GetStringSlice("cors.AllowMethods")


### PR DESCRIPTION
* Fix regression from #895: AllowOrigins option became unreachable
* Use whole string matching instead of substring matching for AllowOriginsRegexp as it is not intuitive and exposes a potential security risk