### PR TITLE
Support for listing managed buckets only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ bin/dep-${DEP_VERSION}:
 
 .PHONY: vendor
 vendor: bin/dep ## Install dependencies
-	bin/dep ensure -vendor-only
+	bin/dep ensure -vendor-only -v
 
 .PHONY: build
 build: ## Builds binary package

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -127,11 +127,12 @@ func ListManagedBuckets(c *gin.Context) {
 	organization := auth.GetCurrentOrganization(c.Request)
 
 	allProviders := []string{
-		pkgProviders.Alibaba,
+		//pkgProviders.Alibaba,
 		pkgProviders.Amazon,
-		pkgProviders.Azure,
+		//pkgProviders.Azure,
 		pkgProviders.Google,
-		pkgProviders.Oracle}
+		//pkgProviders.Oracle
+	}
 
 	allBuckets := make([]*objectstore.BucketInfo, 0)
 	for _, cloudType := range allProviders {

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -41,6 +41,30 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+const (
+	// header key constants
+	secretNameHeader = "secretName"
+	secretIdHeader   = "secretId"
+)
+
+// ListAllBuckets handles bucket list requests. The handler method directs the flow to the appropriate retrieval
+// strategy based on the request header details
+func ListAllBuckets(c *gin.Context) {
+	logger := correlationid.Logger(log, c)
+
+	if hasSecret(c) {
+		// fallback to the initial implementation
+		logger.Debug("proceeding to listing buckets based on the provided secret")
+		ListBuckets(c)
+		return
+	}
+
+	logger.Debug("proceeding to listing managed buckets")
+	ListManagedBuckets(c)
+	return
+
+}
+
 // ListBuckets returns the list of object storage buckets (object storage container in case of Azure)
 // that can be accessed with the credentials from the given secret.
 func ListBuckets(c *gin.Context) {
@@ -95,6 +119,41 @@ func ListBuckets(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, bucketList)
+}
+
+// ListManagedBuckets lists managed buckets for the user when no secret is provided
+func ListManagedBuckets(c *gin.Context) {
+	logger := correlationid.Logger(log, c)
+	organization := auth.GetCurrentOrganization(c.Request)
+
+	allBuckets := make(map[string][]*objectstore.BucketInfo)
+
+	for _, cloudType := range []string{pkgProviders.Alibaba, pkgProviders.Amazon} {
+		logger.Debugf("retrieving buckets for provider: %s", cloudType)
+
+		objectStoreCtx := &providers.ObjectStoreContext{
+			Provider:     cloudType,
+			Organization: organization,
+		}
+
+		objectStore, err := providers.NewObjectStore(objectStoreCtx, logger)
+		if err != nil {
+			errorHandler.Handle(err)
+			continue
+		}
+
+		bucketList, err := objectStore.ListManagedBuckets()
+		if err != nil {
+			logger.Errorf("retrieving object store buckets failed: %s", err.Error())
+			return
+		}
+
+		allBuckets[cloudType] = bucketList
+
+	}
+
+	c.JSON(http.StatusOK, allBuckets)
+
 }
 
 // CreateBucket creates an objectstore bucket (blob container in case of Azure)
@@ -357,17 +416,24 @@ func DeleteBucket(c *gin.Context) {
 	logger.Infof("object store bucket deleted")
 }
 
+// hasSecret checks the header for secret references, returns true in case one of the following headers are found:
+// - secretName
+// - secretId
+// otherwise returns false
+func hasSecret(c *gin.Context) bool {
+	return c.GetHeader(secretNameHeader) != "" || c.GetHeader(secretIdHeader) == ""
+}
 func getBucketContext(c *gin.Context, logger logrus.FieldLogger) (*auth.Organization, *secret.SecretItemResponse, string, bool) {
 	organization := auth.GetCurrentOrganization(c.Request)
 
 	var secretID string
 	var ok bool
 
-	secretName := c.GetHeader("secretName")
+	secretName := c.GetHeader(secretNameHeader)
 	if secretName != "" {
 		secretID = secret.GenerateSecretIDFromName(secretName)
 	} else {
-		secretID, ok = ginutils.GetRequiredHeader(c, "secretId")
+		secretID, ok = ginutils.GetRequiredHeader(c, secretIdHeader)
 		if !ok {
 			return nil, nil, "", false
 		}

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -127,9 +127,9 @@ func ListManagedBuckets(c *gin.Context) {
 	organization := auth.GetCurrentOrganization(c.Request)
 
 	allProviders := []string{
-		//pkgProviders.Alibaba,
+		pkgProviders.Alibaba,
 		pkgProviders.Amazon,
-		//pkgProviders.Azure,
+		pkgProviders.Azure,
 		pkgProviders.Google,
 		//pkgProviders.Oracle
 	}

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -131,7 +131,7 @@ func ListManagedBuckets(c *gin.Context) {
 		pkgProviders.Amazon,
 		pkgProviders.Azure,
 		pkgProviders.Google,
-		//pkgProviders.Oracle
+		pkgProviders.Oracle,
 	}
 
 	allBuckets := make([]*objectstore.BucketInfo, 0)

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -3916,7 +3916,7 @@ paths:
       - info
   /api/v1/orgs/{orgId}/buckets:
     get:
-      description: List object store buckets accessible by the credentials referenced by the given secret.
+      description: List object store buckets accessible by the credentials referenced by the given secret. If no credentials provided all managed buckets are returned for all cloud types.
       operationId: ListObjectStoreBuckets
       parameters:
       - description: Organization identification
@@ -3928,19 +3928,19 @@ paths:
           format: int32
           type: integer
         style: simple
-      - description: Secret identification
+      - description: Secret identification. If not provided only the managed buckets (those created via pipeline) are listed
         explode: false
         in: header
         name: secretId
-        required: true
+        required: false
         schema:
           type: string
         style: simple
-      - description: Identifies the cloud provider
+      - description: Identifies the cloud provider - mandatory if secretId header is provided
         explode: true
         in: query
         name: cloudType
-        required: true
+        required: false
         schema:
           enum:
           - amazon
@@ -7129,8 +7129,10 @@ components:
         azure:
           $ref: '#/components/schemas/AzureBlobStorageProps'
       required:
+      - cloud
       - managed
       - name
+      - secretId
       type: object
     ListStorageBucketsResponse:
       items:

--- a/client/api_storage.go
+++ b/client/api_storage.go
@@ -369,21 +369,23 @@ func (a *StorageApiService) GetObjectStoreBucketStatus(ctx context.Context, orgI
 
 /*
 StorageApiService List object storage buckets
-List object store buckets accessible by the credentials referenced by the given secret.
+List object store buckets accessible by the credentials referenced by the given secret. If no credentials provided all managed buckets are returned for all cloud types.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orgId Organization identification
- * @param secretId Secret identification
- * @param cloudType Identifies the cloud provider
  * @param optional nil or *ListObjectStoreBucketsOpts - Optional Parameters:
+ * @param "SecretId" (optional.String) -  Secret identification. If not provided only the managed buckets (those created via pipeline) are listed
+ * @param "CloudType" (optional.String) -  Identifies the cloud provider - mandatory if secretId header is provided
  * @param "Location" (optional.String) -  Identifies the cloud region. Required by Amazon only.
 @return ListStorageBucketsResponse
 */
 
 type ListObjectStoreBucketsOpts struct {
-	Location optional.String
+	SecretId  optional.String
+	CloudType optional.String
+	Location  optional.String
 }
 
-func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId int32, secretId string, cloudType string, localVarOptionals *ListObjectStoreBucketsOpts) (ListStorageBucketsResponse, *http.Response, error) {
+func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId int32, localVarOptionals *ListObjectStoreBucketsOpts) (ListStorageBucketsResponse, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
@@ -401,7 +403,9 @@ func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId in
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("cloudType", parameterToString(cloudType, ""))
+	if localVarOptionals != nil && localVarOptionals.CloudType.IsSet() {
+		localVarQueryParams.Add("cloudType", parameterToString(localVarOptionals.CloudType.Value(), ""))
+	}
 	if localVarOptionals != nil && localVarOptionals.Location.IsSet() {
 		localVarQueryParams.Add("location", parameterToString(localVarOptionals.Location.Value(), ""))
 	}
@@ -422,7 +426,9 @@ func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId in
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	localVarHeaderParams["secretId"] = parameterToString(secretId, "")
+	if localVarOptionals != nil && localVarOptionals.SecretId.IsSet() {
+		localVarHeaderParams["secretId"] = parameterToString(localVarOptionals.SecretId.Value(), "")
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/client/docs/StorageApi.md
+++ b/client/docs/StorageApi.md
@@ -129,10 +129,10 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListObjectStoreBuckets**
-> ListStorageBucketsResponse ListObjectStoreBuckets(ctx, orgId, secretId, cloudType, optional)
+> ListStorageBucketsResponse ListObjectStoreBuckets(ctx, orgId, optional)
 List object storage buckets
 
-List object store buckets accessible by the credentials referenced by the given secret.
+List object store buckets accessible by the credentials referenced by the given secret. If no credentials provided all managed buckets are returned for all cloud types.
 
 ### Required Parameters
 
@@ -140,8 +140,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **orgId** | **int32**| Organization identification | 
-  **secretId** | **string**| Secret identification | 
-  **cloudType** | **string**| Identifies the cloud provider | 
  **optional** | ***ListObjectStoreBucketsOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -150,8 +148,8 @@ Optional parameters are passed through a pointer to a ListObjectStoreBucketsOpts
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
-
+ **secretId** | **optional.String**| Secret identification. If not provided only the managed buckets (those created via pipeline) are listed | 
+ **cloudType** | **optional.String**| Identifies the cloud provider - mandatory if secretId header is provided | 
  **location** | **optional.String**| Identifies the cloud region. Required by Amazon only. | 
 
 ### Return type

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -3549,7 +3549,7 @@ paths:
                 - storage
             summary: List object storage buckets
             operationId: ListObjectStoreBuckets
-            description: List object store buckets accessible by the credentials referenced by the given secret.
+            description: List object store buckets accessible by the credentials referenced by the given secret. If no credentials provided all managed buckets are returned for all cloud types.
             parameters:
                 - name: orgId
                   in: path
@@ -3559,8 +3559,8 @@ paths:
                       type: integer
                 - name: secretId
                   in: header
-                  required: true
-                  description: Secret identification
+                  required: false
+                  description: Secret identification. If not provided only the managed buckets (those created via pipeline) are listed
                   schema:
                       type: string
                 - name: cloudType
@@ -3568,8 +3568,8 @@ paths:
                   schema:
                       type: string
                       enum: [amazon, google, azure]
-                  required: true
-                  description: Identifies the cloud provider
+                  required: false
+                  description: Identifies the cloud provider - mandatory if secretId header is provided
                 - name: location
                   in: query
                   schema:
@@ -6596,6 +6596,8 @@ components:
             required:
                 - name
                 - managed
+                - cloud
+                - secretId
             properties:
                 name:
                     type: string

--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -19,6 +19,7 @@ package objectstore
 type ObjectStoreService interface {
 	CreateBucket(string) error
 	ListBuckets() ([]*BucketInfo, error)
+	ListManagedBuckets() ([]*BucketInfo, error)
 	DeleteBucket(string) error
 	CheckBucket(string) error
 }

--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -26,10 +26,12 @@ type ObjectStoreService interface {
 
 // BucketInfo desribes a storage bucket
 type BucketInfo struct {
-	Name     string                    `json:"name"  binding:"required"`
-	Managed  bool                      `json:"managed" binding:"required"`
-	Location string                    `json:"location,omitempty"`
-	Azure    *BlobStoragePropsForAzure `json:"aks,omitempty"`
+	Name      string                    `json:"name"  binding:"required"`
+	Managed   bool                      `json:"managed" binding:"required"`
+	Location  string                    `json:"location,omitempty"`
+	SecretRef string                    `json:"secretId,omitempty"`
+	Cloud     string                    `json:"cloud,omitempty"`
+	Azure     *BlobStoragePropsForAzure `json:"aks,omitempty"`
 }
 
 // BlobStoragePropsForAzure describes the Azure specific properties

--- a/internal/providers/alibaba/objectstore.go
+++ b/internal/providers/alibaba/objectstore.go
@@ -124,6 +124,27 @@ func (b *AlibabaObjectStore) ListBuckets() ([]*objectstore.BucketInfo, error) {
 	return bucketList, nil
 }
 
+func (b *AlibabaObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
+
+	var managedAlibabaBuckets []ManagedAlibabaBucket
+
+	if err := queryWithOrderByDb(&ManagedAlibabaBucket{OrgID: b.org.ID}, "name asc", &managedAlibabaBuckets); err != nil {
+		log.Errorf("Retrieving managed buckets in organisation id=%s failed: %s", err.Error())
+		return nil, err
+	}
+
+	bucketInfos := make([]*objectstore.BucketInfo, 0)
+	for _, mb := range managedAlibabaBuckets {
+		bucketInfos = append(bucketInfos, &objectstore.BucketInfo{
+			Managed:  true,
+			Name:     mb.Name,
+			Location: mb.Region,
+		})
+	}
+
+	return bucketInfos, nil
+}
+
 func (b *AlibabaObjectStore) DeleteBucket(bucketName string) error {
 	managedBucket := &ManagedAlibabaBucket{}
 	searchCriteria := b.newManagedBucketSearchCriteria(bucketName)

--- a/internal/providers/alibaba/objectstore.go
+++ b/internal/providers/alibaba/objectstore.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/internal/objectstore"
+	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/jinzhu/gorm"
@@ -65,6 +66,7 @@ func (b *AlibabaObjectStore) CreateBucket(bucketName string) error {
 	managedBucket.Name = bucketName
 	managedBucket.Organization = *b.org
 	managedBucket.Region = b.region
+	managedBucket.SecretRef = b.secret.ID
 
 	if err = persistToDb(managedBucket); err != nil {
 		return errors.Wrap(err, "Error happened during persisting bucket description to DB")
@@ -136,9 +138,11 @@ func (b *AlibabaObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, er
 	bucketInfos := make([]*objectstore.BucketInfo, 0)
 	for _, mb := range managedAlibabaBuckets {
 		bucketInfos = append(bucketInfos, &objectstore.BucketInfo{
-			Managed:  true,
-			Name:     mb.Name,
-			Location: mb.Region,
+			Cloud:     providers.Alibaba,
+			Managed:   true,
+			Name:      mb.Name,
+			Location:  mb.Region,
+			SecretRef: mb.SecretRef,
 		})
 	}
 

--- a/internal/providers/alibaba/objectstore_model.go
+++ b/internal/providers/alibaba/objectstore_model.go
@@ -28,6 +28,7 @@ type ManagedAlibabaBucket struct {
 	OrgID        uint              `gorm:"index;not null"`
 	Name         string            `gorm:"unique_index:idx_bucket_name"`
 	Region       string
+	SecretRef    string
 }
 
 // TableName changes the default table name.

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -62,13 +62,13 @@ func NewObjectStore(
 	db *gorm.DB,
 	logger logrus.FieldLogger,
 ) (*objectStore, error) {
-	ostore, err := getProviderObjectStore(secret, region)
-	if err != nil {
-		errors.Wrap(err, "could not create AWS object storage client")
-	}
+	//ostore, err := getProviderObjectStore(secret, region)
+	//if err != nil {
+	//	errors.Wrap(err, "could not create AWS object storage client")
+	//}
 
 	return &objectStore{
-		objectStore: ostore,
+		//objectStore: ostore,
 		region:      region,
 		secret:      secret,
 		org:         org,
@@ -102,7 +102,7 @@ func getProviderObjectStore(secret *secret.SecretItemResponse, region string) (a
 func (s *objectStore) getLogger() logrus.FieldLogger {
 	return s.logger.WithFields(logrus.Fields{
 		"organization": s.org.ID,
-		"secret":       s.secret.ID,
+		//"secret":       s.secret.ID,
 		"region":       s.region,
 	})
 }

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -124,6 +124,8 @@ func (s *objectStore) CreateBucket(bucketName string) error {
 	bucket.Organization = *s.org
 	bucket.Region = s.region
 
+	bucket.SecretRef = s.secret.ID
+
 	if err := s.db.Save(bucket).Error; err != nil {
 		return errors.Wrap(err, "error happened during saving bucket in DB")
 	}

--- a/internal/providers/amazon/objectstore_model.go
+++ b/internal/providers/amazon/objectstore_model.go
@@ -30,6 +30,8 @@ type ObjectStoreBucketModel struct {
 
 	Name   string `gorm:"unique_index:idx_bucket_name"`
 	Region string
+
+	SecretRef string
 }
 
 // TableName changes the default table name.

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -137,6 +137,7 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 	// TODO: create the bucket in the database later so that we don't have to roll back
 	bucket.ResourceGroup = resourceGroup
 	bucket.Organization = *s.org
+	bucket.SecretRef = s.secret.ID
 
 	logger.Info("saving bucket in DB")
 

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	pipelineAuth "github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/objectstore"
+	"github.com/banzaicloud/pipeline/pkg/providers"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/jinzhu/gorm"
@@ -532,6 +533,8 @@ func (s *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 	for _, bucket := range objectStores {
 		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
 		bucketInfo.Location = bucket.Location
+		bucketInfo.SecretRef = bucket.SecretRef
+		bucketInfo.Cloud = providers.Azure
 		bucketList = append(bucketList, bucketInfo)
 	}
 

--- a/internal/providers/azure/objectstore_model.go
+++ b/internal/providers/azure/objectstore_model.go
@@ -32,6 +32,8 @@ type ObjectStoreBucketModel struct {
 	ResourceGroup  string `gorm:"unique_index:idx_bucket_name"`
 	StorageAccount string `gorm:"unique_index:idx_bucket_name"`
 	Location       string
+
+	SecretRef string
 }
 
 // TableName changes the default table name.

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -299,6 +299,24 @@ func (s *ObjectStore) ListBuckets() ([]*objectstore.BucketInfo, error) {
 	return bucketList, nil
 }
 
+func (s *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
+
+	var objectStores []ObjectStoreBucketModel
+	err := s.db.Where(&ObjectStoreBucketModel{OrganizationID: s.org.ID}).Order("name asc").Find(&objectStores).Error
+	if err != nil {
+		return nil, fmt.Errorf("retrieving managed buckets failed: %s", err.Error())
+	}
+
+	bucketList := make([]*objectstore.BucketInfo, 0)
+	for _, bucket := range objectStores {
+		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
+		bucketInfo.Location = bucket.Location
+		bucketList = append(bucketList, bucketInfo)
+	}
+
+	return bucketList, nil
+}
+
 func (s *ObjectStore) newGoogleCredentials() (*google.Credentials, error) {
 	credentialsJson, err := json.Marshal(s.serviceAccount)
 	if err != nil {

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -23,6 +23,8 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/objectstore"
+	"github.com/banzaicloud/pipeline/pkg/providers"
+	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/gin-gonic/gin/json"
 	"github.com/jinzhu/gorm"
@@ -46,6 +48,7 @@ type ObjectStore struct {
 
 	org            *auth.Organization
 	serviceAccount *verify.ServiceAccount
+	secret         *secret.SecretItemResponse
 
 	location string
 }
@@ -53,15 +56,21 @@ type ObjectStore struct {
 // NewObjectStore returns a new object store instance.
 func NewObjectStore(
 	org *auth.Organization,
-	serviceAccount *verify.ServiceAccount,
+	secret *secret.SecretItemResponse,
 	location string,
 	db *gorm.DB,
 	logger logrus.FieldLogger,
 ) *ObjectStore {
+	var serviceAccount *verify.ServiceAccount
+	if secret != nil {
+		serviceAccount = verify.CreateServiceAccount(secret.Values)
+	}
+
 	return &ObjectStore{
 		db:             db,
 		logger:         logger,
 		org:            org,
+		secret:         secret,
 		serviceAccount: serviceAccount,
 		location:       location,
 	}
@@ -110,6 +119,7 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 	bucket.Name = bucketName
 	bucket.Organization = *s.org
 	bucket.Location = s.location
+	bucket.SecretRef = s.secret.ID
 
 	logger.Info("saving bucket in DB")
 
@@ -311,6 +321,8 @@ func (s *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 	for _, bucket := range objectStores {
 		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
 		bucketInfo.Location = bucket.Location
+		bucketInfo.SecretRef = bucket.SecretRef
+		bucketInfo.Cloud = providers.Google
 		bucketList = append(bucketList, bucketInfo)
 	}
 

--- a/internal/providers/google/objectstore_model.go
+++ b/internal/providers/google/objectstore_model.go
@@ -30,6 +30,8 @@ type ObjectStoreBucketModel struct {
 
 	Name     string `gorm:"unique_index:idx_bucket_name"`
 	Location string
+
+	SecretRef string
 }
 
 // TableName changes the default table name.

--- a/internal/providers/objectstore.go
+++ b/internal/providers/objectstore.go
@@ -26,7 +26,6 @@ import (
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
-	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,7 +59,7 @@ func NewObjectStore(ctx *ObjectStoreContext, logger logrus.FieldLogger) (objects
 		return azure.NewObjectStore(ctx.Location, ctx.ResourceGroup, ctx.StorageAccount, ctx.Secret, ctx.Organization, db, logger), nil
 
 	case providers.Google:
-		return google.NewObjectStore(ctx.Organization, verify.CreateServiceAccount(ctx.Secret.Values), ctx.Location, db, logger), nil
+		return google.NewObjectStore(ctx.Organization, ctx.Secret, ctx.Location, db, logger), nil
 
 	case providers.Oracle:
 		return oracle.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization, db, logger), nil

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -98,6 +98,8 @@ func (o *ObjectStore) CreateBucket(name string) error {
 	bucket.CompartmentID = oci.CompartmentOCID
 	bucket.Location = o.location
 
+	bucket.SecretRef = o.secret.ID
+
 	if err = o.persistBucketToDB(bucket); err != nil {
 		return errors.Wrap(err, "error happened during persisting bucket description to DB")
 	}

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/objectstore"
+	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/pkg/providers/oracle/oci"
 	osecret "github.com/banzaicloud/pipeline/pkg/providers/oracle/secret"
 	"github.com/banzaicloud/pipeline/secret"
@@ -97,7 +98,6 @@ func (o *ObjectStore) CreateBucket(name string) error {
 	bucket.Organization = *o.org
 	bucket.CompartmentID = oci.CompartmentOCID
 	bucket.Location = o.location
-
 	bucket.SecretRef = o.secret.ID
 
 	if err = o.persistBucketToDB(bucket); err != nil {
@@ -182,6 +182,8 @@ func (o *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 	for _, bucket := range objectStores {
 		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
 		bucketInfo.Location = bucket.Location
+		bucketInfo.Cloud = providers.Oracle
+		bucketInfo.SecretRef = bucket.SecretRef
 		bucketList = append(bucketList, bucketInfo)
 	}
 

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -170,6 +170,25 @@ func (o *ObjectStore) ListBuckets() ([]*objectstore.BucketInfo, error) {
 	return bucketList, nil
 }
 
+func (o *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
+
+	var objectStores []ObjectStoreBucketModel
+	err := o.db.Where(&ObjectStoreBucketModel{OrgID: o.org.ID}).Order("name asc").Find(&objectStores).Error
+	if err != nil {
+		return nil, fmt.Errorf("retrieving managed buckets failed: %s", err.Error())
+	}
+
+	bucketList := make([]*objectstore.BucketInfo, 0)
+	for _, bucket := range objectStores {
+		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
+		bucketInfo.Location = bucket.Location
+		bucketList = append(bucketList, bucketInfo)
+	}
+
+	return bucketList, nil
+
+}
+
 // DeleteBucket deletes the managed bucket with the given name from Oracle object store
 func (o *ObjectStore) DeleteBucket(name string) error {
 

--- a/internal/providers/oracle/objectstore_model.go
+++ b/internal/providers/oracle/objectstore_model.go
@@ -33,6 +33,8 @@ type ObjectStoreBucketModel struct {
 	CompartmentID string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 	Name          string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 	Location      string `gorm:"unique_index:idx_bucket_name_location_compartment"`
+
+	SecretRef string
 }
 
 // TableName changes the default table name.

--- a/main.go
+++ b/main.go
@@ -273,7 +273,7 @@ func main() {
 			orgs.POST("/:orgid/users/:id", api.AddUser)
 			orgs.DELETE("/:orgid/users/:id", api.RemoveUser)
 
-			orgs.GET("/:orgid/buckets", api.ListBuckets)
+			orgs.GET("/:orgid/buckets", api.ListAllBuckets)
 			orgs.POST("/:orgid/buckets", api.CreateBucket)
 			orgs.HEAD("/:orgid/buckets/:name", api.CheckBucket)
 			orgs.DELETE("/:orgid/buckets/:name", api.DeleteBucket)

--- a/pkg/providers/amazon/objectstore/objectstore.go
+++ b/pkg/providers/amazon/objectstore/objectstore.go
@@ -54,6 +54,12 @@ type Credentials struct {
 	SecretAccessKey string
 }
 
+// NewPlainObjectStore creates an objectstore with no configuration.
+// Instances created with this function may be used to access methods that don't explicitly access external (cloud) resources
+func NewPlainObjectStore() (*objectStore, error) {
+	return &objectStore{}, nil
+}
+
 // New returns an Object Store instance that manages Amazon S3 buckets.
 func New(config Config, credentials Credentials) (*objectStore, error) {
 


### PR DESCRIPTION
- secret references are stored along with the buckets in the database (new column in cloud specific object store tables)
- when no secretId header is found in the request headers all managed buckets are returned (no filtering support by the backend - if required, to be added later)
- if secretId header is found fallback to the "original" behaviour
- basic (manual) testing on all supported providers

fixes #1082

