### PR TITLE
added bucket not found error so that  getBucket returns with the appro…

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -700,6 +700,7 @@ func GetBucket(c *gin.Context) {
 	if !ok {
 		logger.Error("the mandatory cloud type is missing from the query")
 		ginutils.ReplyWithErrorResponse(c, errorResponseFrom(fmt.Errorf("no cloudType specified in query")))
+		return
 	}
 
 	organization := auth.GetCurrentOrganization(c.Request)
@@ -732,10 +733,25 @@ func GetBucket(c *gin.Context) {
 		}
 	}
 
-	ginutils.ReplyWithErrorResponse(c, errorResponseFrom(fmt.Errorf("bucket with name: %s not found", bucketName)))
+	ginutils.ReplyWithErrorResponse(c, errorResponseFrom(BucketNotFoundError{errMessage: fmt.Sprintf("bucket with name: %s not found", bucketName)}))
 
 	return
 
+}
+
+// SecretNotFoundError signals that a given bucket was not found
+type BucketNotFoundError struct {
+	errMessage string
+}
+
+// Error returns error message as string
+func (err BucketNotFoundError) Error() string {
+	return err.errMessage
+}
+
+// NotFound signals a not found error
+func (err BucketNotFoundError) NotFound() bool {
+	return true
 }
 
 // newBucketResponseItemFromBucketInfo builds a responsItem based opn the provided bucketInfo

--- a/api/bucket_test.go
+++ b/api/bucket_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+)
+
+func TestBucketNotFoundResponseCode(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		errMsg string
+		code   int
+	}{
+		{
+			name:   "response code should be 404",
+			errMsg: "not found",
+			code:   http.StatusNotFound,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nfe := BucketNotFoundError{errMessage: "error message "}
+			er := errorResponseFrom(nfe)
+
+			assert.Equal(t, er.Code, test.code)
+			assert.Equal(t, er.Message, test.errMsg)
+		})
+	}
+}

--- a/api/bucket_test.go
+++ b/api/bucket_test.go
@@ -36,7 +36,7 @@ func TestBucketNotFoundResponseCode(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nfe := BucketNotFoundError{errMessage: "error message "}
+			nfe := BucketNotFoundError{errMessage: test.errMsg}
 			er := errorResponseFrom(nfe)
 
 			assert.Equal(t, er.Code, test.code)

--- a/api/bucket_test.go
+++ b/api/bucket_test.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBucketNotFoundResponseCode(t *testing.T) {

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -139,6 +139,7 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 		return fmt.Errorf("bucket with name %s already exists", bucketName)
 	}
 
+	bucket.Name = bucketName
 	bucket.ResourceGroup = resourceGroup
 	bucket.Organization = *s.org
 	bucket.SecretRef = s.secret.ID


### PR DESCRIPTION
…priate response code

* when no managed bucket was found the api returned with an invalid http response code
* the behaviour has been amended to return with the proper error code (404)
* added simple unit test for the method assembling the response based on the new error type