### PR TITLE
Remove releaseName from WhitelistItem Spec

### DIFF
--- a/api/security.go
+++ b/api/security.go
@@ -124,10 +124,9 @@ func GetWhiteLists(c *gin.Context) {
 	releaseWhitelist := make([]security.ReleaseWhiteListItem, 0)
 	for _, whitelist := range whitelists.Items {
 		whitelistItem := security.ReleaseWhiteListItem{
-			Name:        whitelist.Name,
-			ReleaseName: whitelist.Spec.ReleaseName,
-			Owner:       whitelist.Spec.Creator,
-			Reason:      whitelist.Spec.Reason,
+			Name:   whitelist.Name,
+			Owner:  whitelist.Spec.Creator,
+			Reason: whitelist.Spec.Reason,
 		}
 		releaseWhitelist = append(releaseWhitelist, whitelistItem)
 	}
@@ -165,9 +164,8 @@ func CreateWhiteList(c *gin.Context) {
 			Name: whitelistCreateRequest.Name,
 		},
 		Spec: v1alpha1.WhiteListSpec{
-			ReleaseName: whitelistCreateRequest.ReleaseName,
-			Creator:     whitelistCreateRequest.Owner,
-			Reason:      whitelistCreateRequest.Reason,
+			Creator: whitelistCreateRequest.Owner,
+			Reason:  whitelistCreateRequest.Reason,
 		},
 	}
 	_, err = securityClientSet.Whitelists(metav1.NamespaceDefault).Create(&whitelist)

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -7569,14 +7569,10 @@ components:
       example:
         owner: banzaicloud
         reason: test release
-        releaseName: flying-monkey
         name: flying-monkey-wl
       properties:
         name:
           example: flying-monkey-wl
-          type: string
-        releaseName:
-          example: flying-monkey
           type: string
         owner:
           example: banzaicloud
@@ -7587,7 +7583,6 @@ components:
       required:
       - name
       - owner
-      - releaseName
       type: object
     PolicyBundle:
       description: A bundle containing a set of policies, whitelists, and rules for mapping them to specific images

--- a/client/docs/ReleaseWhiteListItem.md
+++ b/client/docs/ReleaseWhiteListItem.md
@@ -4,7 +4,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | 
-**ReleaseName** | **string** |  | 
 **Owner** | **string** |  | 
 **Reason** | **string** |  | [optional] 
 

--- a/client/model_release_white_list_item.go
+++ b/client/model_release_white_list_item.go
@@ -12,8 +12,7 @@
 package client
 
 type ReleaseWhiteListItem struct {
-	Name        string `json:"name"`
-	ReleaseName string `json:"releaseName"`
-	Owner       string `json:"owner"`
-	Reason      string `json:"reason,omitempty"`
+	Name   string `json:"name"`
+	Owner  string `json:"owner"`
+	Reason string `json:"reason,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -7087,15 +7087,11 @@ components:
             type: object
             required:
                 - name
-                - releaseName
                 - owner
             properties:
                 name:
                     type: string
                     example: 'flying-monkey-wl'
-                releaseName:
-                    type: string
-                    example: 'flying-monkey'
                 owner:
                     type: string
                     example: 'banzaicloud'

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -119,10 +119,9 @@ type WhitelistItem struct {
 }
 
 type ReleaseWhiteListItem struct {
-	Name        string `json:"name" binding:"required"`
-	ReleaseName string `json:"releaseName" binding:"required"`
-	Owner       string `json:"owner" binding:"required"`
-	Reason      string `json:"reason"`
+	Name   string `json:"name" binding:"required"`
+	Owner  string `json:"owner" binding:"required"`
+	Reason string `json:"reason"`
 }
 
 type ScanLogItem struct {


### PR DESCRIPTION
ReleaseName isn't necessary to declare in WhitelistItem Spec, it's removed.
fixes: #14