### PR TITLE
istio mtls configurable

### DIFF
--- a/cluster/hooks_istio.go
+++ b/cluster/hooks_istio.go
@@ -43,17 +43,22 @@ func InstallServiceMesh(cluster CommonCluster, param cluster.PostHookParam) erro
 
 	log.Infof("istio params: %#v", params)
 
-	values := map[string]interface{}{}
+	values := map[string]interface{}{
+		"global": map[string]interface{}{
+			"mtls": map[string]interface{}{
+				"enabled": params.EnableMtls,
+			},
+		},
+	}
 
 	if params.BypassEgressTraffic {
 		ipRanges, err := cluster.GetK8sIpv4Cidrs()
 		if err != nil {
 			log.Warnf("couldn't set included IP ranges in Envoy config, external requests will be intercepted")
 		} else {
-			values["global"] = map[string]interface{}{
-				"proxy": map[string]interface{}{
-					"includeIPRanges": ipRanges.PodIPRange + "," + ipRanges.ServiceClusterIPRange,
-				},
+			globalValues := values["global"].(map[string]interface{})
+			globalValues["proxy"] = map[string]interface{}{
+				"includeIPRanges": ipRanges.PodIPRange + "," + ipRanges.ServiceClusterIPRange,
 			}
 		}
 	}

--- a/internal/istio/istio.go
+++ b/internal/istio/istio.go
@@ -15,3 +15,20 @@
 package istio
 
 const Namespace = "istio-system"
+
+type Config struct {
+	Global Global `json:"global,omitempty"`
+}
+
+type Global struct {
+	Mtls  MTLS  `json:"mtls,omitempty"`
+	Proxy Proxy `json:"proxy,omitempty"`
+}
+
+type MTLS struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type Proxy struct {
+	IncludeIPRanges string `json:"includeIPRanges,omitempty"`
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Mutual TLS can be enabled in the Istio posthook, by setting the property `"mtls": true`.

It sets the corresponding property in Helm, that:
1. creates a mesh-wide authentication policy that specifies that all services in the mesh will only accept TLS requests.
2. creates a `DestinationRule` that configures the client-side part, so all internal requests will include a client certificate.
3. creates another `DestinationRule` that disables `mtls` to the Kubernetes API server.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)