### PR TITLE
Add `spot` flag to cluster status response

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-bed327bce4e002ec621d5724836d45700e2abac20fc50251ad0e0a2c490fc36a  docs/openapi/pipeline.yaml
+da4910eee260d66eb109c64e10348815532e1e2ac2d07519e1aecf39ce3ab3d8  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -7184,20 +7184,21 @@ components:
       type: object
     GetClusterStatusResponse:
       example:
-        cloud: google
-        createdAt: 2018-07-03T14:23:19+02:00
-        name: myClusterName
         creatorName: userName
         creatorId: 1
+        distribution: gke
+        statusMessage: Cluster is running
+        cloud: google
+        createdAt: 2018-07-03T14:23:19+02:00
+        spot: true
+        name: myClusterName
         location: us-central1-a
         id: 1
         nodePools:
           key:
             count: 1
             instanceType: n1-standard-1
-        distribution: gke
         region: us-central1
-        statusMessage: Cluster is running
         status: RUNNING
       properties:
         status:
@@ -7215,6 +7216,8 @@ components:
         distribution:
           example: gke
           type: string
+        spot:
+          type: boolean
         location:
           example: us-central1-a
           type: string

--- a/client/docs/GetClusterStatusResponse.md
+++ b/client/docs/GetClusterStatusResponse.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | [optional] 
 **Cloud** | **string** |  | [optional] 
 **Distribution** | **string** |  | [optional] 
+**Spot** | **bool** |  | [optional] 
 **Location** | **string** |  | [optional] 
 **Id** | **int32** |  | [optional] 
 **CreatedAt** | **string** |  | [optional] 

--- a/client/model_get_cluster_status_response.go
+++ b/client/model_get_cluster_status_response.go
@@ -17,6 +17,7 @@ type GetClusterStatusResponse struct {
 	Name          string                    `json:"name,omitempty"`
 	Cloud         string                    `json:"cloud,omitempty"`
 	Distribution  string                    `json:"distribution,omitempty"`
+	Spot          bool                      `json:"spot,omitempty"`
 	Location      string                    `json:"location,omitempty"`
 	Id            int32                     `json:"id,omitempty"`
 	CreatedAt     string                    `json:"createdAt,omitempty"`

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -776,6 +776,8 @@ func (c *EKSCluster) DownloadK8sConfig() ([]byte, error) {
 // GetStatus describes the status of this EKS cluster.
 func (c *EKSCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 
+	var hasSpotNodePool bool
+
 	nodePools := make(map[string]*pkgCluster.NodePoolStatus)
 	for _, np := range c.modelCluster.EKS.NodePools {
 		if np != nil {
@@ -788,6 +790,9 @@ func (c *EKSCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 				MaxCount:     np.NodeMaxCount,
 				Image:        np.NodeImage,
 			}
+			if np.NodeSpotPrice != "" && np.NodeSpotPrice != "0" {
+				hasSpotNodePool = true
+			}
 		}
 	}
 
@@ -798,6 +803,7 @@ func (c *EKSCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 		Location:          c.modelCluster.Location,
 		Cloud:             c.modelCluster.Cloud,
 		Distribution:      c.modelCluster.Distribution,
+		Spot:              hasSpotNodePool,
 		ResourceID:        c.modelCluster.ID,
 		NodePools:         nodePools,
 		Version:           c.modelCluster.EKS.Version,

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1291,12 +1291,7 @@ func isSpotCluster(cluster CommonCluster) (bool, error) {
 	if err != nil {
 		return false, emperror.Wrap(err, "failed to get cluster status")
 	}
-	for _, nps := range status.NodePools {
-		if nps.SpotPrice != "" && nps.SpotPrice != "0" {
-			return true, nil
-		}
-	}
-	return false, nil
+	return status.Spot, nil
 }
 
 func initializeSpotConfigMap(client *kubernetes.Clientset, systemNs string) error {

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -6541,6 +6541,9 @@ components:
                 distribution:
                     type: string
                     example: "gke"
+                spot:
+                    type: boolean
+                    example: false
                 location:
                     type: string
                     example: "us-central1-a"

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -162,6 +162,7 @@ type GetClusterStatusResponse struct {
 	Location      string                     `json:"location"`
 	Cloud         string                     `json:"cloud"`
 	Distribution  string                     `json:"distribution"`
+	Spot          bool                       `json:"spot"`
 	Version       string                     `json:"version,omitempty"`
 	ResourceID    uint                       `json:"id"`
 	NodePools     map[string]*NodePoolStatus `json:"nodePools,omitempty"`
@@ -191,7 +192,7 @@ type GetClusterConfigResponse struct {
 
 // UpdateClusterRequest describes an update cluster request
 type UpdateClusterRequest struct {
-	Cloud            string `json:"cloud" binding:"required"`
+	Cloud string     `json:"cloud" binding:"required"`
 	UpdateProperties `json:"properties"`
 }
 

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -192,7 +192,7 @@ type GetClusterConfigResponse struct {
 
 // UpdateClusterRequest describes an update cluster request
 type UpdateClusterRequest struct {
-	Cloud string     `json:"cloud" binding:"required"`
+	Cloud            string `json:"cloud" binding:"required"`
 	UpdateProperties `json:"properties"`
 }
 

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -162,7 +162,7 @@ type GetClusterStatusResponse struct {
 	Location      string                     `json:"location"`
 	Cloud         string                     `json:"cloud"`
 	Distribution  string                     `json:"distribution"`
-	Spot          bool                       `json:"spot"`
+	Spot          bool                       `json:"spot,omitempty"`
 	Version       string                     `json:"version,omitempty"`
 	ResourceID    uint                       `json:"id"`
 	NodePools     map[string]*NodePoolStatus `json:"nodePools,omitempty"`


### PR DESCRIPTION
The new flag signals if the cluster has at least one node pool with spot instances configured.

This is needed for the UI implementation of setting "minimum on-demand percentages for replicas".
The GKE implementation will need to be updated once we have [this PR](https://github.com/banzaicloud/pipeline/pull/1352) merged.

Example cluster status call:
GET {{url}}/api/v1/orgs/:orgId/clusters/:clusterId
```
{
    "status": "ERROR",
    "statusMessage": "failed to create kubernetes tunnel: Unauthorized",
    "name": "ekscluster-marton-177",
    "location": "us-east-1",
    "cloud": "amazon",
    "distribution": "eks",
*   "spot": true,
    "version": "1.10",
    "id": 45,
    "nodePools": {
        "pool1": {
            "count": 1,
            "instanceType": "m5.xlarge",
            "spotPrice": "0",
            "minCount": 1,
            "maxCount": 1,
            "image": "ami-0440e4f6b9713faf6"
        },
        "pool2": {
            "count": 1,
            "instanceType": "c5.xlarge",
            "spotPrice": "0.4",
            "minCount": 1,
            "maxCount": 2,
            "image": "ami-0440e4f6b9713faf6"
        }
    },
    "createdAt": "2018-11-09T09:51:17+01:00",
    "creatorName": "martonsereg",
    "creatorId": 1
}
```