### PR TITLE
Use VolumeBindingWaitForFirstConsumer in EKS and ACSK when creating the default StorageClass

### DIFF
--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -276,7 +277,7 @@ func (c *ACSKCluster) CreateCluster() error {
 	}
 
 	// create default storage class
-	err = createDefaultStorageClass(kubeClient, "alicloud/disk")
+	err = createDefaultStorageClass(kubeClient, "alicloud/disk", storagev1.VolumeBindingWaitForFirstConsumer)
 	if err != nil {
 		return err
 	}

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -262,7 +263,7 @@ func (c *EKSCluster) CreateCluster() error {
 	}
 
 	// create default storage class
-	err = createDefaultStorageClass(kubeClient, "kubernetes.io/aws-ebs")
+	err = createDefaultStorageClass(kubeClient, "kubernetes.io/aws-ebs", storagev1.VolumeBindingWaitForFirstConsumer)
 	if err != nil {
 		return err
 	}

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -27,6 +27,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	storageUtil "k8s.io/kubernetes/pkg/apis/storage/util"
 )
 
 // CreateKubernetesClusterFromRequest creates ClusterModel struct from the request
@@ -78,15 +79,16 @@ func (c *KubeCluster) Persist(status, statusMessage string) error {
 
 // createDefaultStorageClass creates a default storage class as some clusters are not created with
 // any storage classes or with default one
-func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provisioner string) error {
+func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provisioner string, volumeBindingMode storagev1.VolumeBindingMode) error {
 	defaultStorageClass := storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 			Annotations: map[string]string{
-				"storageclass.kubernetes.io/is-default-class": "true",
+				storageUtil.IsDefaultStorageClassAnnotation: "true",
 			},
 		},
-		Provisioner: provisioner,
+		VolumeBindingMode: &volumeBindingMode,
+		Provisioner:       provisioner,
 	}
 
 	_, err := kubernetesClient.StorageV1().StorageClasses().Create(&defaultStorageClass)


### PR DESCRIPTION
This helps to prevent issues when trying to cross-mount EBS Volumes across zones.

https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode