### PR TITLE
Fix create oke cluster example values

### DIFF
--- a/docs/postman/e2e_test.postman_collection.json
+++ b/docs/postman/e2e_test.postman_collection.json
@@ -442,7 +442,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"okecluster-demo-{{$randomInt}}\",\n    \"location\": \"eu-frankfurt-1\",\n    \"cloud\": \"oracle\",\n    \"secretId\": \"{{secretIdOracle}}\",\n    \"properties\": {\n        \"oke\": {\n            \"version\":\"v1.10.3\",\n            \"nodePools\": {\n                \"pool1\": {\n                \t\"version\":\"v1.10.3\",\n                \t\"count\": 1,\n                \t\"image\": \"Oracle-Linux-7.5\",\n                \t\"shape\": \"VM.Standard1.1\",\n                \t\"labels\": {\n                \t\t\"type\": \"general\"\n                \t}\n                }\n            }\n        }\n    }\n}"
+							"raw": "{\n    \"name\":\"okecluster-demo-{{$randomInt}}\",\n    \"location\": \"eu-frankfurt-1\",\n    \"cloud\": \"oracle\",\n    \"secretId\": \"{{secretIdOracle}}\",\n    \"properties\": {\n        \"oke\": {\n            \"version\":\"v1.10.11\",\n            \"nodePools\": {\n                \"pool1\": {\n                \t\"version\":\"v1.10.11\",\n                \t\"count\": 1,\n                \t\"image\": \"Oracle-Linux-7.5\",\n                \t\"shape\": \"VM.Standard1.1\",\n                \t\"labels\": {\n                \t\t\"type\": \"general\"\n                \t}\n                }\n            }\n        }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/orgs/:orgId/clusters",

--- a/docs/postman/e2e_test.postman_collection.json
+++ b/docs/postman/e2e_test.postman_collection.json
@@ -442,7 +442,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"okecluster-demo-{{$randomInt}}\",\n    \"location\": \"eu-frankfurt-1\",\n    \"cloud\": \"oracle\",\n    \"secretId\": \"{{secretIdOracle}}\",\n    \"properties\": {\n        \"oke\": {\n            \"version\":\"v1.10.11\",\n            \"nodePools\": {\n                \"pool1\": {\n                \t\"version\":\"v1.10.11\",\n                \t\"count\": 1,\n                \t\"image\": \"Oracle-Linux-7.5\",\n                \t\"shape\": \"VM.Standard1.1\",\n                \t\"labels\": {\n                \t\t\"type\": \"general\"\n                \t}\n                }\n            }\n        }\n    }\n}"
+							"raw": "{\n    \"name\":\"okecluster-demo-{{$randomInt}}\",\n    \"location\": \"eu-frankfurt-1\",\n    \"cloud\": \"oracle\",\n    \"secretId\": \"{{secretIdOracle}}\",\n    \"properties\": {\n        \"oke\": {\n            \"version\":\"v1.10.11\",\n            \"nodePools\": {\n                \"pool1\": {\n                \t\"version\":\"v1.10.11\",\n                \t\"count\": 1,\n                \t\"image\": \"Oracle-Linux-7.5\",\n                \t\"shape\": \"VM.Standard2.1\",\n                \t\"labels\": {\n                \t\t\"type\": \"general\"\n                \t}\n                }\n            }\n        }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/orgs/:orgId/clusters",


### PR DESCRIPTION
I tried to create an OKE cluster using the Postman collection and had a few issues when trying to use the values provided by default:

- I could not create a cluster with version: *v1.10.3* The response was: "Invalid k8s version". As far as I know, the valid versions in OKE right now are *v.1.10.11* and *v1.11.5*. It was working for me with **v.1.10.11**, so I changed to that.
- I could not create a cluster with shape: *VM.Standard1.1* Based on [cloudinfo](https://beta.banzaicloud.io/cloudinfo), the valid types in OKE right now are *VM.Standard2.1* and *VM.Standard2.2*. It was working for me with **VM.Standard2.1**, so I changed to that.