### PR TITLE
support user provided node labels on AKS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   version = "v0.1.8"
 
 [[projects]]
-  digest = "1:d39271d6d7c4b8da215992531266f76ce53aa8d591c71432e73b40417c17694c"
+  digest = "1:17f64e919e61f0d0e09f84f1603af12d0a3965fff868a01f89cdbf035d4a9668"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "services/authorization/mgmt/2015-07-01/authorization",
@@ -2200,6 +2200,7 @@
     "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute",
     "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice",
     "github.com/Azure/azure-sdk-for-go/services/monitor/mgmt/2017-09-01/insights",
+    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-01-01/network",
     "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions",
     "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources",
     "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage",

--- a/api/cluster_get.go
+++ b/api/cluster_get.go
@@ -33,7 +33,7 @@ import (
 // GetCluster fetches a K8S cluster in the cloud
 func (a *ClusterAPI) GetCluster(c *gin.Context) {
 	commonCluster, ok := a.clusterGetter.GetClusterFromRequest(c)
-	if ok != true {
+	if !ok {
 		return
 	}
 

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-70602515c4ee8c0e10a33145c2eb07a6ba7a687aa2280a7ed481ab77123cfebf  docs/openapi/pipeline.yaml
+325d95bd0e416b10466d74dd68bda93aa41f36035343f1c30d8c412be57ad2a9  docs/openapi/pipeline.yaml

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-325d95bd0e416b10466d74dd68bda93aa41f36035343f1c30d8c412be57ad2a9  docs/openapi/pipeline.yaml
+52214fbafa56814b93948e7bf96bb4a30306942830bba4abba875fb4013a2cc4  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -5948,6 +5948,11 @@ components:
         instanceType:
           example: Standard_B2ms
           type: string
+        labels:
+          additionalProperties:
+            example: '{"example.io/label1":"value1"}'
+            type: string
+          type: object
       required:
       - count
       - instanceType

--- a/client/docs/NodePoolsAzure.md
+++ b/client/docs/NodePoolsAzure.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **MinCount** | **int32** |  | [optional] 
 **MaxCount** | **int32** |  | [optional] 
 **InstanceType** | **string** |  | 
+**Labels** | **map[string]string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_node_pools_azure.go
+++ b/client/model_node_pools_azure.go
@@ -12,9 +12,10 @@
 package client
 
 type NodePoolsAzure struct {
-	Autoscaling  bool   `json:"autoscaling,omitempty"`
-	Count        int32  `json:"count"`
-	MinCount     int32  `json:"minCount,omitempty"`
-	MaxCount     int32  `json:"maxCount,omitempty"`
-	InstanceType string `json:"instanceType"`
+	Autoscaling  bool              `json:"autoscaling,omitempty"`
+	Count        int32             `json:"count"`
+	MinCount     int32             `json:"minCount,omitempty"`
+	MaxCount     int32             `json:"maxCount,omitempty"`
+	InstanceType string            `json:"instanceType"`
+	Labels       map[string]string `json:"labels,omitempty"`
 }

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -61,7 +61,7 @@ type AKSCluster struct {
 func CreateAKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID, userID uint) (*AKSCluster, error) {
 	var nodePools = make([]*model.AKSNodePoolModel, 0, len(request.Properties.CreateClusterAKS.NodePools))
 	for name, np := range request.Properties.CreateClusterAKS.NodePools {
-		labels := make([]*model.AKSNodePoolLabelModel, 0)
+		labels := make([]*model.AKSNodePoolLabelModel, len(np.Labels))
 		for name, value := range np.Labels {
 			labels = append(labels, &model.AKSNodePoolLabelModel{
 				Name:  name,
@@ -482,7 +482,7 @@ func (c *AKSCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 	for _, np := range c.modelCluster.AKS.NodePools {
 		if np != nil {
 
-			labels := make(map[string]string)
+			labels := make(map[string]string, len(np.Labels))
 			for _, nodePoolLabels := range np.Labels {
 				labels[nodePoolLabels.Name] = nodePoolLabels.Value
 			}

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -311,11 +311,8 @@ func GetCommonClusterFromModel(modelCluster *model.ClusterModel) (CommonCluster,
 			return nil, err
 		}
 
-		err = db.Where(model.AKSClusterModel{ID: aksCluster.modelCluster.ID}).First(&aksCluster.modelCluster.AKS).Error
-		if err != nil {
-			return nil, err
-		}
-		err = db.Model(&aksCluster.modelCluster.AKS).Related(&aksCluster.modelCluster.AKS.NodePools, "NodePools").Error
+		err = db.Preload("NodePools").Preload("NodePools.Labels").
+			Where(model.AKSClusterModel{ID: aksCluster.modelCluster.ID}).First(&aksCluster.modelCluster.AKS).Error
 
 		return aksCluster, err
 

--- a/cluster/common_test.go
+++ b/cluster/common_test.go
@@ -38,7 +38,7 @@ const (
 	clusterRequestNodeInstance  = "testInstance"
 	clusterRequestNodeCount     = 1
 	clusterRequestRG            = "testResourceGroup"
-	clusterRequestKubernetes    = "1.9.6"
+	clusterRequestKubernetes    = "1.11.5"
 	clusterRequestKubernetesEKS = "1.10"
 	clusterRequestAgentName     = "testAgent"
 	clusterRequestSpotPrice     = "1.2"
@@ -54,7 +54,10 @@ const (
 )
 
 var (
-	clusterRequestSecretId = fmt.Sprintf("%x", sha256.Sum256([]byte(secretName)))
+	clusterRequestSecretId   = fmt.Sprintf("%x", sha256.Sum256([]byte(secretName)))
+	clusterRequestNodeLabels = map[string]string{
+		"testname": "testvalue",
+	}
 
 	amazonSecretRequest = secret.CreateSecretRequest{
 		Name: secretName,
@@ -243,6 +246,7 @@ var (
 						MaxCount:         clusterRequestNodeMaxCount,
 						Count:            clusterRequestNodeCount,
 						NodeInstanceType: clusterRequestNodeInstance,
+						Labels:           clusterRequestNodeLabels,
 					},
 				},
 			},
@@ -364,6 +368,12 @@ var (
 					Count:            clusterRequestNodeCount,
 					NodeInstanceType: clusterRequestNodeInstance,
 					Name:             clusterRequestAgentName,
+					Labels: []*model.AKSNodePoolLabelModel{
+						{
+							Name:  "testname",
+							Value: "testvalue",
+						},
+					},
 				},
 			},
 		},

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -344,7 +344,7 @@ func (c *GKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 	for _, np := range c.model.NodePools {
 		if np != nil {
 
-			labels := make(map[string]string)
+			labels := make(map[string]string, len(np.Labels))
 			for _, nodePoolLabels := range np.Labels {
 				labels[nodePoolLabels.Name] = nodePoolLabels.Value
 			}

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -343,6 +343,12 @@ func (c *GKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 	nodePools := make(map[string]*pkgCluster.NodePoolStatus)
 	for _, np := range c.model.NodePools {
 		if np != nil {
+
+			labels := make(map[string]string)
+			for _, nodePoolLabels := range np.Labels {
+				labels[nodePoolLabels.Name] = nodePoolLabels.Value
+			}
+
 			nodePools[np.Name] = &pkgCluster.NodePoolStatus{
 				Autoscaling:       np.Autoscaling,
 				Preemptible:       np.Preemptible,
@@ -352,6 +358,7 @@ func (c *GKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 				MaxCount:          np.NodeMaxCount,
 				Version:           c.model.NodeVersion,
 				CreatorBaseFields: *NewCreatorBaseFields(np.CreatedAt, np.CreatedBy),
+				Labels:            labels,
 			}
 			if np.Preemptible {
 				hasSpotNodePool = true

--- a/cluster/gke_node_pools.go
+++ b/cluster/gke_node_pools.go
@@ -30,11 +30,18 @@ func createNodePoolsModelFromRequest(nodePoolsData map[string]*pkgClusterGoogle.
 	if nodePoolsCount == 0 {
 		return nil, pkgErrors.ErrorNodePoolNotProvided
 	}
-	nodePoolsModel := make([]*google.GKENodePoolModel, nodePoolsCount)
+	nodePoolsModel := make([]*google.GKENodePoolModel, 0)
 
-	i := 0
 	for nodePoolName, nodePoolData := range nodePoolsData {
-		nodePoolsModel[i] = &google.GKENodePoolModel{
+		labels := make([]*google.GKENodePoolLabelModel, 0)
+		for name, value := range nodePoolData.Labels {
+			labels = append(labels, &google.GKENodePoolLabelModel{
+				Name:  name,
+				Value: value,
+			})
+		}
+
+		nodePoolsModel = append(nodePoolsModel, &google.GKENodePoolModel{
 			CreatedBy:        userID,
 			Name:             nodePoolName,
 			Autoscaling:      nodePoolData.Autoscaling,
@@ -43,17 +50,8 @@ func createNodePoolsModelFromRequest(nodePoolsData map[string]*pkgClusterGoogle.
 			NodeCount:        nodePoolData.Count,
 			NodeInstanceType: nodePoolData.NodeInstanceType,
 			Preemptible:      nodePoolData.Preemptible,
-			Labels:           make([]*google.GKENodePoolLabelModel, 0),
-		}
-
-		for name, value := range nodePoolData.Labels {
-			nodePoolsModel[i].Labels = append(nodePoolsModel[i].Labels, &google.GKENodePoolLabelModel{
-				Name:  name,
-				Value: value,
-			})
-		}
-
-		i++
+			Labels:           labels,
+		})
 	}
 
 	return nodePoolsModel, nil

--- a/cluster/gke_node_pools.go
+++ b/cluster/gke_node_pools.go
@@ -30,10 +30,10 @@ func createNodePoolsModelFromRequest(nodePoolsData map[string]*pkgClusterGoogle.
 	if nodePoolsCount == 0 {
 		return nil, pkgErrors.ErrorNodePoolNotProvided
 	}
-	nodePoolsModel := make([]*google.GKENodePoolModel, 0)
+	nodePoolsModel := make([]*google.GKENodePoolModel, nodePoolsCount)
 
 	for nodePoolName, nodePoolData := range nodePoolsData {
-		labels := make([]*google.GKENodePoolLabelModel, 0)
+		labels := make([]*google.GKENodePoolLabelModel, len(nodePoolData.Labels))
 		for name, value := range nodePoolData.Labels {
 			labels = append(labels, &google.GKENodePoolLabelModel{
 				Name:  name,

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1049,9 +1049,10 @@ func LabelNodes(commonCluster CommonCluster) error {
 	}
 
 	for poolName, nodes := range nodeNames {
-		labels := make(map[string]string, 0)
+		labels := make(map[string]string)
 		for name, np := range clusterStatus.NodePools {
 			if poolName == name {
+
 				labels = np.Labels
 			}
 		}

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1049,11 +1049,17 @@ func LabelNodes(commonCluster CommonCluster) error {
 	}
 
 	for poolName, nodes := range nodeNames {
+		labels := make(map[string]string, 0)
+		for name, np := range clusterStatus.NodePools {
+			if poolName == name {
+				labels = np.Labels
+			}
+		}
 
 		log.Debugf("nodepool: [%s]", poolName)
 		for _, nodeName := range nodes {
 			log.Infof("add label to node [%s]", nodeName)
-			labels := map[string]string{pkgCommon.LabelKey: poolName}
+			labels[pkgCommon.LabelKey] = poolName
 
 			// add spot labels, in case of a Spot cluster. This is only needed for ec2_banzaicloud as in case of
 			// EKS & GKE labels are added by provider

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -119,7 +119,7 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 	}
 	err = retry(func() error {
 		namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
-		left := []string{}
+		left := make([]string, 0)
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining namespaces")
 		}
@@ -210,7 +210,7 @@ func deleteServices(kubeConfig []byte, ns string, logger *logrus.Entry) error {
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining services")
 		}
-		left := []string{}
+		left := make([]string, 0)
 		for _, svc := range services.Items {
 			switch svc.Name {
 			case "kubernetes":

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -119,10 +119,10 @@ func deleteUserNamespaces(kubeConfig []byte, logger *logrus.Entry) error {
 	}
 	err = retry(func() error {
 		namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
-		left := make([]string, 0)
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining namespaces")
 		}
+		left := []string{}
 		for _, ns := range namespaces.Items {
 			switch ns.Name {
 			case "default", "kube-system", "kube-public":
@@ -210,7 +210,7 @@ func deleteServices(kubeConfig []byte, ns string, logger *logrus.Entry) error {
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining services")
 		}
-		left := make([]string, 0)
+		left := []string{}
 		for _, svc := range services.Items {
 			switch svc.Name {
 			case "kubernetes":

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -219,6 +219,12 @@ func (o *OKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 	nodePools := make(map[string]*pkgCluster.NodePoolStatus)
 	for _, np := range o.modelCluster.OKE.NodePools {
 		if np != nil {
+
+			labels := make(map[string]string)
+			for _, nodePoolLabels := range np.Labels {
+				labels[nodePoolLabels.Name] = nodePoolLabels.Value
+			}
+
 			count := getNodeCount(np)
 			nodePools[np.Name] = &pkgCluster.NodePoolStatus{
 				Count:             count,
@@ -229,6 +235,7 @@ func (o *OKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 				Image:             np.Image,
 				Version:           np.Version,
 				CreatorBaseFields: *NewCreatorBaseFields(np.CreatedAt, np.CreatedBy),
+				Labels:            labels,
 			}
 		}
 	}
@@ -500,7 +507,7 @@ func (o *OKECluster) CreatePreconfiguredVCN(name string) (VCNID string, err erro
 	}
 
 	if vcn.Id == nil {
-		return VCNID, fmt.Errorf("Invalid VCN!")
+		return VCNID, errors.New("invalid VCN")
 	}
 
 	VCNID = *vcn.Id
@@ -536,7 +543,7 @@ func (o *OKECluster) PopulateNetworkValues(r *oracle.Cluster, VCNID string) (*or
 
 	r.SetVCNID(VCNID)
 	if len(networkValues.LBSubnetIDs) != 2 {
-		return r, fmt.Errorf("Invalid network config: there must be 2 loadbalancer subnets!")
+		return r, errors.New("invalid network config: there must be 2 loadbalancer subnets")
 	}
 	r.SetLBSubnetID1(networkValues.LBSubnetIDs[0])
 	r.SetLBSubnetID2(networkValues.LBSubnetIDs[1])

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -220,7 +220,7 @@ func (o *OKECluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 	for _, np := range o.modelCluster.OKE.NodePools {
 		if np != nil {
 
-			labels := make(map[string]string)
+			labels := make(map[string]string, len(np.Labels))
 			for _, nodePoolLabels := range np.Labels {
 				labels[nodePoolLabels.Name] = nodePoolLabels.Value
 			}

--- a/database/migrations/1548872445_google_gke_profile_node_pool_labels.down.sql
+++ b/database/migrations/1548872445_google_gke_profile_node_pool_labels.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `google_gke_profile_node_pool_labels`;

--- a/database/migrations/1548872445_google_gke_profile_node_pool_labels.down.sql
+++ b/database/migrations/1548872445_google_gke_profile_node_pool_labels.down.sql
@@ -1,1 +1,3 @@
 DROP TABLE IF EXISTS `google_gke_profile_node_pool_labels`;
+
+ALTER TABLE `google_gke_profile_node_pools` DROP FOREIGN KEY `fk_google_gke_profile_node_pools_name`;

--- a/database/migrations/1548872445_google_gke_profile_node_pool_labels.up.sql
+++ b/database/migrations/1548872445_google_gke_profile_node_pool_labels.up.sql
@@ -6,5 +6,9 @@ CREATE TABLE `google_gke_profile_node_pool_labels` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`)
+  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`),
+  KEY `idx_google_gke_profile_node_pool_profile_id` (`profile_node_pool_id`),
+  CONSTRAINT `fk_google_gke_profile_node_pool_profile_id` FOREIGN KEY (`profile_node_pool_id`) REFERENCES `google_gke_profile_node_pools` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE `google_gke_profile_node_pools` ADD CONSTRAINT `fk_google_gke_profile_node_pools_name` FOREIGN KEY (`name`) REFERENCES `google_gke_profiles`(`name`);

--- a/database/migrations/1548872445_google_gke_profile_node_pool_labels.up.sql
+++ b/database/migrations/1548872445_google_gke_profile_node_pool_labels.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `google_gke_profile_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `profile_node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/1548886943_azure_aks_node_pool_labels.down.sql
+++ b/database/migrations/1548886943_azure_aks_node_pool_labels.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `azure_aks_node_pool_labels`;

--- a/database/migrations/1548886943_azure_aks_node_pool_labels.up.sql
+++ b/database/migrations/1548886943_azure_aks_node_pool_labels.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `azure_aks_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/1548886943_azure_aks_node_pool_labels.up.sql
+++ b/database/migrations/1548886943_azure_aks_node_pool_labels.up.sql
@@ -6,5 +6,7 @@ CREATE TABLE `azure_aks_node_pool_labels` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`)
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`),
+  KEY `idx_azure_node_pool_labels_node_pool_id` (`node_pool_id`),
+  CONSTRAINT `fk_azure_node_pool_labels_node_pool_id` FOREIGN KEY (`node_pool_id`) REFERENCES `azure_aks_node_pools` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/1548977480_azure_aks_profile_node_pool_labels.down.sql
+++ b/database/migrations/1548977480_azure_aks_profile_node_pool_labels.down.sql
@@ -1,1 +1,3 @@
 DROP TABLE IF EXISTS `azure_aks_profile_node_pool_labels`;
+
+ALTER TABLE `azure_aks_profile_node_pools` DROP FOREIGN KEY `fk_azure_aks_profile_node_pools_name`;

--- a/database/migrations/1548977480_azure_aks_profile_node_pool_labels.down.sql
+++ b/database/migrations/1548977480_azure_aks_profile_node_pool_labels.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `azure_aks_profile_node_pool_labels`;

--- a/database/migrations/1548977480_azure_aks_profile_node_pool_labels.up.sql
+++ b/database/migrations/1548977480_azure_aks_profile_node_pool_labels.up.sql
@@ -6,5 +6,9 @@ CREATE TABLE `azure_aks_profile_node_pool_labels` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`)
+  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`),
+  KEY `idx_azure_aks_profile_node_pool_profile_id` (`profile_node_pool_id`),
+  CONSTRAINT `fk_azure_aks_profile_node_pool_profile_id` FOREIGN KEY (`profile_node_pool_id`) REFERENCES `azure_aks_profile_node_pools` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE `azure_aks_profile_node_pools` ADD CONSTRAINT `fk_azure_aks_profile_node_pools_name` FOREIGN KEY (`name`) REFERENCES `azure_aks_profiles`(`name`);

--- a/database/migrations/1548977480_azure_aks_profile_node_pool_labels.up.sql
+++ b/database/migrations/1548977480_azure_aks_profile_node_pool_labels.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `azure_aks_profile_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `profile_node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_name_profile_node_pool_id` (`name`,`profile_node_pool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -5681,6 +5681,12 @@ components:
                 instanceType:
                     type: string
                     example: "Standard_B2ms"
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                        example:
+                            example.io/label1: value1
 
         CreateGKEProperties:
             type: object

--- a/docs/postman/e2e_test.postman_collection.json
+++ b/docs/postman/e2e_test.postman_collection.json
@@ -447,7 +447,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "11adc17b-446e-44df-a646-7d947a40669d",
 								"exec": [
 									"if (responseCode.code === 202) {",
 									"    tests[\"Response Code 202\"] = responseCode.code == 202;",
@@ -465,7 +465,8 @@
 									"    postman.setNextRequest(null);",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -479,7 +480,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\":\"azcluster{{username}}{{$randomInt}}\",\n  \"location\": \"westeurope\",\n  \"cloud\": \"azure\",\n  \"secretId\": \"{{secretIdAzure}}\",\n  \"properties\": {\n        \"aks\": {\n        \t\"resourceGroup\": \"{{azResourceGroup}}\",\n        \t\"kubernetesVersion\": \"1.11.3\",\n            \"nodePools\": {\n            \t\"pool1\": {\n            \t\t\"autoscaling\": false, \n\t                \"minCount\": 1,\n\t                \"maxCount\": 2,\n            \t\t\"count\": 1,\n                \t\"instanceType\": \"Standard_B2ms\"\n            \t},\n            \t\"pool2\": {\n            \t    \"autoscaling\": false, \n\t                \"minCount\": 1,\n\t                \"maxCount\": 2,\n            \t\t\"count\": 1,\n                \t\"instanceType\": \"Standard_B2ms\"\n            \t}\n        \t}\n        }\n    }\n}"
+							"raw": "{\n  \"name\":\"azcluster{{username}}{{$randomInt}}\",\n  \"location\": \"westeurope\",\n  \"cloud\": \"azure\",\n  \"secretId\": \"{{secretIdAzure}}\",\n  \"properties\": {\n        \"aks\": {\n        \t\"resourceGroup\": \"{{azResourceGroup}}\",\n        \t\"kubernetesVersion\": \"1.11.5\",\n            \"nodePools\": {\n            \t\"pool1\": {\n            \t\t\"autoscaling\": false, \n\t                \"minCount\": 1,\n\t                \"maxCount\": 2,\n            \t\t\"count\": 1,\n                \t\"instanceType\": \"Standard_B2ms\",\n                \t\"labels\": {\n                \t\t\"custom\": \"value\"\n                \t}\n            \t}\n        \t}\n        }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/orgs/:orgId/clusters",

--- a/internal/providers/alibaba/objectstore.go
+++ b/internal/providers/alibaba/objectstore.go
@@ -164,7 +164,7 @@ func (os *objectStore) createFailed(bucket *ObjectStoreBucketModel, err error) e
 		return emperror.WrapWith(e, "failed to save bucket", "bucket", bucket.Name)
 	}
 
-	return emperror.With(err, "create failed")
+	return emperror.With(err, "bucket", bucket.Name)
 }
 
 func (os *objectStore) ListBuckets() ([]*objectstore.BucketInfo, error) {

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -177,7 +177,7 @@ func (s *objectStore) createFailed(bucket *ObjectStoreBucketModel, err error) er
 		return emperror.WrapWith(e, "failed to save bucket", "bucket", bucket.Name)
 	}
 
-	return emperror.With(err, "create failed")
+	return emperror.With(err, "bucket", bucket.Name)
 }
 
 // DeleteBucket deletes the S3 bucket identified by the specified name

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -283,7 +283,7 @@ func (s *ObjectStore) createFailed(bucket *ObjectStoreBucketModel, err error) er
 		return emperror.WrapWith(e, "failed to save bucket", "bucket", bucket.Name)
 	}
 
-	return emperror.With(err, "create failed")
+	return emperror.With(err, "bucket", bucket.Name)
 }
 
 func (s *ObjectStore) deleteFailed(bucket *ObjectStoreBucketModel, reason error) error {

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -186,7 +186,7 @@ func (s *ObjectStore) createFailed(bucket *ObjectStoreBucketModel, err error) er
 		return emperror.WrapWith(e, "failed to save bucket", "bucket", bucket.Name)
 	}
 
-	return emperror.With(err, "create failed")
+	return emperror.With(err, "bucket", bucket.Name)
 }
 
 // DeleteBucket deletes the GS bucket identified by the specified name

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -179,7 +179,7 @@ func (o *ObjectStore) createFailed(bucket *ObjectStoreBucketModel, err error) er
 		return emperror.WrapWith(e, "failed to save bucket", "bucket", bucket.Name)
 	}
 
-	return emperror.With(err, "create failed")
+	return emperror.With(err, "bucket", bucket.Name)
 }
 
 // ListBuckets list all buckets in Oracle object store

--- a/model/defaults/base.go
+++ b/model/defaults/base.go
@@ -109,12 +109,14 @@ func GetDefaultProfiles() []ClusterProfile {
 		&AKSProfile{
 			DefaultModel: DefaultModel{Name: GetDefaultProfileName()},
 			NodePools: []*AKSNodePoolProfile{{
+				Name:     GetDefaultProfileName(),
 				NodeName: DefaultNodeName,
 			}},
 		},
 		&GKEProfile{
 			DefaultModel: DefaultModel{Name: GetDefaultProfileName()},
 			NodePools: []*GKENodePoolProfile{{
+				Name:     GetDefaultProfileName(),
 				NodeName: DefaultNodeName,
 			}},
 		},

--- a/model/defaults/base.go
+++ b/model/defaults/base.go
@@ -32,11 +32,13 @@ const (
 	DefaultEKSNodePoolProfileTableName       = "amazon_eks_profile_node_pools"
 	DefaultEKSNodePoolLabelsProfileTableName = "amazon_eks_profile_node_pool_labels"
 
-	DefaultAKSProfileTableName         = "azure_aks_profiles"
-	DefaultAKSNodePoolProfileTableName = "azure_aks_profile_node_pools"
+	DefaultAKSProfileTableName               = "azure_aks_profiles"
+	DefaultAKSNodePoolProfileTableName       = "azure_aks_profile_node_pools"
+	DefaultAKSNodePoolProfileLabelsTableName = "azure_aks_profile_node_pool_labels"
 
-	DefaultGKEProfileTableName         = "google_gke_profiles"
-	DefaultGKENodePoolProfileTableName = "google_gke_profile_node_pools"
+	DefaultGKEProfileTableName               = "google_gke_profiles"
+	DefaultGKENodePoolProfileTableName       = "google_gke_profile_node_pools"
+	DefaultGKENodePoolProfileLabelsTableName = "google_gke_profile_node_pool_labels"
 )
 
 // default node name for all provider
@@ -142,14 +144,14 @@ func GetAllProfiles(distribution string) ([]ClusterProfile, error) {
 
 	case pkgCluster.AKS:
 		var aksProfiles []AKSProfile
-		db.Find(&aksProfiles)
+		db.Preload("NodePools.Labels").Find(&aksProfiles)
 		for i := range aksProfiles {
 			defaults = append(defaults, &aksProfiles[i])
 		}
 
 	case pkgCluster.GKE:
 		var gkeProfiles []GKEProfile
-		db.Find(&gkeProfiles)
+		db.Preload("NodePools.Labels").Find(&gkeProfiles)
 		for i := range gkeProfiles {
 			defaults = append(defaults, &gkeProfiles[i])
 		}
@@ -182,14 +184,16 @@ func GetProfile(distribution string, name string) (ClusterProfile, error) {
 
 	case pkgCluster.AKS:
 		var aksProfile AKSProfile
-		if err := db.Where(GKEProfile{DefaultModel: DefaultModel{Name: name}}).First(&aksProfile).Error; err != nil {
+		if err := db.Where(GKEProfile{DefaultModel: DefaultModel{Name: name}}).
+			Preload("NodePools.Labels").First(&aksProfile).Error; err != nil {
 			return nil, err
 		}
 		return &aksProfile, nil
 
 	case pkgCluster.GKE:
 		var gkeProfile GKEProfile
-		if err := db.Where(GKEProfile{DefaultModel: DefaultModel{Name: name}}).First(&gkeProfile).Error; err != nil {
+		if err := db.Where(GKEProfile{DefaultModel: DefaultModel{Name: name}}).
+			Preload("NodePools.Labels").First(&gkeProfile).Error; err != nil {
 			return nil, err
 		}
 		return &gkeProfile, nil

--- a/model/defaults/base_test.go
+++ b/model/defaults/base_test.go
@@ -133,6 +133,7 @@ var (
 					agentName: {
 						Count:            nodeCount,
 						NodeInstanceType: nodeInstanceType,
+						Labels:           map[string]string{"testname": "testvalue"},
 					},
 				},
 			},
@@ -162,6 +163,12 @@ var (
 				NodeInstanceType: nodeInstanceType,
 				Count:            nodeCount,
 				NodeName:         agentName,
+				Labels: []*defaults.AKSNodePoolLabelsProfile{
+					{
+						Name:  "testname",
+						Value: "testvalue",
+					},
+				},
 			},
 		},
 	}

--- a/model/defaults/eks.go
+++ b/model/defaults/eks.go
@@ -35,7 +35,7 @@ type EKSProfile struct {
 // EKSNodePoolProfile describes an EKS cluster profile's nodepools
 type EKSNodePoolProfile struct {
 	AmazonNodePoolProfileBaseFields
-	Image  string                      `gorm:"default:'ami-0a54c984b9f908c81'"`
+	Image  string                      `gorm:"default:'ami-0a2abab4107669c1b'"`
 	Labels []*EKSNodePoolLabelsProfile `gorm:"foreignkey:NodePoolProfileID"`
 }
 

--- a/model/defaults/migrate.go
+++ b/model/defaults/migrate.go
@@ -58,5 +58,21 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		return err
 	}
 
+	if err := model.AddForeignKey(db, logger, &AKSProfile{}, &AKSNodePoolProfile{}, "Name"); err != nil {
+		return err
+	}
+
+	if err := model.AddForeignKey(db, logger, &AKSNodePoolProfile{}, &AKSNodePoolLabelsProfile{}, "NodePoolProfileID"); err != nil {
+		return err
+	}
+
+	if err := model.AddForeignKey(db, logger, &GKEProfile{}, &GKENodePoolProfile{}, "Name"); err != nil {
+		return err
+	}
+
+	if err := model.AddForeignKey(db, logger, &GKENodePoolProfile{}, &GKENodePoolLabelsProfile{}, "NodePoolProfileID"); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/model/defaults/migrate.go
+++ b/model/defaults/migrate.go
@@ -31,8 +31,10 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&EKSNodePoolLabelsProfile{},
 		&AKSProfile{},
 		&AKSNodePoolProfile{},
+		&AKSNodePoolLabelsProfile{},
 		&GKEProfile{},
 		&GKENodePoolProfile{},
+		&GKENodePoolLabelsProfile{},
 	}
 
 	var tableNames string

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -70,6 +70,11 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		return err
 	}
 
+	err = AddForeignKey(db, logger, &AKSNodePoolModel{}, &AKSNodePoolLabelModel{}, "NodePoolID")
+	if err != nil {
+		return err
+	}
+
 	err = AddForeignKey(db, logger, &AmazonNodePoolsModel{}, &AmazonNodePoolLabelModel{}, "NodePoolID")
 	return err
 }

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -35,6 +35,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&EKSSubnetModel{},
 		&AKSClusterModel{},
 		&AKSNodePoolModel{},
+		&AKSNodePoolLabelModel{},
 		&DummyClusterModel{},
 		&KubernetesClusterModel{},
 	}

--- a/pkg/cluster/aks/aks.go
+++ b/pkg/cluster/aks/aks.go
@@ -38,12 +38,12 @@ type CreateClusterAKS struct {
 
 // NodePoolCreate describes Azure's node fields of a CreateCluster request
 type NodePoolCreate struct {
-	Autoscaling      bool   `json:"autoscaling" yaml:"autoscaling"`
-	MinCount         int    `json:"minCount" yaml:"minCount"`
-	MaxCount         int    `json:"maxCount" yaml:"maxCount"`
-	Count            int    `json:"count" yaml:"count"`
-	NodeInstanceType string `json:"instanceType" yaml:"instanceType"`
-	VNetSubnetID     string `json:"vnetSubnetID,omitempty" yaml:"vnetSubnetID,omitempty"`
+	Autoscaling      bool              `json:"autoscaling" yaml:"autoscaling"`
+	MinCount         int               `json:"minCount" yaml:"minCount"`
+	MaxCount         int               `json:"maxCount" yaml:"maxCount"`
+	Count            int               `json:"count" yaml:"count"`
+	NodeInstanceType string            `json:"instanceType" yaml:"instanceType"`
+	VNetSubnetID     string            `json:"vnetSubnetID,omitempty" yaml:"vnetSubnetID,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 

--- a/pkg/providers/oracle/cluster/cluster.go
+++ b/pkg/providers/oracle/cluster/cluster.go
@@ -15,11 +15,13 @@
 package cluster
 
 import (
-	"fmt"
 	"regexp"
 
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	"github.com/pkg/errors"
 )
+
+var versionRegexp = regexp.MustCompile("^v\\d+\\.\\d+\\.\\d+")
 
 // Cluster describes Pipeline's Oracle fields of a Create/Update request
 type Cluster struct {
@@ -126,7 +128,6 @@ func (c *Cluster) AddDefaults() error {
 		if len(np.Version) == 0 {
 			np.Version = defaultVersion
 		}
-
 	}
 
 	return nil
@@ -136,26 +137,26 @@ func (c *Cluster) AddDefaults() error {
 func (c *Cluster) Validate(update bool) error {
 
 	if c == nil {
-		return fmt.Errorf("Oracle is <nil>")
+		return errors.New("oracle is <nil>")
 	}
 
 	if !isValidVersion(c.Version) {
-		return fmt.Errorf("Invalid k8s version: %s", c.Version)
+		return errors.Errorf("invalid k8s version: %s", c.Version)
 	}
 
 	if len(c.NodePools) < 1 {
-		return fmt.Errorf("At least 1 node pool must be specified")
+		return errors.Errorf("at least 1 node pool must be specified")
 	}
 
 	for name, nodePool := range c.NodePools {
 		if nodePool.Version != c.Version {
-			return fmt.Errorf("NodePool[%s]: Different k8s versions were specified for master and nodes", name)
+			return errors.Errorf("NodePool[%s]: Different k8s versions were specified for master and nodes", name)
 		}
 		if nodePool.Image == "" && !update {
-			return fmt.Errorf("NodePool[%s]: Node image must be specified", name)
+			return errors.Errorf("NodePool[%s]: Node image must be specified", name)
 		}
 		if nodePool.Shape == "" && !update {
-			return fmt.Errorf("NodePool[%s]: Node shape must be specified", name)
+			return errors.Errorf("NodePool[%s]: Node shape must be specified", name)
 		}
 
 		if err := pkgCommon.ValidateNodePoolLabels(nodePool.Labels); err != nil {
@@ -168,7 +169,7 @@ func (c *Cluster) Validate(update bool) error {
 
 // isValidVersion validates the given K8S version
 func isValidVersion(version string) bool {
+	isOk := versionRegexp.MatchString(version)
 
-	isOk, _ := regexp.MatchString("^v\\d+\\.\\d+\\.\\d+", version)
 	return isOk
 }

--- a/pkg/providers/oracle/cluster/cluster.go
+++ b/pkg/providers/oracle/cluster/cluster.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 )
 
@@ -141,22 +142,22 @@ func (c *Cluster) Validate(update bool) error {
 	}
 
 	if !isValidVersion(c.Version) {
-		return errors.Errorf("invalid k8s version: %s", c.Version)
+		return emperror.With(errors.New("invalid k8s version"), "version", c.Version)
 	}
 
 	if len(c.NodePools) < 1 {
-		return errors.Errorf("at least 1 node pool must be specified")
+		return errors.New("at least 1 node pool must be specified")
 	}
 
 	for name, nodePool := range c.NodePools {
 		if nodePool.Version != c.Version {
-			return errors.Errorf("NodePool[%s]: Different k8s versions were specified for master and nodes", name)
+			return emperror.With(errors.New("different k8s versions were specified for master and nodes"), "nodepool", name)
 		}
 		if nodePool.Image == "" && !update {
-			return errors.Errorf("NodePool[%s]: Node image must be specified", name)
+			return emperror.With(errors.New("node image must be specified"), "nodepool", name)
 		}
 		if nodePool.Shape == "" && !update {
-			return errors.Errorf("NodePool[%s]: Node shape must be specified", name)
+			return emperror.With(errors.New("node shape must be specified"), "nodepool", name)
 		}
 
 		if err := pkgCommon.ValidateNodePoolLabels(nodePool.Labels); err != nil {

--- a/pkg/providers/oracle/cluster/manager/cluster.go
+++ b/pkg/providers/oracle/cluster/manager/cluster.go
@@ -15,11 +15,10 @@
 package manager
 
 import (
-	"fmt"
-
 	"github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/containerengine"
+	"github.com/pkg/errors"
 )
 
 // CreateCluster creates a new cluster
@@ -38,7 +37,7 @@ func (cm *ClusterManager) CreateCluster(clusterModel *model.Cluster) error {
 	clusters = ce.FilterClustersByNotInState(clusters, containerengine.ClusterSummaryLifecycleStateDeleted)
 
 	if len(clusters) > 0 {
-		return fmt.Errorf("Cluster[%s] already exists", clusterModel.Name)
+		return errors.Errorf("cluster[%s] already exists", clusterModel.Name)
 	}
 
 	req := containerengine.CreateClusterRequest{}
@@ -70,7 +69,7 @@ func (cm *ClusterManager) UpdateCluster(clusterModel *model.Cluster) error {
 	}
 
 	if cluster.LifecycleState == containerengine.ClusterLifecycleStateDeleted {
-		return fmt.Errorf("Cluster[%s] was deleted", *cluster.Name)
+		return errors.Errorf("cluster[%s] was deleted", *cluster.Name)
 	}
 
 	ce, err := cm.oci.NewContainerEngineClient()
@@ -119,7 +118,7 @@ func (cm *ClusterManager) DeleteCluster(clusterModel *model.Cluster) error {
 	}
 
 	if cluster.LifecycleState == containerengine.ClusterLifecycleStateDeleted {
-		return fmt.Errorf("Cluster[%s] was already deleted", *cluster.Name)
+		return errors.Errorf("cluster[%s] was already deleted", *cluster.Name)
 	}
 
 	req := containerengine.DeleteClusterRequest{

--- a/pkg/providers/oracle/cluster/manager/cluster.go
+++ b/pkg/providers/oracle/cluster/manager/cluster.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
+	"github.com/goph/emperror"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/containerengine"
 	"github.com/pkg/errors"
@@ -37,7 +38,7 @@ func (cm *ClusterManager) CreateCluster(clusterModel *model.Cluster) error {
 	clusters = ce.FilterClustersByNotInState(clusters, containerengine.ClusterSummaryLifecycleStateDeleted)
 
 	if len(clusters) > 0 {
-		return errors.Errorf("cluster[%s] already exists", clusterModel.Name)
+		return emperror.With(errors.New("cluster already exists"), "cluster", clusterModel.Name)
 	}
 
 	req := containerengine.CreateClusterRequest{}
@@ -69,7 +70,7 @@ func (cm *ClusterManager) UpdateCluster(clusterModel *model.Cluster) error {
 	}
 
 	if cluster.LifecycleState == containerengine.ClusterLifecycleStateDeleted {
-		return errors.Errorf("cluster[%s] was deleted", *cluster.Name)
+		return emperror.With(errors.New("cluster was deleted"), "cluster", *cluster.Name)
 	}
 
 	ce, err := cm.oci.NewContainerEngineClient()
@@ -118,7 +119,7 @@ func (cm *ClusterManager) DeleteCluster(clusterModel *model.Cluster) error {
 	}
 
 	if cluster.LifecycleState == containerengine.ClusterLifecycleStateDeleted {
-		return errors.Errorf("cluster[%s] was already deleted", *cluster.Name)
+		return emperror.With(errors.New("cluster was already deleted"), *cluster.Name)
 	}
 
 	req := containerengine.DeleteClusterRequest{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #1579
| License         | Apache 2.0


### What's in this PR?
- Allow providing labels for nodepools during AKS cluster creation which will be applied onto the nodes of the node pool
- Database tables for storing user provided labels and migration sql scripts



### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)