### PR TITLE
Disable schema automigration

### DIFF
--- a/auth/migrate.go
+++ b/auth/migrate.go
@@ -1,0 +1,44 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+)
+
+// Migrate executes the table migrations for the auth module.
+func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
+	tables := []interface{}{
+		&AuthIdentity{},
+		&User{},
+		&UserOrganization{},
+		&Organization{},
+	}
+
+	var tableNames string
+	for _, table := range tables {
+		tableNames += fmt.Sprintf(" %s", db.NewScope(table).TableName())
+	}
+
+	logger.WithFields(logrus.Fields{
+		"table_names": strings.TrimSpace(tableNames),
+	}).Info("migrating auth tables")
+
+	return db.AutoMigrate(tables...).Error
+}

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -20,6 +20,7 @@ role = "pipeline"
 password = "sparky123"
 dbname = "pipeline"
 logging = true
+autoMigrateEnabled = false
 
 [anchore]
 enabled = false

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -85,6 +85,9 @@ const (
 	ARKBucketSyncInterval  = "ark.bucketSyncInterval"
 	ARKRestoreSyncInterval = "ark.restoreSyncInterval"
 	ARKBackupSyncInterval  = "ark.backupSyncInterval"
+
+	// Database
+	DBAutoMigrateEnabled = "database.autoMigrateEnabled"
 )
 
 //Init initializes the configurations
@@ -138,6 +141,7 @@ func init() {
 	viper.SetDefault("database.password", "pipemaster123!")
 	viper.SetDefault("database.dbname", "pipelinedb")
 	viper.SetDefault("database.logging", false)
+	viper.SetDefault(DBAutoMigrateEnabled, false)
 	viper.SetDefault("audit.enabled", true)
 	viper.SetDefault("audit.headers", []string{"secretId"})
 	viper.SetDefault("audit.skippaths", []string{"/auth/github/callback", "/pipeline/api"})

--- a/dns/route53/model/migrate.go
+++ b/dns/route53/model/migrate.go
@@ -1,0 +1,41 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route53model
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+)
+
+// Migrate executes the table migrations for the route53 module.
+func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
+	tables := []interface{}{
+		&Route53Domain{},
+	}
+
+	var tableNames string
+	for _, table := range tables {
+		tableNames += fmt.Sprintf(" %s", db.NewScope(table).TableName())
+	}
+
+	logger.WithFields(logrus.Fields{
+		"table_names": strings.TrimSpace(tableNames),
+	}).Info("migrating route53 tables")
+
+	return db.AutoMigrate(tables...).Error
+}

--- a/internal/ark/model.go
+++ b/internal/ark/model.go
@@ -30,7 +30,7 @@ const (
 	clusterBackupsTableName           = "ark_backups"
 )
 
-// Migrate executes the table migrations
+// Migrate executes the table migrations for Ark.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	tables := []interface{}{
 		&ClusterBackupsModel{},
@@ -46,7 +46,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"service":     "ark",
-		"table_names": strings.TrimLeft(tableNames, " "),
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/audit/model.go
+++ b/internal/audit/model.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Migrate executes the table migrations for the provider.
+// Migrate executes the table migrations for the audit model.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	tables := []interface{}{
 		&AuditEvent{},

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Migrate executes the table migrations for the provider.
+// Migrate executes the table migrations for the cluster module.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	tables := []interface{}{
 		&ClusterModel{},

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
@@ -33,7 +34,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"table_names": tableNames,
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating model tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/providers/alibaba/model.go
+++ b/internal/providers/alibaba/model.go
@@ -16,6 +16,7 @@ package alibaba
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/banzaicloud/pipeline/pkg/providers/alibaba"
 	"github.com/jinzhu/gorm"
@@ -35,7 +36,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"provider":    alibaba.Provider,
-		"table_names": tableNames,
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/providers/amazon/model.go
+++ b/internal/providers/amazon/model.go
@@ -16,6 +16,7 @@ package amazon
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	"github.com/jinzhu/gorm"
@@ -35,7 +36,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"provider":    amazon.Provider,
-		"table_names": tableNames,
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/providers/azure/model.go
+++ b/internal/providers/azure/model.go
@@ -16,6 +16,7 @@ package azure
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/banzaicloud/pipeline/pkg/providers/azure"
 	"github.com/jinzhu/gorm"
@@ -35,7 +36,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"provider":    azure.Provider,
-		"table_names": tableNames,
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/providers/google/model.go
+++ b/internal/providers/google/model.go
@@ -16,6 +16,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/banzaicloud/pipeline/pkg/providers/google"
 	"github.com/jinzhu/gorm"
@@ -38,7 +39,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"provider":    google.Provider,
-		"table_names": tableNames,
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/internal/providers/oracle/model.go
+++ b/internal/providers/oracle/model.go
@@ -44,7 +44,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"provider":    oracle.Provider,
-		"table_names": strings.TrimLeft(tableNames, " "),
+		"table_names": strings.TrimSpace(tableNames),
 	}).Info("migrating provider tables")
 
 	return db.AutoMigrate(tables...).Error

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginlog "github.com/banzaicloud/pipeline/internal/platform/gin/log"
 	platformlog "github.com/banzaicloud/pipeline/internal/platform/log"
-	"github.com/banzaicloud/pipeline/model"
-	"github.com/banzaicloud/pipeline/model/defaults"
+		"github.com/banzaicloud/pipeline/model/defaults"
 	"github.com/banzaicloud/pipeline/notify"
 	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/gin-contrib/cors"
@@ -96,16 +95,7 @@ func main() {
 	// Initialize auth
 	auth.Init(droneDb)
 
-	var tables = []interface{}{&model.ClusterModel{},
-		&model.ACSKClusterModel{},
-		&model.ACSKNodePoolModel{},
-		&model.AmazonNodePoolsModel{},
-		&model.EC2ClusterModel{},
-		&model.EKSClusterModel{},
-		&model.AKSClusterModel{},
-		&model.AKSNodePoolModel{},
-		&model.DummyClusterModel{},
-		&model.KubernetesClusterModel{},
+	var tables = []interface{}{
 		&auth.AuthIdentity{},
 		&auth.User{},
 		&auth.UserOrganization{},

--- a/main.go
+++ b/main.go
@@ -96,14 +96,6 @@ func main() {
 	auth.Init(droneDb)
 
 	var tables = []interface{}{
-		&defaults.EC2Profile{},
-		&defaults.EC2NodePoolProfile{},
-		&defaults.EKSProfile{},
-		&defaults.EKSNodePoolProfile{},
-		&defaults.AKSProfile{},
-		&defaults.AKSNodePoolProfile{},
-		&defaults.GKEProfile{},
-		&defaults.GKENodePoolProfile{},
 		&route53model.Route53Domain{},
 		&spotguide.SpotguideRepo{},
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/banzaicloud/go-gin-prometheus"
 	"github.com/banzaicloud/pipeline/api"
@@ -31,7 +30,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/dns"
-		arkSync "github.com/banzaicloud/pipeline/internal/ark/sync"
+	arkSync "github.com/banzaicloud/pipeline/internal/ark/sync"
 	"github.com/banzaicloud/pipeline/internal/audit"
 	"github.com/banzaicloud/pipeline/internal/dashboard"
 	ginternal "github.com/banzaicloud/pipeline/internal/platform/gin"
@@ -40,7 +39,6 @@ import (
 	platformlog "github.com/banzaicloud/pipeline/internal/platform/log"
 	"github.com/banzaicloud/pipeline/model/defaults"
 	"github.com/banzaicloud/pipeline/notify"
-	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -93,24 +91,6 @@ func main() {
 
 	// Initialize auth
 	auth.Init(droneDb)
-
-	var tables = []interface{}{
-		&spotguide.SpotguideRepo{},
-	}
-
-	var tableNames string
-	for _, table := range tables {
-		tableNames += fmt.Sprintf(" %s", db.NewScope(table).TableName())
-	}
-
-	logger.WithFields(logrus.Fields{
-		"table_names": strings.TrimSpace(tableNames),
-	}).Info("migrating tables")
-
-	// Create tables
-	if err := db.AutoMigrate(tables...).Error; err != nil {
-		panic(err)
-	}
 
 	err = Migrate(db, logger)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -92,9 +92,13 @@ func main() {
 	// Initialize auth
 	auth.Init(droneDb)
 
-	err = Migrate(db, logger)
-	if err != nil {
-		panic(err)
+	if viper.GetBool(config.DBAutoMigrateEnabled) {
+		log.Info("running automatic schema migrations")
+
+		err = Migrate(db, logger)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	err = defaults.SetDefaultValues()

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginlog "github.com/banzaicloud/pipeline/internal/platform/gin/log"
 	platformlog "github.com/banzaicloud/pipeline/internal/platform/log"
-		"github.com/banzaicloud/pipeline/model/defaults"
+	"github.com/banzaicloud/pipeline/model/defaults"
 	"github.com/banzaicloud/pipeline/notify"
 	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/gin-contrib/cors"
@@ -96,10 +96,6 @@ func main() {
 	auth.Init(droneDb)
 
 	var tables = []interface{}{
-		&auth.AuthIdentity{},
-		&auth.User{},
-		&auth.UserOrganization{},
-		&auth.Organization{},
 		&defaults.EC2Profile{},
 		&defaults.EC2NodePoolProfile{},
 		&defaults.EKSProfile{},

--- a/main.go
+++ b/main.go
@@ -31,8 +31,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/dns"
-	"github.com/banzaicloud/pipeline/dns/route53/model"
-	arkSync "github.com/banzaicloud/pipeline/internal/ark/sync"
+		arkSync "github.com/banzaicloud/pipeline/internal/ark/sync"
 	"github.com/banzaicloud/pipeline/internal/audit"
 	"github.com/banzaicloud/pipeline/internal/dashboard"
 	ginternal "github.com/banzaicloud/pipeline/internal/platform/gin"
@@ -96,7 +95,6 @@ func main() {
 	auth.Init(droneDb)
 
 	var tables = []interface{}{
-		&route53model.Route53Domain{},
 		&spotguide.SpotguideRepo{},
 	}
 

--- a/migrate.go
+++ b/migrate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers"
 	"github.com/banzaicloud/pipeline/model"
 	"github.com/banzaicloud/pipeline/model/defaults"
+	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
@@ -42,6 +43,10 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	}
 
 	if err := route53model.Migrate(db, logger); err != nil {
+		return err
+	}
+
+	if err := spotguide.Migrate(db, logger); err != nil {
 		return err
 	}
 

--- a/migrate.go
+++ b/migrate.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"github.com/banzaicloud/pipeline/auth"
+	"github.com/banzaicloud/pipeline/dns/route53/model"
 	"github.com/banzaicloud/pipeline/internal/ark"
 	"github.com/banzaicloud/pipeline/internal/audit"
 	"github.com/banzaicloud/pipeline/internal/cluster"
@@ -37,6 +38,10 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	}
 
 	if err := defaults.Migrate(db, logger); err != nil {
+		return err
+	}
+
+	if err := route53model.Migrate(db, logger); err != nil {
 		return err
 	}
 

--- a/migrate.go
+++ b/migrate.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/ark"
 	"github.com/banzaicloud/pipeline/internal/audit"
 	"github.com/banzaicloud/pipeline/internal/cluster"
@@ -26,6 +27,14 @@ import (
 
 // Migrate runs migrations for the application.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
+	if err := model.Migrate(db, logger); err != nil {
+		return err
+	}
+
+	if err := auth.Migrate(db, logger); err != nil {
+		return err
+	}
+
 	if err := audit.Migrate(db, logger); err != nil {
 		return err
 	}
@@ -39,10 +48,6 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	}
 
 	if err := ark.Migrate(db, logger); err != nil {
-		return err
-	}
-
-	if err := model.Migrate(db, logger); err != nil {
 		return err
 	}
 

--- a/migrate.go
+++ b/migrate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/providers"
 	"github.com/banzaicloud/pipeline/model"
+	"github.com/banzaicloud/pipeline/model/defaults"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
@@ -32,6 +33,10 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	}
 
 	if err := auth.Migrate(db, logger); err != nil {
+		return err
+	}
+
+	if err := defaults.Migrate(db, logger); err != nil {
 		return err
 	}
 

--- a/model/defaults/migrate.go
+++ b/model/defaults/migrate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Migrate executes the table migrations for the auth module.
+// Migrate executes the table migrations for the defaults module.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	tables := []interface{}{
 		&EC2Profile{},

--- a/model/defaults/migrate.go
+++ b/model/defaults/migrate.go
@@ -42,7 +42,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 	logger.WithFields(logrus.Fields{
 		"table_names": strings.TrimSpace(tableNames),
-	}).Info("defaults auth tables")
+	}).Info("migrating defaults tables")
 
 	return db.AutoMigrate(tables...).Error
 }

--- a/model/defaults/migrate.go
+++ b/model/defaults/migrate.go
@@ -1,0 +1,48 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+)
+
+// Migrate executes the table migrations for the auth module.
+func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
+	tables := []interface{}{
+		&EC2Profile{},
+		&EC2NodePoolProfile{},
+		&EKSProfile{},
+		&EKSNodePoolProfile{},
+		&AKSProfile{},
+		&AKSNodePoolProfile{},
+		&GKEProfile{},
+		&GKENodePoolProfile{},
+	}
+
+	var tableNames string
+	for _, table := range tables {
+		tableNames += fmt.Sprintf(" %s", db.NewScope(table).TableName())
+	}
+
+	logger.WithFields(logrus.Fields{
+		"table_names": strings.TrimSpace(tableNames),
+	}).Info("defaults auth tables")
+
+	return db.AutoMigrate(tables...).Error
+}

--- a/spotguide/migrate.go
+++ b/spotguide/migrate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Migrate executes the table migrations for the auth module.
+// Migrate executes the table migrations for the spotguide module.
 func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 	tables := []interface{}{
 		&SpotguideRepo{},

--- a/spotguide/migrate.go
+++ b/spotguide/migrate.go
@@ -1,0 +1,41 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spotguide
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+)
+
+// Migrate executes the table migrations for the auth module.
+func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
+	tables := []interface{}{
+		&SpotguideRepo{},
+	}
+
+	var tableNames string
+	for _, table := range tables {
+		tableNames += fmt.Sprintf(" %s", db.NewScope(table).TableName())
+	}
+
+	logger.WithFields(logrus.Fields{
+		"table_names": strings.TrimSpace(tableNames),
+	}).Info("migrating spotguiide tables")
+
+	return db.AutoMigrate(tables...).Error
+}


### PR DESCRIPTION
This PR disables automatic migration of database schema by default.

To enable it locally add the following line to your config's database section:

```
autoMigrateEnabled = true
```