### PR TITLE
support for access secret (on azure)

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -461,7 +461,7 @@ func DeleteBucket(c *gin.Context) {
 		return
 	}
 
-	logger.Infof("object store bucket deleted")
+	logger.Info("object store bucket deleted")
 }
 
 // hasSecret checks the header for secret references, returns true in case one of the following headers are found:

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -761,10 +761,17 @@ func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint,
 	var (
 		secretName       string
 		accessSecretName string
-		notes            string
+
+		notes string
 	)
 
+	if (bi.AccessSecretRef == "") {
+		// accessSecretRef is only set on Azure, use the SecretRef on other providers
+		bi.AccessSecretRef = bi.SecretRef
+	}
+
 	if withSecretName {
+
 		// get the secret name from the store if requested
 		if secretResponse, err := secret.Store.Get(orgid, bi.SecretRef); err == nil {
 			secretName = secretResponse.Name
@@ -773,6 +780,7 @@ func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint,
 			notes = err.Error()
 		}
 
+		// the accessSecret name needs to be changed on Azure only
 		accessSecretName = secretName
 
 		// in case of azure the access secret differs from the secret used to create it

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -765,7 +765,7 @@ func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint,
 		notes string
 	)
 
-	if (bi.AccessSecretRef == "") {
+	if bi.AccessSecretRef == "" {
 		// accessSecretRef is only set on Azure, use the SecretRef on other providers
 		bi.AccessSecretRef = bi.SecretRef
 	}

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -52,7 +52,7 @@ const (
 type secretData struct {
 	SecretId         string `json:"id"`
 	SecretName       string `json:"name,omitempty"`
-	AccessSecretId   string `json:"accessId"`
+	AccessSecretId   string `json:"accessId,omitempty"`
 	AccessSecretName string `json:"accessName,omitempty"`
 }
 

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -670,37 +670,7 @@ func bucketsResponse(buckets []*objectstore.BucketInfo, orgid uint, withSecretNa
 	bucketItems := make([]*BucketResponseItem, 0)
 
 	for _, bucket := range buckets {
-
-		var (
-			secretName       string
-			accessSecretName string
-			notes            string
-		)
-
-		if withSecretName {
-			// get the secret name from the store if requested
-			if secretResponse, err := secret.Store.Get(orgid, bucket.SecretRef); err == nil {
-				secretName = secretResponse.Name
-			} else {
-				errorHandler.Handle(err)
-				notes = err.Error()
-			}
-
-			accessSecretName = secretName
-
-			// in case of azure the access secret differs from the secret used to create it
-			if bucket.Cloud == pkgCluster.Azure {
-				// get the access - secret name from the store if requested
-				if secretResponse, err := secret.Store.Get(orgid, bucket.AccessSecretRef); err == nil {
-					accessSecretName = secretResponse.Name
-				} else {
-					errorHandler.Handle(err)
-					notes = err.Error()
-				}
-			}
-
-		}
-		bucketItems = append(bucketItems, newBucketResponseItemFromBucketInfo(bucket, notes, secretName, accessSecretName))
+		bucketItems = append(bucketItems, newBucketResponseItemFromBucketInfo(bucket, orgid, withSecretName))
 	}
 
 	return bucketItems
@@ -727,6 +697,13 @@ func GetBucket(c *gin.Context) {
 		return
 	}
 
+	const (
+		fieldsQueryKey = "include"
+		secretName     = "secret"
+	)
+	// is secretName requested?
+	includeSecret := c.Query(fieldsQueryKey) == secretName
+
 	organization := auth.GetCurrentOrganization(c.Request)
 	objectStoreCtx := &providers.ObjectStoreContext{
 		Provider:     provider,
@@ -751,7 +728,7 @@ func GetBucket(c *gin.Context) {
 
 	for _, bucket := range bucketList {
 		if bucket.Name == bucketName {
-			c.JSON(http.StatusOK, newBucketResponseItemFromBucketInfo(bucket, "", "", ""))
+			c.JSON(http.StatusOK, newBucketResponseItemFromBucketInfo(bucket, organization.ID, includeSecret))
 
 			return
 		}
@@ -779,7 +756,37 @@ func (err BucketNotFoundError) NotFound() bool {
 }
 
 // newBucketResponseItemFromBucketInfo builds a responsItem based opn the provided bucketInfo
-func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, notes, secretName, accessSecretName string) *BucketResponseItem {
+func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint, withSecretName bool) *BucketResponseItem {
+	var (
+		secretName       string
+		accessSecretName string
+		notes            string
+	)
+
+	if withSecretName {
+		// get the secret name from the store if requested
+		if secretResponse, err := secret.Store.Get(orgid, bi.SecretRef); err == nil {
+			secretName = secretResponse.Name
+		} else {
+			errorHandler.Handle(err)
+			notes = err.Error()
+		}
+
+		accessSecretName = secretName
+
+		// in case of azure the access secret differs from the secret used to create it
+		if bi.Cloud == pkgCluster.Azure {
+			// get the access - secret name from the store if requested
+			if secretResponse, err := secret.Store.Get(orgid, bi.AccessSecretRef); err == nil {
+				accessSecretName = secretResponse.Name
+			} else {
+				errorHandler.Handle(err)
+				notes = err.Error()
+			}
+		}
+
+	}
+
 	ret := BucketResponseItem{
 		Name:      bi.Name,
 		Status:    bi.Status,

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -471,6 +471,7 @@ func DeleteBucket(c *gin.Context) {
 func hasSecret(c *gin.Context) bool {
 	return c.GetHeader(secretNameHeader) != "" || c.GetHeader(secretIdHeader) != ""
 }
+
 func getBucketContext(c *gin.Context, logger logrus.FieldLogger) (*auth.Organization, *secret.SecretItemResponse, string, bool) {
 	organization := auth.GetCurrentOrganization(c.Request)
 

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-cabe94d23821cbab1d097077ae06f6d79a69ab21be7bae26a00c48e9906235da  docs/openapi/pipeline.yaml
+c560404ba0fc875a28988447433d64a2f3e49d6818d9b610c3cbf90067a1df32  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -7410,6 +7410,8 @@ components:
         managed: true
         name: mybucket
         secret:
+          accessId: cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dcef
+          accessName: myaccesssecretname
           name: mysecretname
           id: cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dca1
         statusMessage: statusMessage
@@ -9533,6 +9535,8 @@ components:
       type: object
     BucketInfo_secret:
       example:
+        accessId: cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dcef
+        accessName: myaccesssecretname
         name: mysecretname
         id: cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dca1
       properties:
@@ -9541,6 +9545,14 @@ components:
           type: string
         name:
           example: mysecretname
+          type: string
+        accessId:
+          description: the secret identifier of the azure access information
+          example: cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dcef
+          type: string
+        accessName:
+          description: the secret name of the azure access information
+          example: myaccesssecretname
           type: string
       type: object
     PodItem_labels:

--- a/client/docs/BucketInfoSecret.md
+++ b/client/docs/BucketInfoSecret.md
@@ -5,6 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** |  | [optional] 
 **Name** | **string** |  | [optional] 
+**AccessId** | **string** | the secret identifier of the azure access information | [optional] 
+**AccessName** | **string** | the secret name of the azure access information | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_bucket_info_secret.go
+++ b/client/model_bucket_info_secret.go
@@ -14,4 +14,8 @@ package client
 type BucketInfoSecret struct {
 	Id   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
+	// the secret identifier of the azure access information
+	AccessId string `json:"accessId,omitempty"`
+	// the secret name of the azure access information
+	AccessName string `json:"accessName,omitempty"`
 }

--- a/database/migrations/1542019624_objectstore_azure_accesssecret_field.down.sql
+++ b/database/migrations/1542019624_objectstore_azure_accesssecret_field.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE azure_buckets DROP COLUMN access_secret_ref;

--- a/database/migrations/1542019624_objectstore_azure_accesssecret_field.up.sql
+++ b/database/migrations/1542019624_objectstore_azure_accesssecret_field.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE azure_buckets ADD access_secret_ref varchar(255) null,

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -6780,6 +6780,14 @@ components:
                         name:
                             type: string
                             example: "mysecretname"
+                        accessId:
+                            description: "the secret identifier of the azure access information"
+                            type: string
+                            example: "cc051aeaf686444e2f125d0e79eb051aaaf4fb73384f7b0f8c89e84a0502dcef"
+                        accessName:
+                            description: "the secret name of the azure access information"
+                            type: string
+                            example: "myaccesssecretname"
                 azure:
                     $ref: '#/components/schemas/AzureBlobStorageProps'
                 status:

--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -26,14 +26,15 @@ type ObjectStoreService interface {
 
 // BucketInfo desribes a storage bucket
 type BucketInfo struct {
-	Name      string                    `json:"name"  binding:"required"`
-	Managed   bool                      `json:"managed" binding:"required"`
-	Location  string                    `json:"location,omitempty"`
-	SecretRef string                    `json:"secretId,omitempty"`
-	Cloud     string                    `json:"cloud,omitempty"`
-	Azure     *BlobStoragePropsForAzure `json:"aks,omitempty"`
-	Status    string                    `json:"status"`
-	StatusMsg string                    `json:"statusMsg"`
+	Name            string                    `json:"name"  binding:"required"`
+	Managed         bool                      `json:"managed" binding:"required"`
+	Location        string                    `json:"location,omitempty"`
+	SecretRef       string                    `json:"secretId,omitempty"`
+	Cloud           string                    `json:"cloud,omitempty"`
+	Azure           *BlobStoragePropsForAzure `json:"aks,omitempty"`
+	Status          string                    `json:"status"`
+	StatusMsg       string                    `json:"statusMsg"`
+	AccessSecretRef string                    `json:"accessSecretId"`
 }
 
 // BlobStoragePropsForAzure describes the Azure specific properties

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -202,9 +202,9 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 		return s.createFailed(bucket, emperror.Wrap(err, "failed to create or update access-secret"))
 	}
 	logger.WithField("acc-secret-name", accSecretName).Info("secret created/updated")
+
 	bucket.Status = providers.BucketCreated
 	bucket.AccessSecretRef = accSecretId
-
 	err = s.db.Save(bucket).Error
 	if err != nil {
 		return s.createFailed(bucket, emperror.Wrap(err, "failed to save bucket"))
@@ -230,7 +230,8 @@ func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (string
 			fmt.Sprintf("azureStorageAccount:%v", s.getStorageAccount()),
 		},
 	}
-	if secretId, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest); err != nil {
+	secretId, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest);
+	if err != nil {
 		return secretId, secretName, emperror.WrapWith(err, "failed to create/update secret", "secret", secretName)
 	}
 	return secretId, secretName, nil
@@ -570,6 +571,7 @@ func (s *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 		bucketInfo := &objectstore.BucketInfo{Name: bucket.Name, Managed: true}
 		bucketInfo.Location = bucket.Location
 		bucketInfo.SecretRef = bucket.SecretRef
+		bucketInfo.AccessSecretRef = bucket.AccessSecretRef
 		bucketInfo.Cloud = providers.Azure
 		bucketInfo.Status = bucket.Status
 		bucketInfo.StatusMsg = bucket.StatusMsg

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -387,9 +387,8 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 	if err := s.db.Where(searchCriteria).Find(bucket).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return bucketNotFoundError{}
-		} else {
-			return emperror.WrapWith(err, "failed to lookup", "bucket", bucketName)
 		}
+		return emperror.WrapWith(err, "failed to lookup", "bucket", bucketName)
 	}
 
 	if err := s.deleteFromProvider(bucket); err != nil {

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -34,8 +34,8 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
+	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -124,8 +124,6 @@ func (s *ObjectStore) getLogger(bucketName string) logrus.FieldLogger {
 // CreateBucket creates an Azure Object Store Blob with the provided name
 // within a generated/provided ResourceGroup and StorageAccount
 func (s *ObjectStore) CreateBucket(bucketName string) error {
-	resourceGroup := s.getResourceGroup()
-	storageAccount := s.getStorageAccount()
 
 	logger := s.getLogger(bucketName)
 
@@ -136,135 +134,130 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 
 	switch dbr.Error {
 	case nil:
-		return errors.Wrapf(dbr.Error, "the bucket [%s] already exists", bucketName)
+		return emperror.WrapWith(dbr.Error, "the bucket already exists", "bucket", bucketName)
 	case gorm.ErrRecordNotFound:
 		// proceed to creation
 	default:
-		return errors.Wrapf(dbr.Error, "error while retrieving bucket [%s]", bucketName)
-
+		return emperror.WrapWith(dbr.Error, "failed to retrieve bucket", "bucket", bucketName)
 	}
 
 	bucket.Name = bucketName
-	bucket.ResourceGroup = resourceGroup
-	bucket.StorageAccount = storageAccount
+	bucket.ResourceGroup = s.getResourceGroup()
+	bucket.StorageAccount = s.getStorageAccount()
 	bucket.Organization = *s.org
 	bucket.SecretRef = s.secret.ID
 	bucket.Status = providers.BucketCreating
 
-	logger.Info("saving bucket in DB")
+	logger.Info("persisting bucket to database...")
 
-	err := s.db.Save(bucket).Error
-	if err != nil {
-		return errors.Wrap(err, "error happened during saving bucket in DB")
+	if err := s.db.Save(bucket).Error; err != nil {
+		return emperror.WrapWith(err, "failed to save bucket", "bucket", bucketName)
 	}
 
-	err = s.createResourceGroup(resourceGroup)
-	if err != nil {
-		return s.rollback(logger, "resource group creation failed", err, bucket)
+	if err := s.createResourceGroup(s.getResourceGroup()); err != nil {
+		return s.createFailed(bucket, emperror.Wrap(err, "failed to create resource group"))
 	}
 
 	// update here so the bucket list does not get inconsistent
 	updateField := &ObjectStoreBucketModel{StorageAccount: s.storageAccount}
-	err = s.db.Model(bucket).Update(updateField).Error
-	if err != nil {
-		return errors.Wrap(err, "error happened during updating storage account")
+	if err := s.db.Model(bucket).Update(updateField).Error; err != nil {
+		return s.createFailed(bucket, emperror.Wrap(err, "could not update bucket with storage account"))
 	}
 
-	exists, err := s.checkStorageAccountExistence(resourceGroup, storageAccount)
-
+	exists, err := s.checkStorageAccountExistence(s.getResourceGroup(), s.getStorageAccount())
 	if err != nil {
-		return s.rollback(logger, "error during creating the storage account:", err, bucket)
+		return s.createFailed(bucket, emperror.Wrap(err, "failed to check storage account"))
 	}
 
 	if !exists {
-		err = s.createStorageAccount(resourceGroup, storageAccount)
-		if err != nil {
-			return s.rollback(logger, "storage account creation failed", err, bucket)
+		if err = s.createStorageAccount(s.getResourceGroup(), s.getStorageAccount()); err != nil {
+			return s.createFailed(bucket, emperror.Wrap(err, "failed to create storage account"))
 		}
 	}
 
-	key, err := GetStorageAccountKey(resourceGroup, storageAccount, s.secret, s.logger)
+	key, err := GetStorageAccountKey(s.getResourceGroup(), s.getStorageAccount(), s.secret, s.logger)
 	if err != nil {
-		return s.rollback(logger, "could not get storage account", err, bucket)
+		return s.createFailed(bucket, emperror.Wrap(err, "failed to retrieve storage account"))
 	}
 
 	// update here so the bucket list does not get inconsistent
 	updateField = &ObjectStoreBucketModel{Name: bucketName, Location: s.location}
-	err = s.db.Model(bucket).Update(updateField).Error
-	if err != nil {
-		return s.rollback(logger, "error happened during updating bucket name", err, bucket)
+	if err = s.db.Model(bucket).Update(updateField).Error; err != nil {
+		return s.createFailed(bucket, emperror.WrapWith(err, "failed to update bucket", "fields", []string{"Name", "Location"}))
 	}
 
-	p := azblob.NewPipeline(azblob.NewSharedKeyCredential(storageAccount, key), azblob.PipelineOptions{})
-	URL, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s", storageAccount, bucketName))
+	p := azblob.NewPipeline(azblob.NewSharedKeyCredential(s.getStorageAccount(), key), azblob.PipelineOptions{})
+	URL, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s", s.getStorageAccount(), bucketName))
 	containerURL := azblob.NewContainerURL(*URL, p)
 
 	_, err = containerURL.GetPropertiesAndMetadata(context.TODO(), azblob.LeaseAccessConditions{})
 	if err != nil && err.(azblob.StorageError).ServiceCode() == azblob.ServiceCodeContainerNotFound {
-		_, err = containerURL.Create(context.TODO(), azblob.Metadata{}, azblob.PublicAccessNone)
-		if err != nil {
-			return s.rollback(logger, "cannot access bucket", err, bucket)
+		if _, err = containerURL.Create(context.TODO(), azblob.Metadata{}, azblob.PublicAccessNone); err != nil {
+			return s.createFailed(bucket, emperror.Wrap(err, "failed to access bucket"))
 		}
 	}
 
-	secretName, err := s.createUpdateStorageAccountSecret(key)
+	accSecretId, accSecretName, err := s.createUpdateStorageAccountSecret(key)
 	if err != nil {
-		return err
+		return s.createFailed(bucket, emperror.Wrap(err, "failed to create or update access-secret"))
 	}
-	logger.Infof("storageAccount secret %v created/updated", secretName)
+	logger.WithField("acc-secret-name", accSecretName).Info("secret created/updated")
 	bucket.Status = providers.BucketCreated
+	bucket.AccessSecretRef = accSecretId
 
 	err = s.db.Save(bucket).Error
 	if err != nil {
-		return s.rollback(logger, "could not save bucket", err, bucket)
+		return s.createFailed(bucket, emperror.Wrap(err, "failed to save bucket"))
 	}
 
 	return nil
 }
 
-func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (string, error) {
-	storageAccount := s.getStorageAccount()
+func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (string, string, error) {
 
-	storageAccountName := alfanumericRegexp.ReplaceAllString(storageAccount, "-")
+	var secretId string
+	storageAccountName := alfanumericRegexp.ReplaceAllString(s.getStorageAccount(), "-")
 	secretName := fmt.Sprintf("%v-key", storageAccountName)
 
 	secretRequest := secret.CreateSecretRequest{
 		Name: secretName,
 		Type: "azureStorageAccount",
 		Values: map[string]string{
-			"storageAccount": storageAccount,
+			"storageAccount": s.getStorageAccount(),
 			"accessKey":      accesskey,
 		},
 		Tags: []string{
-			fmt.Sprintf("azureStorageAccount:%v", storageAccount),
+			fmt.Sprintf("azureStorageAccount:%v", s.getStorageAccount()),
 		},
 	}
-	if _, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest); err != nil {
-		return secretName, errors.Wrap(err, "failed to create/update secret: "+secretRequest.Name)
+	if secretId, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest); err != nil {
+		return secretId, secretName, emperror.WrapWith(err, "failed to create/update secret", "secret", secretName)
 	}
-	return secretName, nil
+	return secretId, secretName, nil
 }
 
-func (s *ObjectStore) rollback(logger logrus.FieldLogger, msg string, err error, bucket *ObjectStoreBucketModel) error {
+func (s *ObjectStore) createFailed(bucket *ObjectStoreBucketModel, err error) error {
+
 	bucket.Status = providers.BucketCreateError
 	bucket.StatusMsg = err.Error()
-	e := s.db.Save(bucket).Error
-	if e != nil {
-		logger.Error(e.Error())
+
+	if e := s.db.Save(bucket).Error; e != nil {
+		return emperror.WrapWith(e, "failed to save bucket", "gorm", "db")
 	}
 
-	return errors.Wrapf(err, "%s", msg)
+	return emperror.With(err, "create failed")
 }
 
-func (s *ObjectStore) deleteFailed(logger logrus.FieldLogger, msg string, err error, bucket *ObjectStoreBucketModel) error {
+func (s *ObjectStore) deleteFailed(bucket *ObjectStoreBucketModel, err error) error {
+
 	bucket.Status = providers.BucketDeleteError
 	bucket.StatusMsg = err.Error()
-	e := s.db.Save(bucket).Error
-	if e != nil {
-		logger.Error(e.Error())
+
+	if e := s.db.Save(bucket).Error; e != nil {
+		return emperror.WrapWith(e, "failed to save bucket", "gorm", "db")
 	}
 
-	return errors.Wrapf(err, "%s", msg)
+	return emperror.With(err, "create failed")
 }
 
 func (s *ObjectStore) createResourceGroup(resourceGroup string) error {
@@ -385,7 +378,7 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 	bucket := &ObjectStoreBucketModel{}
 	searchCriteria := s.searchCriteria(bucketName)
 
-	logger.Info("looking up the bucket")
+	logger.Info("looking up the bucket...")
 
 	if err := s.db.Where(searchCriteria).Find(bucket).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -393,16 +386,21 @@ func (s *ObjectStore) DeleteBucket(bucketName string) error {
 		}
 	}
 
+	bucket.Status = providers.BucketDeleting
+	db := s.db.Save(bucket)
+	if db.Error != nil {
+		return s.deleteFailed(bucket, emperror.WrapWith(db.Error, "failed to update", "bucket", bucketName))
+	}
+
 	if err := s.deleteFromProvider(bucket); err != nil {
 		if !s.force {
 			// if delete is not forced return here
-			return err
+			return s.deleteFailed(bucket, emperror.WrapWith(err, "failed to delete from provider", "bucket", bucketName))
 		}
 	}
 
-	db := s.db.Delete(bucket)
-	if db.Error != nil {
-		return s.deleteFailed(logger, db.Error.Error(), db.Error, bucket)
+	if err := s.db.Delete(bucket).Error; err != nil {
+		return s.deleteFailed(bucket, emperror.WrapWith(db.Error, "failed to delete", "bucket", bucketName))
 	}
 
 	return nil
@@ -420,15 +418,9 @@ func (s *ObjectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
 		return nil
 	}
 
-	bucket.Status = providers.BucketDeleting
-	db := s.db.Save(bucket)
-	if db.Error != nil {
-		return fmt.Errorf("could not update bucket: %s", bucket.Name)
-	}
-
 	key, err := GetStorageAccountKey(s.getResourceGroup(), s.getStorageAccount(), s.secret, s.logger)
 	if err != nil {
-		return s.deleteFailed(logger, "could not get account key", err, bucket)
+		return emperror.WrapWith(err, "filed to retrieve storage account key", "bucket", bucket.Name)
 	}
 
 	p := azblob.NewPipeline(azblob.NewSharedKeyCredential(s.getStorageAccount(), key), azblob.PipelineOptions{})
@@ -436,7 +428,7 @@ func (s *ObjectStore) deleteFromProvider(bucket *ObjectStoreBucketModel) error {
 	containerURL := azblob.NewContainerURL(*URL, p)
 
 	if _, err = containerURL.Delete(context.TODO(), azblob.ContainerAccessConditions{}); err != nil {
-		return s.deleteFailed(logger, "could not delete container", err, bucket)
+		return emperror.WrapWith(err, "failed to delete container", "bucket", bucket.Name)
 	}
 
 	return nil
@@ -448,28 +440,23 @@ func (s *ObjectStore) CheckBucket(bucketName string) error {
 	storageAccount := s.getStorageAccount()
 
 	logger := s.getLogger(bucketName)
-	logger.Info("looking for bucket")
+	logger.Info("looking up the bucket")
 
-	_, err := s.checkStorageAccountExistence(resourceGroup, storageAccount)
-	if err != nil {
-		logger.Error(err.Error())
-		return err
+	if _, err := s.checkStorageAccountExistence(resourceGroup, storageAccount); err != nil {
+		return emperror.WrapWith(err, "failed to check storage account", "bucket", bucketName)
 	}
 
 	key, err := GetStorageAccountKey(resourceGroup, storageAccount, s.secret, s.logger)
 	if err != nil {
-		logger.Error(err.Error())
-
-		return err
+		return emperror.WrapWith(err, "failed to get storage account key", "bucket", bucketName)
 	}
 
 	p := azblob.NewPipeline(azblob.NewSharedKeyCredential(s.storageAccount, key), azblob.PipelineOptions{})
 	URL, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s", s.storageAccount, bucketName))
 	containerURL := azblob.NewContainerURL(*URL, p)
 
-	_, err = containerURL.GetPropertiesAndMetadata(context.TODO(), azblob.LeaseAccessConditions{})
-	if err != nil {
-		return err
+	if _, err = containerURL.GetPropertiesAndMetadata(context.TODO(), azblob.LeaseAccessConditions{}); err != nil {
+		return emperror.WrapWith(err, "failed to get container metadata", "bucket", bucketName)
 	}
 
 	return nil
@@ -599,7 +586,7 @@ func (s *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 func GetStorageAccountKey(resourceGroup string, storageAccount string, s *secret.SecretItemResponse, log logrus.FieldLogger) (string, error) {
 	client, err := createStorageAccountClient(s)
 	if err != nil {
-		return "", err
+		return "", emperror.WrapWith(err, "failed to create storage accounts client", "storageaccount", storageAccount)
 	}
 
 	logger := log.WithFields(logrus.Fields{
@@ -611,7 +598,7 @@ func GetStorageAccountKey(resourceGroup string, storageAccount string, s *secret
 
 	keys, err := client.ListKeys(context.TODO(), resourceGroup, storageAccount)
 	if err != nil {
-		return "", errors.Wrap(err, "error retrieving keys for StorageAccount")
+		return "", emperror.WrapWith(err, "failed to retrieve keys  for storage account", "storageaccount", storageAccount)
 	}
 
 	key := (*keys.Keys)[0].Value
@@ -624,7 +611,7 @@ func createStorageAccountClient(s *secret.SecretItemResponse) (*storage.Accounts
 
 	authorizer, err := newAuthorizer(s)
 	if err != nil {
-		return nil, errors.Wrap(err, "error happened during authentication")
+		return nil, emperror.Wrap(err, "failed to authenticate")
 	}
 
 	accountClient.Authorizer = authorizer

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -708,6 +708,6 @@ func (s *ObjectStore) searchCriteria(bucketName string) *ObjectStoreBucketModel 
 		Name:           bucketName,
 		ResourceGroup:  s.getResourceGroup(),
 		StorageAccount: s.getStorageAccount(),
-		Location:       s.location,
+		//Location:       s.location,
 	}
 }

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -230,7 +230,7 @@ func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (string
 			fmt.Sprintf("azureStorageAccount:%v", s.getStorageAccount()),
 		},
 	}
-	secretId, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest);
+	secretId, err := secret.Store.CreateOrUpdate(s.org.ID, &secretRequest)
 	if err != nil {
 		return secretId, secretName, emperror.WrapWith(err, "failed to create/update secret", "secret", secretName)
 	}

--- a/internal/providers/azure/objectstore_model.go
+++ b/internal/providers/azure/objectstore_model.go
@@ -33,9 +33,10 @@ type ObjectStoreBucketModel struct {
 	StorageAccount string `gorm:"unique_index:idx_bucket_name"`
 	Location       string
 
-	SecretRef string
-	Status    string
-	StatusMsg string `sql:"type:text;"`
+	SecretRef       string
+	Status          string
+	StatusMsg       string `sql:"type:text;"`
+	AccessSecretRef string
 }
 
 // TableName changes the default table name.


### PR DESCRIPTION
* bucket model extended with the access-secret reference (azure only)
* list managed buckets and get bucket calls return the access secret too (with the include=secret query passed also the name of secrets is returned)
* started the cleanup of error handling (azure mainly); context and logging need more elaboration
* added database schema modifier scripts
* openapi changes

Tested mainly on azure, other providers underway (no breaking changes though)

fixes #1336