### PR TITLE
Remove duplicated clusterUID tag from PKE secret

### DIFF
--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -243,11 +243,9 @@ func (c *EC2ClusterPKE) CreatePKECluster(tokenGenerator TokenGenerator, external
 	// Generate certificates
 	clusterUidTag := fmt.Sprintf("clusterUID:%s", c.GetUID())
 	req := &secret.CreateSecretRequest{
-		Name: fmt.Sprintf("cluster-%d-ca", c.GetID()),
-		Values: map[string]string{
-			pkgSecret.ClusterUID: fmt.Sprintf("%d-%d", c.GetOrganizationId(), c.GetID()),
-		},
-		Type: pkgSecret.PKESecretType,
+		Name:   fmt.Sprintf("cluster-%d-ca", c.GetID()),
+		Values: map[string]string{},
+		Type:   pkgSecret.PKESecretType,
 		Tags: []string{
 			clusterUidTag,
 			pkgSecret.TagBanzaiReadonly,

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -106,8 +106,6 @@ const (
 
 // Distribution keys
 const (
-	ClusterUID = "clusterUid"
-
 	KubernetesCACert = "kubernetesCaCert"
 	KubernetesCAKey  = "kubernetesCaKey"
 
@@ -253,8 +251,6 @@ var DefaultRules = map[string]Meta{
 	},
 	PKESecretType: {
 		Fields: []FieldMeta{
-			{Name: ClusterUID, Required: true},
-
 			{Name: CACert, Required: false},
 			{Name: CAKey, Required: false},
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR removes the "clusterUID" secret value from PKE Secret type.


### Why?

Cluster UID was already added to the secret as a tag and the new one introduced an unnecessary complexity.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
