### PR TITLE
Configure bypass egress traffic on ACK for Istio posthook

### DIFF
--- a/pkg/cluster/acsk/template.go
+++ b/pkg/cluster/acsk/template.go
@@ -63,12 +63,18 @@ type AlibabaDescribeClusterResponse struct {
 	ZoneID                 string       `json:"zone_id"`                  // Zone ID.
 	Outputs                []outputItem `json:"outputs,omitempty"`
 	KubernetesVersion      string       `json:"current_version"`
+	SubnetCIDR             string       `json:"subnet_cidr"` // Subnet CIDR (Kubernetes pods are assigned from this range).
+	Parameters             Parameters   `json:"parameters,omitempty"`
 }
 
 type outputItem struct {
 	Description string
 	OutputKey   string
 	OutputValue interface{}
+}
+
+type Parameters struct {
+	ServiceCIDR string // Service CIDR (Kubernetes services are assigned from this range).
 }
 
 type AlibabaScaleClusterParams struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Expand `AlibabaDescribeClusterResponse` struct with `SubnetCIDR` and `Parameters.ServiceCIDR` fields so that these fields can be parsed from such a JSON response. The highlight of this response is like the following:
```
{
  "instance_type": "",
  "name": "mesh1",
  ...
  "subnet_cidr": "172.16.0.0/16",
  ...
  "parameters": {
     ...
    "ServiceCIDR": "172.19.0.0/20",
    ...
  }
}
```
This is why the `SubnetCIDR` field is parsed directly from the root of the JSON response and why `ServiceCIDR` is parsed under the `Parameters` JSON key.
-  Added implementation to `GetK8sIpv4Cidrs()` on ACK to be able to access external services (by [including internal IP ranges](https://istio.io/docs/tasks/traffic-management/egress/#calling-external-services-directly) only). The service and pod CIDR ranges are fetched using Alibaba's GO SDK.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The functionality to configure the `BypassEgressTraffic` variable was only added for GKE in #1643, for EKS in #1701 and for AKS in #1714.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- Launched an ACK cluster with **`BypassEgressTraffic` set to `False`** and `autoSidecarInjectNamespaces` set to `default`. Launched a simple pod in the `default` namespace for which the `istio-proxy` sidecar container was automatically launched as well. Entered the pod's shell and tried to run `wget google.hu`. The result was `404 Not Found`, as expected, because this is what Istio does by default, the `istio-proxy` sidecar container hijacked the request and did not allow it to access the external network by default.
- Then launched an ACK cluster with **`BypassEgressTraffic` set to `True`**. From the same container with the same `wget` call I was able to access the external network.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)

### To Do
<!-- (Please remove this section if you don't need it.) -->

Still need to implement the `GetK8sIpv4Cidrs()` method for the other cloud providers (except for GKE, EKS , AKS and ACK).
