### PR TITLE
Fixed the creation of the EKS default storage class

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2236,6 +2236,7 @@
     "github.com/banzaicloud/anchore-image-validator/pkg/clientset/v1alpha1",
     "github.com/banzaicloud/azure-aks-client/client",
     "github.com/banzaicloud/azure-aks-client/cluster",
+    "github.com/banzaicloud/azure-aks-client/errors",
     "github.com/banzaicloud/azure-aks-client/types",
     "github.com/banzaicloud/bank-vaults/pkg/auth",
     "github.com/banzaicloud/bank-vaults/pkg/db",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes


### Why?
EKS creates default storage class if kubernetes version is 1.11 or higher