### PR TITLE
added wait option to create deployment

### DIFF
--- a/api/helm.go
+++ b/api/helm.go
@@ -84,6 +84,7 @@ func CreateDeployment(c *gin.Context) {
 		parsedRequest.namespace,
 		parsedRequest.deploymentReleaseName,
 		parsedRequest.dryRun,
+		parsedRequest.wait,
 		parsedRequest.values,
 		parsedRequest.odPcts,
 		parsedRequest.kubeConfig,
@@ -455,6 +456,7 @@ type parsedDeploymentRequest struct {
 	kubeConfig            []byte
 	organizationName      string
 	dryRun                bool
+	wait                  bool
 	odPcts                map[string]int
 }
 
@@ -484,6 +486,7 @@ func parseCreateUpdateDeploymentRequest(c *gin.Context, commonCluster cluster.Co
 	pdr.reuseValues = deployment.ReUseValues
 	pdr.namespace = deployment.Namespace
 	pdr.dryRun = deployment.DryRun
+	pdr.wait = deployment.Wait
 	pdr.odPcts = deployment.OdPcts
 
 	if deployment.Values != nil {

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-581612c3cb4051b80c163d8f8f91c67c4b4469b71cec035cd17638f593ac531d  docs/openapi/pipeline.yaml
+26356cd7bc49f98b46a1d277dba55ca021d145aab5b772d408bc5a939c1362c8  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -6010,6 +6010,7 @@ components:
       type: array
     CreateUpdateDeploymentRequest:
       example:
+        wait: true
         package: package
         dryRun: true
         releaseName: singed-bee
@@ -6041,6 +6042,9 @@ components:
           example: singed-bee
           type: string
         dryRun:
+          type: boolean
+        wait:
+          description: if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful
           type: boolean
         odPcts:
           description: 'Map of resources in the template where replicas should have

--- a/client/docs/CreateUpdateDeploymentRequest.md
+++ b/client/docs/CreateUpdateDeploymentRequest.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **Namespace** | **string** |  | [optional] 
 **ReleaseName** | **string** |  | [optional] 
 **DryRun** | **bool** |  | [optional] 
+**Wait** | **bool** | if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful | [optional] 
 **OdPcts** | [**map[string]interface{}**](map[string]interface{}.md) | Map of resources in the template where replicas should have a minimum on-demand percentage. Format: &lt;kind.resourceName: min-percentage&gt; | [optional] 
 **ReuseValues** | **bool** |  | [optional] 
 **Values** | [**map[string]interface{}**](map[string]interface{}.md) | current values of the deployment | [optional] 

--- a/client/model_create_update_deployment_request.go
+++ b/client/model_create_update_deployment_request.go
@@ -20,6 +20,8 @@ type CreateUpdateDeploymentRequest struct {
 	Namespace   string `json:"namespace,omitempty"`
 	ReleaseName string `json:"releaseName,omitempty"`
 	DryRun      bool   `json:"dryRun,omitempty"`
+	// if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful
+	Wait bool `json:"wait,omitempty"`
 	// Map of resources in the template where replicas should have a minimum on-demand percentage. Format: <kind.resourceName: min-percentage>
 	OdPcts      map[string]interface{} `json:"odPcts,omitempty"`
 	ReuseValues bool                   `json:"reuseValues,omitempty"`

--- a/cluster/autoscale.go
+++ b/cluster/autoscale.go
@@ -302,7 +302,7 @@ func deployAutoscalerChart(cluster CommonCluster, nodeGroups []nodeGroup, kubeCo
 
 	switch action {
 	case install:
-		_, err = helm.CreateDeployment(autoScalerChart, "", nil, helm.SystemNamespace, releaseName, false, yamlValues, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), helm.DefaultInstallOptions...)
+		_, err = helm.CreateDeployment(autoScalerChart, "", nil, helm.SystemNamespace, releaseName, false, false, yamlValues, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), helm.DefaultInstallOptions...)
 	case upgrade:
 		_, err = helm.UpgradeDeployment(releaseName, autoScalerChart, "", nil, yamlValues, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
 	default:

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -304,7 +304,7 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 	if err != nil {
 		return err
 	}
-	err = installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/logging-operator", pipConfig.LoggingReleaseName, operatorYamlValues, "", false)
+	err = installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/logging-operator", pipConfig.LoggingReleaseName, operatorYamlValues, "", true)
 	if err != nil {
 		return err
 	}

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -224,7 +224,7 @@ func InstallMonitoring(input interface{}) error {
 		return errors.Errorf("Json Convert Failed : %s", err.Error())
 	}
 
-	return installDeployment(cluster, grafanaNamespace, pkgHelm.BanzaiRepository+"/pipeline-cluster-monitor", pipConfig.MonitorReleaseName, grafanaValuesJson, "InstallMonitoring", "")
+	return installDeployment(cluster, grafanaNamespace, pkgHelm.BanzaiRepository+"/pipeline-cluster-monitor", pipConfig.MonitorReleaseName, grafanaValuesJson, "", false)
 }
 
 // InstallLogging to install logging deployment
@@ -304,7 +304,7 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 	if err != nil {
 		return err
 	}
-	err = installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/logging-operator", pipConfig.LoggingReleaseName, operatorYamlValues, "InstallLogging", "")
+	err = installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/logging-operator", pipConfig.LoggingReleaseName, operatorYamlValues, "", false)
 	if err != nil {
 		return err
 	}
@@ -332,7 +332,7 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 		if err != nil {
 			return err
 		}
-		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/s3-output", "pipeline-s3-output", marshaledValues, "ConfigureLoggingOutPut", "")
+		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/s3-output", "pipeline-s3-output", marshaledValues, "", false)
 	case pkgCluster.Google:
 		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []string{loggingParam.SecretId}}, loggingParam.GenTLSForLogging.Namespace)
 		if err != nil {
@@ -348,7 +348,7 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 		if err != nil {
 			return err
 		}
-		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/gcs-output", "pipeline-gcs-output", marshaledValues, "ConfigureLoggingOutPut", "")
+		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/gcs-output", "pipeline-gcs-output", marshaledValues, "", false)
 	case pkgCluster.Azure:
 
 		sak, err := azure.GetStorageAccountKey(loggingParam.ResourceGroup, loggingParam.StorageAccount, logSecret, log)
@@ -400,7 +400,7 @@ func InstallLogging(input interface{}, param pkgCluster.PostHookParam) error {
 			return err
 		}
 
-		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/azure-output", "pipeline-azure-output", marshaledValues, "ConfigureLoggingOutPut", "")
+		return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/azure-output", "pipeline-azure-output", marshaledValues, "", false)
 
 	default:
 		return fmt.Errorf("unexpected logging secret type: %s", logSecret.Type)
@@ -466,7 +466,7 @@ func getHeadNodeTolerations() []v1.Toleration {
 	}
 }
 
-func installDeployment(cluster CommonCluster, namespace string, deploymentName string, releaseName string, values []byte, actionName string, chartVersion string) error {
+func installDeployment(cluster CommonCluster, namespace string, deploymentName string, releaseName string, values []byte, chartVersion string, wait bool) error {
 	// --- [ Get K8S Config ] --- //
 	kubeConfig, err := cluster.GetK8sConfig()
 	if err != nil {
@@ -511,7 +511,7 @@ func installDeployment(cluster CommonCluster, namespace string, deploymentName s
 		}
 	}
 
-	_, err = helm.CreateDeployment(deploymentName, chartVersion, nil, namespace, releaseName, false, values, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), helm.DefaultInstallOptions...)
+	_, err = helm.CreateDeployment(deploymentName, chartVersion, nil, namespace, releaseName, false, wait, values, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), helm.DefaultInstallOptions...)
 	if err != nil {
 		log.Errorf("Deploying '%s' failed due to: %s", deploymentName, err.Error())
 		return err
@@ -578,7 +578,7 @@ func InstallIngressControllerPostHook(input interface{}) error {
 	}
 	namespace := viper.GetString(pipConfig.PipelineSystemNamespace)
 
-	return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/pipeline-cluster-ingress", "ingress", ingressValuesJson, "InstallIngressController", "")
+	return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/pipeline-cluster-ingress", "ingress", ingressValuesJson, "", false)
 }
 
 //InstallKubernetesDashboardPostHook post hooks can't return value, they can log error and/or update state?
@@ -696,7 +696,7 @@ func InstallKubernetesDashboardPostHook(input interface{}) error {
 
 	}
 
-	return installDeployment(cluster, k8sDashboardNameSpace, pkgHelm.BanzaiRepository+"/kubernetes-dashboard", k8sDashboardReleaseName, valuesJson, "InstallKubernetesDashboard", "")
+	return installDeployment(cluster, k8sDashboardNameSpace, pkgHelm.BanzaiRepository+"/kubernetes-dashboard", k8sDashboardReleaseName, valuesJson, "", false)
 
 }
 
@@ -800,7 +800,7 @@ func InstallHorizontalPodAutoscalerPostHook(input interface{}) error {
 		return err
 	}
 
-	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/hpa-operator", "hpa-operator", valuesOverride, "InstallHorizontalPodAutoscaler", "")
+	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/hpa-operator", "hpa-operator", valuesOverride, "", false)
 }
 
 //InstallPVCOperatorPostHook installs the PVC operator
@@ -821,7 +821,7 @@ func InstallPVCOperatorPostHook(input interface{}) error {
 		return err
 	}
 
-	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/pvc-operator", "pvc-operator", valuesOverride, "InstallPVCOperator", "")
+	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/pvc-operator", "pvc-operator", valuesOverride, "", false)
 }
 
 //InstallAnchoreImageValidator installs Anchore image validator
@@ -857,7 +857,7 @@ func InstallAnchoreImageValidator(input interface{}) error {
 	if err != nil {
 		return err
 	}
-	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/anchore-policy-validator", "anchore", marshalledValues, "InstallAnchoreImageValidator", "")
+	return installDeployment(cluster, infraNamespace, pkgHelm.BanzaiRepository+"/anchore-policy-validator", "anchore", marshalledValues, "", true)
 
 }
 
@@ -1039,7 +1039,7 @@ func RegisterDomainPostHook(input interface{}) error {
 	}
 	chartVersion := viper.GetString(pipConfig.DNSExternalDnsChartVersion)
 
-	return installDeployment(commonCluster, route53SecretNamespace, pkgHelm.StableRepository+"/external-dns", "dns", externalDnsValuesJson, "InstallExternalDNS", chartVersion)
+	return installDeployment(commonCluster, route53SecretNamespace, pkgHelm.StableRepository+"/external-dns", "dns", externalDnsValuesJson, chartVersion, false)
 }
 
 // LabelNodes adds labels for all nodes
@@ -1289,11 +1289,11 @@ func InitSpotConfig(input interface{}) error {
 		return emperror.Wrap(err, "failed to marshal yaml values")
 	}
 
-	err = installDeployment(cluster, pipelineSystemNamespace, pkgHelm.BanzaiRepository+"/spot-scheduler", "spot-scheduler", marshalledValues, "InstallSpotScheduler", "")
+	err = installDeployment(cluster, pipelineSystemNamespace, pkgHelm.BanzaiRepository+"/spot-scheduler", "spot-scheduler", marshalledValues, "", false)
 	if err != nil {
 		return emperror.Wrap(err, "failed to install the spot-scheduler deployment")
 	}
-	err = installDeployment(cluster, pipelineSystemNamespace, pkgHelm.BanzaiRepository+"/spot-config-webhook", "spot-webhook", marshalledValues, "InstallSpotWebhook", "")
+	err = installDeployment(cluster, pipelineSystemNamespace, pkgHelm.BanzaiRepository+"/spot-config-webhook", "spot-webhook", marshalledValues, "", true)
 	if err != nil {
 		return emperror.Wrap(err, "failed to install the spot-config-webhook deployment")
 	}
@@ -1333,7 +1333,7 @@ func deploySpotTerminationAlertExporter(cluster CommonCluster, namespace string)
 		return emperror.Wrap(err, "failed to marshal yaml values")
 	}
 
-	return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/spot-termination-exporter", "spot-termination-exporter", marshalledValues, "InstallSpotTerminationExporter", "")
+	return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/spot-termination-exporter", "spot-termination-exporter", marshalledValues, "", false)
 }
 
 func isSpotCluster(cluster CommonCluster) (bool, error) {

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -5463,6 +5463,10 @@ components:
                 dryRun:
                     type: boolean
                     example: false
+                wait:
+                    type: boolean
+                    description: "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful"
+                    example: false
                 odPcts:
                     type: object
                     description: "Map of resources in the template where replicas should have a minimum on-demand percentage. Format: <kind.resourceName: min-percentage>"

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -73,7 +73,6 @@ var DefaultInstallOptions = []helm.InstallOption{
 	helm.InstallReuseName(true),
 	helm.InstallDisableHooks(false),
 	helm.InstallTimeout(300),
-	helm.InstallWait(false),
 }
 
 // DeploymentNotFoundError is returned when a Helm related operation is executed on
@@ -353,7 +352,7 @@ func UpgradeDeployment(releaseName, chartName, chartVersion string, chartPackage
 }
 
 //CreateDeployment creates a Helm deployment in chosen namespace
-func CreateDeployment(chartName, chartVersion string, chartPackage []byte, namespace string, releaseName string, dryRun bool, valueOverrides []byte, odPcts map[string]int, kubeConfig []byte, env helm_env.EnvSettings, options ...helm.InstallOption) (*rls.InstallReleaseResponse, error) {
+func CreateDeployment(chartName, chartVersion string, chartPackage []byte, namespace string, releaseName string, dryRun bool, wait bool, valueOverrides []byte, odPcts map[string]int, kubeConfig []byte, env helm_env.EnvSettings, options ...helm.InstallOption) (*rls.InstallReleaseResponse, error) {
 
 	chartRequested, err := getRequestedChart(releaseName, chartName, chartVersion, chartPackage, env)
 	if err != nil {

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -299,6 +299,7 @@ func (s *DeploymentsService) installDeployment(
 		namespace,
 		releaseName,
 		false,
+		true,
 		values,
 		nil,
 		kubeConfig,

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -118,6 +118,7 @@ type CreateUpdateDeploymentRequest struct {
 	ReUseValues bool                   `json:"reuseValues" yaml:"reuseValues"`
 	Namespace   string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	DryRun      bool                   `json:"dryrun,omitempty" yaml:"dryrun,omitempty"`
+	Wait        bool                   `json:"wait,omitempty" yaml:"wait,omitempty"`
 	Values      map[string]interface{} `json:"values,omitempty" yaml:"values,omitempty"`
 	OdPcts      map[string]int         `json:"odpcts,omitempty" yaml:"odpcts,omitempty"`
 }


### PR DESCRIPTION
From helm docs:

> if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful

It's fixing the issue with spot mutating webhook that didn't wait until the webhook started before moving on the next deployment.

When sending a create deployment request, it is now configurable on the API.

I've set wait to `false` for all default posthooks other then spot-config-webhook. It was the default before, and setting it to true may increase the cluster creation time.