### PR TITLE
spotguide: fix SIGSEGV during scrape if resp is not available

### DIFF
--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -228,7 +228,7 @@ func (s *SpotguideManager) scrapeSpotguides(org *auth.Organization, githubClient
 
 		if err != nil {
 			// Empty organization, no repositories
-			if resp.StatusCode == http.StatusUnprocessableEntity {
+			if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity {
 				return nil
 			}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1692 
| License         | Apache 2.0