### PR TITLE
Refactor cluster API proxy handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2190,7 +2190,6 @@
     "github.com/gin-gonic/gin",
     "github.com/gin-gonic/gin/json",
     "github.com/go-errors/errors",
-    "github.com/golang/glog",
     "github.com/google/go-github/github",
     "github.com/goph/emperror",
     "github.com/goph/emperror/errorlogrus",

--- a/api/cluster_delete.go
+++ b/api/cluster_delete.go
@@ -45,7 +45,7 @@ func (a *ClusterAPI) DeleteCluster(c *gin.Context) {
 
 	ctx := ginutils.Context(c.Request.Context(), c)
 
-	a.clusterManager.DeleteCluster(ctx, commonCluster, force, &kubeProxyCache)
+	a.clusterManager.DeleteCluster(ctx, commonCluster, force)
 
 	anchore.RemoveAnchoreUser(commonCluster.GetOrganizationId(), commonCluster.GetUID())
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -16,12 +16,14 @@ package cluster
 
 import (
 	"context"
+	"time"
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	pipelineContext "github.com/banzaicloud/pipeline/internal/platform/context"
 	"github.com/banzaicloud/pipeline/model"
 	"github.com/goph/emperror"
+	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -40,12 +42,23 @@ type secretValidator interface {
 	ValidateSecretType(organizationID uint, secretID string, cloud string) error
 }
 
+type kubeProxyCache interface {
+	Get(clusterUID string) (*KubeAPIProxy, bool)
+	Put(clusterUID string, proxy *KubeAPIProxy)
+	Delete(clusterUID string)
+}
+
+type goCacheKubeProxyCache struct {
+	cache *cache.Cache
+}
+
 type Manager struct {
 	clusters                   clusterRepository
 	secrets                    secretValidator
 	events                     clusterEvents
 	statusChangeDurationMetric *prometheus.SummaryVec
 	clusterTotalMetric         *prometheus.CounterVec
+	kubeProxyCache             kubeProxyCache
 
 	logger       logrus.FieldLogger
 	errorHandler emperror.Handler
@@ -64,9 +77,9 @@ func NewManager(clusters clusterRepository,
 		events:                     events,
 		statusChangeDurationMetric: statusChangeDurationMetric,
 		clusterTotalMetric:         clusterTotalMetric,
-
-		logger:       logger,
-		errorHandler: errorHandler,
+		kubeProxyCache:             &goCacheKubeProxyCache{cache: cache.New(defaultProxyExpirationMinutes*time.Minute, 1*time.Minute)},
+		logger:                     logger,
+		errorHandler:               errorHandler,
 	}
 }
 
@@ -88,4 +101,42 @@ func (m *Manager) getPrometheusTimer(provider, location, status string, orgId ui
 		return prometheus.NewTimer(m.statusChangeDurationMetric.WithLabelValues(provider, location, status, org.Name, clusterName)), nil
 	}
 	return prometheus.NewTimer(m.statusChangeDurationMetric.WithLabelValues(provider, location, status, "", "")), nil
+}
+
+func (m *Manager) GetKubeProxy(apiProxyPrefix string, commonCluster CommonCluster) (*KubeAPIProxy, error) {
+	// Currently we do not lock this transaction of getting and optionally creating a KubeAPIProxy.
+	// The worst thing that could happen is that for a short period (a Go GC period) there will be
+	// an extra KubeAPIProxy object in memory, but we can keep this method lock-free I think this is a good trade-off.
+	kubeProxy, found := m.kubeProxyCache.Get(commonCluster.GetUID())
+	if !found {
+		var err error
+
+		kubeProxy, err = NewKubeAPIProxy(apiProxyPrefix, commonCluster, defaultProxyExpirationMinutes*time.Minute)
+
+		if err != nil {
+			return nil, emperror.Wrap(err, "Error during creating cluster API proxy.")
+		}
+
+		m.kubeProxyCache.Put(commonCluster.GetUID(), kubeProxy)
+	}
+	return kubeProxy, nil
+}
+
+func (m *Manager) DeleteKubeProxy(commonCluster CommonCluster) {
+	m.kubeProxyCache.Delete(commonCluster.GetUID())
+}
+
+func (c *goCacheKubeProxyCache) Get(clusterUID string) (*KubeAPIProxy, bool) {
+	if kubeProxy, ok := c.cache.Get(clusterUID); ok {
+		return kubeProxy.(*KubeAPIProxy), true
+	}
+	return nil, false
+}
+
+func (c *goCacheKubeProxyCache) Put(clusterUID string, kubeProxy *KubeAPIProxy) {
+	c.cache.Set(clusterUID, kubeProxy, cache.DefaultExpiration)
+}
+
+func (c *goCacheKubeProxyCache) Delete(clusterUID string) {
+	c.cache.Delete(clusterUID)
 }

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -266,7 +266,7 @@ func main() {
 			orgs.POST("/:orgid/clusters/:id/secrets", api.InstallSecretsToCluster)
 			orgs.POST("/:orgid/clusters/:id/secrets/:secretName", api.InstallSecretToCluster)
 			orgs.PATCH("/:orgid/clusters/:id/secrets/:secretName", api.MergeSecretInCluster)
-			orgs.Any("/:orgid/clusters/:id/proxy/*path", api.ProxyToCluster)
+			orgs.Any("/:orgid/clusters/:id/proxy/*path", clusterAPI.ProxyToCluster)
 			orgs.DELETE("/:orgid/clusters/:id", clusterAPI.DeleteCluster)
 			orgs.HEAD("/:orgid/clusters/:id", api.ClusterHEAD)
 			orgs.GET("/:orgid/clusters/:id/config", api.GetClusterConfig)


### PR DESCRIPTION
- [x] remove global proxy cache, move it into the Cluster Manager
- [x] removes a lot of unused code from proxy.go
- [x] replace sync.Map cache to go-cache and autoremove expired proxies
