### PR TITLE
fix: save github ID as well

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -59,6 +59,7 @@ import (
 	gormadapter "github.com/casbin/gorm-adapter"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/google/go-github/github"
 	"github.com/goph/emperror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -277,9 +278,14 @@ func main() {
 	})
 
 	// insert shared organization to DB if not exists
-	sharedOrg := auth.Organization{Name: viper.GetString(config.SpotguideSharedLibraryGitHubOrganization)}
-	if err := db.Where(sharedOrg).FirstOrCreate(&sharedOrg).Error; err != nil {
+	sharedOrgName := viper.GetString(config.SpotguideSharedLibraryGitHubOrganization)
+	if org, _, err := github.NewClient(nil).Organizations.Get(context.Background(), sharedOrgName); err != nil {
 		log.Errorf("failed to create shared organization: %s", err.Error())
+	} else {
+		sharedOrg := auth.Organization{Name: *org.Login, GithubID: org.ID}
+		if err := db.Where(sharedOrg).FirstOrCreate(&sharedOrg).Error; err != nil {
+			log.Errorf("failed to create shared organization: %s", err.Error())
+		}
 	}
 
 	// periodically sync shared spotguides

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -280,7 +280,7 @@ func main() {
 	// insert shared organization to DB if not exists
 	sharedOrgName := viper.GetString(config.SpotguideSharedLibraryGitHubOrganization)
 	if org, _, err := github.NewClient(nil).Organizations.Get(context.Background(), sharedOrgName); err != nil {
-		log.Errorf("failed to create shared organization: %s", err.Error())
+		log.Errorf("failed to query shared Github organization: %s", err.Error())
 	} else {
 		sharedOrg := auth.Organization{Name: *org.Login, GithubID: org.ID}
 		if err := db.Where(sharedOrg).FirstOrCreate(&sharedOrg).Error; err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

`GithubID` has to be saved alongside of name when inserting shared Spotguide org.

### Why?

Several query in the application uses both `Name` and `GithubID` in the where clause.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
