### PR TITLE
ASG fulfilment and spot request metric changes

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -120,6 +120,7 @@ headNodeTaintRetrySleepSeconds=5
 
 [eks]
 templateLocation="https://raw.githubusercontent.com/banzaicloud/pipeline/master/templates/eks"
+ASGFullfillmentTimeout="10m"
 
 [gke]
 resourceDeleteWaitAttempt = 12

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -59,6 +59,8 @@ const (
 	// EksTemplateLocation is the configuration key the location to get EKS Cloud Formation templates from
 	// the location to get EKS Cloud Formation templates from
 	EksTemplateLocation = "eks.templateLocation"
+	// EksASGFullfillmentTimeout configuration key for the timeout of EKS ASG instance fulfillments
+	EksASGFullfillmentTimeout = "eks.ASGFullfillmentTimeout"
 
 	// AwsCredentialPath is the path in Vault to get AWS credentials from for Pipeline
 	AwsCredentialPath = "aws.credentials.path"
@@ -225,6 +227,7 @@ func init() {
 
 	viper.SetDefault(PipelineSystemNamespace, "pipeline-system")
 	viper.SetDefault(EksTemplateLocation, filepath.Join(pwd, "templates", "eks"))
+	viper.SetDefault(EksASGFullfillmentTimeout, "10m")
 
 	viper.SetDefault(SpotguideAllowPrereleases, false)
 

--- a/internal/monitor/spotmetrics.go
+++ b/internal/monitor/spotmetrics.go
@@ -86,7 +86,7 @@ func (e *spotMetricsExporter) collectMetrics() error {
 		return emperror.Wrap(err, "could not get clusters from cluster manager")
 	}
 
-	requests := make(map[string]*ec2.SpotInstanceRequest)
+	requests := make(map[string]*pkgEC2.SpotInstanceRequest)
 	for _, cluster := range clusters {
 		log := e.logger.WithField("cluster", cluster.GetName())
 

--- a/pkg/providers/amazon/autoscaling/instance.go
+++ b/pkg/providers/amazon/autoscaling/instance.go
@@ -15,9 +15,10 @@
 package autoscaling
 
 import (
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+
+	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
 )
 
 // Instance extends autoscaling.Instance
@@ -41,21 +42,5 @@ func (i *Instance) IsHealthyAndInService() bool {
 
 // Describe returns detailed information about the instance
 func (i *Instance) Describe() (*ec2.Instance, error) {
-	result, err := i.manager.ec2Svc.DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIds: []*string{
-			i.InstanceId,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(result.Reservations) == 1 {
-		reservation := result.Reservations[0]
-		if len(reservation.Instances) == 1 {
-			return reservation.Instances[0], nil
-		}
-	}
-
-	return nil, awserr.New("404", "instance not found", nil)
+	return pkgEC2.DescribeInstanceById(i.manager.ec2Svc, *i.InstanceId)
 }

--- a/pkg/providers/amazon/ec2/instance.go
+++ b/pkg/providers/amazon/ec2/instance.go
@@ -1,0 +1,41 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// DescribeInstanceById returns detailed information about the instance
+func DescribeInstanceById(client *ec2.EC2, instanceId string) (*ec2.Instance, error) {
+	result, err := client.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: []*string{
+			&instanceId,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Reservations) == 1 {
+		reservation := result.Reservations[0]
+		if len(reservation.Instances) == 1 {
+			return reservation.Instances[0], nil
+		}
+	}
+
+	return nil, awserr.New("404", "instance not found", nil)
+}

--- a/pkg/providers/amazon/ec2/spotrequest.go
+++ b/pkg/providers/amazon/ec2/spotrequest.go
@@ -31,6 +31,21 @@ func NewSpotInstanceRequest(request *ec2.SpotInstanceRequest) *SpotInstanceReque
 	}
 }
 
+// IsPipelineRelated checks whether the spot request has a tag which indicates that it was created by Pipeline
+func (r *SpotInstanceRequest) IsPipelineRelated() bool {
+	if len(r.Tags) == 0 {
+		return false
+	}
+
+	for _, tag := range r.Tags {
+		if tag.Key != nil && tag.Value != nil && *tag.Key == instancePipelineCreatedTag && *tag.Value == "true" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsActive is true if the request is an active one
 func (r *SpotInstanceRequest) IsActive() bool {
 	state := r.GetState()
@@ -50,7 +65,7 @@ func (r *SpotInstanceRequest) IsPending() bool {
 	}
 
 	switch r.GetStatusCode() {
-	case "pending-evaluation", "not-scheduled-yet", "pending-fulfillment":
+	case "pending-evaluation", "not-scheduled-yet", "pending-fulfillment", "capacity-not-available", "capacity-oversubscribed":
 		return true
 	}
 


### PR DESCRIPTION
Make ASG fulfilment timeout configurable
Add `capacity-not-available` and `capacity-oversubscribed` as pending states in ASG fulfilment
Add `instance_id` label to spot request duration metric for pipeline created instances
