### PR TITLE
Add EKS templates to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --update --no-cache tzdata
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=0 /go/bin/aws-iam-authenticator /usr/bin/
 COPY --from=0 /go/src/github.com/banzaicloud/pipeline/views /views/
+COPY --from=0 /go/src/github.com/banzaicloud/pipeline/templates/eks /templates/eks
 COPY --from=0 /pipeline /
 
 ENTRYPOINT ["/pipeline"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,5 +12,6 @@ COPY --from=0 /go/bin/aws-iam-authenticator /usr/bin/
 COPY --from=0 /go/bin/dlv /
 COPY build/pipeline-debug /
 COPY views /views/
+COPY templates/eks /templates/eks
 
 ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--log", "exec", "/pipeline-debug"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -10,5 +10,6 @@ RUN apk add --no-cache ca-certificates
 COPY --from=0 /go/bin/aws-iam-authenticator /usr/bin/
 COPY build/pipeline-debug /
 COPY views /views/
+COPY templates/eks /templates/eks
 
 ENTRYPOINT ["/pipeline-debug"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1647 
| License         | Apache 2.0


### What's in this PR?

Build EKS CF templates into the docker images.

### Why?

These templates are closely related to the built code itself.
