### PR TITLE
Project id saved along with the cluster on google

### DIFF
--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -366,13 +366,17 @@ func (c *GKECluster) DeleteCluster() error {
 		return pkgErrors.ErrorNilCluster
 	}
 
-	secretItem, err := c.GetSecretWithValidation()
-	if err != nil {
-		return err
+	if c.model.ProjectId == "" {
+		// if there's no projectid saved with the cluster, take it from the secret
+		secretItem, err := c.GetSecretWithValidation()
+		if err != nil {
+			return err
+		}
+		c.model.ProjectId = secretItem.GetValue(pkgSecret.ProjectId)
 	}
 
 	gkec := googleCluster{
-		ProjectID: secretItem.GetValue(pkgSecret.ProjectId),
+		ProjectID: c.model.ProjectId,
 		Name:      c.model.Cluster.Name,
 		Zone:      c.model.Cluster.Location,
 	}

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -97,6 +97,7 @@ func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID
 		MasterVersion: request.Properties.CreateClusterGKE.Master.Version,
 		NodeVersion:   request.Properties.CreateClusterGKE.NodeVersion,
 		NodePools:     nodePools,
+		ProjectId:     request.Properties.CreateClusterGKE.ProjectId,
 	}
 
 	return &c, nil
@@ -207,10 +208,13 @@ func (c *GKECluster) CreateCluster() error {
 		return err
 	}
 
-	projectId := secretItem.GetValue(pkgSecret.ProjectId)
+	if c.model.ProjectId == "" {
+		// if there's no projectId saved with the cluster take it from the secret
+		c.model.ProjectId = secretItem.GetValue(pkgSecret.ProjectId)
+	}
 
 	cc := googleCluster{
-		ProjectID:     projectId,
+		ProjectID:     c.model.ProjectId,
 		Zone:          c.model.Cluster.Location,
 		Name:          c.model.Cluster.Name,
 		MasterVersion: c.model.MasterVersion,
@@ -234,7 +238,7 @@ func (c *GKECluster) CreateCluster() error {
 		log.Infof("Cluster %s create is called for project %s and zone %s", cc.Name, cc.ProjectID, cc.Zone)
 		log.Info("Waiting for cluster...")
 
-		if err := waitForOperation(newContainerOperation(svc, projectId, c.model.Cluster.Location), createCall.Name); err != nil {
+		if err := waitForOperation(newContainerOperation(svc, c.model.ProjectId, c.model.Cluster.Location), createCall.Name); err != nil {
 			return err
 		}
 	} else {
@@ -253,7 +257,7 @@ func (c *GKECluster) CreateCluster() error {
 	c.updateCurrentVersions(gkeCluster)
 
 	// set region
-	c.model.Region, err = c.getRegionByZone(projectId, gkeCluster.Zone)
+	c.model.Region, err = c.getRegionByZone(c.model.ProjectId, gkeCluster.Zone)
 	if err != nil {
 		log.Warnf("error during getting region: %s", err.Error())
 	}
@@ -765,6 +769,7 @@ func generateClusterCreateRequest(cc googleCluster) *gke.CreateClusterRequest {
 	}
 	request.Cluster.MasterAuth = &gke.MasterAuth{}
 	request.Cluster.NodePools = cc.NodePools
+	request.ProjectId = cc.ProjectID
 
 	return &request
 }

--- a/internal/providers/google/gke_cluster_model.go
+++ b/internal/providers/google/gke_cluster_model.go
@@ -32,6 +32,7 @@ type GKEClusterModel struct {
 	NodeVersion   string
 	Region        string
 	NodePools     []*GKENodePoolModel `gorm:"foreignkey:ClusterID;association_foreignkey:ClusterID"`
+	ProjectId     string
 }
 
 // TableName changes the default table name.

--- a/pkg/cluster/gke/gke.go
+++ b/pkg/cluster/gke/gke.go
@@ -32,6 +32,7 @@ type CreateClusterGKE struct {
 	NodeVersion string               `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
 	NodePools   map[string]*NodePool `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
 	Master      *Master              `json:"master,omitempty" yaml:"master,omitempty"`
+	ProjectId   string               `json:"projectId" yaml:"projectId"`
 }
 
 // Master describes Google's master fields of a CreateCluster request

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -170,7 +170,7 @@ var DefaultRules = map[string]Meta{
 	cluster.Google: {
 		Fields: []FieldMeta{
 			{Name: Type, Required: true},
-			{Name: ProjectId, Required: false},
+			{Name: ProjectId, Required: true},
 			{Name: PrivateKeyId, Required: true},
 			{Name: PrivateKey, Required: true},
 			{Name: ClientEmail, Required: true},

--- a/spotguide/spotguide_test.go
+++ b/spotguide/spotguide_test.go
@@ -165,6 +165,7 @@ pipeline:
               maxCount: 2
               minCount: 1
           nodeVersion: "1.10"
+          projectId: ""
       secretId: c8f9c9fc3835b9a3721165afea97ffb78e1375552ab112ed54aee30b29c962ae
       secretName: ""
     cluster_secret:


### PR DESCRIPTION
- project id saved as a new field in the cluster
- if not provided in the request the project id is taken from the secret
- project id in the secret is made optional

(please review - with focus on any other flows where the cluster specific project needs to be used)
