### PR TITLE
Add drain mode middleware

### DIFF
--- a/internal/platform/gin/drain.go
+++ b/internal/platform/gin/drain.go
@@ -16,6 +16,7 @@ package gin
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -73,7 +74,7 @@ func (m *DrainModeMiddleware) Middleware(c *gin.Context) {
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if m.enabled && isWriteOperation(c) {
+	if m.enabled && isWriteOperation(c) && !isException(c) {
 		c.AbortWithStatusJSON(
 			http.StatusServiceUnavailable,
 			map[string]string{
@@ -93,4 +94,16 @@ func isWriteOperation(c *gin.Context) bool {
 		c.Request.Method == http.MethodPut ||
 		c.Request.Method == http.MethodPatch ||
 		c.Request.Method == http.MethodDelete
+}
+
+func isException(c *gin.Context) bool {
+	if c.Request.URL.Path == "/api/v1/tokens" {
+		return true
+	}
+
+	if strings.HasPrefix(c.Request.URL.Path, "/auth") {
+		return true
+	}
+
+	return false
 }

--- a/internal/platform/gin/drain.go
+++ b/internal/platform/gin/drain.go
@@ -1,0 +1,96 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gin
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/goph/emperror"
+	"github.com/pkg/errors"
+)
+
+// DrainModeMiddleware prevents write operations from succeeding.
+type DrainModeMiddleware struct {
+	enabled bool
+	mu      sync.RWMutex
+
+	errorHandler emperror.Handler
+}
+
+// NewDrainModeMiddleware returns a new DrainModeMiddleware instance.
+func NewDrainModeMiddleware(errorHandler emperror.Handler) *DrainModeMiddleware {
+	return &DrainModeMiddleware{
+		errorHandler: errorHandler,
+	}
+}
+
+// Middleware implements the gin handler for this middleware.
+func (m *DrainModeMiddleware) Middleware(c *gin.Context) {
+	if c.Request.URL.Path == "/-/drain" {
+		clientIP := c.ClientIP()
+
+		if clientIP != "127.0.0.1" && clientIP != "::1" {
+			m.errorHandler.Handle(emperror.With(
+				errors.New("Client cannot set drain mode"),
+				"client_ip", clientIP,
+			))
+
+			c.Next()
+
+			return
+		}
+
+		m.mu.Lock()
+
+		switch c.Request.Method {
+		case http.MethodPost:
+			m.enabled = true
+
+		case http.MethodDelete:
+			m.enabled = false
+		}
+
+		m.mu.Unlock()
+
+		c.AbortWithStatus(http.StatusOK)
+
+		return
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.enabled && isWriteOperation(c) {
+		c.AbortWithStatusJSON(
+			http.StatusServiceUnavailable,
+			map[string]string{
+				"code":    "503",
+				"message": "service is in maintenance mode",
+			},
+		)
+
+		return
+	}
+
+	c.Next()
+}
+
+func isWriteOperation(c *gin.Context) bool {
+	return c.Request.Method == http.MethodPost ||
+		c.Request.Method == http.MethodPut ||
+		c.Request.Method == http.MethodPatch ||
+		c.Request.Method == http.MethodDelete
+}

--- a/internal/platform/gin/drain.go
+++ b/internal/platform/gin/drain.go
@@ -22,7 +22,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
+
+var basePath = viper.GetString("pipeline.basepath")
 
 // DrainModeMiddleware prevents write operations from succeeding.
 type DrainModeMiddleware struct {
@@ -97,7 +100,7 @@ func isWriteOperation(c *gin.Context) bool {
 }
 
 func isException(c *gin.Context) bool {
-	if c.Request.URL.Path == "/api/v1/tokens" {
+	if c.Request.URL.Path == basePath+"/api/v1/tokens" {
 		return true
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/banzaicloud/pipeline/dns/route53/model"
 	"github.com/banzaicloud/pipeline/internal/audit"
 	"github.com/banzaicloud/pipeline/internal/dashboard"
+	ginternal "github.com/banzaicloud/pipeline/internal/platform/gin"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginlog "github.com/banzaicloud/pipeline/internal/platform/gin/log"
 	"github.com/banzaicloud/pipeline/model"
@@ -165,6 +166,7 @@ func main() {
 	router.Use(correlationid.Middleware())
 	router.Use(ginlog.Middleware(log, skipPaths...))
 	router.Use(gin.Recovery())
+	router.Use(ginternal.NewDrainModeMiddleware(errorHandler).Middleware)
 	router.Use(cors.New(config.GetCORS()))
 	if viper.GetBool("audit.enabled") {
 		log.Infoln("Audit enabled, installing Gin audit middleware")


### PR DESCRIPTION
This is a temporary solution for pipeline deployments maintenance mode. It will probably become obsolete when cluster management workflows become durable.

Usage:

Enable drain mode: `curl -X POST http://localhost:9090/-/drain`

Disable drain mode: `curl -X DELETE http://localhost:9090/-/drain`

Note: The middleware disables operations that might change state (POST, PUT, PATCH, DELETE), but it might also break features which use these HTTP methods, but don't change state (eg. authentication).