### PR TITLE
Fix syntax of openapi description

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -91,6 +91,7 @@ Class | Method | HTTP request | Description
 *SecretsApi* | [**UpdateSecrets**](docs/SecretsApi.md#updatesecrets) | **Put** /api/v1/orgs/{orgId}/secrets/{secretId} | Update secrets
 *SecretsApi* | [**ValidateSecret**](docs/SecretsApi.md#validatesecret) | **Get** /api/v1/orgs/{orgId}/secrets/{secretId}/validate | Validate secret
 *SpotguidesApi* | [**GetSpotguideDetail**](docs/SpotguidesApi.md#getspotguidedetail) | **Get** /api/v1/orgs/{orgId}/spotguides/{name} | Get spotguide details
+*SpotguidesApi* | [**ListSpotguides**](docs/SpotguidesApi.md#listspotguides) | **Get** /api/v1/orgs/{orgId}/spotguides | List spotguides
 *SpotguidesApi* | [**UpdateSpotguides**](docs/SpotguidesApi.md#updatespotguides) | **Put** /api/v1/orgs/{orgId}/spotguides | Update spotguide repositories
 *StorageApi* | [**CreateObjectStoreBucket**](docs/StorageApi.md#createobjectstorebucket) | **Post** /api/v1/orgs/{orgId}/buckets | Creates a new object store bucket with the given params
 *StorageApi* | [**DeleteObjectStoreBucket**](docs/StorageApi.md#deleteobjectstorebucket) | **Delete** /api/v1/orgs/{orgId}/buckets/{name} | Deletes the object store bucket with the given name

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -39,6 +39,31 @@ tags:
   name: hpa
 paths:
   /api/v1/orgs/{orgId}/spotguides:
+    get:
+      description: List all available spotguides
+      operationId: ListSpotguides
+      parameters:
+      - description: Organization identification
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          format: int32
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSpotguidesResponse'
+          description: Spotguide list
+      security:
+      - bearerAuth: []
+      summary: List spotguides
+      tags:
+      - spotguides
     put:
       operationId: UpdateSpotguides
       parameters:

--- a/client/api_spotguides.go
+++ b/client/api_spotguides.go
@@ -126,6 +126,93 @@ func (a *SpotguidesApiService) GetSpotguideDetail(ctx context.Context, orgId int
 }
 
 /*
+SpotguidesApiService List spotguides
+List all available spotguides
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgId Organization identification
+@return ListSpotguidesResponse
+*/
+func (a *SpotguidesApiService) ListSpotguides(ctx context.Context, orgId int32) (ListSpotguidesResponse, *http.Response, error) {
+	var (
+		localVarHttpMethod   = strings.ToUpper("Get")
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  ListSpotguidesResponse
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/v1/orgs/{orgId}/spotguides"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", fmt.Sprintf("%v", orgId), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v ListSpotguidesResponse
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}
+
+/*
 SpotguidesApiService Update spotguide repositories
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orgId Organization identification

--- a/client/docs/SpotguidesApi.md
+++ b/client/docs/SpotguidesApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:9090*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**GetSpotguideDetail**](SpotguidesApi.md#GetSpotguideDetail) | **Get** /api/v1/orgs/{orgId}/spotguides/{name} | Get spotguide details
+[**ListSpotguides**](SpotguidesApi.md#ListSpotguides) | **Get** /api/v1/orgs/{orgId}/spotguides | List spotguides
 [**UpdateSpotguides**](SpotguidesApi.md#UpdateSpotguides) | **Put** /api/v1/orgs/{orgId}/spotguides | Update spotguide repositories
 
 
@@ -25,6 +26,34 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**SpotguideDetailsResponse**](SpotguideDetailsResponse.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **ListSpotguides**
+> ListSpotguidesResponse ListSpotguides(ctx, orgId)
+List spotguides
+
+List all available spotguides
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **orgId** | **int32**| Organization identification | 
+
+### Return type
+
+[**ListSpotguidesResponse**](ListSpotguidesResponse.md)
 
 ### Authorization
 

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -64,7 +64,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListSpotguidesResponse'
 
-  '/api/v1/orgs/{orgId}/spotguides':
     put:
       security:
         - bearerAuth: []


### PR DESCRIPTION
Duplicate key masked out one of the endpoints. Error message from [swagger editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/banzaicloud/pipeline/master/docs/openapi/pipeline.yaml):
Parser error duplicated mapping key / Jump to line 67

