### PR TITLE
Configure bypass egress traffic on PKE for Istio posthook

### DIFF
--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -287,7 +287,6 @@ func (c *DummyCluster) GetConfigSecretId() string {
 }
 
 func (c *DummyCluster) GetK8sIpv4Cidrs() (*pkgCluster.Ipv4Cidrs, error) {
-	//TODO
 	return nil, errors.New("not implemented")
 }
 

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -394,9 +394,13 @@ func (c *EC2ClusterPKE) GetAPIEndpoint() (string, error) {
 	return c.APIEndpoint, nil
 }
 
+// GetK8sIpv4Cidrs returns possible IP ranges for pods and services in the cluster
+// On PKE the services and pods IP ranges can be fetched from the model of the cluster
 func (c *EC2ClusterPKE) GetK8sIpv4Cidrs() (*pkgCluster.Ipv4Cidrs, error) {
-	//TODO
-	return nil, errors.New("not implemented")
+	return &pkgCluster.Ipv4Cidrs{
+		ServiceClusterIPRanges: []string{c.model.Network.ServiceCIDR},
+		PodIPRanges:            []string{c.model.Network.PodCIDR},
+	}, nil
 }
 
 func (c *EC2ClusterPKE) GetK8sConfig() ([]byte, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

-  Added implementation to `GetK8sIpv4Cidrs()` on PKE to be able to access external services (by [including internal IP ranges](https://istio.io/docs/tasks/traffic-management/egress/#calling-external-services-directly) only). The service and pod CIDR ranges are fetched from the model of the cluster.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The functionality to configure the `BypassEgressTraffic` variable was only added for GKE in #1643, for EKS in #1701, for AKS in #1714 and for ACK in #1729.
