### PR TITLE
Rename route53 domain table

### DIFF
--- a/dns/route53/model/route53domain.go
+++ b/dns/route53/model/route53domain.go
@@ -20,6 +20,11 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 )
 
+// TableName constants
+const (
+	domainsTableName = "amazon_route53_domains"
+)
+
 // Route53Domain describes the database model
 // for storing the state of domains registered with with Amazon Route53 DNS service
 type Route53Domain struct {
@@ -37,4 +42,9 @@ type Route53Domain struct {
 	AwsAccessKeyId string
 	Status         string `gorm:"not null"`
 	ErrorMessage   string `sql:"type:text;"`
+}
+
+// TableName changes the default table name.
+func (Route53Domain) TableName() string {
+	return domainsTableName
 }


### PR DESCRIPTION
Merge directly before release and rename the table manually so no records get lost on beta.