### PR TITLE
fix: handle empty organizations on Spotguide sync

### DIFF
--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -215,9 +215,16 @@ func (s *SpotguideManager) scrapeSpotguides(org *auth.Organization, githubClient
 			Order:       "asc",
 			ListOptions: listOpts,
 		})
+
 		if err != nil {
+			// Empty organization, no repositories
+			if resp.StatusCode == http.StatusUnprocessableEntity {
+				return nil
+			}
+
 			return emperror.Wrap(err, "failed to list github repositories")
 		}
+
 		allRepositories = append(allRepositories, reposRes.Repositories...)
 
 		if resp.NextPage == 0 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1641
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Check the error code for `422` and return from the sync function.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The GitHub API respond is unexpected when the org doesn't have any repos, handle this case.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
