### PR TITLE
Add missing github token from config example

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -40,6 +40,9 @@ path = ""
 
 [drone]
 
+[github]
+token = "YourPersonalAccessToken"
+
 [auth]
 # GitHub settings
 clientid = ""


### PR DESCRIPTION
This one is missing from #939 