### PR TITLE
Overwrite ARK backup cluster ID in the backup list

### DIFF
--- a/internal/ark/backups_repository.go
+++ b/internal/ark/backups_repository.go
@@ -68,7 +68,7 @@ func (r *BackupsRepository) Find() (backups []*ClusterBackupsModel, err error) {
 		query.ClusterID = r.cluster.GetID()
 	}
 
-	err = r.db.Where(&query).Preload("Bucket").Preload("Organization").Find(&backups).Error
+	err = r.db.Where(&query).Preload("Bucket").Preload("Bucket.Deployment").Preload("Organization").Find(&backups).Error
 
 	return
 }

--- a/internal/ark/backups_svc.go
+++ b/internal/ark/backups_svc.go
@@ -105,6 +105,8 @@ func (s *BackupsService) List() ([]*api.Backup, error) {
 	}
 
 	for _, item := range items {
+		// overwrite ClusterID to the id of the active deployment, 0 if there is no active deployment
+		item.ClusterID = item.Bucket.Deployment.ClusterID
 		backup := item.ConvertModelToEntity()
 		backups = append(backups, backup)
 	}


### PR DESCRIPTION
Overwrite ARK backup cluster ID in the backup list to the cluster ID of the active deployment