### PR TITLE
Handle panics in long running processes

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -35,6 +35,7 @@ import (
 	pkgProviders "github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/googleapi"
@@ -183,6 +184,8 @@ func CreateBucket(c *gin.Context) {
 	})
 
 	go func() {
+		defer emperror.HandleRecover(errorHandler)
+
 		err := objectStore.CreateBucket(createBucketRequest.Name)
 		if err != nil {
 			logger.Error(err.Error())

--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -20,6 +20,7 @@ import (
 
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/secret"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -87,6 +88,8 @@ func (m *Manager) CreateCluster(ctx context.Context, creationCtx CreationContext
 	logger.Info("creating cluster")
 
 	go func() {
+		defer emperror.HandleRecover(m.errorHandler)
+
 		err := m.createCluster(ctx, cluster, creator, creationCtx.PostHooks, logger)
 		if err != nil {
 			logger.Errorf("failed to create cluster: %s", err.Error())

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -40,6 +40,8 @@ func (m *Manager) DeleteCluster(ctx context.Context, cluster CommonCluster, forc
 	)
 
 	go func() {
+		defer emperror.HandleRecover(m.errorHandler)
+
 		err := m.deleteCluster(ctx, cluster, force, kubeProxyCache)
 		if err != nil {
 			errorHandler.Handle(err)

--- a/cluster/manager_update.go
+++ b/cluster/manager_update.go
@@ -79,6 +79,8 @@ func (m *Manager) UpdateCluster(ctx context.Context, updateCtx UpdateContext, up
 	logger.Info("updating cluster")
 
 	go func() {
+		defer emperror.HandleRecover(m.errorHandler)
+
 		err := m.updateCluster(ctx, updateCtx, cluster, updater)
 		if err != nil {
 			errorHandler.Handle(err)


### PR DESCRIPTION
Since we don't want panics in long running processes to stop
Pipeline, these panics must be handled locally.