### PR TITLE
Fix temporary gcp default config

### DIFF
--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -1179,6 +1179,7 @@ func (c *GKECluster) generateServiceAccountTokenForGke(cluster *gke.Cluster) (st
 			Config: map[string]string{
 				"access-token": tokenResp.GetAccessToken(),
 				"expiry":       tokenExpiry.Format(time.RFC3339Nano),
+				"cmd-path":     "/bin/true",
 			},
 		},
 	}


### PR DESCRIPTION
Before creating the final kube config
we create a temporary token which requires a default configuration.
This default configuration can either be a command path
or default gcloud config (which is why it worked locally
and on alpha environment, but not in minikube)

Since we don't actually use this feature because we use the SDK
to retrieve the temporary token, we can use fake command path.