### PR TITLE
rename banzaicloud to pke

### DIFF
--- a/cluster/common.go
+++ b/cluster/common.go
@@ -264,7 +264,7 @@ func GetCommonClusterFromModel(modelCluster *model.ClusterModel) (CommonCluster,
 
 	cloudType := modelCluster.Cloud
 
-	if modelCluster.Distribution == pkgCluster.BanzaiCloud {
+	if modelCluster.Distribution == pkgCluster.PKE {
 		return createCommonClusterWithDistributionFromModel(modelCluster)
 	}
 
@@ -461,7 +461,7 @@ func createCommonClusterWithDistributionFromRequest(createClusterRequest *pkgClu
 }
 
 func createCommonClusterWithDistributionFromModel(modelCluster *model.ClusterModel) (*EC2ClusterPKE, error) {
-	if modelCluster.Distribution != pkgCluster.BanzaiCloud {
+	if modelCluster.Distribution != pkgCluster.PKE {
 		return nil, pkgErrors.ErrorNotSupportedDistributionType
 	}
 

--- a/internal/providers/model.go
+++ b/internal/providers/model.go
@@ -18,9 +18,9 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers/alibaba"
 	"github.com/banzaicloud/pipeline/internal/providers/amazon"
 	"github.com/banzaicloud/pipeline/internal/providers/azure"
-	"github.com/banzaicloud/pipeline/internal/providers/banzaicloud"
 	"github.com/banzaicloud/pipeline/internal/providers/google"
 	"github.com/banzaicloud/pipeline/internal/providers/oracle"
+	"github.com/banzaicloud/pipeline/internal/providers/pke"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
@@ -47,7 +47,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		return err
 	}
 
-	if err := banzaicloud.Migrate(db, logger); err != nil {
+	if err := pke.Migrate(db, logger); err != nil {
 		return err
 	}
 

--- a/internal/providers/pke/config.go
+++ b/internal/providers/pke/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"database/sql"

--- a/internal/providers/pke/cri.go
+++ b/internal/providers/pke/cri.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"database/sql"

--- a/internal/providers/pke/ec2_cluster_model.go
+++ b/internal/providers/pke/ec2_cluster_model.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"github.com/banzaicloud/pipeline/internal/cluster"

--- a/internal/providers/pke/kubeadm.go
+++ b/internal/providers/pke/kubeadm.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"database/sql"

--- a/internal/providers/pke/kubernetes.go
+++ b/internal/providers/pke/kubernetes.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"fmt"

--- a/internal/providers/pke/model.go
+++ b/internal/providers/pke/model.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"fmt"

--- a/internal/providers/pke/network.go
+++ b/internal/providers/pke/network.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"database/sql"

--- a/internal/providers/pke/nodepool.go
+++ b/internal/providers/pke/nodepool.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 import (
 	"database/sql"

--- a/internal/providers/pke/nodepool_provider_config_amazon.go
+++ b/internal/providers/pke/nodepool_provider_config_amazon.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package banzaicloud
+package pke
 
 type NodePoolProviderConfigAmazon struct {
 	AutoScalingGroup struct {

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -60,13 +60,13 @@ const (
 
 // Distribution constants
 const (
-	ACSK        = "acsk"
-	EKS         = "eks"
-	AKS         = "aks"
-	GKE         = "gke"
-	OKE         = "oke"
-	BanzaiCloud = "banzaicloud"
-	Unknown     = "unknown"
+	ACSK    = "acsk"
+	EKS     = "eks"
+	AKS     = "aks"
+	GKE     = "gke"
+	OKE     = "oke"
+	PKE     = "pke"
+	Unknown = "unknown"
 )
 
 // constants for posthooks

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -31,7 +31,7 @@ type Network struct {
 	ServiceCIDR      string          `json:"serviceCIDR" yaml:"serviceCIDR"`
 	PodCIDR          string          `json:"podCIDR" yaml:"podCIDR"`
 	Provider         NetworkProvider `json:"provider" yaml:"provider"`
-	APIServerAddress string          `json:"apiServerAddress" yaml:"apiServerAddress" binding:"required"`
+	APIServerAddress string          `json:"apiServerAddress" yaml:"apiServerAddress"`
 }
 
 type NetworkProvider string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Renames all identifiers containing "distribution" or "banzaicloud" referring to PKE to "pke".
Partially addressed in #1691, now remaining identifiers/packages are renamed too.



### Checklist

- [ ] Implementation tested (with at least one cloud provider)