### PR TITLE
Upgrade alpine version and install tzdata in every docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD . /go/src/github.com/banzaicloud/pipeline
 RUN BUILD_DIR=/ make build
 
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --update --no-cache tzdata
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,8 +6,8 @@ RUN cd $GOPATH/src/github.com/kubernetes-sigs/aws-iam-authenticator && \
     go install ./cmd/aws-iam-authenticator
 RUN go get github.com/derekparker/delve/cmd/dlv
 
-FROM alpine:3.7
-RUN apk add --no-cache ca-certificates libc6-compat
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates tzdata libc6-compat
 COPY --from=0 /go/bin/aws-iam-authenticator /usr/bin/
 COPY --from=0 /go/bin/dlv /
 COPY build/pipeline-debug /

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,8 +5,8 @@ RUN cd $GOPATH/src/github.com/kubernetes-sigs/aws-iam-authenticator && \
     git checkout 981ecbe && \
     go install ./cmd/aws-iam-authenticator
 
-FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates tzdata
 COPY --from=0 /go/bin/aws-iam-authenticator /usr/bin/
 COPY build/pipeline-debug /
 COPY views /views/


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR upgrades Alpine to the latest version and installs timezone info in every docker image.


### Why?

Locally built docker images lacked the system timezone info.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
