### PR TITLE
amended delete bucket operation

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -381,6 +381,13 @@ func CheckBucket(c *gin.Context) {
 // DeleteBucket deletes object storage buckets (object storage container in case of Azure)
 // that can be accessed with the credentials from the given secret
 func DeleteBucket(c *gin.Context) {
+
+	const (
+		forceQueryKey = "force"
+	)
+	// is secretName requested?
+	force := c.Query(forceQueryKey) == "true"
+
 	logger := correlationid.Logger(log, c)
 
 	bucketName := c.Param("name")
@@ -400,9 +407,10 @@ func DeleteBucket(c *gin.Context) {
 	logger.Infof("deleting object store bucket")
 
 	objectStoreCtx := &providers.ObjectStoreContext{
-		Provider:     cloudType,
-		Secret:       secretItem,
-		Organization: organization,
+		Provider:       cloudType,
+		Secret:         secretItem,
+		Organization:   organization,
+		ForceOperation: force,
 	}
 
 	switch cloudType {

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -17,6 +17,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-storage-blob-go/2016-05-31/azblob"
@@ -385,8 +386,8 @@ func DeleteBucket(c *gin.Context) {
 	const (
 		forceQueryKey = "force"
 	)
-	// is secretName requested?
-	force := c.Query(forceQueryKey) == "true"
+
+	force, _ := strconv.ParseBool(c.Query(forceQueryKey))
 
 	logger := correlationid.Logger(log, c)
 

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -3778,6 +3778,10 @@ paths:
                       type: string
                       enum: [amazon, google, azure]
                   required: true
+                - name: force
+                  in: query
+                  description: Is the operation forced
+                  required: false
                 - name: resourceGroup
                   in: query
                   description: Azure resource group the storage account that holds the bucket (storage container) to be deleted

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -184,7 +184,7 @@ func (s *objectStore) DeleteBucket(bucketName string) error {
 	bucket := &ObjectStoreBucketModel{}
 	searchCriteria := s.searchCriteria(bucketName)
 
-	logger.Info("looking up bucket %s", bucketName)
+	logger.Infof("looking up bucket %s", bucketName)
 
 	if err := s.db.Where(searchCriteria).Find(bucket).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -209,11 +209,11 @@ func (s *objectStore) DeleteBucket(bucketName string) error {
 
 func (s *objectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
 	logger := s.getLogger().WithField("bucket", bucket.Name)
-	logger.Info("deleting bucket %s on provider", bucket.Name)
+	logger.Infof("deleting bucket %s on provider", bucket.Name)
 	// todo the assumption here is, that a bucket in 'ERROR_CREATE' doesn't exist on the provider
 	// todo however there might be -presumably rare cases- when a bucket in 'ERROR_DELETE' that has already been deleted on the provider
 	if bucket.Status == providers.BucketCreateError {
-		logger.Debugf("bucket %s doesn't exist on provider")
+		logger.Debug("bucket doesn't exist on provider")
 		return nil
 	}
 

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -53,6 +53,8 @@ type objectStore struct {
 
 	db     *gorm.DB
 	logger logrus.FieldLogger
+
+	force bool
 }
 
 // NewObjectStore returns a new object store instance.
@@ -62,6 +64,7 @@ func NewObjectStore(
 	org *auth.Organization,
 	db *gorm.DB,
 	logger logrus.FieldLogger,
+	force bool,
 ) (*objectStore, error) {
 	ostore, err := getProviderObjectStore(secret, region)
 	if err != nil {
@@ -75,6 +78,7 @@ func NewObjectStore(
 		org:         org,
 		db:          db,
 		logger:      logger,
+		force:       force,
 	}, nil
 }
 
@@ -189,7 +193,10 @@ func (s *objectStore) DeleteBucket(bucketName string) error {
 	}
 
 	if err := s.deleteFromProvider(bucket); err != nil {
-		return err
+		if !s.force {
+			// if delete is not forced return here
+			return err
+		}
 	}
 
 	db := s.db.Delete(bucket)

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -409,12 +409,12 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 
 func (s *ObjectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
 	logger := s.getLogger(bucket.Name)
-	logger.Info("deleting bucket %s on provider", bucket.Name)
+	logger.Info("deleting bucket on provider")
 
 	// todo the assumption here is, that a bucket in 'ERROR_CREATE' doesn't exist on the provider
 	// todo however there might be -presumably rare cases- when a bucket in 'ERROR_DELETE' that has already been deleted on the provider
 	if bucket.Status == providers.BucketCreateError {
-		logger.Debugf("bucket %s doesn't exist on provider")
+		logger.Debug("bucket doesn't exist on provider")
 		return nil
 	}
 

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -144,6 +144,7 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 
 	bucket.Name = bucketName
 	bucket.ResourceGroup = resourceGroup
+	bucket.StorageAccount = storageAccount
 	bucket.Organization = *s.org
 	bucket.SecretRef = s.secret.ID
 	bucket.Status = providers.BucketCreating

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -63,6 +63,7 @@ type ObjectStore struct {
 
 	db     *gorm.DB
 	logger logrus.FieldLogger
+	force  bool
 }
 
 // NewObjectStore returns a new object store instance.
@@ -74,6 +75,7 @@ func NewObjectStore(
 	org *pipelineAuth.Organization,
 	db *gorm.DB,
 	logger logrus.FieldLogger,
+	force bool,
 ) *ObjectStore {
 	return &ObjectStore{
 		location:       location,
@@ -83,6 +85,7 @@ func NewObjectStore(
 		db:             db,
 		logger:         logger,
 		org:            org,
+		force:          force,
 	}
 }
 
@@ -388,7 +391,10 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 	}
 
 	if err := s.deleteFromProvider(bucket); err != nil {
-		return err
+		if !s.force {
+			// if delete is not forced return here
+			return err
+		}
 	}
 
 	db := s.db.Delete(bucket)

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -51,6 +51,7 @@ type ObjectStore struct {
 	secret         *secret.SecretItemResponse
 
 	location string
+	force    bool
 }
 
 // NewObjectStore returns a new object store instance.
@@ -60,6 +61,7 @@ func NewObjectStore(
 	location string,
 	db *gorm.DB,
 	logger logrus.FieldLogger,
+	force bool,
 ) *ObjectStore {
 	var serviceAccount *verify.ServiceAccount
 	if secret != nil {
@@ -73,6 +75,7 @@ func NewObjectStore(
 		secret:         secret,
 		serviceAccount: serviceAccount,
 		location:       location,
+		force:          force,
 	}
 }
 
@@ -177,7 +180,10 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 	}
 
 	if err := s.deleteFromProvider(bucket); err != nil {
-		return err
+		if !s.force {
+			// if delete is not forced return here
+			return err
+		}
 	}
 
 	db := s.db.Delete(bucket)

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -166,48 +166,62 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 // provided the storage container is of 'managed' type.
 func (s *ObjectStore) DeleteBucket(bucketName string) error {
 	logger := s.getLogger(bucketName)
-
 	bucket := &ObjectStoreBucketModel{}
 	searchCriteria := s.searchCriteria(bucketName)
 
-	logger.Info("looking for bucket")
-
+	logger.Infof("looking up the bucket %s", bucketName)
 	if err := s.db.Where(searchCriteria).Find(bucket).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return bucketNotFoundError{}
 		}
 	}
 
+	if err := s.deleteFromProvider(bucket); err != nil {
+		return err
+	}
+
+	db := s.db.Delete(bucket)
+	if db.Error != nil {
+		return s.deleteFailed(bucket, db.Error)
+	}
+
+	return nil
+}
+
+func (s *ObjectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
+	logger := s.getLogger(bucket.Name)
+	logger.Info("deleting bucket %s on provider", bucket.Name)
+
+	// todo the assumption here is, that a bucket in 'ERROR_CREATE' doesn't exist on the provider
+	// todo however there might be -presumably rare cases- when a bucket in 'ERROR_DELETE' that has already been deleted on the provider
+	if bucket.Status == providers.BucketCreateError {
+		logger.Debugf("bucket %s doesn't exist on provider")
+		return nil
+	}
+
 	bucket.Status = providers.BucketDeleting
 	db := s.db.Save(bucket)
 	if db.Error != nil {
-		return fmt.Errorf("could not delete bucket: %s", bucketName)
+		return fmt.Errorf("could not update bucket: %s", bucket.Name)
 	}
 
 	logger.Info("getting credentials")
 	credentials, err := s.newGoogleCredentials()
-
 	if err != nil {
-		s.deleteFailed(bucket, err)
-		return fmt.Errorf("getting credentials failed: %s", err.Error())
+		return s.deleteFailed(bucket, err)
 	}
 
 	logger.Info("creating new storage client")
-
 	ctx := context.Background()
 
 	client, err := storage.NewClient(ctx, option.WithCredentials(credentials))
 	if err != nil {
-		s.deleteFailed(bucket, err)
-
-		return fmt.Errorf("failed to create client: %s", err.Error())
+		return s.deleteFailed(bucket, err)
 	}
 	defer client.Close()
-
 	logger.Info("storage client created successfully")
 
-	bucketHandle := client.Bucket(bucketName)
-
+	bucketHandle := client.Bucket(bucket.Name)
 	if err := bucketHandle.Delete(ctx); err != nil {
 		// delete failed on the provider
 		s.deleteFailed(bucket, err)
@@ -215,15 +229,8 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 		return err
 	}
 
-	err = s.db.Delete(bucket).Error
-	if err != nil {
-		// delete failed in the dbs
-		s.deleteFailed(bucket, err)
-
-		return fmt.Errorf("deleting bucket failed: %s", err.Error())
-	}
-
 	return nil
+
 }
 
 // CheckBucket checks the status of the given Google bucket.

--- a/internal/providers/objectstore.go
+++ b/internal/providers/objectstore.go
@@ -42,7 +42,7 @@ type ObjectStoreContext struct {
 	ResourceGroup  string
 	StorageAccount string
 
-	// ForceOperation indicates the kind of the operation to be performed on object store
+	// ForceOperation indicates whether the operation needs to be executed forcibly (some errors are ignored)
 	ForceOperation bool
 }
 

--- a/internal/providers/objectstore.go
+++ b/internal/providers/objectstore.go
@@ -41,6 +41,9 @@ type ObjectStoreContext struct {
 	// Azure specific parameters
 	ResourceGroup  string
 	StorageAccount string
+
+	// ForceOperation indicates the kind of the operation to be performed on object store
+	ForceOperation bool
 }
 
 // NewObjectStore creates an object store client for the given cloud provider.
@@ -53,16 +56,16 @@ func NewObjectStore(ctx *ObjectStoreContext, logger logrus.FieldLogger) (objects
 		return alibaba.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization), nil
 
 	case providers.Amazon:
-		return amazon.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization, db, logger)
+		return amazon.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization, db, logger, ctx.ForceOperation)
 
 	case providers.Azure:
-		return azure.NewObjectStore(ctx.Location, ctx.ResourceGroup, ctx.StorageAccount, ctx.Secret, ctx.Organization, db, logger), nil
+		return azure.NewObjectStore(ctx.Location, ctx.ResourceGroup, ctx.StorageAccount, ctx.Secret, ctx.Organization, db, logger, ctx.ForceOperation), nil
 
 	case providers.Google:
-		return google.NewObjectStore(ctx.Organization, ctx.Secret, ctx.Location, db, logger), nil
+		return google.NewObjectStore(ctx.Organization, ctx.Secret, ctx.Location, db, logger, ctx.ForceOperation), nil
 
 	case providers.Oracle:
-		return oracle.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization, db, logger), nil
+		return oracle.NewObjectStore(ctx.Location, ctx.Secret, ctx.Organization, db, logger, ctx.ForceOperation), nil
 
 	default:
 		return nil, pkgErrors.ErrorNotSupportedCloudType

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -44,6 +44,7 @@ type ObjectStore struct {
 
 	db     *gorm.DB
 	logger logrus.FieldLogger
+	force  bool
 }
 
 // NewObjectStore returns a new object store instance.
@@ -53,6 +54,7 @@ func NewObjectStore(
 	org *auth.Organization,
 	db *gorm.DB,
 	logger logrus.FieldLogger,
+	force bool,
 ) *ObjectStore {
 	return &ObjectStore{
 		location: location,
@@ -60,6 +62,7 @@ func NewObjectStore(
 		org:      org,
 		db:       db,
 		logger:   logger,
+		force:    force,
 	}
 }
 
@@ -222,7 +225,10 @@ func (o *ObjectStore) DeleteBucket(name string) error {
 	}
 
 	if err := o.deleteFromProvider(bucket); err != nil {
-		return err
+		if !o.force {
+			// if delete is not forced return here
+			return err
+		}
 	}
 
 	if err := o.deleteBucketFromDB(bucket); err != nil {

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -244,7 +244,7 @@ func (o *ObjectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
 	// todo the assumption here is, that a bucket in 'ERROR_CREATE' doesn't exist on the provider
 	// todo however there might be -presumably rare cases- when a bucket in 'ERROR_DELETE' that has already been deleted on the provider
 	if bucket.Status == providers.BucketCreateError {
-		logger.Debugf("bucket %s doesn't exist on provider")
+		logger.Debug("bucket doesn't exist on provider")
 		return nil
 	}
 

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -17,6 +17,7 @@ package oracle
 import (
 	"fmt"
 
+	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/pkg/errors"
@@ -289,7 +290,7 @@ func (o *ObjectStore) deleteFailed(bucket *ObjectStoreBucketModel, reason error)
 	bucket.StatusMsg = reason.Error()
 	db := o.db.Save(bucket)
 	if db.Error != nil {
-		return fmt.Errorf("could not delete bucket: %s", bucket.Name)
+		return emperror.With(db.Error, "could not delete bucket", bucket.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
- the operation accesses the provider only when it makes sense (the bucket is in the state created, or deletion failed)
- added `force` query parameter to be able to force the deletion (the buclket is wiped from the pipeline db)