### PR TITLE
Collect failure events from Azure Activity Log in case of cluster cre…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,12 +35,13 @@
   version = "0.1.6"
 
 [[projects]]
-  digest = "1:ac61480b85935507e4926aa3f8c91a4363c16a0780727ed288ba351e76ba5191"
+  digest = "1:af4b364a2bbf29ec2d241efca2cae36993494f1f8d6a544fbcf2cc1f878423cb"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "services/authorization/mgmt/2015-07-01/authorization",
     "services/compute/mgmt/2018-10-01/compute",
     "services/containerservice/mgmt/2018-03-31/containerservice",
+    "services/monitor/mgmt/2017-09-01/insights",
     "services/network/mgmt/2018-01-01/network",
     "services/resources/mgmt/2016-06-01/subscriptions",
     "services/resources/mgmt/2018-02-01/resources",
@@ -2190,6 +2191,7 @@
     "cloud.google.com/go/storage",
     "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute",
     "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice",
+    "github.com/Azure/azure-sdk-for-go/services/monitor/mgmt/2017-09-01/insights",
     "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources",
     "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage",
     "github.com/Azure/azure-sdk-for-go/storage",

--- a/cluster/manager_common_updater.go
+++ b/cluster/manager_common_updater.go
@@ -108,7 +108,7 @@ func (c *commonUpdater) Prepare(ctx context.Context) (CommonCluster, error) {
 func (c *commonUpdater) Update(ctx context.Context) error {
 	err := c.cluster.UpdateCluster(c.request, c.userID)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if err := DeployClusterAutoscaler(c.cluster); err != nil {

--- a/internal/providers/azure/activitylog.go
+++ b/internal/providers/azure/activitylog.go
@@ -1,0 +1,39 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/monitor/mgmt/2017-09-01/insights"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/banzaicloud/azure-aks-client/cluster"
+	"github.com/goph/emperror"
+)
+
+// NewActivityLogsClient instantiates a new Azure Activity Logs client using the specified credentials
+func NewActivityLogsClient(creds *cluster.AKSCredential) (*insights.ActivityLogsClient, error) {
+	authorizer, err := auth.NewClientCredentialsConfig(
+		creds.ClientId,
+		creds.ClientSecret,
+		creds.TenantId).Authorizer()
+
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to instantiate new Authorizer from Azure client credentials")
+	}
+
+	activityLogClient := insights.NewActivityLogsClient(creds.SubscriptionId)
+	activityLogClient.Authorizer = authorizer
+
+	return &activityLogClient, nil
+}


### PR DESCRIPTION
…ate/update failure

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1645
| License         | Apache 2.0


### What's in this PR?
In case AKS cluster create or update operation fails collect failure events from Azure Activity Log as those events contain additional information on the root cause.

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)