### PR TITLE
Followup on #1647 remove eks template path points to github from conf…

### DIFF
--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -136,7 +136,6 @@ headNodeTaintRetryAttempt=30
 headNodeTaintRetrySleepSeconds=5
 
 [eks]
-templateLocation="https://raw.githubusercontent.com/banzaicloud/pipeline/master/templates/eks"
 ASGFulfillmentTimeout="10m"
 
 [gke]


### PR DESCRIPTION
…igfile

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #1647 
| License         | Apache 2.0


### What's in this PR?
EKS templates are now part of the docker image, so don't need to download from GitHub anymore.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)