### PR TITLE
Create anchore user during ClusterCreate instead of ImageValidator posthook

### DIFF
--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	"github.com/banzaicloud/pipeline/internal/security"
 	"github.com/banzaicloud/pipeline/model/defaults"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
@@ -167,6 +168,13 @@ func (a *ClusterAPI) CreateCluster(
 			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 			Error:   err.Error(),
+		}
+	}
+
+	if anchore.AnchoreEnabled {
+		_, err := anchore.SetupAnchoreUser(commonCluster.GetOrganizationId(), commonCluster.GetUID())
+		if err != nil {
+			log.Errorf("error creating anchore user: %s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
- If anchore is enabled in Pipeline, anchore user will be created with ClusterCreate
- AnchoreImageValidator just install anchore-policy-validator helm package with right credentials