### PR TITLE
Return error in case of unsupported field query value

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -79,7 +79,7 @@ func getClusterFromRequest(c *gin.Context) (cluster.CommonCluster, bool) {
 
 	logger = logger.WithField("organization", organizationID)
 
-	switch c.DefaultQuery("field", "id") {
+	switch field := c.DefaultQuery("field", "id"); field {
 	case "id":
 		clusterID, ok := ginutils.UintParam(c, "id")
 		if !ok {
@@ -98,6 +98,7 @@ func getClusterFromRequest(c *gin.Context) (cluster.CommonCluster, bool) {
 
 		cl, err = clusterManager.GetClusterByName(ctx, organizationID, clusterName)
 	default:
+		err = fmt.Errorf("field=%s is not supported", field)
 	}
 
 	if isNotFound(err) {


### PR DESCRIPTION
If the URL query param `field` was set to someting else then `id`or `name` the following panic occured:
```
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:513 (0x42cee8)
/usr/local/go/src/runtime/panic.go:82 (0x42c03d)
/usr/local/go/src/runtime/signal_unix.go:390 (0x442271)
/go/src/github.com/banzaicloud/pipeline/api/helm.go:52 (0x252ed08)
/go/src/github.com/banzaicloud/pipeline/api/helm.go:118 (0x252f8f2)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/api/organization.go:62 (0x253bb2a)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/internal/platform/gin/drain.go:92 (0x2564594)
/go/src/github.com/banzaicloud/pipeline/main.go:168 (0x256bff3)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/recovery.go:47 (0x9760d9)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/internal/platform/gin/log/middleware.go:47 (0x256533d)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/internal/platform/gin/correlationid/middleware.go:67 (0x166fd25)
/go/src/github.com/banzaicloud/pipeline/internal/platform/gin/correlationid/middleware.go:53 (0x166ff43)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/context.go:107 (0x965732)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/gin.go:359 (0x96d4da)
/go/src/github.com/banzaicloud/pipeline/vendor/github.com/gin-gonic/gin/gin.go:326 (0x96cd01)
/usr/local/go/src/net/http/server.go:2741 (0x6b6fea)
/usr/local/go/src/net/http/server.go:3291 (0x6b8c0c)
/usr/local/go/src/net/http/h2_bundle.go:5592 (0x6da54c)
/usr/local/go/src/net/http/h2_bundle.go:5877 (0x68f168)
/usr/local/go/src/net/http/h2_bundle.go:5877 (0x68f168)
/usr/local/go/src/runtime/asm_amd64.s:1333 (0x45a830)
```