### PR TITLE
Introduce error handling concept

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -694,6 +694,18 @@
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:76de154494231e7856bd7f421dbe501e16fe1c825904db886d24fd8238767d6a"
+  name = "github.com/goph/emperror"
+  packages = [
+    ".",
+    "errorlogrus",
+    "internal/keyvals",
+  ]
+  pruneopts = "NUT"
+  revision = "d328ac744d45a846ad0608dda4a70cea9d90f935"
+  version = "v0.11.0"
+
+[[projects]]
   digest = "1:dbd86d229eacaa86a98b10f8fb3e3fc69a1913e0f4e010e7cc1f92bf12edca92"
   name = "github.com/gorilla/context"
   packages = ["."]
@@ -2332,6 +2344,8 @@
     "github.com/go-errors/errors",
     "github.com/golang/glog",
     "github.com/google/go-github/github",
+    "github.com/goph/emperror",
+    "github.com/goph/emperror/errorlogrus",
     "github.com/gorilla/sessions",
     "github.com/hashicorp/vault/api",
     "github.com/jinzhu/copier",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -265,3 +265,7 @@
 [[constraint]]
   name = "github.com/drone/drone-go"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/goph/emperror"
+  version = "0.11.0"

--- a/config/error_handler.go
+++ b/config/error_handler.go
@@ -26,7 +26,7 @@ func ErrorHandler() emperror.Handler {
 func newErrorHandler() emperror.Handler {
 	logger := log.NewLogger(log.Config{
 		Level:  logrus.ErrorLevel.String(),
-		Format: viper.GetString("log.logformat"),
+		Format: viper.GetString("logging.logformat"),
 	})
 
 	loggerHandler := errorlogrus.NewHandler(logger)

--- a/config/error_handler.go
+++ b/config/error_handler.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/banzaicloud/pipeline/internal/platform/log"
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/errorlogrus"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+var errorHandler emperror.Handler
+var errorHandlerOnce sync.Once
+
+// ErrorHandler returns an error handler.
+func ErrorHandler() emperror.Handler {
+	errorHandlerOnce.Do(func() {
+		errorHandler = newErrorHandler()
+	})
+
+	return errorHandler
+}
+
+func newErrorHandler() emperror.Handler {
+	logger := log.NewLogger(log.Config{
+		Level:  logrus.ErrorLevel.String(),
+		Format: viper.GetString("log.logformat"),
+	})
+
+	loggerHandler := errorlogrus.NewHandler(logger)
+
+	return emperror.HandlerFunc(func(err error) {
+		if stackTrace, ok := emperror.StackTrace(err); ok && len(stackTrace) > 0 {
+			frame := stackTrace[0]
+
+			err = emperror.With(
+				err,
+				"func", fmt.Sprintf("%n", frame), // nolint: govet
+				"file", fmt.Sprintf("%s", frame), // nolint: govet
+				"line", fmt.Sprintf("%d", frame),
+			)
+		}
+
+		loggerHandler.Handle(err)
+	})
+}

--- a/config/error_handler.go
+++ b/config/error_handler.go
@@ -38,8 +38,7 @@ func newErrorHandler() emperror.Handler {
 			err = emperror.With(
 				err,
 				"func", fmt.Sprintf("%n", frame), // nolint: govet
-				"file", fmt.Sprintf("%s", frame), // nolint: govet
-				"line", fmt.Sprintf("%d", frame),
+				"file", fmt.Sprintf("%v", frame), // nolint: govet
 			)
 		}
 

--- a/config/logger.go
+++ b/config/logger.go
@@ -22,7 +22,7 @@ func Logger() *logrus.Logger {
 func newLogger() *logrus.Logger {
 	logger := log.NewLogger(log.Config{
 		Level:  viper.GetString("logging.loglevel"),
-		Format: viper.GetString("log.logformat"),
+		Format: viper.GetString("logging.logformat"),
 	})
 
 	logger.Formatter = &runtime.Formatter{ChildFormatter: logger.Formatter}

--- a/config/logger.go
+++ b/config/logger.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/banzaicloud/logrus-runtime-formatter"
+	"github.com/banzaicloud/pipeline/internal/platform/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -19,28 +20,12 @@ func Logger() *logrus.Logger {
 }
 
 func newLogger() *logrus.Logger {
-	logger := logrus.New()
+	logger := log.NewLogger(log.Config{
+		Level:  viper.GetString("logging.loglevel"),
+		Format: viper.GetString("log.logformat"),
+	})
 
-	level, err := logrus.ParseLevel(viper.GetString("logging.loglevel"))
-	if err != nil {
-		level = logrus.InfoLevel
-	}
-
-	logger.Level = level
-
-	var childFormatter logrus.Formatter
-
-	switch viper.GetString("log.logformat") {
-	case "json":
-		childFormatter = new(logrus.JSONFormatter)
-
-	default:
-		textFormatter := new(logrus.TextFormatter)
-		textFormatter.FullTimestamp = true
-		childFormatter = textFormatter
-	}
-
-	logger.Formatter = &runtime.Formatter{ChildFormatter: childFormatter}
+	logger.Formatter = &runtime.Formatter{ChildFormatter: logger.Formatter}
 
 	return logger
 }

--- a/internal/platform/log/config.go
+++ b/internal/platform/log/config.go
@@ -1,0 +1,7 @@
+package log
+
+// Config holds information necessary for customizing the logger.
+type Config struct {
+	Level  string
+	Format string
+}

--- a/internal/platform/log/logger.go
+++ b/internal/platform/log/logger.go
@@ -1,0 +1,28 @@
+package log
+
+import "github.com/sirupsen/logrus"
+
+// NewLogger creates a new logrus logger instance.
+func NewLogger(config Config) *logrus.Logger {
+	logger := logrus.New()
+
+	level, err := logrus.ParseLevel(config.Level)
+	if err != nil {
+		level = logrus.InfoLevel
+	}
+
+	logger.Level = level
+
+	switch config.Format {
+	case "json":
+		logger.Formatter = new(logrus.JSONFormatter)
+
+	default:
+		textFormatter := new(logrus.TextFormatter)
+		textFormatter.FullTimestamp = true
+
+		logger.Formatter = textFormatter
+	}
+
+	return logger
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -55,6 +56,7 @@ func main() {
 
 	logger = initLog()
 	logger.Info("Pipeline initialization")
+	errorHandler := config.ErrorHandler()
 
 	// Connect to database
 	db := config.DB()
@@ -142,7 +144,7 @@ func main() {
 	go func() {
 		err := spotguide.ScrapeSpotguides()
 		if err != nil {
-			log.Errorln("Failed to scrape Spotguide repositories:", err)
+			errorHandler.Handle(errors.Wrap(err, "failed to scrape Spotguide repositories"))
 		}
 	}()
 

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -11,6 +11,7 @@ import (
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/ghodss/yaml"
 	"github.com/google/go-github/github"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/log"
 	"github.com/spf13/viper"
@@ -132,7 +133,7 @@ func ScrapeSpotguides() error {
 		})
 
 		if err != nil {
-			return err
+			return emperror.Wrap(err, "failed to list github repositories")
 		}
 
 		allRepositories = append(allRepositories, repositories...)
@@ -152,12 +153,12 @@ func ScrapeSpotguides() error {
 
 				pipelineRaw, err := downloadGithubFile(githubClient, owner, name, PipelineYAMLPath)
 				if err != nil {
-					return err
+					return emperror.Wrap(err, "failed to download pipeline YAML")
 				}
 
 				spotguideRaw, err := downloadGithubFile(githubClient, owner, name, SpotguideYAMLPath)
 				if err != nil {
-					return err
+					return emperror.Wrap(err, "failed to download spotguide YAML")
 				}
 
 				model := Repo{


### PR DESCRIPTION
This PR adds the concept of "error handler" mentioned in [Error handling practices in Go](https://banzaicloud.com/blog/error-handling-go/) to Pipeline.

Instead of logging errors using logrus an error that we cannot gracefully handle should be passed to the error handler. The underlying handler implementation in turn will pass the error to logrus, but it also gives us the ability to use any third-party error tracking service or whichever way we want to handle errors. Conceptually logging is one way to "handle" an error.

Here is an example of the log (adds file and line information):

```
time="2018-08-30T15:13:14+02:00" level=error msg="failed to scrape Spotguide repositories: failed to list github repositories: GET https://api.github.com/orgs/banzaicloud/repos?per_page=100: 401 Bad credentials []" file=main.go func=main.func1 line=147
```

Compared to the old log:

```
time="2018-08-30T15:13:14+02:00" level=error msg="Failed to scrape Spotguide repositories: GET https://api.github.com/orgs/banzaicloud/repos?per_page=100: 401 Bad credentials []" func=func1
```

Attaching stack trace and additional messages to the error is also recommended:

```go
import "github.com/pkg/errors"

func doSomething() error {
    // returns whatever error, eg. awsErr
}

func doSomethingElse() error {
    err := doSomething()
    if err != nil {
        return errors.Wrap(err, "doSomething failed")
    }
}
```

For the time being this causes however existing stack trace to be overwritten when wrapping errors multiple times. To preserve the original stack trace, one can use `errors.WithMessage` when the error is known to have a stack trace in it.

Alternatively you can use the extended Wrap/Wrapf functions from `github.com/goph/emperror`.

It is also a good idea to add context to errors. There are two ways to do that.

One is to wrap the error handler itself to make sure that every error receives the same context:

```go

import "github.com/goph/emperror"

// ...

errorHandler := emperror.WithHandler(
    globalErrorHandler,
    "correlation-id", "somecid",
)
```

The other way is to attach context to errors directly. The earlier policy of handling/logging errors as high in the stack as possible still applies, so in most cases errors are returned instead of passing them to an error handler. In these cases annotating an error with the context is the only way of propagating context:

```go

import "github.com/goph/emperror"

// ...

err = emperror.With(
    err,
    "key", "value",
)
```

The idea of attaching context to an error is explained in the linked article. If you have any further questions, feel free to ask me.