### PR TITLE
Deploy instance-termination-handler instead of spot-termination-handler

### DIFF
--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -92,6 +92,10 @@ var HookMap = map[string]PostFunctioner{
 		f:            InitSpotConfig,
 		ErrorHandler: ErrorHandler{},
 	},
+	pkgCluster.DeployInstanceTerminationHandler: &BasePostFunction{
+		f:            DeployInstanceTerminationHandler,
+		ErrorHandler: ErrorHandler{},
+	},
 }
 
 // BasePostHookFunctions default posthook functions after cluster create
@@ -109,6 +113,7 @@ var BasePostHookFunctions = []PostFunctioner{
 	HookMap[pkgCluster.InstallHorizontalPodAutoscalerPostHook],
 	HookMap[pkgCluster.InstallPVCOperator],
 	HookMap[pkgCluster.InitSpotConfig],
+	HookMap[pkgCluster.DeployInstanceTerminationHandler],
 }
 
 // PostFunctioner manages posthook functions

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1257,7 +1257,7 @@ func InitSpotConfig(cluster CommonCluster) error {
 func DeployInstanceTerminationHandler(cluster CommonCluster) error {
 	distribution := cluster.GetDistribution()
 
-	if distribution != pkgCluster.GKE && distribution != pkgCluster.Amazon {
+	if distribution != pkgCluster.GKE && distribution != pkgCluster.EKS {
 		return nil
 	}
 

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1250,43 +1250,23 @@ func InitSpotConfig(cluster CommonCluster) error {
 	if err != nil {
 		return emperror.Wrap(err, "failed to install the spot-config-webhook deployment")
 	}
-	err = deploySpotTerminationHandler(cluster, pipelineSystemNamespace)
-	if err != nil {
-		return emperror.Wrap(err, "failed to install spot-termination-handler deployment")
-	}
 	return nil
 }
 
-func deploySpotTerminationHandler(cluster CommonCluster, namespace string) error {
+// DeployInstanceTerminationHandler deploys the instance termination handler
+func DeployInstanceTerminationHandler(cluster CommonCluster) error {
+	distribution := cluster.GetDistribution()
+
+	if distribution != pkgCluster.GKE && distribution != pkgCluster.Amazon {
+		return nil
+	}
+
+	pipelineSystemNamespace := viper.GetString(pipConfig.PipelineSystemNamespace)
 
 	values := map[string]interface{}{
 		"tolerations": []v1.Toleration{
 			{
 				Operator: v1.TolerationOpExists,
-				Effect:   v1.TaintEffectNoExecute,
-			},
-			{
-				Operator: v1.TolerationOpExists,
-				Effect:   v1.TaintEffectNoSchedule,
-			},
-		},
-		"affinity": v1.Affinity{
-			NodeAffinity: &v1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-					NodeSelectorTerms: []v1.NodeSelectorTerm{
-						{
-							MatchExpressions: []v1.NodeSelectorRequirement{
-								{
-									Key:      pkgCommon.OnDemandLabelKey,
-									Operator: v1.NodeSelectorOpIn,
-									Values: []string{
-										"false",
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 	}
@@ -1296,7 +1276,7 @@ func deploySpotTerminationHandler(cluster CommonCluster, namespace string) error
 		return emperror.Wrap(err, "failed to marshal yaml values")
 	}
 
-	return installDeployment(cluster, namespace, pkgHelm.BanzaiRepository+"/spot-termination-handler", "sth", marshalledValues, "", false)
+	return installDeployment(cluster, pipelineSystemNamespace, pkgHelm.BanzaiRepository+"/instance-termination-handler", "ith", marshalledValues, "", false)
 }
 
 func isSpotCluster(cluster CommonCluster) (bool, error) {

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -88,6 +88,7 @@ const (
 	InstallAnchoreImageValidator           = "InstallAnchoreImageValidator"
 	RestoreFromBackup                      = "RestoreFromBackup"
 	InitSpotConfig                         = "InitSpotConfig"
+	DeployInstanceTerminationHandler       = "DeployInstanceTerminationHandler"
 )
 
 // Provider name regexp

--- a/templates/eks/amazon-eks-vpc-cf.yaml
+++ b/templates/eks/amazon-eks-vpc-cf.yaml
@@ -242,6 +242,7 @@ Resources:
               - autoscaling:DescribeLifecycleHooks
               - autoscaling:CompleteLifecycleAction
               - autoscaling:DeleteLifecycleHook
+              - autoscaling:DetachInstances
               Resource: "*"
 
 Outputs:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | fixes #1635 
| License         | Apache 2.0


### What's in this PR?

Deploying the more general instance termination handler instead of the spot-termination-handler.

### Why?

The more general instance termination handler also handles ondemand ASG managed EC2 instance termination and also supports Hollowtrees managed scaling by removing the EC2 instance from the ASG when a termination notice arrives.

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

!! Do not merge yet !!

It depends on https://github.com/banzaicloud/banzai-charts/pull/613
