### PR TITLE
Add location info to bucket list endpoint in case of Amazon

### DIFF
--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -193,6 +193,12 @@ func (s *objectStore) ListBuckets() ([]*objectstore.BucketInfo, error) {
 			bucketInfo.Managed = true
 		}
 
+		region, err := s.objectStore.GetRegion(bucket)
+		if err != nil {
+			return nil, err
+		}
+		bucketInfo.Location = region
+
 		bucketList = append(bucketList, bucketInfo)
 	}
 

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -13,4 +13,7 @@ type ObjectStore interface {
 
 	// DeleteBucket removes a bucket from the object store.
 	DeleteBucket(string) error
+
+	// GetRegion returns the region for a given bucket
+	GetRegion(string) (string, error)
 }

--- a/pkg/providers/amazon/objectstore/objectstore.go
+++ b/pkg/providers/amazon/objectstore/objectstore.go
@@ -79,16 +79,25 @@ func (s *objectStore) ListBuckets() ([]string, error) {
 	return bucketList, nil
 }
 
-// CheckBucket checks the status of the given bucket.
-func (s *objectStore) CheckBucket(bucketName string) error {
-	// Check if the bucket's region matches the current region
-	actualRegion, err := s3manager.GetBucketRegionWithClient(context.Background(), s.client, bucketName)
+// GetRegion gets the region of the given bucket
+func (s *objectStore) GetRegion(bucketName string) (string, error) {
+	region, err := s3manager.GetBucketRegionWithClient(context.Background(), s.client, bucketName)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFound" {
 			err = errBucketNotFound{}
 		}
 
-		return errors.Wrap(err, "checking bucket region failed")
+		return "", errors.Wrap(err, "checking bucket region failed")
+	}
+	return region, nil
+}
+
+// CheckBucket checks the status of the given bucket.
+func (s *objectStore) CheckBucket(bucketName string) error {
+	// Check if the bucket's region matches the current region
+	actualRegion, err := s.GetRegion(bucketName)
+	if err != nil {
+		return err
 	}
 
 	client := s.client


### PR DESCRIPTION
Fixes #973 
It will return the list of the buckets enhanced by the location.
```
    {   "name": "your-mysql-backup",
        "managed": false,
        "location": "us-west-1"
    },
    {
        "name": "zeppelin-sample-notebooks",
        "managed": false,
        "location": "us-west-2"
    },
```