### PR TITLE
secretName support

### DIFF
--- a/api/bucket_messages.go
+++ b/api/bucket_messages.go
@@ -17,6 +17,7 @@ package api
 // CreateBucketRequest to create bucket
 type CreateBucketRequest struct {
 	SecretId   string `json:"secretId" binding:"required"`
+	SecretName string `json:"secretName"`
 	Name       string `json:"name" binding:"required"`
 	Properties struct {
 		Alibaba *CreateAlibabaObjectStoreBucketProperties `json:"alibaba,omitempty"`

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -52,6 +52,18 @@ func CreateClusterRequest(c *gin.Context) {
 		return
 	}
 
+	if createClusterRequest.SecretId == "" {
+		if createClusterRequest.SecretName == "" {
+			c.JSON(http.StatusBadRequest, pkgCommon.ErrorResponse{
+				Code:    http.StatusBadRequest,
+				Message: "either secretId or secretName has to be set",
+			})
+			return
+		}
+
+		createClusterRequest.SecretId = secret.GenerateSecretIDFromName(createClusterRequest.SecretName)
+	}
+
 	orgID := auth.GetCurrentOrganization(c.Request).ID
 	userID := auth.GetCurrentUser(c.Request).ID
 

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -4137,6 +4137,7 @@ components:
         cluster:
           cloud: google
           profileName: profileName
+          secretName: my-aws-secret
           name: gkecluster-pipelineuser-123
           secretId: 62bc3c75-91fb-4670-bad4-24b401a9deac
           location: us-central1-a
@@ -4412,6 +4413,7 @@ components:
       example:
         cloud: google
         profileName: profileName
+        secretName: my-aws-secret
         name: gkecluster-pipelineuser-123
         secretId: 62bc3c75-91fb-4670-bad4-24b401a9deac
         location: us-central1-a
@@ -4441,6 +4443,9 @@ components:
           type: string
         secretId:
           example: 62bc3c75-91fb-4670-bad4-24b401a9deac
+          type: string
+        secretName:
+          example: my-aws-secret
           type: string
         postHooks:
           example:
@@ -4476,7 +4481,6 @@ components:
       - location
       - name
       - properties
-      - secretId
       type: object
     CreateEC2Properties:
       properties:
@@ -6546,11 +6550,15 @@ components:
       type: object
     CreateObjectStoreBucketRequest:
       example:
+        secretName: my-aws-secret
         name: mybucket
         secretId: secretId
         properties: ""
       properties:
         secretId:
+          type: string
+        secretName:
+          example: my-aws-secret
           type: string
         name:
           example: mybucket
@@ -6564,7 +6572,6 @@ components:
       required:
       - name
       - properties
-      - secretId
       type: object
     CreateAmazonObjectStoreBucketProperties:
       properties:
@@ -8877,6 +8884,9 @@ components:
           type: string
         secretId:
           example: 62bc3c75-91fb-4670-bad4-24b401a9deac
+          type: string
+        secretName:
+          example: my-aws-secret
           type: string
         tls:
           $ref: '#/components/schemas/GenTLSForLogging'

--- a/client/docs/CreateClusterRequest.md
+++ b/client/docs/CreateClusterRequest.md
@@ -6,7 +6,8 @@ Name | Type | Description | Notes
 **Name** | **string** |  | 
 **Location** | **string** |  | 
 **Cloud** | **string** |  | 
-**SecretId** | **string** |  | 
+**SecretId** | **string** |  | [optional] 
+**SecretName** | **string** |  | [optional] 
 **PostHooks** | [**map[string]interface{}**](map[string]interface{}.md) |  | [optional] 
 **ProfileName** | **string** |  | [optional] 
 **Properties** | [**map[string]interface{}**](map[string]interface{}.md) |  | 

--- a/client/docs/CreateObjectStoreBucketRequest.md
+++ b/client/docs/CreateObjectStoreBucketRequest.md
@@ -3,7 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SecretId** | **string** |  | 
+**SecretId** | **string** |  | [optional] 
+**SecretName** | **string** |  | [optional] 
 **Name** | **string** |  | 
 **Properties** | [**map[string]interface{}**](map[string]interface{}.md) |  | 
 

--- a/client/docs/LoggingPostHookInstallLogging.md
+++ b/client/docs/LoggingPostHookInstallLogging.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **ResourceGroup** | **string** |  | [optional] 
 **StorageAccount** | **string** |  | [optional] 
 **SecretId** | **string** |  | [optional] 
+**SecretName** | **string** |  | [optional] 
 **Tls** | [**GenTlsForLogging**](GenTLSForLogging.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/model_create_cluster_request.go
+++ b/client/model_create_cluster_request.go
@@ -15,7 +15,8 @@ type CreateClusterRequest struct {
 	Name        string                 `json:"name"`
 	Location    string                 `json:"location"`
 	Cloud       string                 `json:"cloud"`
-	SecretId    string                 `json:"secretId"`
+	SecretId    string                 `json:"secretId,omitempty"`
+	SecretName  string                 `json:"secretName,omitempty"`
 	PostHooks   map[string]interface{} `json:"postHooks,omitempty"`
 	ProfileName string                 `json:"profileName,omitempty"`
 	Properties  map[string]interface{} `json:"properties"`

--- a/client/model_create_object_store_bucket_request.go
+++ b/client/model_create_object_store_bucket_request.go
@@ -12,7 +12,8 @@
 package client
 
 type CreateObjectStoreBucketRequest struct {
-	SecretId   string                 `json:"secretId"`
+	SecretId   string                 `json:"secretId,omitempty"`
+	SecretName string                 `json:"secretName,omitempty"`
 	Name       string                 `json:"name"`
 	Properties map[string]interface{} `json:"properties"`
 }

--- a/client/model_logging_post_hook_install_logging.go
+++ b/client/model_logging_post_hook_install_logging.go
@@ -17,5 +17,6 @@ type LoggingPostHookInstallLogging struct {
 	ResourceGroup  string           `json:"resourceGroup,omitempty"`
 	StorageAccount string           `json:"storageAccount,omitempty"`
 	SecretId       string           `json:"secretId,omitempty"`
+	SecretName     string           `json:"secretName,omitempty"`
 	Tls            GenTlsForLogging `json:"tls,omitempty"`
 }

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -206,6 +206,12 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 	namespace := viper.GetString(pipConfig.PipelineSystemNamespace)
 	loggingParam.GenTLSForLogging.TLSEnabled = true
 	// Set TLS default values (default True)
+	if loggingParam.SecretId == "" {
+		if loggingParam.SecretName == "" {
+			return fmt.Errorf("either secretId or secretName has to be set")
+		}
+		loggingParam.SecretId = secret.GenerateSecretIDFromName(loggingParam.SecretName)
+	}
 	if loggingParam.GenTLSForLogging.Namespace == "" {
 		loggingParam.GenTLSForLogging.Namespace = namespace
 	}

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -3921,7 +3921,6 @@ components:
         - name
         - location
         - cloud
-        - secretId
         - properties
       properties:
         name:
@@ -3936,6 +3935,9 @@ components:
         secretId:
           type: string
           example: "62bc3c75-91fb-4670-bad4-24b401a9deac"
+        secretName:
+          type: string
+          example: "my-aws-secret"
         postHooks:
           type: object
           oneOf:
@@ -6203,12 +6205,14 @@ components:
     CreateObjectStoreBucketRequest:
       type: object
       required:
-        - secretId
         - name
         - properties
       properties:
         secretId:
           type: string
+        secretName:
+          type: string
+          example: "my-aws-secret"
         name:
           type: string
           example: "mybucket"
@@ -6514,6 +6518,9 @@ components:
             secretId:
               type: string
               example: "62bc3c75-91fb-4670-bad4-24b401a9deac"
+            secretName:
+              type: string
+              example: "my-aws-secret"
             tls:
               $ref: '#/components/schemas/GenTLSForLogging'
 

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -105,7 +105,8 @@ type CreateClusterRequest struct {
 	Name        string                   `json:"name" binding:"required"`
 	Location    string                   `json:"location"`
 	Cloud       string                   `json:"cloud" binding:"required"`
-	SecretId    string                   `json:"secretId" binding:"required"`
+	SecretId    string                   `json:"secretId"`
+	SecretName  string                   `json:"secretName"`
 	ProfileName string                   `json:"profileName"`
 	PostHooks   PostHooks                `json:"postHooks"`
 	Properties  *CreateClusterProperties `json:"properties" binding:"required"`
@@ -140,7 +141,8 @@ type LoggingParam struct {
 	Region           string           `json:"region"`
 	ResourceGroup    string           `json:"resourceGroup"`
 	StorageAccount   string           `json:"storageAccount"`
-	SecretId         string           `json:"secretId" binding:"required"`
+	SecretId         string           `json:"secretId"`
+	SecretName       string           `json:"secretName"`
 	GenTLSForLogging GenTLSForLogging `json:"tls" binding:"required"`
 }
 


### PR DESCRIPTION
This PR makes it possible to pass in secretId or secretName (only one is required) in requests where a secret reference is required. This makes the API a bit more user-friendly and simpler.

Fixes: https://github.com/banzaicloud/pipeline/issues/1091