### PR TITLE
Fix/spotguide sync

### DIFF
--- a/api/spotguide.go
+++ b/api/spotguide.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,7 +45,7 @@ func (s *SpotguideAPI) GetSpotguide(c *gin.Context) {
 	spotguideVersion := c.Query("version")
 	spotguideDetails, err := s.spotguide.GetSpotguide(orgID, spotguideName, spotguideVersion)
 	if err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if gorm.IsRecordNotFoundError(errors.Cause(err)) {
 			c.JSON(http.StatusNotFound, pkgCommon.ErrorResponse{
 				Code:    http.StatusNotFound,
 				Message: "spotguide not found",
@@ -96,7 +97,7 @@ func (s *SpotguideAPI) GetSpotguideIcon(c *gin.Context) {
 	spotguideVersion := c.Query("version")
 	spotguideDetails, err := s.spotguide.GetSpotguide(orgID, spotguideName, spotguideVersion)
 	if err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if gorm.IsRecordNotFoundError(errors.Cause(err)) {
 			c.JSON(http.StatusNotFound, pkgCommon.ErrorResponse{
 				Code:    http.StatusNotFound,
 				Message: "spotguide not found",

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -205,7 +205,7 @@ func (s *SpotguideManager) ScrapeSpotguides(orgID uint, userID uint) error {
 
 func (s *SpotguideManager) scrapeSpotguides(org *auth.Organization, githubClient *github.Client) error {
 	var allRepositories []github.Repository
-	query := fmt.Sprintf("org:%s topic:%s", SpotguideGithubOrganization, SpotguideGithubTopic)
+	query := fmt.Sprintf("org:%s topic:%s fork:true", org.Name, SpotguideGithubTopic)
 	if !viper.GetBool(config.SpotguideAllowPrivateRepos) {
 		query += " is:public"
 	}


### PR DESCRIPTION
- use `errors.Cause`
- include forks when listing repos
- use name of the scraped org