### PR TITLE
Fix ClusterDetails API call to hold information about Kubernetes version

### DIFF
--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -600,6 +600,7 @@ func (c *AKSCluster) GetClusterDetails() (*pkgCluster.DetailsResponse, error) {
 			Name:              c.modelCluster.Name,
 			Id:                c.modelCluster.ID,
 			Location:          c.modelCluster.Location,
+			MasterVersion:     c.modelCluster.AKS.KubernetesVersion,
 			NodePools:         nodePools,
 			Status:            c.modelCluster.Status,
 		}, nil


### PR DESCRIPTION
Fixes #1309 