### PR TITLE
handle secret install when spec is empty and source secret name is not defined

### DIFF
--- a/api/cluster_secret.go
+++ b/api/cluster_secret.go
@@ -81,10 +81,10 @@ func InstallSecretToCluster(c *gin.Context) {
 
 	secretName := c.Param("secretName")
 
-	// Either spec is not defined (empty) or at least one spec is not a value
+	// Either spec is not defined (empty) or at least one spec is not a value or empty
 	needsSecret := len(secretRequest.Spec) == 0
 	for _, spec := range secretRequest.Spec {
-		if spec.Source != "" || len(spec.SourceMap) != 0 {
+		if spec.Source != "" || len(spec.SourceMap) != 0 || spec.Value == "" {
 			needsSecret = true
 			break
 		}
@@ -174,10 +174,10 @@ func MergeSecretInCluster(c *gin.Context) {
 
 	secretName := c.Param("secretName")
 
-	// Either spec is not defined (empty) or at least one spec is not a value
+	// Either spec is not defined (empty) or at least one spec is not a value or empty
 	needsSecret := len(secretRequest.Spec) == 0
 	for _, spec := range secretRequest.Spec {
-		if spec.Source != "" || len(spec.SourceMap) != 0 {
+		if spec.Source != "" || len(spec.SourceMap) != 0 || spec.Value == "" {
 			needsSecret = true
 			break
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Install all keys as JSON under the given name when source secret name is not specified and the spec is empty.

### Why?

A current change didn't handle this case properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)