### PR TITLE
Rename profile tables

### DIFF
--- a/model/defaults/base.go
+++ b/model/defaults/base.go
@@ -27,17 +27,17 @@ import (
 
 // cluster profile table names
 const (
-	DefaultEC2ProfileTableName         = "profiles_ec2"
-	DefaultEC2NodePoolProfileTableName = "profiles_nodepools_ec2"
+	DefaultEC2ProfileTableName         = "amazon_ec2_profiles"
+	DefaultEC2NodePoolProfileTableName = "amazon_ec2_profile_nodepools"
 
-	DefaultEKSProfileTableName         = "profiles_eks"
-	DefaultEKSNodePoolProfileTableName = "profiles_nodepools_eks"
+	DefaultEKSProfileTableName         = "amazon_eks_profiles"
+	DefaultEKSNodePoolProfileTableName = "amazon_eks_profile_nodepools"
 
-	DefaultAKSProfileTableName         = "profiles_aks"
-	DefaultAKSNodePoolProfileTableName = "profiles_nodepools_aks"
+	DefaultAKSProfileTableName         = "azure_aks_profiles"
+	DefaultAKSNodePoolProfileTableName = "azure_aks_profile_nodepools"
 
-	DefaultGKEProfileTableName         = "profiles_gke"
-	DefaultGKENodePoolProfileTableName = "profiles_nodepools_gke"
+	DefaultGKEProfileTableName         = "google_gke_profiles"
+	DefaultGKENodePoolProfileTableName = "google_gke_profile_nodepools"
 )
 
 // default node name for all provider

--- a/pkg/providers/oracle/model/profile.go
+++ b/pkg/providers/oracle/model/profile.go
@@ -24,9 +24,9 @@ import (
 
 // SQL table names
 const (
-	ProfileTableName              = "profiles_oke"
-	ProfileNodePoolTableName      = "profiles_nodepools_oke"
-	ProfileNodePoolLabelTableName = "profiles_nodepools_oke_labels"
+	ProfileTableName              = "oracle_oke_profiles"
+	ProfileNodePoolTableName      = "oracle_oke_profile_nodepools"
+	ProfileNodePoolLabelTableName = "oracle_oke_profile_nodepool_labels"
 )
 
 // Profile describes the Oracle cluster profile model


### PR DESCRIPTION
Currently table names are quite inconsistent. Some are grouped by feature, some are grouped by cloud provider. Personally I find the latter better as it follows the group by provider logic that we apply in the code as well.