### PR TITLE
Configure bypass egress traffic on OKE for Istio posthook

### DIFF
--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -404,9 +404,18 @@ func (o *OKECluster) GetConfigSecretId() string {
 	return o.modelCluster.ConfigSecretId
 }
 
+// GetK8sIpv4Cidrs returns possible IP ranges for pods and services in the cluster
+// On OKE the services and pods IP ranges can be fetched from Oracle
 func (o *OKECluster) GetK8sIpv4Cidrs() (*pkgCluster.Ipv4Cidrs, error) {
-	//TODO
-	return nil, errors.New("not implemented")
+	cluster, err := o.GetCluster()
+	if err != nil {
+		return nil, err
+	}
+
+	return &pkgCluster.Ipv4Cidrs{
+		ServiceClusterIPRanges: []string{*cluster.Options.KubernetesNetworkConfig.ServicesCidr},
+		PodIPRanges:            []string{*cluster.Options.KubernetesNetworkConfig.PodsCidr},
+	}, nil
 }
 
 // GetK8sConfig returns the Kubernetes config


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Added `GetCluster()` method to extract some common functionality which was used from multiple places in the codebase
-  Added implementation to `GetK8sIpv4Cidrs()` on OKE to be able to access external services (by [including internal IP ranges](https://istio.io/docs/tasks/traffic-management/egress/#calling-external-services-directly) only). The service and pod CIDR ranges are fetched using Oracle's GO SDK.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The functionality to configure the `BypassEgressTraffic` variable was only added for GKE in #1643, for EKS in #1701, for AKS in #1714 and for ACK in #1729.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- Launched an OKE cluster with **`BypassEgressTraffic` set to `False`** and `autoSidecarInjectNamespaces` set to `default`. Launched a simple pod in the `default` namespace for which the `istio-proxy` sidecar container was automatically launched as well. Entered the pod's shell and tried to run `wget google.hu`. The result was `404 Not Found`, as expected, because this is what Istio does by default, the `istio-proxy` sidecar container hijacked the request and did not allow it to access the external network by default.
- Then launched an OKE cluster with **`BypassEgressTraffic` set to `True`**. From the same container with the same `wget` call I was able to access the external network.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
