### PR TITLE
Add supported flag to deployment listings

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -7093,6 +7093,8 @@ components:
         createdAt:
           example: 2018-07-03T14:23:19+02:00
           type: string
+        supported:
+          type: boolean
       type: object
     GetDeploymentResourcesResponse_inner:
       properties:

--- a/client/docs/ListDeploymentsResponseInner.md
+++ b/client/docs/ListDeploymentsResponseInner.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **Status** | **string** |  | [optional] 
 **Namespace** | **string** |  | [optional] 
 **CreatedAt** | **string** |  | [optional] 
+**Supported** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_list_deployments_response_inner.go
+++ b/client/model_list_deployments_response_inner.go
@@ -21,4 +21,5 @@ type ListDeploymentsResponseInner struct {
 	Status       string `json:"status,omitempty"`
 	Namespace    string `json:"namespace,omitempty"`
 	CreatedAt    string `json:"createdAt,omitempty"`
+	Supported    bool   `json:"supported,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -4392,6 +4392,9 @@ components:
           createdAt:
             type: string
             example: "2018-07-03T14:23:19+02:00"
+          supported:
+            type: boolean
+            example: true
 
     CreateUpdateDeploymentRequest:
       type: object

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -123,6 +123,7 @@ type ListDeploymentResponse struct {
 	Status       string `json:"status"`
 	Namespace    string `json:"namespace"`
 	CreatedAt    string `json:"createdAt,omitempty"`
+	Supported    bool   `json:"supported"`
 }
 
 // DeploymentStatusResponse describes a deployment status response


### PR DESCRIPTION
This marks deployments with `supported: true` if they were installed from a known Helm repository.