### PR TITLE
remove invalid S3 permission from CF template

### DIFF
--- a/templates/eks/amazon-eks-vpc-cf.yaml
+++ b/templates/eks/amazon-eks-vpc-cf.yaml
@@ -228,7 +228,6 @@ Resources:
               - s3:ListBucket
               - s3:GetObject
               - s3:PutObject
-              - s3:ListObjects
               - s3:DeleteObject
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:UpdateAutoScalingGroup


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Removes an invalid S3 permission (ListObjects) from the CF template
