### PR TITLE
added section about golang-migrate to migration docs

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -73,5 +73,3 @@ To revert back to the previous version, use the `down` command:
 ```
 bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" down 1  
 ```
-
-TODO: write acceptance tests with migrations?

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,9 +56,10 @@ bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYS
 
 When using the migrate tool for the first time, you probably have a dirty version: use the `force` command to go to the latest version before your migration script.
 `version` is a unix timestamp that's generated for the migration scripts (example: 1547126472).
-Find the latest timestamp in `database/migrations` and run this command:
+Find the latest timestamp in `database/migrations` and force that version (if the `find` command doesn't work for some reason, find the latest timestamp manually):
 
 ```
+find database/migrations -type f -exec basename {} ';' | cut -d_ -f1 | sort -r | head -1
 bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" force $last_version
 ```
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -40,15 +40,6 @@ Download the `golang-migrate` tool to the `./bin` directory.
 make bin/migrate
 ```
 
-Create a migration script with a unix timestamp, and a title (example: `title="add_service_mesh"`).
-The command should create 2 files in the `database/migrations` directory: `$timestamp_$title.up.sql` and `$timestamp_$title.down.sql`).
-```
-bin/migrate create  -ext sql -dir database/migrations/ -format "unix" "$title"
-```
-
-Write your migration scripts in the generated files.
-Disable auto-migrate in Pipeline's `config.toml` file.
-
 Check the version of your database.
 ```
 bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" version
@@ -62,6 +53,15 @@ Find the latest timestamp in `database/migrations` and force that version (if th
 find database/migrations -type f -exec basename {} ';' | cut -d_ -f1 | sort -r | head -1
 bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" force $last_version
 ```
+
+Create a migration script with a unix timestamp, and a title (example: `title="add_service_mesh"`).
+The command should create 2 files in the `database/migrations` directory: `$timestamp_$title.up.sql` and `$timestamp_$title.down.sql`).
+```
+bin/migrate create  -ext sql -dir database/migrations/ -format "unix" "$title"
+```
+
+Write your migration scripts in the generated files.
+Disable auto-migrate in Pipeline's `config.toml` file.
 
 To apply your new migration script on the database, run the `up` command (1 means moving up one version):
 ```

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -25,5 +25,53 @@ Before submitting migrations, please:
 2. Run the migration manually
 3. Test that the change works
 
-TODO: Use golang-migrate for running migrations?
+## Using golang-migrate
+
+[Golang-migrate](https://github.com/golang-migrate/migrate) is a CLI tool that can be used to create and apply database migrations.
+If you need to write a migration script, please use it to test the migration locally.
+
+Issue commands from the pipeline source directory.
+```
+cd $GOPATH/src/github.com/banzaicloud/pipeline
+```
+
+Download the `golang-migrate` tool to the `./bin` directory.
+```
+make bin/migrate
+```
+
+Create a migration script with a unix timestamp, and a title (example: `title="add_service_mesh"`).
+The command should create 2 files in the `database/migrations` directory: `$timestamp_$title.up.sql` and `$timestamp_$title.down.sql`).
+```
+bin/migrate create  -ext sql -dir database/migrations/ -format "unix" "$title"
+```
+
+Write your migration scripts in the generated files.
+Disable auto-migrate in Pipeline's `config.toml` file.
+
+Check the version of your database.
+```
+bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" version
+```
+
+When using the migrate tool for the first time, you probably have a dirty version: use the `force` command to go to the latest version before your migration script.
+`version` is a unix timestamp that's generated for the migration scripts (example: 1547126472).
+Find the latest timestamp in `database/migrations` and run this command:
+
+```
+bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" force $last_version
+```
+
+To apply your new migration script on the database, run the `up` command (1 means moving up one version):
+```
+bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" up 1
+```
+
+Run Pipeline, and test if your changes are working on the updated schema.
+
+To revert back to the previous version, use the `down` command:
+```
+bin/migrate  -source "file://$(pwd)/database/migrations" -database "mysql://$MYSQL_USER:$MYSQL_PW@tcp(127.0.0.1:3306)/pipeline" down 1  
+```
+
 TODO: write acceptance tests with migrations?


### PR DESCRIPTION
Extended developer docs about migrations with the [golang-migrate](https://github.com/golang-migrate/migrate) tool.