### PR TITLE
Internal GetNodePools api call changes

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -370,14 +370,15 @@ func GetNodePools(c *gin.Context) {
 
 	headNodePoolName := viper.GetString(config.PipelineHeadNodePoolName)
 	for nodePoolName, nodePool := range clusterStatus.NodePools {
+		if nodePoolName == headNodePoolName {
+			continue
+		}
+
 		nodePoolStatus[nodePoolName] = &pkgCluster.ActualNodePoolStatus{
 			NodePoolStatus: *nodePool,
 			ActualCount:    nodePoolCounts[nodePoolName],
 		}
 
-		if nodePoolName == headNodePoolName {
-			continue
-		}
 		machineDetails, err := cloudinfo.GetMachineDetails(clusterStatus.Cloud,
 			clusterStatus.Distribution,
 			clusterStatus.Region,
@@ -405,6 +406,9 @@ func GetNodePools(c *gin.Context) {
 		ClusterDesiredResources: clusterDesiredResources,
 		ClusterTotalResources:   clusterTotalResources,
 		ClusterStatus:           clusterStatus.Status,
+		Cloud:                   clusterStatus.Cloud,
+		Distribution:            clusterStatus.Distribution,
+		Location:                clusterStatus.Location,
 	}
 
 	c.JSON(http.StatusOK, response)

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -227,7 +227,10 @@ type GetNodePoolsResponse struct {
 	NodePools               map[string]*ActualNodePoolStatus `json:"nodePools,omitempty"`
 	ClusterTotalResources   map[string]float64               `json:"clusterTotalResources,omitempty"`
 	ClusterDesiredResources map[string]float64               `json:"clusterDesiredResources,omitempty"`
-	ClusterStatus           string                           `json:"string,omitempty"`
+	ClusterStatus           string                           `json:"status,omitempty"`
+	Cloud                   string                           `json:"cloud"`
+	Distribution            string                           `json:"distribution"`
+	Location                string                           `json:"location"`
 }
 
 type ActualNodePoolStatus struct {


### PR DESCRIPTION
- do not return head node pool
- add location, cloud and distribution values into GetNodePoolsResponse

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
