### PR TITLE
spotguide release tags can be filtered by pre-releases

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,6 +68,10 @@
   version = "2.14.1"
 
 [[constraint]]
+  name = "github.com/Masterminds/semver"
+  version = "1.4.0"
+
+[[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "=1.15.*"
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,3 +143,6 @@ logLevel = "info"
 bucketSyncInterval = "10m"
 restoreSyncInterval = "20s"
 backupSyncInterval = "20s"
+
+[spotguide]
+allowPrereleases = false

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -107,6 +107,9 @@ const (
 
 	// Logging constants
 	LoggingReleaseName = "logging-operator"
+
+	// Spotguides constants
+	SpotguideAllowPrereleases = "spotguide.allowPrereleases"
 )
 
 //Init initializes the configurations
@@ -204,6 +207,8 @@ func init() {
 
 	viper.SetDefault(PipelineSystemNamespace, "pipeline-system")
 	viper.SetDefault(EksTemplateLocation, filepath.Join(pwd, "templates", "eks"))
+
+	viper.SetDefault(SpotguideAllowPrereleases, false)
 
 	// Find and read the config file
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
This follows the rules of semantic versioning, pre-releases are not visible by default.