### PR TITLE
OKE enhancements

### DIFF
--- a/pkg/providers/oracle/cluster/manager/cluster.go
+++ b/pkg/providers/oracle/cluster/manager/cluster.go
@@ -64,7 +64,7 @@ func (cm *ClusterManager) CreateCluster(clusterModel *model.Cluster) error {
 // UpdateCluster updates the cluster
 func (cm *ClusterManager) UpdateCluster(clusterModel *model.Cluster) error {
 
-	cluster, err := cm.GetCluster(&clusterModel.OCID)
+	cluster, err := cm.GetCluster(clusterModel)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (cm *ClusterManager) DeleteCluster(clusterModel *model.Cluster) error {
 		return err
 	}
 
-	cluster, err := cm.GetCluster(&clusterModel.OCID)
+	cluster, err := cm.GetCluster(clusterModel)
 	if err != nil {
 		return err
 	}
@@ -131,13 +131,39 @@ func (cm *ClusterManager) DeleteCluster(clusterModel *model.Cluster) error {
 	return ce.DeleteCluster(req)
 }
 
-// GetCluster gets cluster info by id
-func (cm *ClusterManager) GetCluster(id *string) (cluster containerengine.Cluster, err error) {
+// GetCluster gets a cluster by ID or name
+func (cm *ClusterManager) GetCluster(model *model.Cluster) (cluster containerengine.Cluster, err error) {
+
+	if model.OCID != "" {
+		return cm.GetClusterByID(&model.OCID)
+	}
+
+	return cm.GetClusterByName(model.Name)
+}
+
+// GetClusterByID gets cluster by ID
+func (cm *ClusterManager) GetClusterByID(id *string) (cluster containerengine.Cluster, err error) {
 
 	ce, err := cm.oci.NewContainerEngineClient()
 	if err != nil {
 		return cluster, err
 	}
 
-	return ce.GetCluster(id)
+	return ce.GetClusterByID(id)
+}
+
+// GetClusterByName gets cluster by name
+func (cm *ClusterManager) GetClusterByName(name string) (cluster containerengine.Cluster, err error) {
+
+	ce, err := cm.oci.NewContainerEngineClient()
+	if err != nil {
+		return cluster, err
+	}
+
+	c, err := ce.GetClusterByName(name)
+	if err != nil {
+		return cluster, err
+	}
+
+	return ce.GetClusterByID(c.Id)
 }

--- a/pkg/providers/oracle/cluster/manager/nodepool.go
+++ b/pkg/providers/oracle/cluster/manager/nodepool.go
@@ -35,11 +35,14 @@ func (cm *ClusterManager) SyncNodePools(clusterModel *model.Cluster) error {
 	}
 
 	waitForChange := false
+	nodepoolNamesToCheck := make(map[string]bool, 0)
 	for _, np := range nodePools {
+		if !np.Delete {
+			nodepoolNamesToCheck[np.Name] = true
+		}
 		if waitForChange == false && !np.Delete {
 			waitForChange = true
 		}
-
 		if np.Add {
 			if err := cm.AddNodePool(clusterModel, np); err != nil {
 				return err
@@ -53,7 +56,7 @@ func (cm *ClusterManager) SyncNodePools(clusterModel *model.Cluster) error {
 
 	// waiting for add/update operations to finish
 	if waitForChange {
-		err = ce.WaitingForClusterNodePoolActiveState(&clusterModel.OCID)
+		err = ce.WaitingForClusterNodePoolActiveState(&clusterModel.OCID, nodepoolNamesToCheck)
 		if err != nil {
 			return err
 		}
@@ -72,7 +75,7 @@ func (cm *ClusterManager) SyncNodePools(clusterModel *model.Cluster) error {
 	}
 
 	if waitForDelete {
-		err = ce.WaitingForClusterNodePoolActiveState(&clusterModel.OCID)
+		err = ce.WaitingForClusterNodePoolActiveState(&clusterModel.OCID, make(map[string]bool, 0))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Remove the preconfigured VCN if cluster creation request validation fails
- Return node errors raised during node pool manipulations
- Trying to get OKE cluster by it's name if OCID is empty
- Fix node pool config persistance in case of an error

Fixes #1284 and #1285 
