### PR TITLE
[WIP] put back auth middleware before token operations

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -256,10 +256,10 @@ func Install(engine *gin.Engine, generateTokenHandler gin.HandlerFunc) {
 		authGroup.GET("/github/logout", authHandler)
 		authGroup.GET("/github/register", authHandler)
 		authGroup.GET("/github/callback", authHandler)
-		authGroup.POST("/tokens", generateTokenHandler)
-		authGroup.GET("/tokens", GetTokens)
-		authGroup.GET("/tokens/:id", GetTokens)
-		authGroup.DELETE("/tokens/:id", DeleteToken)
+		authGroup.POST("/tokens", Handler, generateTokenHandler)
+		authGroup.GET("/tokens", Handler, GetTokens)
+		authGroup.GET("/tokens/:id", Handler, GetTokens)
+		authGroup.DELETE("/tokens/:id", Handler, DeleteToken)
 	}
 }
 


### PR DESCRIPTION
Fixes:
```
runtime error: invalid memory address or nil pointer dereference
/usr/local/Cellar/go/1.11.2/libexec/src/runtime/panic.go:513 (0x102cc88)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/Cellar/go/1.11.2/libexec/src/runtime/panic.go:82 (0x102bddd)
	panicmem: panic(memoryError)
/usr/local/Cellar/go/1.11.2/libexec/src/runtime/signal_unix.go:390 (0x10421c1)
	sigpanic: panicmem()
/Users/nandi/go/src/github.com/banzaicloud/pipeline/auth/user.go:131 (0x226651e)
	(*User).IDString: return fmt.Sprint(user.ID)
/Users/nandi/go/src/github.com/banzaicloud/pipeline/auth/authn.go:419 (0x2263c84)
	GetTokens: tokens, err := TokenStore.List(currentUser.IDString())
```