### PR TITLE
Oracle VCN query API fix

### DIFF
--- a/internal/providers/network.go
+++ b/internal/providers/network.go
@@ -45,7 +45,7 @@ func NewNetworkService(params ServiceParams) (network.Service, error) {
 	case providers.Google:
 		return google.NewNetworkService(params.Region, params.Secret, params.Logger)
 	case providers.Oracle:
-		return oracle.NewNetworkService(params.Secret, params.Logger)
+		return oracle.NewNetworkService(params.Region, params.Secret, params.Logger)
 	default:
 		return nil, pkgErrors.ErrorNotSupportedCloudType
 	}

--- a/internal/providers/oracle/network.go
+++ b/internal/providers/oracle/network.go
@@ -83,10 +83,14 @@ type oracleNetworkService struct {
 }
 
 // NewNetworkService returns a new Oracle network Service
-func NewNetworkService(secret *secret.SecretItemResponse, logger logrus.FieldLogger) (network.Service, error) {
+func NewNetworkService(region string, secret *secret.SecretItemResponse, logger logrus.FieldLogger) (network.Service, error) {
 	o, err := oci.NewOCI(secretOracle.CreateOCICredential(secret.Values))
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to create OCI credential")
+	}
+	err = o.ChangeRegion(region)
+	if err != nil {
+		return nil, emperror.Wrap(err, "failed to change OCI region")
 	}
 	client, err := o.NewVirtualNetworkClient()
 	if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Use the provided `region` query parameter when listing VCNs.


### Why?
I thought the region couldn't be specified, but it was pointed out to me, that it can.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)