### PR TITLE
WIP Oracle VCN query API

### DIFF
--- a/internal/providers/network.go
+++ b/internal/providers/network.go
@@ -19,6 +19,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers/amazon"
 	"github.com/banzaicloud/pipeline/internal/providers/azure"
 	"github.com/banzaicloud/pipeline/internal/providers/google"
+	"github.com/banzaicloud/pipeline/internal/providers/oracle"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
@@ -43,6 +44,8 @@ func NewNetworkService(params ServiceParams) (network.Service, error) {
 		return azure.NewNetworkService(params.ResourceGroupName, params.Secret, params.Logger)
 	case providers.Google:
 		return google.NewNetworkService(params.Region, params.Secret, params.Logger)
+	case providers.Oracle:
+		return oracle.NewNetworkService(params.Secret, params.Logger)
 	default:
 		return nil, pkgErrors.ErrorNotSupportedCloudType
 	}

--- a/internal/providers/oracle/network.go
+++ b/internal/providers/oracle/network.go
@@ -1,0 +1,157 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"github.com/banzaicloud/pipeline/internal/network"
+	"github.com/banzaicloud/pipeline/pkg/providers/oracle/oci"
+	secretOracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/secret"
+	"github.com/banzaicloud/pipeline/secret"
+	"github.com/goph/emperror"
+	"github.com/sirupsen/logrus"
+)
+
+type oracleNetwork struct {
+	cidrs []string
+	id    string
+	name  string
+}
+
+func (g oracleNetwork) CIDRs() []string {
+	return g.cidrs
+}
+
+func (g oracleNetwork) ID() string {
+	return g.id
+}
+
+func (g oracleNetwork) Name() string {
+	return g.name
+}
+
+type oracleSubnet struct {
+	cidrs    []string
+	id       string
+	location string
+	name     string
+}
+
+func (g oracleSubnet) CIDRs() []string {
+	return g.cidrs
+}
+
+func (g oracleSubnet) ID() string {
+	return g.id
+}
+
+func (g oracleSubnet) Location() string {
+	return g.location
+}
+
+func (g oracleSubnet) Name() string {
+	return g.name
+}
+
+type oracleRouteTable struct {
+	id   string
+	name string
+}
+
+func (g oracleRouteTable) ID() string {
+	return g.id
+}
+
+func (g oracleRouteTable) Name() string {
+	return g.name
+}
+
+type oracleNetworkService struct {
+	client *oci.VirtualNetwork
+	logger logrus.FieldLogger
+}
+
+// NewNetworkService returns a new Oracle network Service
+func NewNetworkService(secret *secret.SecretItemResponse, logger logrus.FieldLogger) (network.Service, error) {
+	o, err := oci.NewOCI(secretOracle.CreateOCICredential(secret.Values))
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to create OCI credential")
+	}
+	client, err := o.NewVirtualNetworkClient()
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to create virtual network client")
+	}
+	return &oracleNetworkService{
+		client: client,
+		logger: logger,
+	}, nil
+}
+
+// ListNetworks returns VCNs
+func (ns *oracleNetworkService) ListNetworks() ([]network.Network, error) {
+	vcns, err := ns.client.GetVCNs()
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to retreive VCNs")
+	}
+	networks := make([]network.Network, len(vcns))
+	for idx, item := range vcns {
+		networks[idx] = &oracleNetwork{
+			cidrs: []string{deref(item.CidrBlock)},
+			id:    deref(item.Id),
+			name:  deref(item.DisplayName),
+		}
+	}
+	return networks, nil
+}
+
+// ListSubnets returns VCN subnetworks
+func (ns *oracleNetworkService) ListSubnets(networkID string) ([]network.Subnet, error) {
+	sns, err := ns.client.GetSubnets(&networkID)
+	if err != nil {
+		return nil, emperror.WrapWith(err, "failed to retreive subnets", "networkID", networkID)
+	}
+	subnets := make([]network.Subnet, len(sns))
+	for idx, item := range sns {
+		subnets[idx] = &oracleSubnet{
+			cidrs:    []string{deref(item.CidrBlock)},
+			id:       deref(item.Id),
+			location: deref(item.AvailabilityDomain),
+			name:     deref(item.DisplayName),
+		}
+	}
+	return subnets, nil
+}
+
+// ListRouteTables returns VCN route tables
+func (ns *oracleNetworkService) ListRouteTables(networkID string) ([]network.RouteTable, error) {
+	rts, err := ns.client.GetRouteTables(&networkID)
+	if err != nil {
+		return nil, emperror.WrapWith(err, "failed to retreive route tables", "networkID", networkID)
+	}
+	routeTables := make([]network.RouteTable, len(rts))
+	for idx, item := range rts {
+		routeTables[idx] = &oracleRouteTable{
+			id:   deref(item.Id),
+			name: deref(item.DisplayName),
+		}
+	}
+	return routeTables, nil
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
This PR implements the virtual network/subnetwork/route table querying API for Oracle.


### Why?
Allow API users to query OKE VCN resources to simplify creating clusters in existing VCNs.


### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
