### PR TITLE
Configure bypass egress traffic on AKS for Istio posthook

### DIFF
--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -933,9 +933,18 @@ func (c *AKSCluster) SaveSshSecretId(sshSecretID string) error {
 	return c.modelCluster.UpdateSshSecret(sshSecretID)
 }
 
+// GetK8sIpv4Cidrs returns possible IP ranges for pods and services in the cluster
+// On AKS the services and pods IP ranges can be fetched from Azure
 func (c *AKSCluster) GetK8sIpv4Cidrs() (*pkgCluster.Ipv4Cidrs, error) {
-	//TODO
-	return nil, errors.New("not implemented")
+	cluster, err := c.getAzureCluster()
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to retrieve AKS cluster")
+	}
+
+	return &pkgCluster.Ipv4Cidrs{
+		ServiceClusterIPRanges: []string{*cluster.NetworkProfile.ServiceCidr},
+		PodIPRanges:            []string{*cluster.NetworkProfile.PodCidr},
+	}, nil
 }
 
 // GetK8sConfig returns the Kubernetes config

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -644,18 +644,6 @@ func (c *AKSCluster) GetModel() *model.ClusterModel {
 	return c.modelCluster
 }
 
-func (c *AKSCluster) retreiveAzureCluster() (*containerservice.ManagedCluster, error) {
-	cc, err := c.getCloudConnection()
-	if err != nil {
-		return nil, emperror.Wrap(err, "failed to create cloud connection")
-	}
-	cluster, err := cc.GetManagedClustersClient().Get(context.TODO(), c.GetResourceGroupName(), c.GetName())
-	if err != nil {
-		return nil, emperror.Wrap(err, "failed to get managed cluster")
-	}
-	return &cluster, nil
-}
-
 // getAzureCluster returns cluster from cloud
 func (c *AKSCluster) getAzureCluster() (*containerservice.ManagedCluster, error) {
 	cc, err := c.getCloudConnection()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Deleted method `retreiveAzureCluster()` because it had the same functionality as `getAzureCluster()` and it was never used in the codebase (`getAzureCluster()` is used four times)
-  Added implementation to `GetK8sIpv4Cidrs()` on AKS to be able to access external services (by [including internal IP ranges](https://istio.io/docs/tasks/traffic-management/egress/#calling-external-services-directly) only). The service and pod CIDR ranges are fetched using Azure's GO SDK.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The functionality to configure the `BypassEgressTraffic` variable was only added for GKE in #1643 and for EKS in #1701.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- Launched an AKS cluster with **`BypassEgressTraffic` set to `False`** and `autoSidecarInjectNamespaces` set to `default`. Launched a simple pod in the `default` namespace for which the `istio-proxy` sidecar container was automatically launched as well. Entered the pod's shell and tried to run `wget google.hu`. The result was `404 Not Found`, as expected, because this is what Istio does by default, the `istio-proxy` sidecar container hijacked the request and did not allow it to access the external network by default.
- Then launched an AKS cluster with **`BypassEgressTraffic` set to `True`**. From the same container with the same `wget` call I was able to access the external network.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)

### To Do
<!-- (Please remove this section if you don't need it.) -->

Still need to implement the `GetK8sIpv4Cidrs()` method for the other cloud providers (except for GKE, EKS and AKS).
