### PR TITLE
ACK custom VPC

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-8441572c848859a74e8d78d6b850b651b79a01b4395faf47fc494d921e7510e0  docs/openapi/pipeline.yaml
+1b4cd0962774889cc308a86da416d0eef536d61b6e6d93615e8d3c185112ae3f  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -9457,6 +9457,9 @@ components:
           type: string
         zoneId:
           type: string
+        vswitchId:
+          example: vsw-zysrfslpfhasklu338qys
+          type: string
         nodePools:
           additionalProperties:
             $ref: '#/components/schemas/NodePoolsACK'

--- a/client/docs/CreateAckPropertiesAcsk.md
+++ b/client/docs/CreateAckPropertiesAcsk.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **RegionId** | **string** |  | [optional] 
 **ZoneId** | **string** |  | [optional] 
+**VswitchId** | **string** |  | [optional] 
 **NodePools** | [**map[string]NodePoolsAck**](NodePoolsACK.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/model_create_ack_properties_acsk.go
+++ b/client/model_create_ack_properties_acsk.go
@@ -14,5 +14,6 @@ package client
 type CreateAckPropertiesAcsk struct {
 	RegionId  string                  `json:"regionId,omitempty"`
 	ZoneId    string                  `json:"zoneId,omitempty"`
+	VswitchId string                  `json:"vswitchId,omitempty"`
 	NodePools map[string]NodePoolsAck `json:"nodePools,omitempty"`
 }

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -321,6 +321,7 @@ func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgI
 			SNATEntry:                true,
 			SSHFlags:                 true,
 			NodePools:                nodePools,
+			VSwitchID:                request.Properties.CreateClusterACSK.VSwitchID,
 		},
 		CreatedBy: userId,
 	}

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ess"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/acsk"
@@ -40,7 +41,7 @@ import (
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/goph/emperror"
-	"github.com/jmespath/go-jmespath"
+	jmespath "github.com/jmespath/go-jmespath"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -181,6 +182,17 @@ func (c *ACSKCluster) GetAlibabaESSClient(cfg *sdk.Config) (*ess.Client, error) 
 	}
 
 	client, err := createAlibabaESSClient(cred, c.modelCluster.ACSK.RegionID, cfg)
+	return client, emperror.With(err, "cluster", c.modelCluster.Name)
+}
+
+// GetAlibabaVPCClient creates an Alibaba Virtual Private Cloud client with credentials
+func (c *ACSKCluster) GetAlibabaVPCClient(cfg *sdk.Config) (*vpc.Client, error) {
+	cred, err := c.createAlibabaCredentialsFromSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := createAlibabaVPCClient(cred, c.modelCluster.ACSK.RegionID, cfg)
 	return client, emperror.With(err, "cluster", c.modelCluster.Name)
 }
 
@@ -335,6 +347,10 @@ func (c *ACSKCluster) CreateCluster() error {
 	}
 
 	c.modelCluster.RbacEnabled = true
+	vpcID, err := c.getVPCID()
+	if err != nil {
+		return emperror.Wrap(err, "failed to retreive VPC ID")
+	}
 
 	context := action.NewACKContext("", csClient, ecsClient, essClient)
 
@@ -357,6 +373,10 @@ func (c *ACSKCluster) CreateCluster() error {
 			SNATEntry:                c.modelCluster.ACSK.SNATEntry,                // true,
 			SSHFlags:                 c.modelCluster.ACSK.SSHFlags,                 // true,
 			DisableRollback:          true,
+			VPCID:                    vpcID,
+			VSwitchID:                c.modelCluster.ACSK.VSwitchID,
+			ContainerCIDR:            "172.19.0.0/20",
+			ServiceCIDR:              "172.16.0.0/16",
 		},
 	)
 
@@ -407,6 +427,28 @@ func (c *ACSKCluster) CreateCluster() error {
 	}
 
 	return c.modelCluster.Save()
+}
+
+func (c *ACSKCluster) getVPCID() (string, error) {
+	if c.modelCluster.ACSK.VSwitchID == "" {
+		return "", nil
+	}
+
+	vpcClient, err := c.GetAlibabaVPCClient(nil)
+	if err != nil {
+		return "", emperror.Wrap(err, "failed to get Alibaba VPC client")
+	}
+
+	req := vpc.CreateDescribeVSwitchesRequest()
+	req.VSwitchId = c.modelCluster.ACSK.VSwitchID
+	res, err := vpcClient.DescribeVSwitches(req)
+	if err != nil {
+		return "", emperror.WrapWith(err, "could not get VSwitch details", "vswitch", c.modelCluster.ACSK.VSwitchID)
+	}
+	if len(res.VSwitches.VSwitch) != 1 {
+		return "", errors.New("VSwitch not found")
+	}
+	return res.VSwitches.VSwitch[0].VpcId, nil
 }
 
 type setSchemeSetDomainer interface {
@@ -1116,6 +1158,15 @@ func createAlibabaESSClient(auth *credentials.AccessKeyCredential, regionID stri
 	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
 	client, err := ess.NewClientWithOptions(regionID, cfg, cred)
 	return client, emperror.Wrap(err, "could not create Alibaba ESSClient")
+}
+
+func createAlibabaVPCClient(auth *credentials.AccessKeyCredential, regionID string, cfg *sdk.Config) (*vpc.Client, error) {
+	if cfg == nil {
+		cfg = createAlibabaConfig()
+	}
+	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
+	client, err := vpc.NewClientWithOptions(regionID, cfg, cred)
+	return client, emperror.Wrap(err, "could not create Alibaba VPCClient")
 }
 
 // GetCreatedBy returns cluster create userID.

--- a/database/migrations/1549864170_add_ack_vswitch_field.down.sql
+++ b/database/migrations/1549864170_add_ack_vswitch_field.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `alibaba_acsk_clusters` DROP COLUMN `v_switch_id`;

--- a/database/migrations/1549864170_add_ack_vswitch_field.up.sql
+++ b/database/migrations/1549864170_add_ack_vswitch_field.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `alibaba_acsk_clusters` ADD COLUMN `v_switch_id` varchar(255) DEFAULT NULL;
+
+UPDATE `alibaba_acsk_clusters` SET `v_switch_id` = NULL;

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -5613,6 +5613,9 @@ components:
                         zoneId:
                             type: string
                             example: ""
+                        vswitchId:
+                            type: string
+                            example: "vsw-zysrfslpfhasklu338qys"
                         nodePools:
                             type: object
                             additionalProperties:

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -126,6 +126,7 @@ type ACSKClusterModel struct {
 	SSHFlags                 bool
 	NodePools                []*ACSKNodePoolModel `gorm:"foreignkey:ClusterID"`
 	KubernetesVersion        string
+	VSwitchID                string
 }
 
 //AmazonNodePoolsModel describes Amazon node groups model of a cluster

--- a/pkg/cluster/acsk/acsk.go
+++ b/pkg/cluster/acsk/acsk.go
@@ -36,6 +36,7 @@ type CreateClusterACSK struct {
 	MasterSystemDiskSize     int       `json:"masterSystemDiskSize,omitempty" yaml:"masterSystemDiskSize,omitempty"`
 	KeyPair                  string    `json:"keyPair,omitempty" yaml:"keyPair,omitempty"`
 	NodePools                NodePools `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
+	VSwitchID                string    `json:"vswitchId,omitempty" yaml:"vswitchId,omitempty"`
 }
 
 // UpdateClusterACSK describes Alibaba's node fields of an UpdateCluster request


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | BC only
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Allow specifying the VPC/VSwitch that the Alibaba cluster should be created in.


### Why?
Custom VPCs were not supported on Alibaba before.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)