### PR TITLE
spotguide: add org name to enable-repo request

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -284,12 +284,12 @@
   version = "0.3.27"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3886346341c9405ada3bec342c98fa2494137926bfd38158b832c63afd41cae6"
+  digest = "1:56e4607cd7937ef27d0a7a6a7ba2516a40a658f1278781cc8aa9caebb9d59e21"
   name = "github.com/banzaicloud/cicd-go"
   packages = ["cicd"]
   pruneopts = "NUT"
-  revision = "de6f3f91e590b34a68773144cd24e313cde0411f"
+  revision = "832df3e92677593b342a15e948c67a1ae8721599"
+  version = "0.1.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -239,7 +239,7 @@
 
 [[constraint]]
   name = "github.com/banzaicloud/cicd-go"
-  branch = "master"
+  version = "0.1.0"
 
 [[constraint]]
   name = "github.com/goph/emperror"

--- a/api/spotguide.go
+++ b/api/spotguide.go
@@ -154,10 +154,10 @@ func (s *SpotguideAPI) LaunchSpotguide(c *gin.Context) {
 		return
 	}
 
-	orgID := auth.GetCurrentOrganization(c.Request).ID
-	userID := auth.GetCurrentUser(c.Request).ID
+	org := auth.GetCurrentOrganization(c.Request)
+	user := auth.GetCurrentUser(c.Request)
 
-	err := s.spotguide.LaunchSpotguide(&launchRequest, c.Request, orgID, userID)
+	err := s.spotguide.LaunchSpotguide(&launchRequest, org, user)
 	if err != nil {
 		log.Errorf("failed to Launch spotguide %s: %s", launchRequest.RepoFullname(), err.Error())
 		c.JSON(http.StatusInternalServerError, pkgCommon.ErrorResponse{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
             RECOMMENDER_URL: https://beta.banzaicloud.io/recommender
 
     dex:
-        image: banzaicloud/dex-shim:0.3.0
+        image: banzaicloud/dex-shim:0.3.1
         command: serve /dex.yml
         volumes:
             - ./config/dex.yml:/dex.yml

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -356,8 +356,8 @@ func (s *SpotguideManager) GetSpotguide(orgID uint, name, version string) (*Spot
 	return &spotguide, nil
 }
 
-func (s *SpotguideManager) LaunchSpotguide(request *LaunchRequest, httpRequest *http.Request, orgID, userID uint) error {
-	sourceRepo, err := s.GetSpotguide(orgID, request.SpotguideName, request.SpotguideVersion)
+func (s *SpotguideManager) LaunchSpotguide(request *LaunchRequest, org *auth.Organization, user *auth.User) error {
+	sourceRepo, err := s.GetSpotguide(org.ID, request.SpotguideName, request.SpotguideVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to find spotguide repo")
 	}
@@ -365,27 +365,29 @@ func (s *SpotguideManager) LaunchSpotguide(request *LaunchRequest, httpRequest *
 	// LaunchRequest might not have the version
 	request.SpotguideVersion = sourceRepo.Version
 
-	err = createSecrets(request, orgID, userID)
+	err = createSecrets(request, org.ID, user.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to create secrets for spotguide")
 	}
 
-	githubClient, err := auth.NewGithubClientForUser(userID)
+	githubClient, err := auth.NewGithubClientForUser(user.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to create GitHub client")
 	}
 
-	err = createGithubRepo(githubClient, request, userID, sourceRepo)
+	err = createGithubRepo(githubClient, request, user.ID, sourceRepo)
 	if err != nil {
 		return errors.Wrap(err, "failed to create GitHub repository")
 	}
 
-	err = enableCICD(request, httpRequest)
+	cicdClient := auth.NewCICDClient(user.APIToken)
+
+	err = enableCICD(cicdClient, request, org.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to enable CI/CD for spotguide")
 	}
 
-	err = addSpotguideContent(githubClient, request, userID, sourceRepo)
+	err = addSpotguideContent(githubClient, request, user.ID, sourceRepo)
 	if err != nil {
 		return errors.Wrap(err, "failed to add spotguide content to repository")
 	}
@@ -606,19 +608,14 @@ func createSecrets(request *LaunchRequest, orgID, userID uint) error {
 	return nil
 }
 
-func enableCICD(request *LaunchRequest, httpRequest *http.Request) error {
+func enableCICD(cicdClient cicd.Client, request *LaunchRequest, org string) error {
 
-	cicdClient, err := auth.NewCICDClient(httpRequest)
-	if err != nil {
-		return errors.Wrap(err, "failed to create CICD client")
-	}
-
-	_, err = cicdClient.RepoListOpts(true, true)
+	_, err := cicdClient.RepoListOpts(true, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to sync CICD repositories")
 	}
 
-	_, err = cicdClient.RepoPost(request.RepoOrganization, request.RepoName)
+	_, err = cicdClient.RepoPost(request.RepoOrganization, request.RepoName, org)
 	if err != nil {
 		return errors.Wrap(err, "failed to enable CICD repository")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
For non-github authenticated setups the user's login name might differ from it's SCM user name and in this case organization name in the virtual token won't be correct, so we have to tell CICD to which organizations it should request a virtual token.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
Also abstraction levels in `spotguide/spotguide.go` are corrected a bit, so no `http.Request` has to be sent down there again, and the `User` context object holds the `APIToken`, so the Pipeline can proxy authenticated requests to other services.

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
