### PR TITLE
Move /version endpoint to basepath

### DIFF
--- a/api/security.go
+++ b/api/security.go
@@ -581,8 +581,8 @@ func GetReleaseScanLog(c *gin.Context) (map[string]bool, bool) {
 	return releaseScanLogReject, true
 }
 
-// SecurytiScanEnabled checks if security scan is enabled in pipeline
-func SecurytiScanEnabled(c *gin.Context) {
+// SecurityScanEnabled checks if security scan is enabled in pipeline
+func SecurityScanEnabled(c *gin.Context) {
 
 	if viper.GetBool("anchore.enabled") {
 		c.JSON(http.StatusOK, gin.H{

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -250,7 +250,7 @@ func main() {
 		router.Use(audit.LogWriter(skipPaths, viper.GetStringSlice("audit.headers"), db, log))
 	}
 
-	router.GET("/version", VersionHandler)
+	router.GET(path.Join(basePath, "/version"), VersionHandler)
 	router.GET(path.Join(basePath, "notifications"), notification.GetNotifications)
 
 	root := router.Group("/")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes (non-public)
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Move the /version endpoint under basepath so it can be shown on the UI.

Also some refactor to eliminate joining paths by hand.

### Why?
Using basePath before all API endpoints is required for consistent UI calls.

### Checklist

- [x] Implementation tested (with at least one cloud provider -- no cluster created)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
   - would not include this

### To Do
- [ ] needs line-by-line code review!!!
- [ ] needs some manual testing from someone else
- Please **do not squash** the two commits.