### PR TITLE
Get bucket call fixed to return only one item

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -691,7 +691,11 @@ func GetBucket(c *gin.Context) {
 
 	bucketName := c.Param("name")
 	if bucketName == "" {
-		ginutils.ReplyWithErrorResponse(c, errorResponseFrom(fmt.Errorf("bucketname path parameter is missing")))
+		ginutils.ReplyWithErrorResponse(c,
+			&pkgCommon.ErrorResponse{
+				Code:  http.StatusBadRequest,
+				Error: "`bucketname`path parameter is missing",
+			})
 		return
 	}
 
@@ -703,12 +707,22 @@ func GetBucket(c *gin.Context) {
 
 	if qd, err = bc.queryData(c); err != nil {
 		logger.Error("failed to parse query parameters")
-		ginutils.ReplyWithErrorResponse(c, errorResponseFrom(emperror.Wrap(err, "failed to parse query parameters")))
+		ginutils.ReplyWithErrorResponse(c,
+			&pkgCommon.ErrorResponse{
+				Code:    http.StatusBadRequest,
+				Error:   err.Error(),
+				Message: err.Error(),
+			})
 		return
 	}
 
 	if err = qd.validateForGetBucket(); err != nil {
-		ginutils.ReplyWithErrorResponse(c, errorResponseFrom(err))
+		ginutils.ReplyWithErrorResponse(c,
+			&pkgCommon.ErrorResponse{
+				Code:    http.StatusBadRequest,
+				Error:   err.Error(),
+				Message: err.Error(),
+			})
 		return
 	}
 

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -728,7 +728,7 @@ func GetBucket(c *gin.Context) {
 
 	organization := auth.GetCurrentOrganization(c.Request)
 	objectStoreCtx := &providers.ObjectStoreContext{
-		Provider:     qd.CloudType[0],
+		Provider:     qd.paramValue(qd.CloudType),
 		Organization: organization,
 	}
 

--- a/database/migrations/1542019624_objectstore_azure_accesssecret_field.up.sql
+++ b/database/migrations/1542019624_objectstore_azure_accesssecret_field.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE azure_buckets ADD access_secret_ref varchar(255) null,
+ALTER TABLE azure_buckets ADD access_secret_ref varchar(255) null;


### PR DESCRIPTION
* new way of handling query parameters (ease parsing, validation)
* cleaned the getBucket implementation
* bucket filtering done at "controller" level (possibly to be moved later to the database query layer)
* tested manually (mainly azure)

fixes #1315