### PR TITLE
Add source spotguide repo name to spotguide repos in Drone

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -458,11 +458,11 @@
 
 [[projects]]
   branch = "banzaidrone"
-  digest = "1:51da19b8983e62196d61850e35c5ff42a2f482b7fb8f998936e39c630ee47b9b"
+  digest = "1:dcccc00826cb77e0e53a9e8ca3093e5c69e5e81959b488e9821def8f19fd893c"
   name = "github.com/drone/drone-go"
   packages = ["drone"]
   pruneopts = "NUT"
-  revision = "2f6075cf9eea8ccd2314a9d5fb28583cfd3c6f2c"
+  revision = "8d59833cbc929793d621180fb639b4391b62fe2b"
   source = "github.com/banzaicloud/drone-go"
 
 [[projects]]

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -596,7 +596,8 @@ func enableCICD(request *LaunchRequest, httpRequest *http.Request) error {
 	}
 
 	isSpotguide := true
-	repoPatch := drone.RepoPatch{IsSpotguide: &isSpotguide}
+	spotguideSource := request.RepoFullname()
+	repoPatch := drone.RepoPatch{IsSpotguide: &isSpotguide, SpotguideSource: &spotguideSource}
 	_, err = droneClient.RepoPatch(request.RepoOrganization, request.RepoName, &repoPatch)
 	if err != nil {
 		return errors.Wrap(err, "failed to patch Drone repository")


### PR DESCRIPTION
So the repo can be linked to the original spotguide repo it was started from.