### PR TITLE
Wait more for namespace termination during cluster deletion

### DIFF
--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -25,6 +25,7 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/goph/emperror"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -133,7 +134,7 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 			}
 		}
 		if len(left) > 0 {
-			return fmt.Errorf("%d namespaces remained after deletion: %v", len(left), left)
+			return emperror.With(errors.Errorf("namespaces remained after deletion: %v", left), "namespaces", left)
 		}
 		return nil
 	}, 20, 30)

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -211,18 +211,18 @@ func deleteServices(kubeConfig []byte, ns string, logger *logrus.Entry) error {
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining services")
 		}
-		left := 0
+		left := []string{}
 		for _, svc := range services.Items {
 			switch svc.Name {
 			case "kubernetes":
 				continue
 			default:
 				logger.Infof("service %q still %s", svc.Name, svc.Status)
-				left++
+				left = append(left, svc.Name)
 			}
 		}
-		if left > 0 {
-			return fmt.Errorf("%d services remained after deletion", left)
+		if len(left) > 0 {
+			return emperror.With(errors.Errorf("services remained after deletion: %v", left), "services", left)
 		}
 		return nil
 	}, 6, 30)

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -136,7 +136,7 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 			return fmt.Errorf("%d namespaces remained after deletion: %v", len(left), left)
 		}
 		return nil
-	}, 6, 30)
+	}, 20, 30)
 	return err
 }
 

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -119,7 +119,7 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 	}
 	err = retry(func() error {
 		namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
-		left := 0
+		left := []string{}
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining namespaces")
 		}
@@ -129,11 +129,11 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 				continue
 			default:
 				logger.Infof("namespace %q still %s", ns.Name, ns.Status)
-				left++
+				left = append(left, ns.Name)
 			}
 		}
-		if left > 0 {
-			return fmt.Errorf("%d namespaces remained after deletion", left)
+		if len(left) > 0 {
+			return fmt.Errorf("%d namespaces remained after deletion: %v", len(left), left)
 		}
 		return nil
 	}, 6, 30)


### PR DESCRIPTION
In more than one case the deletion of a cluster with monitoring timeouted because the deleted pipeline-system namespace was still in terminating state after 3 minutes.