### PR TITLE
feat: make spotguide readme and icon optional

### DIFF
--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -276,13 +276,11 @@ func (s *SpotguideManager) scrapeSpotguides(org *auth.Organization, githubClient
 			readme, err := downloadGithubFile(githubClient, owner, name, ReadmePath, tag)
 			if err != nil {
 				log.Warnf("failed to scrape the readme of '%s/%s' at version '%s': %s", owner, name, tag, err)
-				continue
 			}
 
 			icon, err := downloadGithubFile(githubClient, owner, name, IconPath, tag)
 			if err != nil {
 				log.Warnf("failed to scrape the icon of '%s/%s' at version '%s': %s", owner, name, tag, err)
-				continue
 			}
 
 			model := SpotguideRepo{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### Why?

We should accept a Spotguide repo without readme or icon, these are not necessary for a functional Spotguide.