### PR TITLE
posthooks can be priorized

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/banzaicloud/pipeline/api/common"
@@ -76,7 +77,6 @@ func getClusterFromRequest(c *gin.Context) (cluster.CommonCluster, bool) {
 func getPostHookFunctions(postHooks pkgCluster.PostHooks) (ph []cluster.PostFunctioner) {
 
 	log.Info("Get posthook function(s)")
-	var securityScanPosthook cluster.PostFunctioner
 
 	for postHookName, param := range postHooks {
 
@@ -91,19 +91,13 @@ func getPostHookFunctions(postHooks pkgCluster.PostHooks) (ph []cluster.PostFunc
 
 			log.Infof("posthook function: %s", function)
 			log.Infof("posthook params: %#v", param)
-			if postHookName == pkgCluster.InstallAnchoreImageValidator {
-				securityScanPosthook = function
-			} else {
-				ph = append(ph, function)
-			}
+			ph = append(ph, function)
 		} else {
 			log.Warnf("there's no function with this name [%s]", postHookName)
 		}
 	}
-	if securityScanPosthook != nil {
-		ph = append(ph, securityScanPosthook)
-	}
 
+	sort.Sort(cluster.ByPriority(ph))
 	log.Infof("Found posthooks: %v", ph)
 
 	return


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Posthooks got a priority so they can run in a specific order.
Default priority is 0, for now 2 posthooks got a priority: Security Scan and Service Mesh.

### Why?
Security Scan posthook must run as the last posthook and we had an `if` statement for that before.
Service Mesh posthook must run after the Monitoring posthook.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
