### PR TITLE
Typed IDs

### DIFF
--- a/api/ark/backups/list.go
+++ b/api/ark/backups/list.go
@@ -23,7 +23,8 @@ import (
 	"github.com/banzaicloud/pipeline/api/ark/common"
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
-	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 // List lists ARK backups
@@ -46,7 +47,7 @@ func List(c *gin.Context) {
 
 	backups := make([]*api.Backup, 0)
 	for _, backup := range orgBackups {
-		if backup.ClusterID == cluserID {
+		if backup.ClusterID == pkgCluster.ClusterID(cluserID) {
 			backups = append(backups, backup)
 		}
 	}

--- a/api/ark/backupservice/enable.go
+++ b/api/ark/backupservice/enable.go
@@ -104,7 +104,7 @@ func Enable(c *gin.Context) {
 	if spec.Labels == nil {
 		spec.Labels = make(labels.Set, 0)
 	}
-	spec.Labels[api.LabelKeyDistribution] = svc.GetDeploymentsService().GetCluster().GetDistribution()
+	spec.Labels[api.LabelKeyDistribution] = string(svc.GetDeploymentsService().GetCluster().GetDistribution())
 	spec.Labels[api.LabelKeyCloud] = svc.GetDeploymentsService().GetCluster().GetCloud()
 
 	err = svc.GetSchedulesService().Create(spec, request.Schedule)

--- a/api/ark/schedules/create.go
+++ b/api/ark/schedules/create.go
@@ -51,7 +51,7 @@ func Create(c *gin.Context) {
 	if spec.Labels == nil {
 		spec.Labels = make(labels.Set, 0)
 	}
-	spec.Labels[api.LabelKeyDistribution] = svc.GetDeploymentsService().GetCluster().GetDistribution()
+	spec.Labels[api.LabelKeyDistribution] = string(svc.GetDeploymentsService().GetCluster().GetDistribution())
 	spec.Labels[api.LabelKeyCloud] = svc.GetDeploymentsService().GetCluster().GetCloud()
 
 	err := svc.GetSchedulesService().Create(spec, request.Schedule)

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -30,6 +30,7 @@ import (
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgProviders "github.com/banzaicloud/pipeline/pkg/providers"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
@@ -46,10 +47,10 @@ const (
 
 // secretData secret representation
 type secretData struct {
-	SecretId         string `json:"id"`
-	SecretName       string `json:"name,omitempty"`
-	AccessSecretId   string `json:"accessId,omitempty"`
-	AccessSecretName string `json:"accessName,omitempty"`
+	SecretId         pkgSecret.SecretID `json:"id"`
+	SecretName       string             `json:"name,omitempty"`
+	AccessSecretId   pkgSecret.SecretID `json:"accessId,omitempty"`
+	AccessSecretName string             `json:"accessName,omitempty"`
 }
 
 // BucketResponseItem encapsulates bucket and secret details to be returned
@@ -471,17 +472,17 @@ func hasSecret(c *gin.Context) bool {
 func getBucketContext(c *gin.Context, logger logrus.FieldLogger) (*auth.Organization, *secret.SecretItemResponse, string, bool) {
 	organization := auth.GetCurrentOrganization(c.Request)
 
-	var secretID string
-	var ok bool
+	var secretID pkgSecret.SecretID
 
 	secretName := c.GetHeader(secretNameHeader)
 	if secretName != "" {
 		secretID = secret.GenerateSecretIDFromName(secretName)
 	} else {
-		secretID, ok = ginutils.GetRequiredHeader(c, secretIdHeader)
+		secretIDValue, ok := ginutils.GetRequiredHeader(c, secretIdHeader)
 		if !ok {
 			return nil, nil, "", false
 		}
+		secretID = pkgSecret.SecretID(secretIDValue)
 	}
 
 	provider, ok := ginutils.RequiredQueryOrAbort(c, "cloudType")
@@ -520,7 +521,7 @@ func (err SecretNotFoundError) Error() string {
 
 // getValidatedSecret looks up the secret by secretId under the given organisation
 // it also verifies if the found secret is of appropriate type for the given cloud provider
-func getValidatedSecret(organizationId pkgAuth.OrganizationID, secretId, cloudType string) (*secret.SecretItemResponse, error) {
+func getValidatedSecret(organizationId pkgAuth.OrganizationID, secretId pkgSecret.SecretID, cloudType string) (*secret.SecretItemResponse, error) {
 	retrievedSecret, err := secret.Store.Get(organizationId, secretId)
 
 	if err != nil {

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	"github.com/banzaicloud/pipeline/internal/providers"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -519,7 +520,7 @@ func (err SecretNotFoundError) Error() string {
 
 // getValidatedSecret looks up the secret by secretId under the given organisation
 // it also verifies if the found secret is of appropriate type for the given cloud provider
-func getValidatedSecret(organizationId uint, secretId, cloudType string) (*secret.SecretItemResponse, error) {
+func getValidatedSecret(organizationId pkgAuth.OrganizationID, secretId, cloudType string) (*secret.SecretItemResponse, error) {
 	retrievedSecret, err := secret.Store.Get(organizationId, secretId)
 
 	if err != nil {
@@ -561,7 +562,7 @@ func determineCloudProviderFromRequest(req CreateBucketRequest) (string, error) 
 }
 
 // bucketsResponse decorates and formats the list of buckets to be returned
-func bucketsResponse(buckets []*objectstore.BucketInfo, orgid uint, withSecretName bool) []*BucketResponseItem {
+func bucketsResponse(buckets []*objectstore.BucketInfo, orgid pkgAuth.OrganizationID, withSecretName bool) []*BucketResponseItem {
 	bucketItems := make([]*BucketResponseItem, 0)
 
 	for _, bucket := range buckets {
@@ -668,7 +669,7 @@ func (err BucketNotFoundError) NotFound() bool {
 }
 
 // newBucketResponseItemFromBucketInfo builds a responsItem based opn the provided bucketInfo
-func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint, withSecretName bool) *BucketResponseItem {
+func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid pkgAuth.OrganizationID, withSecretName bool) *BucketResponseItem {
 	var (
 		secretName       string
 		accessSecretName string

--- a/api/bucket_messages.go
+++ b/api/bucket_messages.go
@@ -14,11 +14,13 @@
 
 package api
 
+import pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+
 // CreateBucketRequest to create bucket
 type CreateBucketRequest struct {
-	SecretId   string `json:"secretId"`
-	SecretName string `json:"secretName"`
-	Name       string `json:"name" binding:"required"`
+	SecretId   pkgSecret.SecretID `json:"secretId"`
+	SecretName string             `json:"secretName"`
+	Name       string             `json:"name" binding:"required"`
 	Properties struct {
 		Alibaba *CreateAlibabaObjectStoreBucketProperties `json:"alibaba,omitempty"`
 		Amazon  *CreateAmazonObjectStoreBucketProperties  `json:"amazon,omitempty"`

--- a/api/cluster/pke/pke.go
+++ b/api/cluster/pke/pke.go
@@ -18,13 +18,14 @@ import (
 	"github.com/banzaicloud/pipeline/api/common"
 	"github.com/banzaicloud/pipeline/cluster"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/sirupsen/logrus"
 )
 
 type tokenGenerator interface {
-	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error)
+	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID) (string, string, error)
 }
 
 type API struct {

--- a/api/cluster/pke/pke.go
+++ b/api/cluster/pke/pke.go
@@ -17,13 +17,14 @@ package pke
 import (
 	"github.com/banzaicloud/pipeline/api/common"
 	"github.com/banzaicloud/pipeline/cluster"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/sirupsen/logrus"
 )
 
 type tokenGenerator interface {
-	GenerateClusterToken(orgID, clusterID uint) (string, string, error)
+	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error)
 }
 
 type API struct {

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -82,7 +82,7 @@ func (a *ClusterAPI) CreateCluster(
 	ctx context.Context,
 	createClusterRequest *pkgCluster.CreateClusterRequest,
 	organizationID pkgAuth.OrganizationID,
-	userID uint,
+	userID pkgAuth.UserID,
 	postHooks []cluster.PostFunctioner,
 ) (cluster.CommonCluster, *pkgCommon.ErrorResponse) {
 	logger := a.logger.WithFields(logrus.Fields{

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -25,6 +25,7 @@ import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -57,7 +58,7 @@ func (a *ClusterAPI) CreateClusterRequest(c *gin.Context) {
 			return
 		}
 
-		createClusterRequest.SecretId = secret.GenerateSecretIDFromName(createClusterRequest.SecretName)
+		createClusterRequest.SecretId = string(secret.GenerateSecretIDFromName(createClusterRequest.SecretName))
 	}
 
 	orgID := auth.GetCurrentOrganization(c.Request).ID
@@ -162,8 +163,8 @@ func (a *ClusterAPI) CreateCluster(
 		OrganizationID: organizationID,
 		UserID:         userID,
 		Name:           createClusterRequest.Name,
-		SecretID:       createClusterRequest.SecretId,
-		SecretIDs:      createClusterRequest.SecretIds,
+		SecretID:       pkgSecret.SecretID(createClusterRequest.SecretId),
+		SecretIDs:      pkgSecret.StringsToSecretIDs(createClusterRequest.SecretIds),
 		Provider:       createClusterRequest.Cloud,
 		PostHooks:      postHooks,
 	}

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -20,8 +20,9 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
-	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	"github.com/banzaicloud/pipeline/model/defaults"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/secret"
@@ -80,7 +81,7 @@ func (a *ClusterAPI) CreateClusterRequest(c *gin.Context) {
 func (a *ClusterAPI) CreateCluster(
 	ctx context.Context,
 	createClusterRequest *pkgCluster.CreateClusterRequest,
-	organizationID uint,
+	organizationID pkgAuth.OrganizationID,
 	userID uint,
 	postHooks []cluster.PostFunctioner,
 ) (cluster.CommonCluster, *pkgCommon.ErrorResponse) {

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -98,7 +98,7 @@ func (a *ClusterAPI) CreateCluster(
 
 		logger.Info("fill data from profile")
 
-		distribution := ""
+		distribution := pkgCluster.Unknown
 		switch createClusterRequest.Cloud {
 		case pkgCluster.Amazon:
 			distribution = pkgCluster.EKS

--- a/api/cluster_delete.go
+++ b/api/cluster_delete.go
@@ -18,17 +18,18 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
-	"github.com/banzaicloud/pipeline/internal/security"
+	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	anchore "github.com/banzaicloud/pipeline/internal/security"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/gin-gonic/gin"
 )
 
 // DeleteClusterResponse describes Pipeline's DeleteCluster API response
 type DeleteClusterResponse struct {
-	Status     int    `json:"status"`
-	Name       string `json:"name"`
-	Message    string `json:"message"`
-	ResourceID uint   `json:"id"`
+	Status     int                  `json:"status"`
+	Name       string               `json:"name"`
+	Message    string               `json:"message"`
+	ResourceID pkgCluster.ClusterID `json:"id"`
 }
 
 // DeleteCluster deletes a K8S cluster from the cloud

--- a/api/cluster_get.go
+++ b/api/cluster_get.go
@@ -25,6 +25,7 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
@@ -240,8 +241,8 @@ type GetClusterResponse struct {
 	Version       string `json:"version,omitempty"`
 	MasterVersion string `json:"masterVersion,omitempty"`
 
-	SecretID   string `json:"secretId"`
-	SecretName string `json:"secretName"`
+	SecretID   pkgSecret.SecretID `json:"secretId"`
+	SecretName string             `json:"secretName"`
 
 	Endpoint     string                        `json:"endpoint,omitempty"`
 	NodePools    map[string]GetClusterNodePool `json:"nodePools,omitempty"`

--- a/api/cluster_get.go
+++ b/api/cluster_get.go
@@ -219,10 +219,10 @@ func (a *ClusterAPI) GetCluster(c *gin.Context) {
 
 // GetClusterResponse contains the details of a cluster.
 type GetClusterResponse struct {
-	ID            uint   `json:"id"`
-	Status        string `json:"status"`
-	StatusMessage string `json:"statusMessage,omitempty"`
-	Name          string `json:"name"`
+	ID            pkgCluster.ClusterID `json:"id"`
+	Status        string               `json:"status"`
+	StatusMessage string               `json:"statusMessage,omitempty"`
+	Name          string               `json:"name"`
 
 	// If region not available fall back to Location
 	Region       string                    `json:"region,omitempty"`

--- a/api/cluster_get.go
+++ b/api/cluster_get.go
@@ -20,7 +20,8 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/internal/cluster/resourcesummary"
-	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
@@ -246,9 +247,9 @@ type GetClusterResponse struct {
 	NodePools    map[string]GetClusterNodePool `json:"nodePools,omitempty"`
 	TotalSummary *ResourceSummary              `json:"totalSummary,omitempty"`
 
-	CreatedAt   time.Time `json:"createdAt,omitempty"`
-	CreatorName string    `json:"creatorName,omitempty"`
-	CreatorID   uint      `json:"creatorId,omitempty"`
+	CreatedAt   time.Time      `json:"createdAt,omitempty"`
+	CreatorName string         `json:"creatorName,omitempty"`
+	CreatorID   pkgAuth.UserID `json:"creatorId,omitempty"`
 }
 
 // GetClusterNodePool describes a cluster's node pool.
@@ -265,9 +266,9 @@ type GetClusterNodePool struct {
 	ResourceSummary map[string]NodeResourceSummary `json:"resourceSummary,omitempty"`
 	Labels          map[string]string              `json:"labels,omitempty"`
 
-	CreatedAt   time.Time `json:"createdAt,omitempty"`
-	CreatorName string    `json:"creatorName,omitempty"`
-	CreatorID   uint      `json:"creatorId,omitempty"`
+	CreatedAt   time.Time      `json:"createdAt,omitempty"`
+	CreatorName string         `json:"creatorName,omitempty"`
+	CreatorID   pkgAuth.UserID `json:"creatorId,omitempty"`
 }
 
 // ResourceSummary describes a node's resource summary with CPU and Memory capacity/request/limit/allocatable

--- a/api/cluster_get.go
+++ b/api/cluster_get.go
@@ -225,11 +225,11 @@ type GetClusterResponse struct {
 	Name          string `json:"name"`
 
 	// If region not available fall back to Location
-	Region       string `json:"region,omitempty"`
-	Location     string `json:"location"`
-	Cloud        string `json:"cloud"`
-	Distribution string `json:"distribution"`
-	Spot         bool   `json:"spot,omitempty"`
+	Region       string                    `json:"region,omitempty"`
+	Location     string                    `json:"location"`
+	Cloud        string                    `json:"cloud"`
+	Distribution pkgCluster.DistributionID `json:"distribution"`
+	Spot         bool                      `json:"spot,omitempty"`
 
 	Logging      bool                     `json:"logging"`
 	Monitoring   bool                     `json:"monitoring"`

--- a/api/network.go
+++ b/api/network.go
@@ -22,6 +22,7 @@ import (
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	"github.com/banzaicloud/pipeline/internal/providers"
 	pkgProviders "github.com/banzaicloud/pipeline/pkg/providers"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -284,9 +285,9 @@ func getRequiredRegionOrResourceGroupFromContext(ctx *gin.Context, provider stri
 	}
 }
 
-func getRequiredSecretIDFromContext(ctx *gin.Context, logger logrus.FieldLogger) (string, bool) {
+func getRequiredSecretIDFromContext(ctx *gin.Context, logger logrus.FieldLogger) (pkgSecret.SecretID, bool) {
 	secretID, ok := ginutils.GetRequiredHeader(ctx, "secretId")
-	return secretID, ok
+	return pkgSecret.SecretID(secretID), ok
 }
 
 func replyWithError(ctx *gin.Context, err error) {

--- a/api/organization.go
+++ b/api/organization.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/gin-gonic/gin"
 )
@@ -44,7 +45,7 @@ func OrganizationMiddleware(c *gin.Context) {
 		return
 	}
 
-	organization := &auth.Organization{ID: uint(orgid)}
+	organization := &auth.Organization{ID: pkgAuth.OrganizationID(orgid)}
 
 	db := config.DB()
 	err = db.Where(organization).Find(organization).Error
@@ -95,7 +96,7 @@ func (a *OrganizationAPI) GetOrganizations(c *gin.Context) {
 		return
 	}
 
-	var organization = auth.Organization{ID: uint(id)}
+	var organization = auth.Organization{ID: pkgAuth.OrganizationID(id)}
 	var organizations []auth.Organization
 
 	db := config.DB()
@@ -203,7 +204,7 @@ func (a *OrganizationAPI) DeleteOrganization(c *gin.Context) {
 	}
 
 	user := auth.GetCurrentUser(c.Request)
-	organization, err := auth.GetOrganizationById(uint(id))
+	organization, err := auth.GetOrganizationById(pkgAuth.OrganizationID(id))
 	deleteName := organization.Name
 
 	err = deleteOrgFromDB(organization, user)

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -36,7 +36,7 @@ const (
 // Sends back the saved cluster profiles
 func GetClusterProfiles(c *gin.Context) {
 
-	distributionType := c.Param(distributionTypeKey)
+	distributionType := pkgCluster.DistributionID(c.Param(distributionTypeKey))
 	log.Infof("Start getting saved cluster profiles [%s]", distributionType)
 
 	resp, err := getProfiles(distributionType)
@@ -113,7 +113,7 @@ func AddClusterProfile(c *gin.Context) {
 }
 
 // getProfiles loads cluster profiles from database by distribution
-func getProfiles(distribution string) ([]pkgCluster.ClusterProfileResponse, error) {
+func getProfiles(distribution pkgCluster.DistributionID) ([]pkgCluster.ClusterProfileResponse, error) {
 
 	var response []pkgCluster.ClusterProfileResponse
 	profiles, err := defaults.GetAllProfiles(distribution)
@@ -187,7 +187,7 @@ func UpdateClusterProfile(c *gin.Context) {
 
 	log.Infof("Load cluster from database: %s[%s]", profileRequest.Name, profileRequest.Cloud)
 
-	distribution := ""
+	distribution := pkgCluster.Unknown
 	switch profileRequest.Cloud {
 	case pkgCluster.Amazon:
 		distribution = pkgCluster.EKS
@@ -233,7 +233,7 @@ func UpdateClusterProfile(c *gin.Context) {
 // Deleting failed if the name is the default name.
 func DeleteClusterProfile(c *gin.Context) {
 
-	distribution := c.Param(distributionTypeKey)
+	distribution := pkgCluster.DistributionID(c.Param(distributionTypeKey))
 	name := c.Param(nameKey)
 	log.Infof("Start deleting cluster profile: %s[%s]", name, distribution)
 

--- a/api/projects.go
+++ b/api/projects.go
@@ -22,6 +22,7 @@ import (
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/providers"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -37,11 +38,11 @@ type ListProjectsResponse struct {
 type servicesContext struct {
 	log      logrus.FieldLogger
 	orgId    pkgAuth.OrganizationID
-	secretId string
+	secretId pkgSecret.SecretID
 }
 
 // newServicesCtx
-func newServicesCtx(orgId pkgAuth.OrganizationID, secretId string) *servicesContext {
+func newServicesCtx(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID) *servicesContext {
 	return &servicesContext{
 		orgId:    orgId,
 		secretId: secretId,
@@ -60,7 +61,7 @@ func GetProjects(c *gin.Context) {
 	}
 	log.Debugf("retrieving projects for orgId: [%d], secretId [%s]",
 		organization.ID, secretID)
-	servicesCtx := newServicesCtx(organization.ID, secretID)
+	servicesCtx := newServicesCtx(organization.ID, pkgSecret.SecretID(secretID))
 
 	cli, err := servicesCtx.httpClient()
 	if err != nil {

--- a/api/projects.go
+++ b/api/projects.go
@@ -19,7 +19,8 @@ import (
 	"net/http"
 
 	"github.com/banzaicloud/pipeline/auth"
-	"github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/gin-gonic/gin"
@@ -35,12 +36,12 @@ type ListProjectsResponse struct {
 // Primarily it's intended to be populated with information coming from the Gin context (header, path, request ...)
 type servicesContext struct {
 	log      logrus.FieldLogger
-	orgId    uint
+	orgId    pkgAuth.OrganizationID
 	secretId string
 }
 
 // newServicesCtx
-func newServicesCtx(orgId uint, secretId string) *servicesContext {
+func newServicesCtx(orgId pkgAuth.OrganizationID, secretId string) *servicesContext {
 	return &servicesContext{
 		orgId:    orgId,
 		secretId: secretId,

--- a/api/resourcegroup.go
+++ b/api/resourcegroup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -117,6 +118,6 @@ func DeleteResourceGroups(c *gin.Context) {
 
 }
 
-func getSecretIdFromHeader(c *gin.Context) string {
-	return c.GetHeader(secretIdKey)
+func getSecretIdFromHeader(c *gin.Context) pkgSecret.SecretID {
+	return pkgSecret.SecretID(c.GetHeader(secretIdKey))
 }

--- a/api/resourcegroup_messages.go
+++ b/api/resourcegroup_messages.go
@@ -14,11 +14,13 @@
 
 package api
 
+import pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+
 // CreateResourceGroupRequest describes the resource group create request
 type CreateResourceGroupRequest struct {
-	Name     string `json:"name" binding:"required"`
-	Location string `json:"location" binding:"required"`
-	SecretId string `json:"secretId" binding:"required"`
+	Name     string             `json:"name" binding:"required"`
+	Location string             `json:"location" binding:"required"`
+	SecretId pkgSecret.SecretID `json:"secretId" binding:"required"`
 }
 
 // CreateResourceGroupResponse describes the resource group create response

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/config"
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
@@ -571,7 +572,7 @@ func IsValidSecretType(secretType string) error {
 }
 
 // checkClustersBeforeDelete returns error if there's a running cluster that created with the given secret
-func checkClustersBeforeDelete(orgId uint, secretId string) error {
+func checkClustersBeforeDelete(orgId pkgAuth.OrganizationID, secretId string) error {
 	// TODO: move these to a struct and create them only once upon application init
 	secretValidator := providers.NewSecretValidator(secret.Store)
 	clusterManager := cluster.NewManager(intCluster.NewClusters(config.DB()), secretValidator, cluster.NewNopClusterEvents(), nil, nil, log, errorHandler)

--- a/api/secrets_test.go
+++ b/api/secrets_test.go
@@ -170,7 +170,7 @@ func TestDeleteSecrets(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		secretId string
+		secretId secretTypes.SecretID
 	}{
 		{name: "Delete amazon secret", secretId: secretIdAmazon},
 		{name: "Delete azure secret", secretId: secretIdAzure},
@@ -211,10 +211,10 @@ var (
 
 // nolint: gochecknoglobals
 var (
-	secretIdAmazon = fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameAmazon)))
-	secretIdAzure  = fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameAzure)))
-	secretIdGoogle = fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameGoogle)))
-	secretIdOracle = fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameOracle)))
+	secretIdAmazon = secretTypes.SecretID(fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameAmazon))))
+	secretIdAzure  = secretTypes.SecretID(fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameAzure))))
+	secretIdGoogle = secretTypes.SecretID(fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameGoogle))))
+	secretIdOracle = secretTypes.SecretID(fmt.Sprintf("%x", sha256.Sum256([]byte(secretNameOracle))))
 )
 
 const (

--- a/api/user.go
+++ b/api/user.go
@@ -120,7 +120,7 @@ func (a *UserAPI) GetUsers(c *gin.Context) {
 
 	var users []auth.User
 
-	err = a.db.Model(organization).Where(&auth.User{ID: uint(id)}).Related(&users, "Users").Error
+	err = a.db.Model(organization).Where(&auth.User{ID: pkgAuth.UserID(id)}).Related(&users, "Users").Error
 	if err != nil {
 		message := "failed to fetch users"
 		a.errorHandler.Handle(emperror.Wrap(err, message))
@@ -190,7 +190,7 @@ func (a *UserAPI) AddUser(c *gin.Context) {
 	}
 
 	organization := auth.GetCurrentOrganization(c.Request)
-	user := &auth.User{ID: uint(id)}
+	user := &auth.User{ID: pkgAuth.UserID(id)}
 
 	err = a.addUserToOrgInDb(organization, user, role.Role)
 
@@ -252,7 +252,7 @@ func (a *UserAPI) RemoveUser(c *gin.Context) {
 		return
 	}
 
-	err = a.db.Model(organization).Association("Users").Delete(auth.User{ID: uint(id)}).Error
+	err = a.db.Model(organization).Association("Users").Delete(auth.User{ID: pkgAuth.UserID(id)}).Error
 	if err != nil {
 		message := "failed to delete user"
 		a.errorHandler.Handle(emperror.Wrap(err, message))

--- a/api/user.go
+++ b/api/user.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
@@ -28,8 +29,8 @@ import (
 )
 
 type userAccessManager interface {
-	GrantOrganizationAccessToUser(userID string, orgID uint)
-	RevokeOrganizationAccessFromUser(userID string, orgID uint)
+	GrantOrganizationAccessToUser(userID string, orgID pkgAuth.OrganizationID)
+	RevokeOrganizationAccessFromUser(userID string, orgID pkgAuth.OrganizationID)
 }
 
 // UserAPI implements user functions.

--- a/auth/authn.go
+++ b/auth/authn.go
@@ -112,7 +112,7 @@ type CICDClaims struct {
 func claimConverter(claims *bauth.ScopedClaims) interface{} {
 	userID, _ := strconv.ParseUint(claims.Subject, 10, 32)
 	return &User{
-		ID:      uint(userID),
+		ID:      pkgAuth.UserID(userID),
 		Login:   claims.Text, // This is needed for CICD virtual user tokens
 		Virtual: claims.Type == CICDHookTokenType,
 	}

--- a/auth/authn.go
+++ b/auth/authn.go
@@ -25,6 +25,7 @@ import (
 
 	bauth "github.com/banzaicloud/bank-vaults/pkg/auth"
 	"github.com/banzaicloud/pipeline/config"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/utils"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -128,9 +129,9 @@ func (c cookieExtractor) ExtractToken(r *http.Request) (string, error) {
 type accessManager interface {
 	GrantDefaultAccessToUser(userID string)
 	GrantDefaultAccessToVirtualUser(userID string)
-	AddOrganizationPolicies(orgID uint)
-	GrantOrganizationAccessToUser(userID string, orgID uint)
-	RevokeOrganizationAccessFromUser(userID string, orgID uint)
+	AddOrganizationPolicies(orgID pkgAuth.OrganizationID)
+	GrantOrganizationAccessToUser(userID string, orgID pkgAuth.OrganizationID)
+	RevokeOrganizationAccessFromUser(userID string, orgID pkgAuth.OrganizationID)
 	RevokeAllAccessFromUser(userID string)
 }
 
@@ -361,12 +362,12 @@ func (h *tokenHandler) GenerateToken(c *gin.Context) {
 }
 
 // getClusterUserID maps cluster to a unique identifier for the cluster's technical user
-func getClusterUserID(orgID, clusterID uint) string {
+func getClusterUserID(orgID pkgAuth.OrganizationID, clusterID uint) string {
 	return fmt.Sprintf("clusters/%d/%d", orgID, clusterID)
 }
 
 //GenerateClusterToken looks up, or generates and stores a token for a cluster
-func (h *tokenHandler) GenerateClusterToken(orgID, clusterID uint) (string, string, error) {
+func (h *tokenHandler) GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error) {
 	userID := getClusterUserID(orgID, clusterID)
 	if tokens, err := TokenStore.List(userID); err == nil {
 		for _, token := range tokens {

--- a/auth/authn.go
+++ b/auth/authn.go
@@ -26,6 +26,7 @@ import (
 	bauth "github.com/banzaicloud/bank-vaults/pkg/auth"
 	"github.com/banzaicloud/pipeline/config"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/utils"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -362,12 +363,12 @@ func (h *tokenHandler) GenerateToken(c *gin.Context) {
 }
 
 // getClusterUserID maps cluster to a unique identifier for the cluster's technical user
-func getClusterUserID(orgID pkgAuth.OrganizationID, clusterID uint) string {
+func getClusterUserID(orgID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID) string {
 	return fmt.Sprintf("clusters/%d/%d", orgID, clusterID)
 }
 
 //GenerateClusterToken looks up, or generates and stores a token for a cluster
-func (h *tokenHandler) GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error) {
+func (h *tokenHandler) GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID) (string, string, error) {
 	userID := getClusterUserID(orgID, clusterID)
 	if tokens, err := TokenStore.List(userID); err == nil {
 		for _, token := range tokens {

--- a/auth/events.go
+++ b/auth/events.go
@@ -14,13 +14,15 @@
 
 package auth
 
+import pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+
 // OrganizationRegisteredTopic is the name of the topic where organization registration events are published.
 const OrganizationRegisteredTopic = "organization_registered"
 
 // authEvents is responsible for dispatching domain events throughout the system.
 // It does not express any infrastructural detail (like pubsub).
 type authEvents interface {
-	OrganizationRegistered(organizationID uint, userID uint)
+	OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID uint)
 }
 
 type eventBus interface {
@@ -31,6 +33,6 @@ type ebAuthEvents struct {
 	eb eventBus
 }
 
-func (e ebAuthEvents) OrganizationRegistered(organizationID uint, userID uint) {
+func (e ebAuthEvents) OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID uint) {
 	e.eb.Publish(OrganizationRegisteredTopic, organizationID, userID)
 }

--- a/auth/events.go
+++ b/auth/events.go
@@ -22,7 +22,7 @@ const OrganizationRegisteredTopic = "organization_registered"
 // authEvents is responsible for dispatching domain events throughout the system.
 // It does not express any infrastructural detail (like pubsub).
 type authEvents interface {
-	OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID uint)
+	OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID pkgAuth.UserID)
 }
 
 type eventBus interface {
@@ -33,6 +33,6 @@ type ebAuthEvents struct {
 	eb eventBus
 }
 
-func (e ebAuthEvents) OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID uint) {
+func (e ebAuthEvents) OrganizationRegistered(organizationID pkgAuth.OrganizationID, userID pkgAuth.UserID) {
 	e.eb.Publish(OrganizationRegisteredTopic, organizationID, userID)
 }

--- a/auth/github.go
+++ b/auth/github.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/google/go-github/github"
 	"github.com/goph/emperror"
 	"github.com/mitchellh/mapstructure"
@@ -49,7 +50,7 @@ func NewGithubClient(accessToken string) *github.Client {
 	return github.NewClient(httpClient)
 }
 
-func GetUserGithubToken(userID uint) (string, error) {
+func GetUserGithubToken(userID pkgAuth.UserID) (string, error) {
 	token, err := TokenStore.Lookup(fmt.Sprint(userID), GithubTokenID)
 	if err != nil {
 		return "", emperror.Wrap(err, "failed to lookup user token")
@@ -62,7 +63,7 @@ func GetUserGithubToken(userID uint) (string, error) {
 	return token.Value, nil
 }
 
-func NewGithubClientForUser(userID uint) (*github.Client, error) {
+func NewGithubClientForUser(userID pkgAuth.UserID) (*github.Client, error) {
 	accessToken, err := GetUserGithubToken(userID)
 	if err != nil {
 		return nil, err

--- a/auth/user.go
+++ b/auth/user.go
@@ -89,7 +89,7 @@ func (t IdentityType) Value() (driver.Value, error)  { return string(t), nil }
 
 //User struct
 type User struct {
-	ID            uint           `gorm:"primary_key" json:"id"`
+	ID            pkgAuth.UserID `gorm:"primary_key" json:"id"`
 	CreatedAt     time.Time      `json:"createdAt"`
 	UpdatedAt     time.Time      `json:"updatedAt"`
 	Name          string         `form:"name" json:"name,omitempty"`
@@ -118,7 +118,7 @@ type CICDUser struct {
 
 // UserOrganization describes the user organization
 type UserOrganization struct {
-	UserID         uint
+	UserID         pkgAuth.UserID
 	OrganizationID pkgAuth.OrganizationID
 	Role           string `gorm:"default:'admin'"`
 }
@@ -570,7 +570,7 @@ func GetOrganizationByName(name string) (*Organization, error) {
 }
 
 // GetUserById returns user
-func GetUserById(userId uint) (*User, error) {
+func GetUserById(userId pkgAuth.UserID) (*User, error) {
 	db := config.DB()
 	var user User
 	err := db.Find(&user, User{ID: userId}).Error
@@ -586,7 +586,7 @@ func GetUserByLoginName(login string) (*User, error) {
 }
 
 // GetUserNickNameById returns user's login name
-func GetUserNickNameById(userId uint) (userName string) {
+func GetUserNickNameById(userId pkgAuth.UserID) (userName string) {
 	if user, err := GetUserById(userId); err != nil {
 		log.Warnf("Error during getting user name: %s", err.Error())
 	} else {

--- a/auth/user.go
+++ b/auth/user.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/cicd-go/cicd"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/helm"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/copier"
@@ -118,20 +119,20 @@ type CICDUser struct {
 // UserOrganization describes the user organization
 type UserOrganization struct {
 	UserID         uint
-	OrganizationID uint
+	OrganizationID pkgAuth.OrganizationID
 	Role           string `gorm:"default:'admin'"`
 }
 
 //Organization struct
 type Organization struct {
-	ID        uint      `gorm:"primary_key" json:"id"`
-	GithubID  *int64    `gorm:"unique" json:"githubId,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	Name      string    `gorm:"unique;not null" json:"name"`
-	Provider  string    `gorm:"not null" json:"provider"`
-	Users     []User    `gorm:"many2many:user_organizations" json:"users,omitempty"`
-	Role      string    `json:"-" gorm:"-"` // Used only internally
+	ID        pkgAuth.OrganizationID `gorm:"primary_key" json:"id"`
+	GithubID  *int64                 `gorm:"unique" json:"githubId,omitempty"`
+	CreatedAt time.Time              `json:"createdAt"`
+	UpdatedAt time.Time              `json:"updatedAt"`
+	Name      string                 `gorm:"unique;not null" json:"name"`
+	Provider  string                 `gorm:"not null" json:"provider"`
+	Users     []User                 `gorm:"many2many:user_organizations" json:"users,omitempty"`
+	Role      string                 `json:"-" gorm:"-"` // Used only internally
 }
 
 //IDString returns the ID as string
@@ -490,9 +491,9 @@ func (i *GithubImporter) ImportGithubOrganizations(currentUser *User, orgs []org
 	return nil
 }
 
-func importGithubOrganizations(db *gorm.DB, currentUser *User, orgs []organization) (map[uint]bool, error) {
+func importGithubOrganizations(db *gorm.DB, currentUser *User, orgs []organization) (map[pkgAuth.OrganizationID]bool, error) {
 
-	orgIDs := make(map[uint]bool, len(orgs))
+	orgIDs := make(map[pkgAuth.OrganizationID]bool, len(orgs))
 
 	tx := db.Begin()
 	for _, org := range orgs {
@@ -553,7 +554,7 @@ func importGithubOrganizations(db *gorm.DB, currentUser *User, orgs []organizati
 }
 
 // GetOrganizationById returns an organization from database by ID
-func GetOrganizationById(orgID uint) (*Organization, error) {
+func GetOrganizationById(orgID pkgAuth.OrganizationID) (*Organization, error) {
 	db := config.DB()
 	var org Organization
 	err := db.Find(&org, Organization{ID: orgID}).Error

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -38,6 +38,7 @@ import (
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 	"github.com/banzaicloud/pipeline/utils"
@@ -312,7 +313,7 @@ func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgI
 		Cloud:          request.Cloud,
 		Distribution:   pkgCluster.ACSK,
 		OrganizationId: orgId,
-		SecretId:       request.SecretId,
+		SecretId:       pkgSecret.SecretID(request.SecretId),
 		ACSK: model.ACSKClusterModel{
 			RegionID:                 request.Properties.CreateClusterACSK.RegionID,
 			ZoneID:                   request.Properties.CreateClusterACSK.ZoneID,
@@ -738,11 +739,11 @@ func (c *ACSKCluster) GetUID() string {
 	return c.modelCluster.UID
 }
 
-func (c *ACSKCluster) GetSecretId() string {
+func (c *ACSKCluster) GetSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SecretId
 }
 
-func (c *ACSKCluster) GetSshSecretId() string {
+func (c *ACSKCluster) GetSshSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SshSecretId
 }
 
@@ -751,7 +752,7 @@ func (c *ACSKCluster) GetLocation() string {
 	return c.modelCluster.Location
 }
 
-func (c *ACSKCluster) SaveSshSecretId(sshSecretId string) error {
+func (c *ACSKCluster) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateSshSecret(sshSecretId)
 }
 
@@ -1052,11 +1053,11 @@ func (c *ACSKCluster) GetSecretWithValidation() (*secret.SecretItemResponse, err
 	return c.CommonClusterBase.getSecret(c)
 }
 
-func (c *ACSKCluster) SaveConfigSecretId(configSecretId string) error {
+func (c *ACSKCluster) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateConfigSecret(configSecretId)
 }
 
-func (c *ACSKCluster) GetConfigSecretId() string {
+func (c *ACSKCluster) GetConfigSecretId() pkgSecret.SecretID {
 	return c.modelCluster.ConfigSecretId
 }
 

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -197,7 +197,7 @@ func (c *ACSKCluster) GetAlibabaVPCClient(cfg *sdk.Config) (*vpc.Client, error) 
 	return client, emperror.With(err, "cluster", c.modelCluster.Name)
 }
 
-func createACSKNodePoolsFromRequest(pools acsk.NodePools, userId uint) ([]*model.ACSKNodePoolModel, error) {
+func createACSKNodePoolsFromRequest(pools acsk.NodePools, userId pkgAuth.UserID) ([]*model.ACSKNodePoolModel, error) {
 	nodePoolsCount := len(pools)
 	if nodePoolsCount == 0 {
 		return nil, pkgErrors.ErrorNodePoolNotProvided
@@ -220,7 +220,7 @@ func createACSKNodePoolsFromRequest(pools acsk.NodePools, userId uint) ([]*model
 	return res, nil
 }
 
-func (c *ACSKCluster) createACSKNodePoolsModelFromUpdateRequestData(pools acsk.NodePools, userId uint) ([]*model.ACSKNodePoolModel, error) {
+func (c *ACSKCluster) createACSKNodePoolsModelFromUpdateRequestData(pools acsk.NodePools, userId pkgAuth.UserID) ([]*model.ACSKNodePoolModel, error) {
 	currentNodePoolMap := make(map[string]*model.ACSKNodePoolModel, len(c.modelCluster.ACSK.NodePools))
 	updatedNodePools := make([]*model.ACSKNodePoolModel, 0, len(pools))
 
@@ -296,7 +296,7 @@ func CreateACSKClusterFromModel(clusterModel *model.ClusterModel) (*ACSKCluster,
 	return &alibabaCluster, nil
 }
 
-func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*ACSKCluster, error) {
+func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*ACSKCluster, error) {
 	cluster := ACSKCluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -647,7 +647,7 @@ func (c *ACSKCluster) DeleteCluster() error {
 	return nil
 }
 
-func (c *ACSKCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, userId uint) error {
+func (c *ACSKCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, userId pkgAuth.UserID) error {
 	c.log.Info("Start updating cluster (Alibaba)")
 
 	csClient, err := c.GetAlibabaCSClient(nil)
@@ -726,7 +726,7 @@ func (c *ACSKCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, us
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *ACSKCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (c *ACSKCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 	return nil
 }
 
@@ -1146,6 +1146,6 @@ func createAlibabaVPCClient(auth *credentials.AccessKeyCredential, regionID stri
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *ACSKCluster) GetCreatedBy() uint {
+func (c *ACSKCluster) GetCreatedBy() pkgAuth.UserID {
 	return c.modelCluster.CreatedBy
 }

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ess"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/acsk"
 	"github.com/banzaicloud/pipeline/pkg/cluster/acsk/action"
@@ -295,7 +296,7 @@ func CreateACSKClusterFromModel(clusterModel *model.ClusterModel) (*ACSKCluster,
 	return &alibabaCluster, nil
 }
 
-func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId, userId uint) (*ACSKCluster, error) {
+func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*ACSKCluster, error) {
 	cluster := ACSKCluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -813,7 +814,7 @@ func (c *ACSKCluster) DeleteFromDatabase() error {
 	return nil
 }
 
-func (c *ACSKCluster) GetOrganizationId() uint {
+func (c *ACSKCluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.modelCluster.OrganizationId
 }
 

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -731,7 +731,7 @@ func (c *ACSKCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest
 	return nil
 }
 
-func (c *ACSKCluster) GetID() uint {
+func (c *ACSKCluster) GetID() pkgCluster.ClusterID {
 	return c.modelCluster.ID
 }
 

--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -562,7 +562,7 @@ func (c *ACSKCluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *ACSKCluster) GetDistribution() string {
+func (c *ACSKCluster) GetDistribution() pkgCluster.DistributionID {
 	return c.modelCluster.Distribution
 }
 

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -464,7 +464,7 @@ func (c *AKSCluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *AKSCluster) GetDistribution() string {
+func (c *AKSCluster) GetDistribution() pkgCluster.DistributionID {
 	return c.modelCluster.Distribution
 }
 

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -646,7 +646,7 @@ func (c *AKSCluster) getNodePoolByName(name string) *model.AKSNodePoolModel {
 }
 
 // GetID returns the cluster's ID
-func (c *AKSCluster) GetID() uint {
+func (c *AKSCluster) GetID() pkgCluster.ClusterID {
 	return c.modelCluster.ID
 }
 

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -60,7 +60,7 @@ type AKSCluster struct {
 }
 
 // CreateAKSClusterFromRequest returns an AKS cluster instance created from the specified request
-func CreateAKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID pkgAuth.OrganizationID, userID uint) (*AKSCluster, error) {
+func CreateAKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID pkgAuth.OrganizationID, userID pkgAuth.UserID) (*AKSCluster, error) {
 	var nodePools = make([]*model.AKSNodePoolModel, 0, len(request.Properties.CreateClusterAKS.NodePools))
 	for name, np := range request.Properties.CreateClusterAKS.NodePools {
 		nodePools = append(nodePools, &model.AKSNodePoolModel{
@@ -534,7 +534,7 @@ func getAgentPoolProfileByName(cluster *containerservice.ManagedCluster, name st
 }
 
 // UpdateCluster updates the cluster in AKS
-func (c *AKSCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, userID uint) error {
+func (c *AKSCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, userID pkgAuth.UserID) error {
 	cc, err := c.getCloudConnection()
 	if err != nil {
 		return emperror.Wrap(err, "failed to get cloud connection")
@@ -586,7 +586,7 @@ func (c *AKSCluster) UpdateCluster(request *pkgCluster.UpdateClusterRequest, use
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *AKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userID uint) error {
+func (c *AKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userID pkgAuth.UserID) error {
 	cc, err := c.getCloudConnection()
 	if err != nil {
 		return emperror.Wrap(err, "failed to get cloud connection")
@@ -1126,7 +1126,7 @@ func (c *AKSCluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *AKSCluster) GetCreatedBy() uint {
+func (c *AKSCluster) GetCreatedBy() pkgAuth.UserID {
 	return c.modelCluster.CreatedBy
 }
 

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -36,6 +36,7 @@ import (
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgAzure "github.com/banzaicloud/pipeline/pkg/providers/azure"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/goph/emperror"
@@ -83,7 +84,7 @@ func CreateAKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID
 		Cloud:          request.Cloud,
 		OrganizationId: orgID,
 		CreatedBy:      userID,
-		SecretId:       request.SecretId,
+		SecretId:       pkgSecret.SecretID(request.SecretId),
 		Distribution:   pkgCluster.AKS,
 		AKS: model.AKSClusterModel{
 			ResourceGroup:     request.Properties.CreateClusterAKS.ResourceGroup,
@@ -150,7 +151,7 @@ func (c *AKSCluster) GetOrganizationId() pkgAuth.OrganizationID {
 }
 
 // GetSecretId returns the cluster secret's ID
-func (c *AKSCluster) GetSecretId() string {
+func (c *AKSCluster) GetSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SecretId
 }
 
@@ -750,7 +751,7 @@ func (c *AKSCluster) getCredentials() (*pkgAzure.Credentials, error) {
 	return pkgAzure.NewCredentials(clusterSecret.Values), nil
 }
 
-func getAzureCredentials(orgID pkgAuth.OrganizationID, secretID string) (*pkgAzure.Credentials, error) {
+func getAzureCredentials(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) (*pkgAzure.Credentials, error) {
 	sir, err := getSecret(orgID, secretID)
 	if err != nil {
 		return nil, emperror.WrapWith(err, "failed to retreive secret", "orgID", orgID, "secretID", secretID)
@@ -762,7 +763,7 @@ func getAzureCredentials(orgID pkgAuth.OrganizationID, secretID string) (*pkgAzu
 	return pkgAzure.NewCredentials(sir.Values), nil
 }
 
-func getDefaultCloudConnection(orgID pkgAuth.OrganizationID, secretID string) (*pkgAzure.CloudConnection, error) {
+func getDefaultCloudConnection(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) (*pkgAzure.CloudConnection, error) {
 	creds, err := getAzureCredentials(orgID, secretID)
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to retrieve Azure credentials")
@@ -771,7 +772,7 @@ func getDefaultCloudConnection(orgID pkgAuth.OrganizationID, secretID string) (*
 }
 
 // GetLocations returns all the locations that are available for resource providers
-func GetLocations(orgID pkgAuth.OrganizationID, secretID string) (locations []string, err error) {
+func GetLocations(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) (locations []string, err error) {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return
@@ -791,7 +792,7 @@ func GetLocations(orgID pkgAuth.OrganizationID, secretID string) (locations []st
 }
 
 // GetMachineTypes lists all available virtual machine sizes for a subscription in a location
-func GetMachineTypes(orgID pkgAuth.OrganizationID, secretID, location string) (pkgCluster.MachineTypes, error) {
+func GetMachineTypes(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, location string) (pkgCluster.MachineTypes, error) {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to get cloud connection")
@@ -800,7 +801,7 @@ func GetMachineTypes(orgID pkgAuth.OrganizationID, secretID, location string) (p
 }
 
 // GetKubernetesVersion returns a list of supported kubernetes version in the specified subscription
-func GetKubernetesVersion(orgID pkgAuth.OrganizationID, secretID, location string) ([]string, error) {
+func GetKubernetesVersion(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, location string) ([]string, error) {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to get cloud connection")
@@ -928,22 +929,22 @@ func (c *AKSCluster) GetSecretWithValidation() (*secret.SecretItemResponse, erro
 }
 
 // SaveConfigSecretId saves the config secret ID in database
-func (c *AKSCluster) SaveConfigSecretId(configSecretID string) error {
+func (c *AKSCluster) SaveConfigSecretId(configSecretID pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateConfigSecret(configSecretID)
 }
 
 // GetConfigSecretId returns the cluster's config secret ID
-func (c *AKSCluster) GetConfigSecretId() string {
+func (c *AKSCluster) GetConfigSecretId() pkgSecret.SecretID {
 	return c.modelCluster.ConfigSecretId
 }
 
 // GetSSHSecretID returns the cluster's SSH secret ID
-func (c *AKSCluster) GetSshSecretId() string {
+func (c *AKSCluster) GetSshSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SshSecretId
 }
 
 // SaveSshSecretId saves the SSH secret ID to database
-func (c *AKSCluster) SaveSshSecretId(sshSecretID string) error {
+func (c *AKSCluster) SaveSshSecretId(sshSecretID pkgSecret.SecretID) error {
 	c.log.Debugf("Saving SSH secret ID [%s]", sshSecretID)
 	return c.modelCluster.UpdateSshSecret(sshSecretID)
 }
@@ -1055,7 +1056,7 @@ func (c *AKSCluster) SetServiceMesh(m bool) {
 }
 
 // ListResourceGroups returns all resource group
-func ListResourceGroups(orgID pkgAuth.OrganizationID, secretID string) (res []string, err error) {
+func ListResourceGroups(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) (res []string, err error) {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to get cloud connection")
@@ -1074,7 +1075,7 @@ func ListResourceGroups(orgID pkgAuth.OrganizationID, secretID string) (res []st
 }
 
 // CreateOrUpdateResourceGroup creates or updates a resource group
-func CreateOrUpdateResourceGroup(orgID pkgAuth.OrganizationID, secretID, resourceGroupName, location string) error {
+func CreateOrUpdateResourceGroup(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, resourceGroupName, location string) error {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return emperror.Wrap(err, "failed to get cloud connection")
@@ -1086,7 +1087,7 @@ func CreateOrUpdateResourceGroup(orgID pkgAuth.OrganizationID, secretID, resourc
 }
 
 // DeleteResourceGroup creates or updates a resource group
-func DeleteResourceGroup(orgID pkgAuth.OrganizationID, secretID, resourceGroupName string) error {
+func DeleteResourceGroup(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, resourceGroupName string) error {
 	cc, err := getDefaultCloudConnection(orgID, secretID)
 	if err != nil {
 		return emperror.Wrap(err, "failed to get cloud connection")

--- a/cluster/amazon.go
+++ b/cluster/amazon.go
@@ -18,10 +18,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
 )
 
-func newEC2Client(orgID pkgAuth.OrganizationID, secretID, region string) (*ec2.EC2, error) {
+func newEC2Client(orgID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, region string) (*ec2.EC2, error) {
 	s, err := getSecret(orgID, secretID)
 	if err != nil {
 		return nil, err
@@ -38,7 +39,7 @@ func newEC2Client(orgID pkgAuth.OrganizationID, secretID, region string) (*ec2.E
 }
 
 // ListRegions lists supported regions
-func ListRegions(orgId pkgAuth.OrganizationID, secretId, region string) ([]*ec2.Region, error) {
+func ListRegions(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID, region string) ([]*ec2.Region, error) {
 	client, err := newEC2Client(orgId, secretId, region)
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func ListRegions(orgId pkgAuth.OrganizationID, secretId, region string) ([]*ec2.
 }
 
 // ListAMIs returns supported AMIs by region and tags
-func ListAMIs(orgId pkgAuth.OrganizationID, secretId, region string, tags []*string) ([]*ec2.Image, error) {
+func ListAMIs(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID, region string, tags []*string) ([]*ec2.Image, error) {
 	client, err := newEC2Client(orgId, secretId, region)
 	if err != nil {
 		return nil, err

--- a/cluster/amazon.go
+++ b/cluster/amazon.go
@@ -16,11 +16,12 @@ package cluster
 
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/secret/verify"
 )
 
-func newEC2Client(orgID uint, secretID, region string) (*ec2.EC2, error) {
+func newEC2Client(orgID pkgAuth.OrganizationID, secretID, region string) (*ec2.EC2, error) {
 	s, err := getSecret(orgID, secretID)
 	if err != nil {
 		return nil, err
@@ -37,7 +38,7 @@ func newEC2Client(orgID uint, secretID, region string) (*ec2.EC2, error) {
 }
 
 // ListRegions lists supported regions
-func ListRegions(orgId uint, secretId, region string) ([]*ec2.Region, error) {
+func ListRegions(orgId pkgAuth.OrganizationID, secretId, region string) ([]*ec2.Region, error) {
 	client, err := newEC2Client(orgId, secretId, region)
 	if err != nil {
 		return nil, err
@@ -52,7 +53,7 @@ func ListRegions(orgId uint, secretId, region string) ([]*ec2.Region, error) {
 }
 
 // ListAMIs returns supported AMIs by region and tags
-func ListAMIs(orgId uint, secretId, region string, tags []*string) ([]*ec2.Image, error) {
+func ListAMIs(orgId pkgAuth.OrganizationID, secretId, region string, tags []*string) ([]*ec2.Image, error) {
 	client, err := newEC2Client(orgId, secretId, region)
 	if err != nil {
 		return nil, err

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/platform/database"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -42,7 +43,7 @@ type CommonCluster interface {
 	// Entity properties
 	GetID() uint
 	GetUID() string
-	GetOrganizationId() uint
+	GetOrganizationId() pkgAuth.OrganizationID
 	GetName() string
 	GetCloud() string
 	GetDistribution() string
@@ -220,7 +221,7 @@ func StoreKubernetesConfig(cluster CommonCluster, config []byte) error {
 	return nil
 }
 
-func getSecret(organizationId uint, secretId string) (*secret.SecretItemResponse, error) {
+func getSecret(organizationId pkgAuth.OrganizationID, secretId string) (*secret.SecretItemResponse, error) {
 	return secret.Store.Get(organizationId, secretId)
 }
 
@@ -370,7 +371,7 @@ func GetCommonClusterFromModel(modelCluster *model.ClusterModel) (CommonCluster,
 }
 
 //CreateCommonClusterFromRequest creates a CommonCluster from a request
-func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId, userId uint) (CommonCluster, error) {
+func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (CommonCluster, error) {
 
 	if err := createClusterRequest.AddDefaults(); err != nil {
 		return nil, err
@@ -450,7 +451,7 @@ func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClust
 }
 
 //createCommonClusterWithDistributionFromRequest creates a CommonCluster from a request
-func createCommonClusterWithDistributionFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId, userId uint) (*EC2ClusterPKE, error) {
+func createCommonClusterWithDistributionFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EC2ClusterPKE, error) {
 	switch createClusterRequest.Cloud {
 	case pkgCluster.Amazon:
 		return CreateEC2ClusterPKEFromRequest(createClusterRequest, orgId, userId)

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -46,7 +46,7 @@ type CommonCluster interface {
 	GetOrganizationId() pkgAuth.OrganizationID
 	GetName() string
 	GetCloud() string
-	GetDistribution() string
+	GetDistribution() pkgCluster.DistributionID
 	GetLocation() string
 	GetCreatedBy() pkgAuth.UserID
 

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -51,11 +51,11 @@ type CommonCluster interface {
 	GetCreatedBy() pkgAuth.UserID
 
 	// Secrets
-	GetSecretId() string
-	GetSshSecretId() string
-	SaveSshSecretId(string) error
-	SaveConfigSecretId(string) error
-	GetConfigSecretId() string
+	GetSecretId() pkgSecret.SecretID
+	GetSshSecretId() pkgSecret.SecretID
+	SaveSshSecretId(pkgSecret.SecretID) error
+	SaveConfigSecretId(pkgSecret.SecretID) error
+	GetConfigSecretId() pkgSecret.SecretID
 	GetSecretWithValidation() (*secret.SecretItemResponse, error)
 
 	// Persistence
@@ -221,7 +221,7 @@ func StoreKubernetesConfig(cluster CommonCluster, config []byte) error {
 	return nil
 }
 
-func getSecret(organizationId pkgAuth.OrganizationID, secretId string) (*secret.SecretItemResponse, error) {
+func getSecret(organizationId pkgAuth.OrganizationID, secretId pkgSecret.SecretID) (*secret.SecretItemResponse, error) {
 	return secret.Store.Get(organizationId, secretId)
 }
 

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -41,7 +41,7 @@ import (
 // CommonCluster interface for clusters.
 type CommonCluster interface {
 	// Entity properties
-	GetID() uint
+	GetID() pkgCluster.ClusterID
 	GetUID() string
 	GetOrganizationId() pkgAuth.OrganizationID
 	GetName() string

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -48,7 +48,7 @@ type CommonCluster interface {
 	GetCloud() string
 	GetDistribution() string
 	GetLocation() string
-	GetCreatedBy() uint
+	GetCreatedBy() pkgAuth.UserID
 
 	// Secrets
 	GetSecretId() string
@@ -66,8 +66,8 @@ type CommonCluster interface {
 	// Cluster management
 	CreateCluster() error
 	ValidateCreationFields(r *pkgCluster.CreateClusterRequest) error
-	UpdateCluster(*pkgCluster.UpdateClusterRequest, uint) error
-	UpdateNodePools(*pkgCluster.UpdateNodePoolsRequest, uint) error
+	UpdateCluster(*pkgCluster.UpdateClusterRequest, pkgAuth.UserID) error
+	UpdateNodePools(*pkgCluster.UpdateNodePoolsRequest, pkgAuth.UserID) error
 	CheckEqualityToUpdate(*pkgCluster.UpdateClusterRequest) error
 	AddDefaultsToUpdate(*pkgCluster.UpdateClusterRequest)
 	DeleteCluster() error
@@ -371,7 +371,7 @@ func GetCommonClusterFromModel(modelCluster *model.ClusterModel) (CommonCluster,
 }
 
 //CreateCommonClusterFromRequest creates a CommonCluster from a request
-func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (CommonCluster, error) {
+func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (CommonCluster, error) {
 
 	if err := createClusterRequest.AddDefaults(); err != nil {
 		return nil, err
@@ -451,7 +451,7 @@ func CreateCommonClusterFromRequest(createClusterRequest *pkgCluster.CreateClust
 }
 
 //createCommonClusterWithDistributionFromRequest creates a CommonCluster from a request
-func createCommonClusterWithDistributionFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EC2ClusterPKE, error) {
+func createCommonClusterWithDistributionFromRequest(createClusterRequest *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*EC2ClusterPKE, error) {
 	switch createClusterRequest.Cloud {
 	case pkgCluster.Amazon:
 		return CreateEC2ClusterPKEFromRequest(createClusterRequest, orgId, userId)
@@ -491,14 +491,14 @@ func CleanHelmFolder(organizationName string) error {
 }
 
 // GetUserIdAndName returns userId and userName from DB
-func GetUserIdAndName(modelCluster *model.ClusterModel) (userId uint, userName string) {
+func GetUserIdAndName(modelCluster *model.ClusterModel) (userId pkgAuth.UserID, userName string) {
 	userId = modelCluster.CreatedBy
 	userName = auth.GetUserNickNameById(userId)
 	return
 }
 
 // NewCreatorBaseFields creates a new CreatorBaseFields instance from createdAt and createdBy
-func NewCreatorBaseFields(createdAt time.Time, createdBy uint) *pkgCommon.CreatorBaseFields {
+func NewCreatorBaseFields(createdAt time.Time, createdBy pkgAuth.UserID) *pkgCommon.CreatorBaseFields {
 
 	var userName string
 	if createdBy != 0 {

--- a/cluster/common_test.go
+++ b/cluster/common_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster/gke"
 	"github.com/banzaicloud/pipeline/pkg/cluster/kubernetes"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -55,7 +56,7 @@ const (
 
 // nolint: gochecknoglobals
 var (
-	clusterRequestSecretId = fmt.Sprintf("%x", sha256.Sum256([]byte(secretName)))
+	clusterRequestSecretId = pkgSecret.SecretID(fmt.Sprintf("%x", sha256.Sum256([]byte(secretName))))
 
 	amazonSecretRequest = secret.CreateSecretRequest{
 		Name: secretName,
@@ -234,7 +235,7 @@ var (
 		Name:     clusterRequestName,
 		Location: clusterRequestLocation,
 		Cloud:    pkgCluster.Azure,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterAKS: &aks.CreateClusterAKS{
 				ResourceGroup:     clusterRequestRG,
@@ -256,7 +257,7 @@ var (
 		Name:     clusterRequestName,
 		Location: "",
 		Cloud:    pkgCluster.Azure,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterAKS: &aks.CreateClusterAKS{
 				ResourceGroup:     clusterRequestRG,
@@ -275,7 +276,7 @@ var (
 		Name:     clusterRequestName,
 		Location: clusterRequestLocation,
 		Cloud:    pkgCluster.Amazon,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterEKS: &eks.CreateClusterEKS{
 				Version: clusterRequestKubernetesEKS,
@@ -298,7 +299,7 @@ var (
 		Name:     clusterRequestName,
 		Location: clusterRequestLocation,
 		Cloud:    pkgCluster.Dummy,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterDummy: &dummy.CreateClusterDummy{
 				Node: &dummy.Node{
@@ -313,7 +314,7 @@ var (
 		Name:     clusterRequestName,
 		Location: clusterRequestLocation,
 		Cloud:    pkgCluster.Kubernetes,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterKubernetes: &kubernetes.CreateClusterKubernetes{
 				Metadata: map[string]string{
@@ -327,7 +328,7 @@ var (
 		Name:     clusterRequestName,
 		Location: "",
 		Cloud:    pkgCluster.Kubernetes,
-		SecretId: clusterRequestSecretId,
+		SecretId: string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{
 			CreateClusterKubernetes: &kubernetes.CreateClusterKubernetes{
 				Metadata: map[string]string{
@@ -341,7 +342,7 @@ var (
 		Name:       clusterRequestName,
 		Location:   clusterRequestLocation,
 		Cloud:      "nonExistsCloud",
-		SecretId:   clusterRequestSecretId,
+		SecretId:   string(clusterRequestSecretId),
 		Properties: &pkgCluster.CreateClusterProperties{},
 	}
 )

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -32,7 +32,7 @@ type DummyCluster struct {
 }
 
 // CreateDummyClusterFromRequest creates ClusterModel struct from the request
-func CreateDummyClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*DummyCluster, error) {
+func CreateDummyClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*DummyCluster, error) {
 	var cluster DummyCluster
 
 	cluster.modelCluster = &model.ClusterModel{
@@ -109,12 +109,12 @@ func (c *DummyCluster) DeleteCluster() error {
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *DummyCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (c *DummyCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 	return nil
 }
 
 // UpdateCluster updates the dummy cluster
-func (c *DummyCluster) UpdateCluster(r *pkgCluster.UpdateClusterRequest, _ uint) error {
+func (c *DummyCluster) UpdateCluster(r *pkgCluster.UpdateClusterRequest, _ pkgAuth.UserID) error {
 	c.modelCluster.Dummy.KubernetesVersion = r.Dummy.Node.KubernetesVersion
 	c.modelCluster.Dummy.NodeCount = r.Dummy.Node.Count
 	return nil
@@ -367,6 +367,6 @@ func (c *DummyCluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *DummyCluster) GetCreatedBy() uint {
+func (c *DummyCluster) GetCreatedBy() pkgAuth.UserID {
 	return c.modelCluster.CreatedBy
 }

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -21,6 +21,7 @@ import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/ghodss/yaml"
 )
@@ -41,7 +42,7 @@ func CreateDummyClusterFromRequest(request *pkgCluster.CreateClusterRequest, org
 		Cloud:          request.Cloud,
 		OrganizationId: orgId,
 		CreatedBy:      userId,
-		SecretId:       request.SecretId,
+		SecretId:       pkgSecret.SecretID(request.SecretId),
 		Distribution:   pkgCluster.Dummy,
 		Dummy: model.DummyClusterModel{
 			KubernetesVersion: request.Properties.CreateClusterDummy.Node.KubernetesVersion,
@@ -166,17 +167,17 @@ func (c *DummyCluster) GetLocation() string {
 }
 
 //GetSecretId retrieves the secret id
-func (c *DummyCluster) GetSecretId() string {
+func (c *DummyCluster) GetSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SecretId
 }
 
 //GetSshSecretId retrieves the ssh secret id
-func (c *DummyCluster) GetSshSecretId() string {
+func (c *DummyCluster) GetSshSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SshSecretId
 }
 
 // SaveSshSecretId saves the ssh secret id to database
-func (c *DummyCluster) SaveSshSecretId(sshSecretId string) error {
+func (c *DummyCluster) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	c.modelCluster.SshSecretId = sshSecretId
 	return nil
 }
@@ -278,12 +279,12 @@ func (c *DummyCluster) GetSecretWithValidation() (*secret.SecretItemResponse, er
 }
 
 // SaveConfigSecretId saves the config secret id in database
-func (c *DummyCluster) SaveConfigSecretId(configSecretId string) error {
+func (c *DummyCluster) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateConfigSecret(configSecretId)
 }
 
 // GetConfigSecretId return config secret id
-func (c *DummyCluster) GetConfigSecretId() string {
+func (c *DummyCluster) GetConfigSecretId() pkgSecret.SecretID {
 	return c.modelCluster.ConfigSecretId
 }
 

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -122,7 +122,7 @@ func (c *DummyCluster) UpdateCluster(r *pkgCluster.UpdateClusterRequest, _ pkgAu
 }
 
 //GetID returns the specified cluster id
-func (c *DummyCluster) GetID() uint {
+func (c *DummyCluster) GetID() pkgCluster.ClusterID {
 	return c.modelCluster.ID
 }
 

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -18,10 +18,11 @@ import (
 	"errors"
 
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/secret"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 // DummyCluster struct for DC
@@ -31,7 +32,7 @@ type DummyCluster struct {
 }
 
 // CreateDummyClusterFromRequest creates ClusterModel struct from the request
-func CreateDummyClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId, userId uint) (*DummyCluster, error) {
+func CreateDummyClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*DummyCluster, error) {
 	var cluster DummyCluster
 
 	cluster.modelCluster = &model.ClusterModel{
@@ -155,7 +156,7 @@ func (c *DummyCluster) DeleteFromDatabase() error {
 }
 
 // GetOrganizationId gets org where the cluster belongs
-func (c *DummyCluster) GetOrganizationId() uint {
+func (c *DummyCluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.modelCluster.OrganizationId
 }
 

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -79,7 +79,7 @@ func (c *DummyCluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *DummyCluster) GetDistribution() string {
+func (c *DummyCluster) GetDistribution() pkgCluster.DistributionID {
 	return c.modelCluster.Distribution
 }
 

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -31,6 +31,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	internalPke "github.com/banzaicloud/pipeline/internal/providers/pke"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
 	"github.com/banzaicloud/pipeline/pkg/common"
@@ -43,7 +44,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var _ CommonCluster = (*EC2ClusterPKE)(nil)
@@ -108,7 +109,7 @@ func (c *EC2ClusterPKE) GetUID() string {
 	return c.model.Cluster.UID
 }
 
-func (c *EC2ClusterPKE) GetOrganizationId() uint {
+func (c *EC2ClusterPKE) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.model.Cluster.OrganizationID
 }
 
@@ -556,7 +557,7 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url, token string) str
 		cmd, url, token, c.model.Cluster.OrganizationID, c.model.Cluster.ID, nodePoolName)
 }
 
-func CreateEC2ClusterPKEFromRequest(request *pkgCluster.CreateClusterRequest, orgId uint, userId uint) (*EC2ClusterPKE, error) {
+func CreateEC2ClusterPKEFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EC2ClusterPKE, error) {
 	c := &EC2ClusterPKE{
 		log: log.WithField("cluster", request.Name).WithField("organization", orgId),
 	}

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -133,15 +133,15 @@ func (c *EC2ClusterPKE) GetCreatedBy() pkgAuth.UserID {
 	return c.model.Cluster.CreatedBy
 }
 
-func (c *EC2ClusterPKE) GetSecretId() string {
+func (c *EC2ClusterPKE) GetSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.SecretID
 }
 
-func (c *EC2ClusterPKE) GetSshSecretId() string {
+func (c *EC2ClusterPKE) GetSshSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.SSHSecretID
 }
 
-func (c *EC2ClusterPKE) SaveSshSecretId(sshSecretId string) error {
+func (c *EC2ClusterPKE) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	c.model.Cluster.SSHSecretID = sshSecretId
 
 	err := c.db.Save(&c.model).Error
@@ -152,7 +152,7 @@ func (c *EC2ClusterPKE) SaveSshSecretId(sshSecretId string) error {
 	return nil
 }
 
-func (c *EC2ClusterPKE) SaveConfigSecretId(configSecretId string) error {
+func (c *EC2ClusterPKE) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	c.model.Cluster.ConfigSecretID = configSecretId
 
 	err := c.db.Save(&c.model).Error
@@ -163,7 +163,7 @@ func (c *EC2ClusterPKE) SaveConfigSecretId(configSecretId string) error {
 	return nil
 }
 
-func (c *EC2ClusterPKE) GetConfigSecretId() string {
+func (c *EC2ClusterPKE) GetConfigSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.ConfigSecretID
 }
 

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -121,7 +121,7 @@ func (c *EC2ClusterPKE) GetCloud() string {
 	return c.model.Cluster.Cloud
 }
 
-func (c *EC2ClusterPKE) GetDistribution() string {
+func (c *EC2ClusterPKE) GetDistribution() pkgCluster.DistributionID {
 	return c.model.Cluster.Distribution
 }
 

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -129,7 +129,7 @@ func (c *EC2ClusterPKE) GetLocation() string {
 	return c.model.Cluster.Location
 }
 
-func (c *EC2ClusterPKE) GetCreatedBy() uint {
+func (c *EC2ClusterPKE) GetCreatedBy() pkgAuth.UserID {
 	return c.model.Cluster.CreatedBy
 }
 
@@ -348,11 +348,11 @@ func (c *EC2ClusterPKE) ValidateCreationFields(r *pkgCluster.CreateClusterReques
 	return nil
 }
 
-func (c *EC2ClusterPKE) UpdateCluster(*pkgCluster.UpdateClusterRequest, uint) error {
+func (c *EC2ClusterPKE) UpdateCluster(*pkgCluster.UpdateClusterRequest, pkgAuth.UserID) error {
 	panic("implement me")
 }
 
-func (c *EC2ClusterPKE) UpdateNodePools(*pkgCluster.UpdateNodePoolsRequest, uint) error {
+func (c *EC2ClusterPKE) UpdateNodePools(*pkgCluster.UpdateNodePoolsRequest, pkgAuth.UserID) error {
 	panic("implement me")
 }
 
@@ -557,7 +557,7 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url, token string) str
 		cmd, url, token, c.model.Cluster.OrganizationID, c.model.Cluster.ID, nodePoolName)
 }
 
-func CreateEC2ClusterPKEFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EC2ClusterPKE, error) {
+func CreateEC2ClusterPKEFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*EC2ClusterPKE, error) {
 	c := &EC2ClusterPKE{
 		log: log.WithField("cluster", request.Name).WithField("organization", orgId),
 	}
@@ -630,7 +630,7 @@ func CreateEC2ClusterPKEFromModel(modelCluster *model.ClusterModel) (*EC2Cluster
 	return c, nil
 }
 
-func createEC2ClusterPKENodePoolsFromRequest(pools pke.NodePools, userId uint) internalPke.NodePools {
+func createEC2ClusterPKENodePoolsFromRequest(pools pke.NodePools, userId pkgAuth.UserID) internalPke.NodePools {
 	var nps internalPke.NodePools
 
 	for _, pool := range pools {
@@ -688,7 +688,7 @@ func convertTaints(taints pke.Taints) (result internalPke.Taints) {
 	return
 }
 
-func createEC2PKENetworkFromRequest(network pke.Network, userId uint) internalPke.Network {
+func createEC2PKENetworkFromRequest(network pke.Network, userId pkgAuth.UserID) internalPke.Network {
 	n := internalPke.Network{
 		ServiceCIDR:      network.ServiceCIDR,
 		PodCIDR:          network.PodCIDR,
@@ -703,7 +703,7 @@ func convertNetworkProvider(provider pke.NetworkProvider) (result internalPke.Ne
 	return internalPke.NetworkProvider(provider)
 }
 
-func createEC2ClusterPKEFromRequest(kubernetes pke.Kubernetes, userId uint) internalPke.Kubernetes {
+func createEC2ClusterPKEFromRequest(kubernetes pke.Kubernetes, userId pkgAuth.UserID) internalPke.Kubernetes {
 	k := internalPke.Kubernetes{
 		Version: kubernetes.Version,
 		RBAC:    internalPke.RBAC{Enabled: kubernetes.RBAC.Enabled},
@@ -712,7 +712,7 @@ func createEC2ClusterPKEFromRequest(kubernetes pke.Kubernetes, userId uint) inte
 	return k
 }
 
-func createEC2ClusterPKEKubeADMFromRequest(kubernetes pke.KubeADM, userId uint) internalPke.KubeADM {
+func createEC2ClusterPKEKubeADMFromRequest(kubernetes pke.KubeADM, userId pkgAuth.UserID) internalPke.KubeADM {
 	a := internalPke.KubeADM{
 		ExtraArgs: convertExtraArgs(kubernetes.ExtraArgs),
 	}
@@ -728,7 +728,7 @@ func convertExtraArgs(extraArgs pke.ExtraArgs) internalPke.ExtraArgs {
 	return res
 }
 
-func createEC2ClusterPKECRIFromRequest(cri pke.CRI, userId uint) internalPke.CRI {
+func createEC2ClusterPKECRIFromRequest(cri pke.CRI, userId pkgAuth.UserID) internalPke.CRI {
 	c := internalPke.CRI{
 		Runtime:       internalPke.Runtime(cri.Runtime),
 		RuntimeConfig: cri.RuntimeConfig,

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -101,7 +101,7 @@ func (c *EC2ClusterPKE) SetServiceMesh(m bool) {
 	c.model.Cluster.ServiceMesh = m
 }
 
-func (c *EC2ClusterPKE) GetID() uint {
+func (c *EC2ClusterPKE) GetID() pkgCluster.ClusterID {
 	return c.model.Cluster.ID
 }
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -444,7 +444,7 @@ func (c *EKSCluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *EKSCluster) GetDistribution() string {
+func (c *EKSCluster) GetDistribution() pkgCluster.DistributionID {
 	return c.modelCluster.Distribution
 }
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -1013,7 +1013,7 @@ func (c *EKSCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, error) {
 }
 
 // GetID returns the DB ID of this cluster
-func (c *EKSCluster) GetID() uint {
+func (c *EKSCluster) GetID() pkgCluster.ClusterID {
 	return c.modelCluster.ID
 }
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -70,7 +70,7 @@ const mapUsersTemplate = `- userarn: %s
 const asgWaitLoopSleepSeconds = 5
 
 //CreateEKSClusterFromRequest creates ClusterModel struct from the request
-func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EKSCluster, error) {
+func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*EKSCluster, error) {
 	cluster := EKSCluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -99,7 +99,7 @@ func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId
 	return &cluster, nil
 }
 
-func createNodePoolsFromRequest(nodePools map[string]*pkgEks.NodePool, userId uint) []*model.AmazonNodePoolsModel {
+func createNodePoolsFromRequest(nodePools map[string]*pkgEks.NodePool, userId pkgAuth.UserID) []*model.AmazonNodePoolsModel {
 	var modelNodePools = make([]*model.AmazonNodePoolsModel, len(nodePools))
 	i := 0
 	for nodePoolName, nodePool := range nodePools {
@@ -523,7 +523,7 @@ func (c *EKSCluster) getNodepoolStackNamesToDelete(sess *session.Session) []stri
 	return stackNames
 }
 
-func (c *EKSCluster) createNodePoolsFromUpdateRequest(requestedNodePools map[string]*pkgEks.NodePool, userId uint) ([]*model.AmazonNodePoolsModel, error) {
+func (c *EKSCluster) createNodePoolsFromUpdateRequest(requestedNodePools map[string]*pkgEks.NodePool, userId pkgAuth.UserID) ([]*model.AmazonNodePoolsModel, error) {
 
 	currentNodePoolMap := make(map[string]*model.AmazonNodePoolsModel, len(c.modelCluster.EKS.NodePools))
 	for _, nodePool := range c.modelCluster.EKS.NodePools {
@@ -604,7 +604,7 @@ func (c *EKSCluster) createNodePoolsFromUpdateRequest(requestedNodePools map[str
 }
 
 // UpdateCluster updates EKS cluster in cloud
-func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, updatedBy uint) error {
+func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, updatedBy pkgAuth.UserID) error {
 	c.log.Info("Start updating EKS cluster")
 
 	awsCred, err := c.createAWSCredentialsFromSecret()
@@ -781,7 +781,7 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *EKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (c *EKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 	c.log.Info("Start updating nodepools")
 
 	awsCred, err := c.createAWSCredentialsFromSecret()
@@ -1478,6 +1478,6 @@ func (c *EKSCluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *EKSCluster) GetCreatedBy() uint {
+func (c *EKSCluster) GetCreatedBy() pkgAuth.UserID {
 	return c.modelCluster.CreatedBy
 }

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgEks "github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/eks/action"
@@ -46,7 +47,7 @@ import (
 	"github.com/goph/emperror"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -69,7 +70,7 @@ const mapUsersTemplate = `- userarn: %s
 const asgWaitLoopSleepSeconds = 5
 
 //CreateEKSClusterFromRequest creates ClusterModel struct from the request
-func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId uint, userId uint) (*EKSCluster, error) {
+func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*EKSCluster, error) {
 	cluster := EKSCluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -206,7 +207,7 @@ type EKSCluster struct {
 }
 
 // GetOrganizationId gets org where the cluster belongs
-func (c *EKSCluster) GetOrganizationId() uint {
+func (c *EKSCluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.modelCluster.OrganizationId
 }
 
@@ -1327,7 +1328,7 @@ func (c *EKSCluster) RequiresSshPublicKey() bool {
 }
 
 // ListEksRegions returns the regions in which AmazonEKS service is enabled
-func ListEksRegions(orgId uint, secretId string) ([]string, error) {
+func ListEksRegions(orgId pkgAuth.OrganizationID, secretId string) ([]string, error) {
 	// AWS API https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/ doesn't recognizes AmazonEKS service yet
 	// thus we can not use it to query what locations the service is enabled in.
 

--- a/cluster/events.go
+++ b/cluster/events.go
@@ -14,12 +14,14 @@
 
 package cluster
 
+import pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+
 type clusterEvents interface {
 	// ClusterCreated event is emitted when a cluster creation workflow finishes.
 	ClusterCreated(clusterID uint)
 
 	// ClusterDeleted event is emitted when a cluster is completely deleted.
-	ClusterDeleted(orgID uint, clusterName string)
+	ClusterDeleted(orgID pkgAuth.OrganizationID, clusterName string)
 }
 
 type nopClusterEvents struct {
@@ -32,7 +34,7 @@ func NewNopClusterEvents() *nopClusterEvents {
 func (*nopClusterEvents) ClusterCreated(clusterID uint) {
 }
 
-func (*nopClusterEvents) ClusterDeleted(orgID uint, clusterName string) {
+func (*nopClusterEvents) ClusterDeleted(orgID pkgAuth.OrganizationID, clusterName string) {
 }
 
 type eventBus interface {
@@ -58,6 +60,6 @@ func (c *clusterEventBus) ClusterCreated(clusterID uint) {
 	c.eb.Publish(clusterCreatedTopic, clusterID)
 }
 
-func (c *clusterEventBus) ClusterDeleted(orgID uint, clusterName string) {
+func (c *clusterEventBus) ClusterDeleted(orgID pkgAuth.OrganizationID, clusterName string) {
 	c.eb.Publish(clusterDeletedTopic, orgID, clusterName)
 }

--- a/cluster/events.go
+++ b/cluster/events.go
@@ -14,11 +14,14 @@
 
 package cluster
 
-import pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+import (
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+)
 
 type clusterEvents interface {
 	// ClusterCreated event is emitted when a cluster creation workflow finishes.
-	ClusterCreated(clusterID uint)
+	ClusterCreated(clusterID pkgCluster.ClusterID)
 
 	// ClusterDeleted event is emitted when a cluster is completely deleted.
 	ClusterDeleted(orgID pkgAuth.OrganizationID, clusterName string)
@@ -31,7 +34,7 @@ func NewNopClusterEvents() *nopClusterEvents {
 	return &nopClusterEvents{}
 }
 
-func (*nopClusterEvents) ClusterCreated(clusterID uint) {
+func (*nopClusterEvents) ClusterCreated(clusterID pkgCluster.ClusterID) {
 }
 
 func (*nopClusterEvents) ClusterDeleted(orgID pkgAuth.OrganizationID, clusterName string) {
@@ -56,7 +59,7 @@ func NewClusterEvents(eb eventBus) *clusterEventBus {
 	}
 }
 
-func (c *clusterEventBus) ClusterCreated(clusterID uint) {
+func (c *clusterEventBus) ClusterCreated(clusterID pkgCluster.ClusterID) {
 	c.eb.Publish(clusterCreatedTopic, clusterID)
 }
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -79,7 +79,7 @@ const (
 )
 
 // CreateGKEClusterFromRequest creates ClusterModel struct from the request
-func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID pkgAuth.OrganizationID, userID uint) (*GKECluster, error) {
+func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID pkgAuth.OrganizationID, userID pkgAuth.UserID) (*GKECluster, error) {
 	c := GKECluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -577,7 +577,7 @@ func checkResources(checkers resourceCheckers, maxAttempts, sleepSeconds int) er
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *GKECluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (c *GKECluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 
 	c.log.Info("Start updating cluster (gke) nodepools")
 
@@ -615,7 +615,7 @@ func (c *GKECluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest,
 }
 
 // UpdateCluster updates GKE cluster in cloud
-func (c *GKECluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, userId uint) error {
+func (c *GKECluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, userId pkgAuth.UserID) error {
 
 	c.log.Info("Start updating cluster (gke)")
 
@@ -2218,6 +2218,6 @@ func (c *GKECluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *GKECluster) GetCreatedBy() uint {
+func (c *GKECluster) GetCreatedBy() pkgAuth.UserID {
 	return c.model.Cluster.CreatedBy
 }

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/providers/google"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgClusterGoogle "github.com/banzaicloud/pipeline/pkg/cluster/gke"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
@@ -78,7 +79,7 @@ const (
 )
 
 // CreateGKEClusterFromRequest creates ClusterModel struct from the request
-func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID, userID uint) (*GKECluster, error) {
+func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID pkgAuth.OrganizationID, userID uint) (*GKECluster, error) {
 	c := GKECluster{
 		log: log.WithField("cluster", request.Name),
 	}
@@ -125,7 +126,7 @@ type GKECluster struct {
 }
 
 // GetOrganizationId gets org where the cluster belongs
-func (c *GKECluster) GetOrganizationId() uint {
+func (c *GKECluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.model.Cluster.OrganizationID
 }
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -331,7 +331,7 @@ func (c *GKECluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *GKECluster) GetDistribution() string {
+func (c *GKECluster) GetDistribution() pkgCluster.DistributionID {
 	return c.model.Cluster.Distribution
 }
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -96,7 +96,7 @@ func CreateGKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgID
 			Name:           request.Name,
 			Location:       request.Location,
 			OrganizationID: orgID,
-			SecretID:       request.SecretId,
+			SecretID:       pkgSecret.SecretID(request.SecretId),
 			Cloud:          google.Provider,
 			Distribution:   google.ClusterDistributionGKE,
 			CreatedBy:      userID,
@@ -136,17 +136,17 @@ func (c *GKECluster) GetLocation() string {
 }
 
 // GetSecretId retrieves the secret id
-func (c *GKECluster) GetSecretId() string {
+func (c *GKECluster) GetSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.SecretID
 }
 
 // GetSshSecretId retrieves the secret id
-func (c *GKECluster) GetSshSecretId() string {
+func (c *GKECluster) GetSshSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.SSHSecretID
 }
 
 // SaveSshSecretId saves the ssh secret id to database
-func (c *GKECluster) SaveSshSecretId(sshSecretId string) error {
+func (c *GKECluster) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	c.model.Cluster.SSHSecretID = sshSecretId
 
 	err := c.db.Save(&c.model).Error
@@ -2089,7 +2089,7 @@ func (c *GKECluster) GetSecretWithValidation() (*secret.SecretItemResponse, erro
 }
 
 // SaveConfigSecretId saves the config secret id in database
-func (c *GKECluster) SaveConfigSecretId(configSecretId string) error {
+func (c *GKECluster) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	c.model.Cluster.ConfigSecretID = configSecretId
 
 	err := c.db.Save(&c.model).Error
@@ -2101,7 +2101,7 @@ func (c *GKECluster) SaveConfigSecretId(configSecretId string) error {
 }
 
 // GetConfigSecretId return config secret id
-func (c *GKECluster) GetConfigSecretId() string {
+func (c *GKECluster) GetConfigSecretId() pkgSecret.SecretID {
 	return c.model.Cluster.ConfigSecretID
 }
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -748,7 +748,7 @@ func (c *GKECluster) updateModel(cluster *gke.Cluster, updatedNodePools []*gke.N
 }
 
 //GetID returns the specified cluster id
-func (c *GKECluster) GetID() uint {
+func (c *GKECluster) GetID() pkgCluster.ClusterID {
 	return c.model.Cluster.ID
 }
 

--- a/cluster/gke_global.go
+++ b/cluster/gke_global.go
@@ -19,11 +19,12 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers/google"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	gke "google.golang.org/api/container/v1"
 )
 
 // GetGkeServerConfig returns all supported K8S versions
-func GetGkeServerConfig(orgId pkgAuth.OrganizationID, secretId, zone string) (*gke.ServerConfig, error) {
+func GetGkeServerConfig(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID, zone string) (*gke.ServerConfig, error) {
 	g := GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -37,7 +38,7 @@ func GetGkeServerConfig(orgId pkgAuth.OrganizationID, secretId, zone string) (*g
 }
 
 // GetAllMachineTypesByZone returns all supported machine type by zone
-func GetAllMachineTypesByZone(orgId pkgAuth.OrganizationID, secretId, zone string) (map[string]pkgCluster.MachineTypes, error) {
+func GetAllMachineTypesByZone(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID, zone string) (map[string]pkgCluster.MachineTypes, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -51,7 +52,7 @@ func GetAllMachineTypesByZone(orgId pkgAuth.OrganizationID, secretId, zone strin
 }
 
 // GetAllMachineTypes returns all supported machine types
-func GetAllMachineTypes(orgId pkgAuth.OrganizationID, secretId string) (map[string]pkgCluster.MachineTypes, error) {
+func GetAllMachineTypes(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID) (map[string]pkgCluster.MachineTypes, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -66,7 +67,7 @@ func GetAllMachineTypes(orgId pkgAuth.OrganizationID, secretId string) (map[stri
 }
 
 // GetZones lists all supported zones
-func GetZones(orgId pkgAuth.OrganizationID, secretId string) ([]string, error) {
+func GetZones(orgId pkgAuth.OrganizationID, secretId pkgSecret.SecretID) ([]string, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{

--- a/cluster/gke_global.go
+++ b/cluster/gke_global.go
@@ -17,12 +17,13 @@ package cluster
 import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/providers/google"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	gke "google.golang.org/api/container/v1"
 )
 
 // GetGkeServerConfig returns all supported K8S versions
-func GetGkeServerConfig(orgId uint, secretId, zone string) (*gke.ServerConfig, error) {
+func GetGkeServerConfig(orgId pkgAuth.OrganizationID, secretId, zone string) (*gke.ServerConfig, error) {
 	g := GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -36,7 +37,7 @@ func GetGkeServerConfig(orgId uint, secretId, zone string) (*gke.ServerConfig, e
 }
 
 // GetAllMachineTypesByZone returns all supported machine type by zone
-func GetAllMachineTypesByZone(orgId uint, secretId, zone string) (map[string]pkgCluster.MachineTypes, error) {
+func GetAllMachineTypesByZone(orgId pkgAuth.OrganizationID, secretId, zone string) (map[string]pkgCluster.MachineTypes, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -50,7 +51,7 @@ func GetAllMachineTypesByZone(orgId uint, secretId, zone string) (map[string]pkg
 }
 
 // GetAllMachineTypes returns all supported machine types
-func GetAllMachineTypes(orgId uint, secretId string) (map[string]pkgCluster.MachineTypes, error) {
+func GetAllMachineTypes(orgId pkgAuth.OrganizationID, secretId string) (map[string]pkgCluster.MachineTypes, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{
@@ -65,7 +66,7 @@ func GetAllMachineTypes(orgId uint, secretId string) (map[string]pkgCluster.Mach
 }
 
 // GetZones lists all supported zones
-func GetZones(orgId uint, secretId string) ([]string, error) {
+func GetZones(orgId pkgAuth.OrganizationID, secretId string) ([]string, error) {
 	g := &GKECluster{
 		model: &google.GKEClusterModel{
 			Cluster: cluster.ClusterModel{

--- a/cluster/gke_node_pools.go
+++ b/cluster/gke_node_pools.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 
 	"github.com/banzaicloud/pipeline/internal/providers/google"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgClusterGoogle "github.com/banzaicloud/pipeline/pkg/cluster/gke"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -25,7 +26,7 @@ import (
 )
 
 // createNodePoolsModelFromRequest creates an array of GoogleNodePoolModel from the nodePoolsData received through create/update requests
-func createNodePoolsModelFromRequest(nodePoolsData map[string]*pkgClusterGoogle.NodePool, userID uint) ([]*google.GKENodePoolModel, error) {
+func createNodePoolsModelFromRequest(nodePoolsData map[string]*pkgClusterGoogle.NodePool, userID pkgAuth.UserID) ([]*google.GKENodePoolModel, error) {
 	nodePoolsCount := len(nodePoolsData)
 	if nodePoolsCount == 0 {
 		return nil, pkgErrors.ErrorNodePoolNotProvided

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -169,7 +169,7 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 		if loggingParam.SecretName == "" {
 			return fmt.Errorf("either secretId or secretName has to be set")
 		}
-		loggingParam.SecretId = secret.GenerateSecretIDFromName(loggingParam.SecretName)
+		loggingParam.SecretId = string(secret.GenerateSecretIDFromName(loggingParam.SecretName))
 	}
 	if loggingParam.GenTLSForLogging.Namespace == "" {
 		loggingParam.GenTLSForLogging.Namespace = namespace
@@ -233,14 +233,14 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 	}
 
 	// Determine the type of output plugin
-	logSecret, err := secret.Store.Get(cluster.GetOrganizationId(), loggingParam.SecretId)
+	logSecret, err := secret.Store.Get(cluster.GetOrganizationId(), pkgSecret.SecretID(loggingParam.SecretId))
 	if err != nil {
 		return err
 	}
 	log.Infof("logging-hook secret type: %s", logSecret.Type)
 	switch logSecret.Type {
 	case pkgCluster.Amazon:
-		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []string{loggingParam.SecretId}}, loggingParam.GenTLSForLogging.Namespace)
+		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []pkgSecret.SecretID{pkgSecret.SecretID(loggingParam.SecretId)}}, loggingParam.GenTLSForLogging.Namespace)
 		if err != nil {
 			return emperror.Wrap(err, "install amazon secret failed")
 		}
@@ -260,7 +260,7 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 			return emperror.Wrap(err, "install s3-output failed")
 		}
 	case pkgCluster.Google:
-		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []string{loggingParam.SecretId}}, loggingParam.GenTLSForLogging.Namespace)
+		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []pkgSecret.SecretID{pkgSecret.SecretID(loggingParam.SecretId)}}, loggingParam.GenTLSForLogging.Namespace)
 		if err != nil {
 			return emperror.Wrap(err, "install google secret failed")
 		}
@@ -279,7 +279,7 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 			return emperror.Wrap(err, "install gcs-output failed")
 		}
 	case pkgCluster.Alibaba:
-		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []string{loggingParam.SecretId}}, loggingParam.GenTLSForLogging.Namespace)
+		installedSecretValues, err := InstallSecrets(cluster, &pkgSecret.ListSecretsQuery{IDs: []pkgSecret.SecretID{pkgSecret.SecretID(loggingParam.SecretId)}}, loggingParam.GenTLSForLogging.Namespace)
 		if err != nil {
 			return emperror.Wrap(err, "could not install alibaba logging secret")
 		}
@@ -971,7 +971,7 @@ func RegisterDomainPostHook(commonCluster CommonCluster) error {
 		commonCluster,
 		&pkgSecret.ListSecretsQuery{
 			Type: pkgCluster.Amazon,
-			IDs:  []string{route53Secret.ID},
+			IDs:  []pkgSecret.SecretID{route53Secret.ID},
 		},
 		route53SecretNamespace,
 	)

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/goph/emperror"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,7 +34,7 @@ import (
 )
 
 // CreateKubernetesClusterFromRequest creates ClusterModel struct from the request
-func CreateKubernetesClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId, userId uint) (*KubeCluster, error) {
+func CreateKubernetesClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*KubeCluster, error) {
 
 	var cluster KubeCluster
 
@@ -234,7 +235,7 @@ func (c *KubeCluster) DeleteFromDatabase() error {
 }
 
 // GetOrganizationId returns the specified organization id
-func (c *KubeCluster) GetOrganizationId() uint {
+func (c *KubeCluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return c.modelCluster.OrganizationId
 }
 

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -168,7 +168,7 @@ func (c *KubeCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReque
 }
 
 // GetID returns the specified cluster id
-func (c *KubeCluster) GetID() uint {
+func (c *KubeCluster) GetID() pkgCluster.ClusterID {
 	return c.modelCluster.ID
 }
 

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -120,7 +120,7 @@ func (c *KubeCluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (c *KubeCluster) GetDistribution() string {
+func (c *KubeCluster) GetDistribution() pkgCluster.DistributionID {
 	return c.modelCluster.Distribution
 }
 

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -34,7 +34,7 @@ import (
 )
 
 // CreateKubernetesClusterFromRequest creates ClusterModel struct from the request
-func CreateKubernetesClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*KubeCluster, error) {
+func CreateKubernetesClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*KubeCluster, error) {
 
 	var cluster KubeCluster
 
@@ -158,12 +158,12 @@ func (c *KubeCluster) DeleteCluster() error {
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (c *KubeCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (c *KubeCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 	return nil
 }
 
 // UpdateCluster updates cluster in cloud, in this case no update function
-func (c *KubeCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, _ uint) error {
+func (c *KubeCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, _ pkgAuth.UserID) error {
 	return nil
 }
 
@@ -368,6 +368,6 @@ func (c *KubeCluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (c *KubeCluster) GetCreatedBy() uint {
+func (c *KubeCluster) GetCreatedBy() pkgAuth.UserID {
 	return c.modelCluster.CreatedBy
 }

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -44,7 +44,7 @@ func CreateKubernetesClusterFromRequest(request *pkgCluster.CreateClusterRequest
 		Cloud:          request.Cloud,
 		OrganizationId: orgId,
 		CreatedBy:      userId,
-		SecretId:       request.SecretId,
+		SecretId:       pkgSecret.SecretID(request.SecretId),
 		Distribution:   pkgCluster.Unknown,
 		Kubernetes: model.KubernetesClusterModel{
 			Metadata: request.Properties.CreateClusterKubernetes.Metadata,
@@ -177,17 +177,17 @@ func (c *KubeCluster) GetUID() string {
 }
 
 // GetSecretId returns the specified secret id
-func (c *KubeCluster) GetSecretId() string {
+func (c *KubeCluster) GetSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SecretId
 }
 
 // GetSshSecretId returns the specified ssh secret id
-func (c *KubeCluster) GetSshSecretId() string {
+func (c *KubeCluster) GetSshSecretId() pkgSecret.SecretID {
 	return c.modelCluster.SshSecretId
 }
 
 // SaveSshSecretId saves the ssh secret id to database
-func (c *KubeCluster) SaveSshSecretId(sshSecretId string) error {
+func (c *KubeCluster) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateSshSecret(sshSecretId)
 }
 
@@ -278,12 +278,12 @@ func (c *KubeCluster) GetSecretWithValidation() (*secret.SecretItemResponse, err
 }
 
 // SaveConfigSecretId saves the config secret id in database
-func (c *KubeCluster) SaveConfigSecretId(configSecretId string) error {
+func (c *KubeCluster) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	return c.modelCluster.UpdateConfigSecret(configSecretId)
 }
 
 // GetConfigSecretId return config secret id
-func (c *KubeCluster) GetConfigSecretId() string {
+func (c *KubeCluster) GetConfigSecretId() pkgSecret.SecretID {
 	return c.modelCluster.ConfigSecretId
 }
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -22,24 +22,25 @@ import (
 	"github.com/banzaicloud/pipeline/config"
 	pipelineContext "github.com/banzaicloud/pipeline/internal/platform/context"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/goph/emperror"
-	"github.com/patrickmn/go-cache"
+	cache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 type clusterRepository interface {
-	Exists(organizationID uint, name string) (bool, error)
+	Exists(organizationID pkgAuth.OrganizationID, name string) (bool, error)
 	All() ([]*model.ClusterModel, error)
-	FindByOrganization(organizationID uint) ([]*model.ClusterModel, error)
-	FindOneByID(organizationID uint, clusterID uint) (*model.ClusterModel, error)
-	FindOneByName(organizationID uint, clusterName string) (*model.ClusterModel, error)
-	FindBySecret(organizationID uint, secretID string) ([]*model.ClusterModel, error)
+	FindByOrganization(organizationID pkgAuth.OrganizationID) ([]*model.ClusterModel, error)
+	FindOneByID(organizationID pkgAuth.OrganizationID, clusterID uint) (*model.ClusterModel, error)
+	FindOneByName(organizationID pkgAuth.OrganizationID, clusterName string) (*model.ClusterModel, error)
+	FindBySecret(organizationID pkgAuth.OrganizationID, secretID string) ([]*model.ClusterModel, error)
 }
 
 type secretValidator interface {
-	ValidateSecretType(organizationID uint, secretID string, cloud string) error
+	ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID string, cloud string) error
 }
 
 type kubeProxyCache interface {
@@ -90,7 +91,7 @@ func (m *Manager) getErrorHandler(ctx context.Context) emperror.Handler {
 	return pipelineContext.ErrorHandlerWithCorrelationID(ctx, m.errorHandler)
 }
 
-func (m *Manager) getPrometheusTimer(provider, location, status string, orgId uint, clusterName string) (*prometheus.Timer, error) {
+func (m *Manager) getPrometheusTimer(provider, location, status string, orgId pkgAuth.OrganizationID, clusterName string) (*prometheus.Timer, error) {
 	if viper.GetBool(config.MetricsDebug) {
 		org, err := auth.GetOrganizationById(orgId)
 		if err != nil {

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -23,6 +23,7 @@ import (
 	pipelineContext "github.com/banzaicloud/pipeline/internal/platform/context"
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/goph/emperror"
 	cache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,11 +37,11 @@ type clusterRepository interface {
 	FindByOrganization(organizationID pkgAuth.OrganizationID) ([]*model.ClusterModel, error)
 	FindOneByID(organizationID pkgAuth.OrganizationID, clusterID uint) (*model.ClusterModel, error)
 	FindOneByName(organizationID pkgAuth.OrganizationID, clusterName string) (*model.ClusterModel, error)
-	FindBySecret(organizationID pkgAuth.OrganizationID, secretID string) ([]*model.ClusterModel, error)
+	FindBySecret(organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) ([]*model.ClusterModel, error)
 }
 
 type secretValidator interface {
-	ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID string, cloud string) error
+	ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, cloud string) error
 }
 
 type kubeProxyCache interface {

--- a/cluster/manager_common_creator.go
+++ b/cluster/manager_common_creator.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
@@ -59,7 +60,7 @@ type createPKEClusterer interface {
 }
 
 type TokenGenerator interface {
-	GenerateClusterToken(orgID, clusterID uint) (string, string, error)
+	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error)
 }
 
 // NewClusterCreator returns a new PKE or Common cluster creator instance depending on the cluster.

--- a/cluster/manager_common_creator.go
+++ b/cluster/manager_common_creator.go
@@ -18,16 +18,16 @@ import (
 	"context"
 
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
-	"github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 type commonCreator struct {
-	request *cluster.CreateClusterRequest
+	request *pkgCluster.CreateClusterRequest
 	cluster CommonCluster
 }
 
 // NewCommonClusterCreator returns a new cluster creator instance.
-func NewCommonClusterCreator(request *cluster.CreateClusterRequest, cluster CommonCluster) *commonCreator {
+func NewCommonClusterCreator(request *pkgCluster.CreateClusterRequest, cluster CommonCluster) *commonCreator {
 	return &commonCreator{
 		request: request,
 		cluster: cluster,
@@ -41,7 +41,7 @@ func (c *commonCreator) Validate(ctx context.Context) error {
 
 // Prepare implements the clusterCreator interface.
 func (c *commonCreator) Prepare(ctx context.Context) (CommonCluster, error) {
-	return c.cluster, c.cluster.Persist(cluster.Creating, cluster.CreatingMessage)
+	return c.cluster, c.cluster.Persist(pkgCluster.Creating, pkgCluster.CreatingMessage)
 }
 
 // Create implements the clusterCreator interface.
@@ -60,11 +60,11 @@ type createPKEClusterer interface {
 }
 
 type TokenGenerator interface {
-	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID uint) (string, string, error)
+	GenerateClusterToken(orgID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID) (string, string, error)
 }
 
 // NewClusterCreator returns a new PKE or Common cluster creator instance depending on the cluster.
-func NewClusterCreator(request *cluster.CreateClusterRequest, cluster CommonCluster, tokenGenerator TokenGenerator, externalBaseURL string) clusterCreator {
+func NewClusterCreator(request *pkgCluster.CreateClusterRequest, cluster CommonCluster, tokenGenerator TokenGenerator, externalBaseURL string) clusterCreator {
 	common := NewCommonClusterCreator(request, cluster)
 	if _, ok := cluster.(createPKEClusterer); !ok {
 		return common

--- a/cluster/manager_common_nodepool_updater.go
+++ b/cluster/manager_common_nodepool_updater.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/goph/emperror"
 )
@@ -25,7 +26,7 @@ import (
 type commonNodepoolUpdater struct {
 	request *cluster.UpdateNodePoolsRequest
 	cluster CommonCluster
-	userID  uint
+	userID  pkgAuth.UserID
 }
 
 type commonNodepoolUpdateValidationError struct {
@@ -48,7 +49,7 @@ func (e *commonNodepoolUpdateValidationError) IsPreconditionFailed() bool {
 }
 
 // NewCommonNodepoolUpdater returns a new cluster creator instance.
-func NewCommonNodepoolUpdater(request *cluster.UpdateNodePoolsRequest, cluster CommonCluster, userID uint) *commonNodepoolUpdater {
+func NewCommonNodepoolUpdater(request *cluster.UpdateNodePoolsRequest, cluster CommonCluster, userID pkgAuth.UserID) *commonNodepoolUpdater {
 	return &commonNodepoolUpdater{
 		request: request,
 		cluster: cluster,

--- a/cluster/manager_common_updater.go
+++ b/cluster/manager_common_updater.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/goph/emperror"
 )
@@ -25,7 +26,7 @@ import (
 type commonUpdater struct {
 	request                  *cluster.UpdateClusterRequest
 	cluster                  CommonCluster
-	userID                   uint
+	userID                   pkgAuth.UserID
 	scaleOptionsChanged      bool
 	clusterPropertiesChanged bool
 }
@@ -50,7 +51,7 @@ func (e *commonUpdateValidationError) IsPreconditionFailed() bool {
 }
 
 // NewCommonClusterUpdater returns a new cluster creator instance.
-func NewCommonClusterUpdater(request *cluster.UpdateClusterRequest, cluster CommonCluster, userID uint) *commonUpdater {
+func NewCommonClusterUpdater(request *cluster.UpdateClusterRequest, cluster CommonCluster, userID pkgAuth.UserID) *commonUpdater {
 	return &commonUpdater{
 		request: request,
 		cluster: cluster,

--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -30,7 +30,7 @@ import (
 // CreationContext represents the data necessary to do generic cluster creation steps/checks.
 type CreationContext struct {
 	OrganizationID pkgAuth.OrganizationID
-	UserID         uint
+	UserID         pkgAuth.UserID
 	Name           string
 	Provider       string
 	SecretID       string

--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -33,8 +33,8 @@ type CreationContext struct {
 	UserID         pkgAuth.UserID
 	Name           string
 	Provider       string
-	SecretID       string
-	SecretIDs      []string
+	SecretID       secretTypes.SecretID
+	SecretIDs      []secretTypes.SecretID
 	PostHooks      []PostFunctioner
 }
 

--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
@@ -28,7 +29,7 @@ import (
 
 // CreationContext represents the data necessary to do generic cluster creation steps/checks.
 type CreationContext struct {
-	OrganizationID uint
+	OrganizationID pkgAuth.OrganizationID
 	UserID         uint
 	Name           string
 	Provider       string

--- a/cluster/manager_get.go
+++ b/cluster/manager_get.go
@@ -18,13 +18,14 @@ import (
 	"context"
 
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
 // GetClusters returns the cluster instances for an organization ID.
-func (m *Manager) GetClusters(ctx context.Context, organizationID uint) ([]CommonCluster, error) {
+func (m *Manager) GetClusters(ctx context.Context, organizationID pkgAuth.OrganizationID) ([]CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": organizationID,
 	})
@@ -65,7 +66,7 @@ func (m *Manager) GetAllClusters(ctx context.Context) ([]CommonCluster, error) {
 }
 
 // GetClusterByID returns the cluster instance for an organization ID by cluster ID.
-func (m *Manager) GetClusterByID(ctx context.Context, organizationID uint, clusterID uint) (CommonCluster, error) {
+func (m *Manager) GetClusterByID(ctx context.Context, organizationID pkgAuth.OrganizationID, clusterID uint) (CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": organizationID,
 		"cluster":      clusterID,
@@ -108,7 +109,7 @@ func (m *Manager) GetClusterByIDOnly(ctx context.Context, clusterID uint) (Commo
 }
 
 // GetClusterByName returns the cluster instance for an organization ID by cluster name.
-func (m *Manager) GetClusterByName(ctx context.Context, organizationID uint, clusterName string) (CommonCluster, error) {
+func (m *Manager) GetClusterByName(ctx context.Context, organizationID pkgAuth.OrganizationID, clusterName string) (CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": organizationID,
 		"cluster":      clusterName,
@@ -130,7 +131,7 @@ func (m *Manager) GetClusterByName(ctx context.Context, organizationID uint, clu
 }
 
 // GetClustersBySecretID returns the cluster instance for an organization ID by secret ID.
-func (m *Manager) GetClustersBySecretID(ctx context.Context, organizationID uint, secretID string) ([]CommonCluster, error) {
+func (m *Manager) GetClustersBySecretID(ctx context.Context, organizationID pkgAuth.OrganizationID, secretID string) ([]CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": organizationID,
 		"secret":       secretID,

--- a/cluster/manager_get.go
+++ b/cluster/manager_get.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -131,7 +132,7 @@ func (m *Manager) GetClusterByName(ctx context.Context, organizationID pkgAuth.O
 }
 
 // GetClustersBySecretID returns the cluster instance for an organization ID by secret ID.
-func (m *Manager) GetClustersBySecretID(ctx context.Context, organizationID pkgAuth.OrganizationID, secretID string) ([]CommonCluster, error) {
+func (m *Manager) GetClustersBySecretID(ctx context.Context, organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) ([]CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": organizationID,
 		"secret":       secretID,

--- a/cluster/manager_update.go
+++ b/cluster/manager_update.go
@@ -27,7 +27,7 @@ import (
 // UpdateContext represents the data necessary to do generic cluster update steps/checks.
 type UpdateContext struct {
 	OrganizationID pkgAuth.OrganizationID
-	UserID         uint
+	UserID         pkgAuth.UserID
 	ClusterID      uint
 }
 

--- a/cluster/manager_update.go
+++ b/cluster/manager_update.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
@@ -25,7 +26,7 @@ import (
 
 // UpdateContext represents the data necessary to do generic cluster update steps/checks.
 type UpdateContext struct {
-	OrganizationID uint
+	OrganizationID pkgAuth.OrganizationID
 	UserID         uint
 	ClusterID      uint
 }

--- a/cluster/manager_update.go
+++ b/cluster/manager_update.go
@@ -28,7 +28,7 @@ import (
 type UpdateContext struct {
 	OrganizationID pkgAuth.OrganizationID
 	UserID         pkgAuth.UserID
-	ClusterID      uint
+	ClusterID      pkgCluster.ClusterID
 }
 
 type clusterUpdater interface {

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -49,7 +49,7 @@ func CreateOKEClusterFromModel(clusterModel *model.ClusterModel) (*OKECluster, e
 }
 
 // CreateOKEClusterFromRequest creates ClusterModel struct from the request
-func CreateOKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*OKECluster, error) {
+func CreateOKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId pkgAuth.UserID) (*OKECluster, error) {
 
 	var oke OKECluster
 
@@ -104,12 +104,12 @@ func (o *OKECluster) CreateCluster() error {
 }
 
 // UpdateNodePools updates nodes pools of a cluster
-func (o *OKECluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId uint) error {
+func (o *OKECluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest, userId pkgAuth.UserID) error {
 	return nil
 }
 
 // UpdateCluster updates the cluster
-func (o *OKECluster) UpdateCluster(r *pkgCluster.UpdateClusterRequest, userId uint) error {
+func (o *OKECluster) UpdateCluster(r *pkgCluster.UpdateClusterRequest, userId pkgAuth.UserID) error {
 
 	updated, err := o.PopulateNetworkValues(r.UpdateProperties.OKE, o.modelCluster.OKE.VCNID)
 	if err != nil {
@@ -654,7 +654,7 @@ func (o *OKECluster) GetKubernetesUserName() (string, error) {
 }
 
 // GetCreatedBy returns cluster create userID.
-func (o *OKECluster) GetCreatedBy() uint {
+func (o *OKECluster) GetCreatedBy() pkgAuth.UserID {
 	return o.modelCluster.CreatedBy
 }
 

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -258,7 +258,7 @@ func getNodeCount(np *modelOracle.NodePool) int {
 }
 
 //GetID returns the specified cluster id
-func (o *OKECluster) GetID() uint {
+func (o *OKECluster) GetID() pkgCluster.ClusterID {
 	return o.modelCluster.ID
 }
 

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -210,7 +210,7 @@ func (o *OKECluster) GetCloud() string {
 }
 
 // GetDistribution returns the distribution type of the cluster
-func (o *OKECluster) GetDistribution() string {
+func (o *OKECluster) GetDistribution() pkgCluster.DistributionID {
 	return o.modelCluster.Distribution
 }
 

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	oracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/cluster"
@@ -48,7 +49,7 @@ func CreateOKEClusterFromModel(clusterModel *model.ClusterModel) (*OKECluster, e
 }
 
 // CreateOKEClusterFromRequest creates ClusterModel struct from the request
-func CreateOKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId, userId uint) (*OKECluster, error) {
+func CreateOKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId pkgAuth.OrganizationID, userId uint) (*OKECluster, error) {
 
 	var oke OKECluster
 
@@ -315,7 +316,7 @@ func (o *OKECluster) DeleteFromDatabase() error {
 }
 
 // GetOrganizationId gets org where the cluster belongs
-func (o *OKECluster) GetOrganizationId() uint {
+func (o *OKECluster) GetOrganizationId() pkgAuth.OrganizationID {
 	return o.modelCluster.OrganizationId
 }
 

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -58,7 +58,7 @@ func CreateOKEClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId
 		Location:       request.Location,
 		Cloud:          request.Cloud,
 		OrganizationId: orgId,
-		SecretId:       request.SecretId,
+		SecretId:       pkgSecret.SecretID(request.SecretId),
 		CreatedBy:      userId,
 		Distribution:   pkgCluster.OKE,
 	}
@@ -326,7 +326,7 @@ func (o *OKECluster) GetLocation() string {
 }
 
 //GetSecretId retrieves the secret id
-func (o *OKECluster) GetSecretId() string {
+func (o *OKECluster) GetSecretId() pkgSecret.SecretID {
 	return o.modelCluster.SecretId
 }
 
@@ -336,12 +336,12 @@ func (o *OKECluster) RequiresSshPublicKey() bool {
 }
 
 //GetSshSecretId retrieves the ssh secret id
-func (o *OKECluster) GetSshSecretId() string {
+func (o *OKECluster) GetSshSecretId() pkgSecret.SecretID {
 	return o.modelCluster.SshSecretId
 }
 
 // SaveSshSecretId saves the ssh secret id to database
-func (o *OKECluster) SaveSshSecretId(sshSecretId string) error {
+func (o *OKECluster) SaveSshSecretId(sshSecretId pkgSecret.SecretID) error {
 	return o.modelCluster.UpdateSshSecret(sshSecretId)
 }
 
@@ -396,12 +396,12 @@ func (o *OKECluster) GetSecretWithValidation() (*secret.SecretItemResponse, erro
 }
 
 // SaveConfigSecretId saves the config secret id in database
-func (o *OKECluster) SaveConfigSecretId(configSecretId string) error {
+func (o *OKECluster) SaveConfigSecretId(configSecretId pkgSecret.SecretID) error {
 	return o.modelCluster.UpdateConfigSecret(configSecretId)
 }
 
 // GetConfigSecretId return config secret id
-func (o *OKECluster) GetConfigSecretId() string {
+func (o *OKECluster) GetConfigSecretId() pkgSecret.SecretID {
 	return o.modelCluster.ConfigSecretId
 }
 

--- a/cluster/secrets.go
+++ b/cluster/secrets.go
@@ -18,13 +18,14 @@ import (
 	stderrors "errors"
 
 	intSecret "github.com/banzaicloud/pipeline/internal/secret"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,7 +44,7 @@ func InstallSecrets(cc CommonCluster, query *secretTypes.ListSecretsQuery, names
 }
 
 // InstallSecretsByK8SConfig is the same as InstallSecrets but use this if you already have a K8S config at hand.
-func InstallSecretsByK8SConfig(kubeConfig []byte, orgID uint, query *secretTypes.ListSecretsQuery, namespace string) ([]secretTypes.K8SSourceMeta, error) {
+func InstallSecretsByK8SConfig(kubeConfig []byte, orgID pkgAuth.OrganizationID, query *secretTypes.ListSecretsQuery, namespace string) ([]secretTypes.K8SSourceMeta, error) {
 
 	// Values are always needed in this case
 	query.Values = true
@@ -159,7 +160,7 @@ func InstallSecret(cc CommonCluster, secretName string, req InstallSecretRequest
 }
 
 // InstallSecretByK8SConfig is the same as InstallSecret but use this if you already have a K8S config at hand.
-func InstallSecretByK8SConfig(kubeConfig []byte, orgID uint, secretName string, req InstallSecretRequest) (*secretTypes.K8SSourceMeta, error) {
+func InstallSecretByK8SConfig(kubeConfig []byte, orgID pkgAuth.OrganizationID, secretName string, req InstallSecretRequest) (*secretTypes.K8SSourceMeta, error) {
 	clusterClient, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kubernetes client")
@@ -229,7 +230,7 @@ func MergeSecret(cc CommonCluster, secretName string, req InstallSecretRequest) 
 }
 
 // MergeSecretByK8SConfig is the same as MergeSecret but use this if you already have a K8S config at hand.
-func MergeSecretByK8SConfig(kubeConfig []byte, orgID uint, secretName string, req InstallSecretRequest) (*secretTypes.K8SSourceMeta, error) {
+func MergeSecretByK8SConfig(kubeConfig []byte, orgID pkgAuth.OrganizationID, secretName string, req InstallSecretRequest) (*secretTypes.K8SSourceMeta, error) {
 	clusterClient, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kubernetes client")

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -282,7 +282,7 @@ func main() {
 	spotguideManager := spotguide.NewSpotguideManager(config.DB(), version, viper.GetString("github.token"), sharedSpotguideOrg)
 
 	// subscribe to organization creations and sync spotguides into the newly created organizations
-	spotguide.AuthEventEmitter.NotifyOrganizationRegistered(func(orgID pkgAuth.OrganizationID, userID uint) {
+	spotguide.AuthEventEmitter.NotifyOrganizationRegistered(func(orgID pkgAuth.OrganizationID, userID pkgAuth.UserID) {
 		if err := spotguideManager.ScrapeSpotguides(orgID, userID); err != nil {
 			log.Warnf("failed to scrape Spotguide repositories for org [%d]: %s", orgID, err)
 		}

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -54,6 +54,7 @@ import (
 	ginlog "github.com/banzaicloud/pipeline/internal/platform/gin/log"
 	platformlog "github.com/banzaicloud/pipeline/internal/platform/log"
 	"github.com/banzaicloud/pipeline/model/defaults"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
@@ -281,7 +282,7 @@ func main() {
 	spotguideManager := spotguide.NewSpotguideManager(config.DB(), version, viper.GetString("github.token"), sharedSpotguideOrg)
 
 	// subscribe to organization creations and sync spotguides into the newly created organizations
-	spotguide.AuthEventEmitter.NotifyOrganizationRegistered(func(orgID uint, userID uint) {
+	spotguide.AuthEventEmitter.NotifyOrganizationRegistered(func(orgID pkgAuth.OrganizationID, userID uint) {
 		if err := spotguideManager.ScrapeSpotguides(orgID, userID); err != nil {
 			log.Warnf("failed to scrape Spotguide repositories for org [%d]: %s", orgID, err)
 		}

--- a/dns/externaldns.go
+++ b/dns/externaldns.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/dns/route53"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gofrs/uuid"
@@ -59,12 +60,12 @@ type DnsEventsSubscription struct {
 
 // DnsServiceClient contains the operations for managing domains in a Dns Service
 type DnsServiceClient interface {
-	RegisterDomain(orgId uint, domain string) error
-	UnregisterDomain(orgId uint, domain string) error
-	IsDomainRegistered(orgId uint, domain string) (bool, error)
-	GetOrgDomain(orgId uint) (string, error)
+	RegisterDomain(orgId pkgAuth.OrganizationID, domain string) error
+	UnregisterDomain(orgId pkgAuth.OrganizationID, domain string) error
+	IsDomainRegistered(orgId pkgAuth.OrganizationID, domain string) (bool, error)
+	GetOrgDomain(orgId pkgAuth.OrganizationID) (string, error)
 	Cleanup()
-	DeleteDnsRecordsOwnedBy(ownerId string, orgId uint) error
+	DeleteDnsRecordsOwnedBy(ownerId string, orgId pkgAuth.OrganizationID) error
 	ProcessUnfinishedTasks()
 }
 

--- a/dns/route53/dbstatestore.go
+++ b/dns/route53/dbstatestore.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 
 	"github.com/banzaicloud/pipeline/config"
-	"github.com/banzaicloud/pipeline/dns/route53/model"
+	route53model "github.com/banzaicloud/pipeline/dns/route53/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
@@ -57,7 +58,7 @@ func (stateStore *awsRoute53DatabaseStateStore) update(state *domainState) error
 
 // find looks up in the database the domain state identified by origId and domain. The found data is passed back
 // through stateOut
-func (stateStore *awsRoute53DatabaseStateStore) find(orgId uint, domain string, stateOut *domainState) (bool, error) {
+func (stateStore *awsRoute53DatabaseStateStore) find(orgId pkgAuth.OrganizationID, domain string, stateOut *domainState) (bool, error) {
 	db := config.DB()
 
 	dbRec := &route53model.Route53Domain{}
@@ -134,7 +135,7 @@ func (stateStore *awsRoute53DatabaseStateStore) findByStatus(status string) ([]d
 
 // findByOrgId looks up in the database the domain state identified by origId. The found data is passed back
 // through stateOut
-func (stateStore *awsRoute53DatabaseStateStore) findByOrgId(orgId uint, stateOut *domainState) (bool, error) {
+func (stateStore *awsRoute53DatabaseStateStore) findByOrgId(orgId pkgAuth.OrganizationID, stateOut *domainState) (bool, error) {
 	db := config.DB()
 	dbRec := &route53model.Route53Domain{}
 

--- a/dns/route53/domainState.go
+++ b/dns/route53/domainState.go
@@ -14,7 +14,11 @@
 
 package route53
 
-import "time"
+import (
+	"time"
+
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // status
 const (
@@ -27,7 +31,7 @@ const (
 // domainState represents the state of a domain registered with Amazon Route53 DNS service
 type domainState struct {
 	createdAt      time.Time
-	organisationId uint
+	organisationId pkgAuth.OrganizationID
 	domain         string
 	hostedZoneId   string
 	policyArn      string

--- a/dns/route53/event.go
+++ b/dns/route53/event.go
@@ -14,10 +14,12 @@
 
 package route53
 
+import pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+
 // DomainEvent holds the common fields for the domain events
 type DomainEvent struct {
 	Domain         string
-	OrganisationId uint
+	OrganisationId pkgAuth.OrganizationID
 }
 
 // RegisterDomainSucceededEvent is fired when a domain is registered or re-registered in an external DNS service

--- a/dns/route53/model/route53domain.go
+++ b/dns/route53/model/route53domain.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // TableName constants
@@ -34,8 +35,8 @@ type Route53Domain struct {
 
 	Organization auth.Organization `gorm:"foreignkey:OrganizationId"`
 
-	OrganizationId uint   `gorm:"unique_index;not null"`
-	Domain         string `gorm:"unique_index;not null"`
+	OrganizationId pkgAuth.OrganizationID `gorm:"unique_index;not null"`
+	Domain         string                 `gorm:"unique_index;not null"`
 	HostedZoneId   string
 	PolicyArn      string
 	IamUser        string

--- a/dns/route53/policy.go
+++ b/dns/route53/policy.go
@@ -22,13 +22,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/pkg/amazon"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 // createHostedZoneRoute53Policy creates an AWS policy that allows listing route53 hosted zones and record  sets in general
 // also modifying only the records of the hosted zone identified by the given id.
-func (dns *awsRoute53) createHostedZoneRoute53Policy(orgId uint, hostedZoneId string) (*iam.Policy, error) {
+func (dns *awsRoute53) createHostedZoneRoute53Policy(orgId pkgAuth.OrganizationID, hostedZoneId string) (*iam.Policy, error) {
 	log := loggerWithFields(logrus.Fields{"hostedzone": hostedZoneId})
 
 	org, err := dns.getOrganization(orgId)

--- a/dns/route53/route53.go
+++ b/dns/route53/route53.go
@@ -793,7 +793,7 @@ func (dns *awsRoute53) storeRoute53Secret(updateSecret *secret.SecretItemRespons
 		},
 	}
 
-	var secretId string
+	var secretId secretTypes.SecretID
 	var err error
 
 	if updateSecret != nil {

--- a/dns/route53/route53.go
+++ b/dns/route53/route53.go
@@ -30,6 +30,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/pkg/amazon"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
@@ -106,7 +107,7 @@ func (ctx *context) rollback() {
 
 type workerTask struct {
 	operation        operationType
-	organisationId   uint
+	organisationId   pkgAuth.OrganizationID
 	domain           *string
 	dnsRecordownerId *string
 
@@ -128,14 +129,14 @@ type awsRoute53 struct {
 	// orgDomainWorkers maps organisation id to the channel of the worker that
 	// serves Route53 operations for the organisation. There is one worker allocated for each
 	// organisation
-	orgDomainWorkers map[uint]chan workerTask
+	orgDomainWorkers map[pkgAuth.OrganizationID]chan workerTask
 
 	route53Svc       route53iface.Route53API
 	iamSvc           iamiface.IAMAPI
 	stateStore       awsRoute53StateStore
 	baseHostedZoneId string // the id of the hosted zone of the base domain
 
-	getOrganization func(orgId uint) (*auth.Organization, error)
+	getOrganization func(orgId pkgAuth.OrganizationID) (*auth.Organization, error)
 
 	notificationChannel chan<- interface{}
 	region              string
@@ -183,7 +184,7 @@ func NewAwsRoute53(region, awsSecretId, awsSecretKey, baseDomain string, notific
 }
 
 // IsDomainRegistered returns true if the domain has already been registered in Route53 for the given organisation
-func (dns *awsRoute53) IsDomainRegistered(orgId uint, domain string) (bool, error) {
+func (dns *awsRoute53) IsDomainRegistered(orgId pkgAuth.OrganizationID, domain string) (bool, error) {
 	responseQueue := make(chan workerResponse)
 
 	dns.getWorker(orgId) <- newWorkerTask(isDomainRegistered, orgId, &domain, responseQueue)
@@ -194,7 +195,7 @@ func (dns *awsRoute53) IsDomainRegistered(orgId uint, domain string) (bool, erro
 }
 
 // RegisterDomain registers the given domain with AWS Route53
-func (dns *awsRoute53) RegisterDomain(orgId uint, domain string) error {
+func (dns *awsRoute53) RegisterDomain(orgId pkgAuth.OrganizationID, domain string) error {
 	responseQueue := make(chan workerResponse)
 
 	dns.getWorker(orgId) <- newWorkerTask(registerDomain, orgId, &domain, responseQueue)
@@ -221,7 +222,7 @@ func (dns *awsRoute53) RegisterDomain(orgId uint, domain string) error {
 
 // UnregisterDomain delete the hosted zone with given domain from AWS Route53, also it removes the user access policy
 // that was created to allow access to the hosted zone and the IAM user that was created for accessing the hosted zone.
-func (dns *awsRoute53) UnregisterDomain(orgId uint, domain string) error {
+func (dns *awsRoute53) UnregisterDomain(orgId pkgAuth.OrganizationID, domain string) error {
 	responseQueue := make(chan workerResponse)
 
 	dns.getWorker(orgId) <- newWorkerTask(unregisterDomain, orgId, &domain, responseQueue)
@@ -247,7 +248,7 @@ func (dns *awsRoute53) UnregisterDomain(orgId uint, domain string) error {
 }
 
 // isDomainRegistered returns true if the domain has already been registered in Route53 for the given organisation
-func (dns *awsRoute53) isDomainRegistered(orgId uint, domain string) (bool, error) {
+func (dns *awsRoute53) isDomainRegistered(orgId pkgAuth.OrganizationID, domain string) (bool, error) {
 	log := loggerWithFields(logrus.Fields{"organisationId": orgId, "domain": domain})
 
 	// check statestore to see if domain was already registered
@@ -262,7 +263,7 @@ func (dns *awsRoute53) isDomainRegistered(orgId uint, domain string) (bool, erro
 }
 
 // RegisterDomain registers the given domain with AWS Route53
-func (dns *awsRoute53) registerDomain(orgId uint, domain string) error {
+func (dns *awsRoute53) registerDomain(orgId pkgAuth.OrganizationID, domain string) error {
 	log := loggerWithFields(logrus.Fields{"organisationId": orgId, "domain": domain})
 
 	state := &domainState{}
@@ -370,7 +371,7 @@ func (dns *awsRoute53) registerDomain(orgId uint, domain string) error {
 
 // UnregisterDomain delete the hosted zone with given domain from AWS Route53, also it removes the user access policy
 // that was created to allow access to the hosted zone and the IAM user that was created for accessing the hosted zone.
-func (dns *awsRoute53) unregisterDomain(orgId uint, domain string) error {
+func (dns *awsRoute53) unregisterDomain(orgId pkgAuth.OrganizationID, domain string) error {
 	log := loggerWithFields(logrus.Fields{"organisationId": orgId, "domain": domain})
 
 	log.Info("unregistering domain")
@@ -632,7 +633,7 @@ func (dns *awsRoute53) ProcessUnfinishedTasks() {
 }
 
 // DeleteDnsRecordsOwnedBy deletes DNS records that belong to the specified owner
-func (dns *awsRoute53) DeleteDnsRecordsOwnedBy(ownerId string, orgId uint) error {
+func (dns *awsRoute53) DeleteDnsRecordsOwnedBy(ownerId string, orgId pkgAuth.OrganizationID) error {
 	responseQueue := make(chan workerResponse)
 
 	task := newWorkerTask(deleteDnsRecordsOwnedBy, orgId, nil, responseQueue)
@@ -646,7 +647,7 @@ func (dns *awsRoute53) DeleteDnsRecordsOwnedBy(ownerId string, orgId uint) error
 }
 
 // GetOrgDomain returns the DNS domain name registered for the organization with given id
-func (dns *awsRoute53) GetOrgDomain(orgId uint) (string, error) {
+func (dns *awsRoute53) GetOrgDomain(orgId pkgAuth.OrganizationID) (string, error) {
 	responseQueue := make(chan workerResponse)
 
 	dns.getWorker(orgId) <- newWorkerTask(getOrgDomain, orgId, nil, responseQueue)
@@ -767,7 +768,7 @@ func (dns *awsRoute53) setupAmazonAccess(iamUser string, ctx *context) error {
 
 // getRoute53Secret returns the secret from Vault that stores the IAM user
 // aws access credentials that is used for accessing the Route53 Amazon service
-func (dns *awsRoute53) getRoute53Secret(orgId uint) (*secret.SecretItemResponse, error) {
+func (dns *awsRoute53) getRoute53Secret(orgId pkgAuth.OrganizationID) (*secret.SecretItemResponse, error) {
 	route53Secret, err := secret.Store.GetByName(orgId, IAMUserAccessKeySecretName)
 	if err != nil && err != secret.ErrSecretNotExists {
 		return nil, err
@@ -816,7 +817,7 @@ func (dns *awsRoute53) storeRoute53Secret(updateSecret *secret.SecretItemRespons
 	return nil
 }
 
-func (dns *awsRoute53) getOrgDomain(orgId uint) (string, error) {
+func (dns *awsRoute53) getOrgDomain(orgId pkgAuth.OrganizationID) (string, error) {
 	state := domainState{}
 	found, err := dns.stateStore.findByOrgId(orgId, &state)
 
@@ -862,7 +863,7 @@ func wrapAwsError(err error) error {
 	return &wrappedAwsError{err}
 }
 
-func getOrgById(orgId uint) (*auth.Organization, error) {
+func getOrgById(orgId pkgAuth.OrganizationID) (*auth.Organization, error) {
 	org, err := auth.GetOrganizationById(orgId)
 	if err != nil {
 		return nil, err
@@ -873,12 +874,12 @@ func getOrgById(orgId uint) (*auth.Organization, error) {
 
 // getWorker returns a worker that handles route53 related requests for the given organisation.
 // It ensures that there is only one worker assigned for an organisation
-func (dns *awsRoute53) getWorker(orgId uint) chan workerTask {
+func (dns *awsRoute53) getWorker(orgId pkgAuth.OrganizationID) chan workerTask {
 	dns.muxWorkers.Lock()
 	defer dns.muxWorkers.Unlock()
 
 	if dns.orgDomainWorkers == nil {
-		dns.orgDomainWorkers = make(map[uint]chan workerTask)
+		dns.orgDomainWorkers = make(map[pkgAuth.OrganizationID]chan workerTask)
 	}
 
 	worker, ok := dns.orgDomainWorkers[orgId]
@@ -931,7 +932,7 @@ func (dns *awsRoute53) startNewWorker() chan workerTask {
 	return workQueue
 }
 
-func newWorkerTask(operation operationType, orgId uint, domain *string, responseQueue chan<- workerResponse) workerTask {
+func newWorkerTask(operation operationType, orgId pkgAuth.OrganizationID, domain *string, responseQueue chan<- workerResponse) workerTask {
 	return workerTask{
 		operation:      operation,
 		organisationId: orgId,
@@ -940,7 +941,7 @@ func newWorkerTask(operation operationType, orgId uint, domain *string, response
 	}
 }
 
-func createCommonEvent(orgId uint, domain string) *DomainEvent {
+func createCommonEvent(orgId pkgAuth.OrganizationID, domain string) *DomainEvent {
 	return &DomainEvent{
 		Domain:         domain,
 		OrganisationId: orgId,

--- a/dns/route53/route53_test.go
+++ b/dns/route53/route53_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
@@ -33,22 +34,22 @@ import (
 )
 
 const (
-	testOrgId                uint = 1
-	testOrgName                   = "testorg"
-	testBaseDomain                = "domain"
-	testDomain                    = "test.domain"
-	testDomainInUse               = "inuse.domain"
-	testDomainMismatch            = "domain.mismatch"
-	testPolicyArn                 = "testpolicyarn"
-	testHostedZoneIdShort         = "testhostedzone1"
-	testBaseHostedZoneId          = "/hostedzone/testhostedzonebase"
-	testHostedZoneId              = "/hostedzone/testhostedzone1"
-	testInUseHostedZoneId         = "/hostedzone/inuse.hostedzone.id"
-	testMismatchHostedZoneId      = "/hostedzone/mismatch.hostedzone.id"
-	testIamUser                   = "a05932df.r53.testorg" // getHashedControlPlaneHostName("example.org")
-	testAccessKeyId               = "testaccesskeyid1"
-	testAccessSecretKey           = "testsecretkey1"
-	testPolicyDocument            = `{
+	testOrgId                pkgAuth.OrganizationID = 1
+	testOrgName                                     = "testorg"
+	testBaseDomain                                  = "domain"
+	testDomain                                      = "test.domain"
+	testDomainInUse                                 = "inuse.domain"
+	testDomainMismatch                              = "domain.mismatch"
+	testPolicyArn                                   = "testpolicyarn"
+	testHostedZoneIdShort                           = "testhostedzone1"
+	testBaseHostedZoneId                            = "/hostedzone/testhostedzonebase"
+	testHostedZoneId                                = "/hostedzone/testhostedzone1"
+	testInUseHostedZoneId                           = "/hostedzone/inuse.hostedzone.id"
+	testMismatchHostedZoneId                        = "/hostedzone/mismatch.hostedzone.id"
+	testIamUser                                     = "a05932df.r53.testorg" // getHashedControlPlaneHostName("example.org")
+	testAccessKeyId                                 = "testaccesskeyid1"
+	testAccessSecretKey                             = "testsecretkey1"
+	testPolicyDocument                              = `{
 		"Version": "2012-10-17",
 		"Statement": [{
 				"Effect": "Allow",
@@ -186,7 +187,7 @@ func (stateStore *inMemoryStateStore) update(state *domainState) error {
 	return nil
 }
 
-func (stateStore *inMemoryStateStore) find(orgId uint, domain string, state *domainState) (bool, error) {
+func (stateStore *inMemoryStateStore) find(orgId pkgAuth.OrganizationID, domain string, state *domainState) (bool, error) {
 	key := stateKey(orgId, domain)
 
 	s, ok := stateStore.orgDomains[key]
@@ -216,7 +217,7 @@ func (stateStore *inMemoryStateStore) findByStatus(status string) ([]domainState
 	return res, nil
 }
 
-func (stateStore *inMemoryStateStore) findByOrgId(orgId uint, state *domainState) (bool, error) {
+func (stateStore *inMemoryStateStore) findByOrgId(orgId pkgAuth.OrganizationID, state *domainState) (bool, error) {
 
 	for _, v := range stateStore.orgDomains {
 		if v.organisationId == orgId {
@@ -253,7 +254,7 @@ func (stateStore *inMemoryStateStore) delete(state *domainState) error {
 	return nil
 }
 
-func stateKey(orgId uint, domain string) string {
+func stateKey(orgId pkgAuth.OrganizationID, domain string) string {
 	return fmt.Sprintf("%d-%s", orgId, domain)
 }
 
@@ -1168,6 +1169,6 @@ func cleanupVaultTestSecrets() {
 
 }
 
-func getTestOrgById(orgId uint) (*auth.Organization, error) {
+func getTestOrgById(orgId pkgAuth.OrganizationID) (*auth.Organization, error) {
 	return &auth.Organization{ID: testOrgId, Name: testOrgName}, nil
 }

--- a/dns/route53/statestore.go
+++ b/dns/route53/statestore.go
@@ -14,14 +14,16 @@
 
 package route53
 
+import pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+
 // awsRoute53StateStore manages the state of the domains
 // registered by us in the Amazon Route53 external DNS service
 type awsRoute53StateStore interface {
 	create(state *domainState) error
 	update(state *domainState) error
-	find(orgId uint, domain string, state *domainState) (bool, error)
+	find(orgId pkgAuth.OrganizationID, domain string, state *domainState) (bool, error)
 	findByStatus(status string) ([]domainState, error)
-	findByOrgId(orgId uint, state *domainState) (bool, error)
+	findByOrgId(orgId pkgAuth.OrganizationID, state *domainState) (bool, error)
 	listUnused() ([]domainState, error)
 	delete(state *domainState) error
 }

--- a/internal/ark/api/backups.go
+++ b/internal/ark/api/backups.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"time"
 
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	arkAPI "github.com/heptio/ark/pkg/apis/ark/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +40,7 @@ type PersistBackupRequest struct {
 	BucketID uint
 
 	Cloud          string
-	Distribution   string
+	Distribution   pkgCluster.DistributionID
 	NodeCount      uint
 	ContentChecked bool
 
@@ -58,7 +59,7 @@ type Backup struct {
 	TTL              metav1.Duration                     `json:"ttl"`
 	Labels           labels.Set                          `json:"labels"`
 	Cloud            string                              `json:"cloud"`
-	Distribution     string                              `json:"distribution"`
+	Distribution     pkgCluster.DistributionID           `json:"distribution"`
 	Options          BackupOptions                       `json:"options,omitempty"`
 	Status           string                              `json:"status"`
 	StartAt          time.Time                           `json:"startAt"`
@@ -163,7 +164,7 @@ func (req *PersistBackupRequest) ExtendFromLabels() {
 	}
 
 	if req.Distribution == "" {
-		req.Distribution = req.Backup.Labels[LabelKeyDistribution]
+		req.Distribution = pkgCluster.DistributionID(req.Backup.Labels[LabelKeyDistribution])
 	}
 
 	if count, err := strconv.Atoi(req.Backup.Labels[LabelKeyNodeCount]); req.NodeCount == 0 && err == nil {

--- a/internal/ark/api/backups.go
+++ b/internal/ark/api/backups.go
@@ -44,7 +44,7 @@ type PersistBackupRequest struct {
 	NodeCount      uint
 	ContentChecked bool
 
-	ClusterID    uint
+	ClusterID    pkgCluster.ClusterID
 	DeploymentID uint
 
 	Nodes  *core.NodeList
@@ -67,9 +67,9 @@ type Backup struct {
 	VolumeBackups    map[string]*arkAPI.VolumeBackupInfo `json:"volumeBackups,omitempty"`
 	ValidationErrors []string                            `json:"validationErrors,omitempty"`
 
-	ClusterID       uint    `json:"clusterId,omitempty"`
-	ActiveClusterID uint    `json:"activeClusterId,omitempty"`
-	Bucket          *Bucket `json:"-"`
+	ClusterID       pkgCluster.ClusterID `json:"clusterId,omitempty"`
+	ActiveClusterID pkgCluster.ClusterID `json:"activeClusterId,omitempty"`
+	Bucket          *Bucket              `json:"-"`
 }
 
 // DeleteBackupResponse describes a delete backup response

--- a/internal/ark/api/buckets.go
+++ b/internal/ark/api/buckets.go
@@ -14,12 +14,14 @@
 
 package api
 
+import pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+
 // CreateBucketRequest describes create bucket request
 type CreateBucketRequest struct {
-	Cloud      string `json:"cloud" binding:"required"`
-	BucketName string `json:"bucketName" binding:"required"`
-	SecretID   string `json:"secretId" binding:"required"`
-	Location   string `json:"location"`
+	Cloud      string             `json:"cloud" binding:"required"`
+	BucketName string             `json:"bucketName" binding:"required"`
+	SecretID   pkgSecret.SecretID `json:"secretId" binding:"required"`
+	Location   string             `json:"location"`
 
 	AzureBucketProperties `json:"azure"`
 }
@@ -39,11 +41,11 @@ type FindBucketRequest struct {
 
 // Bucket describes a Bucket used for ARK backups
 type Bucket struct {
-	ID       uint   `json:"id"`
-	Name     string `json:"name"`
-	Cloud    string `json:"cloud"`
-	SecretID string `json:"secretId"`
-	Location string `json:"location,omitempty"`
+	ID       uint               `json:"id"`
+	Name     string             `json:"name"`
+	Cloud    string             `json:"cloud"`
+	SecretID pkgSecret.SecretID `json:"secretId"`
+	Location string             `json:"location,omitempty"`
 	AzureBucketProperties
 	Status              string `json:"status"`
 	InUse               bool   `json:"inUse"`

--- a/internal/ark/api/buckets.go
+++ b/internal/ark/api/buckets.go
@@ -53,7 +53,7 @@ type Bucket struct {
 	Status              string                    `json:"status"`
 	InUse               bool                      `json:"inUse"`
 	DeploymentID        uint                      `json:"deploymentId,omitempty"`
-	ClusterID           uint                      `json:"clusterId,omitempty"`
+	ClusterID           pkgCluster.ClusterID      `json:"clusterId,omitempty"`
 	ClusterCloud        string                    `json:"clusterCloud,omitempty"`
 	ClusterDistribution pkgCluster.DistributionID `json:"clusterDistribution,omitempty"`
 }

--- a/internal/ark/api/buckets.go
+++ b/internal/ark/api/buckets.go
@@ -14,7 +14,10 @@
 
 package api
 
-import pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+import (
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+)
 
 // CreateBucketRequest describes create bucket request
 type CreateBucketRequest struct {
@@ -47,12 +50,12 @@ type Bucket struct {
 	SecretID pkgSecret.SecretID `json:"secretId"`
 	Location string             `json:"location,omitempty"`
 	AzureBucketProperties
-	Status              string `json:"status"`
-	InUse               bool   `json:"inUse"`
-	DeploymentID        uint   `json:"deploymentId,omitempty"`
-	ClusterID           uint   `json:"clusterId,omitempty"`
-	ClusterCloud        string `json:"clusterCloud,omitempty"`
-	ClusterDistribution string `json:"clusterDistribution,omitempty"`
+	Status              string                    `json:"status"`
+	InUse               bool                      `json:"inUse"`
+	DeploymentID        uint                      `json:"deploymentId,omitempty"`
+	ClusterID           uint                      `json:"clusterId,omitempty"`
+	ClusterCloud        string                    `json:"clusterCloud,omitempty"`
+	ClusterDistribution pkgCluster.DistributionID `json:"clusterDistribution,omitempty"`
 }
 
 // DeleteBucketResponse describes a delete bucket response

--- a/internal/ark/api/cluster.go
+++ b/internal/ark/api/cluster.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -30,7 +31,7 @@ type Cluster interface {
 	GetName() string
 	GetOrganizationId() pkgAuth.OrganizationID
 	GetCloud() string
-	GetDistribution() string
+	GetDistribution() pkgCluster.DistributionID
 	GetK8sConfig() ([]byte, error)
 	GetSecretWithValidation() (*secret.SecretItemResponse, error)
 	GetLocation() string

--- a/internal/ark/api/cluster.go
+++ b/internal/ark/api/cluster.go
@@ -27,7 +27,7 @@ type AKSCluster interface {
 
 // Cluster interface for cluster implementations
 type Cluster interface {
-	GetID() uint
+	GetID() pkgCluster.ClusterID
 	GetName() string
 	GetOrganizationId() pkgAuth.OrganizationID
 	GetCloud() string

--- a/internal/ark/api/restores.go
+++ b/internal/ark/api/restores.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	arkAPI "github.com/heptio/ark/pkg/apis/ark/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,7 +24,7 @@ import (
 // PersistRestoreRequest describes a persist restore request
 type PersistRestoreRequest struct {
 	BucketID  uint
-	ClusterID uint
+	ClusterID pkgCluster.ClusterID
 
 	Results *RestoreResults
 	Restore *arkAPI.Restore

--- a/internal/ark/ark.go
+++ b/internal/ark/ark.go
@@ -22,6 +22,7 @@ import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/providers"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -47,7 +48,7 @@ func IsProviderSupported(provider string) error {
 }
 
 // GetSecretWithValidation gives back a secret response with validation
-func GetSecretWithValidation(secretID string, orgID pkgAuth.OrganizationID, provider string) (*secret.SecretItemResponse, error) {
+func GetSecretWithValidation(secretID pkgSecret.SecretID, orgID pkgAuth.OrganizationID, provider string) (*secret.SecretItemResponse, error) {
 
 	secret, err := secret.Store.Get(orgID, secretID)
 	if err != nil {

--- a/internal/ark/ark.go
+++ b/internal/ark/ark.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/banzaicloud/pipeline/config"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
@@ -46,7 +47,7 @@ func IsProviderSupported(provider string) error {
 }
 
 // GetSecretWithValidation gives back a secret response with validation
-func GetSecretWithValidation(secretID string, orgID uint, provider string) (*secret.SecretItemResponse, error) {
+func GetSecretWithValidation(secretID string, orgID pkgAuth.OrganizationID, provider string) (*secret.SecretItemResponse, error) {
 
 	secret, err := secret.Store.Get(orgID, secretID)
 	if err != nil {

--- a/internal/ark/backups_model.go
+++ b/internal/ark/backups_model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // ClusterBackupsModel describes a cluster backup
@@ -48,7 +49,7 @@ type ClusterBackupsModel struct {
 	StatusMessage string `sql:"type:text"`
 
 	Organization   auth.Organization             `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint                          `gorm:"index;not null"`
+	OrganizationID pkgAuth.OrganizationID        `gorm:"index;not null"`
 	Cluster        model.ClusterModel            `gorm:"foreignkey:ClusterID"`
 	ClusterID      uint                          `gorm:"index;not null"`
 	Deployment     ClusterBackupDeploymentsModel `gorm:"foreignkey:DeploymentID"`

--- a/internal/ark/backups_model.go
+++ b/internal/ark/backups_model.go
@@ -52,7 +52,7 @@ type ClusterBackupsModel struct {
 	Organization   auth.Organization             `gorm:"foreignkey:OrganizationID"`
 	OrganizationID pkgAuth.OrganizationID        `gorm:"index;not null"`
 	Cluster        model.ClusterModel            `gorm:"foreignkey:ClusterID"`
-	ClusterID      uint                          `gorm:"index;not null"`
+	ClusterID      pkgCluster.ClusterID          `gorm:"index;not null"`
 	Deployment     ClusterBackupDeploymentsModel `gorm:"foreignkey:DeploymentID"`
 	DeploymentID   uint                          `gorm:"not null"`
 	Bucket         ClusterBackupBucketsModel     `gorm:"foreignkey:BucketID"`

--- a/internal/ark/backups_model.go
+++ b/internal/ark/backups_model.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 // ClusterBackupsModel describes a cluster backup
@@ -35,7 +36,7 @@ type ClusterBackupsModel struct {
 	UID            string
 	Name           string
 	Cloud          string
-	Distribution   string
+	Distribution   pkgCluster.DistributionID
 	NodeCount      uint
 	ContentChecked bool
 	StartedAt      *time.Time

--- a/internal/ark/buckets_model.go
+++ b/internal/ark/buckets_model.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/ark/api"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // ClusterBackupBucketsModel describes a cluster backup bucket
@@ -38,7 +39,7 @@ type ClusterBackupBucketsModel struct {
 	StatusMessage string `sql:"type:text;"`
 
 	Organization   auth.Organization             `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint                          `gorm:"index;not null"`
+	OrganizationID pkgAuth.OrganizationID        `gorm:"index;not null"`
 	Deployment     ClusterBackupDeploymentsModel `gorm:"foreignkey:BucketID"`
 
 	CreatedAt time.Time

--- a/internal/ark/buckets_model.go
+++ b/internal/ark/buckets_model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // ClusterBackupBucketsModel describes a cluster backup bucket
@@ -29,7 +30,7 @@ type ClusterBackupBucketsModel struct {
 	ID uint `gorm:"primary_key"`
 
 	Cloud          string
-	SecretID       string
+	SecretID       pkgSecret.SecretID
 	BucketName     string
 	Location       string
 	StorageAccount string

--- a/internal/ark/cluster_backups_svc.go
+++ b/internal/ark/cluster_backups_svc.go
@@ -142,7 +142,7 @@ func (s *ClusterBackupsService) Create(req api.CreateBackupRequest) error {
 	if req.Labels == nil {
 		req.Labels = make(labels.Set)
 	}
-	req.Labels[api.LabelKeyDistribution] = s.cluster.GetDistribution()
+	req.Labels[api.LabelKeyDistribution] = string(s.cluster.GetDistribution())
 	req.Labels[api.LabelKeyCloud] = s.cluster.GetCloud()
 
 	backup, err := client.CreateBackup(req)

--- a/internal/ark/deployments_model.go
+++ b/internal/ark/deployments_model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 // ClusterBackupDeploymentsModel describes an ARK deployment model
@@ -39,7 +40,7 @@ type ClusterBackupDeploymentsModel struct {
 	Organization   auth.Organization      `gorm:"foreignkey:OrganizationID"`
 	OrganizationID pkgAuth.OrganizationID `gorm:"index;not null"`
 	Cluster        model.ClusterModel     `gorm:"foreignkey:ClusterID"`
-	ClusterID      uint                   `gorm:"index;not null"`
+	ClusterID      pkgCluster.ClusterID   `gorm:"index;not null"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/ark/deployments_model.go
+++ b/internal/ark/deployments_model.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // ClusterBackupDeploymentsModel describes an ARK deployment model
@@ -34,11 +35,11 @@ type ClusterBackupDeploymentsModel struct {
 	Status        string
 	StatusMessage string `sql:"type:text;"`
 
-	BucketID       uint               `gorm:"index;not null"`
-	Organization   auth.Organization  `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint               `gorm:"index;not null"`
-	Cluster        model.ClusterModel `gorm:"foreignkey:ClusterID"`
-	ClusterID      uint               `gorm:"index;not null"`
+	BucketID       uint                   `gorm:"index;not null"`
+	Organization   auth.Organization      `gorm:"foreignkey:OrganizationID"`
+	OrganizationID pkgAuth.OrganizationID `gorm:"index;not null"`
+	Cluster        model.ClusterModel     `gorm:"foreignkey:ClusterID"`
+	ClusterID      uint                   `gorm:"index;not null"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/ark/events/cluster_event_handler.go
+++ b/internal/ark/events/cluster_event_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/banzaicloud/pipeline/internal/ark"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // ClusterEventHandler is for handling cluster events
@@ -37,7 +38,7 @@ func NewClusterEventHandler(events clusterEvents, db *gorm.DB, logger logrus.Fie
 		logger: logger,
 	}
 
-	eh.events.NotifyClusterDeleted(func(orgID uint, clusterName string) {
+	eh.events.NotifyClusterDeleted(func(orgID pkgAuth.OrganizationID, clusterName string) {
 		eh.DeleteStaleARKDeployments(orgID)
 	})
 
@@ -45,7 +46,7 @@ func NewClusterEventHandler(events clusterEvents, db *gorm.DB, logger logrus.Fie
 }
 
 // RemoveStaleDeployments deletes stale ARK deployment records from database
-func (eh *ClusterEventHandler) DeleteStaleARKDeployments(orgID uint) error {
+func (eh *ClusterEventHandler) DeleteStaleARKDeployments(orgID pkgAuth.OrganizationID) error {
 	var deployments []*ark.ClusterBackupDeploymentsModel
 
 	eh.logger.WithField("org", orgID).Debug("removing stale ark deployment records")

--- a/internal/ark/events/cluster_events_test.go
+++ b/internal/ark/events/cluster_events_test.go
@@ -20,17 +20,18 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/banzaicloud/pipeline/cluster"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 func TestClusterCreatedEvent(t *testing.T) {
-	oid := uint(1)
+	oid := pkgCluster.ClusterID(1)
 
 	clusterEventBus := evbus.New()
 	publisher := cluster.NewClusterEvents(clusterEventBus)
 
 	ok := false
 	listener := NewClusterEvents(clusterEventBus)
-	listener.NotifyClusterCreated(func(clusterID uint) {
+	listener.NotifyClusterCreated(func(clusterID pkgCluster.ClusterID) {
 		if clusterID == oid {
 			ok = true
 		}

--- a/internal/ark/events/cluster_events_test.go
+++ b/internal/ark/events/cluster_events_test.go
@@ -19,6 +19,7 @@ import (
 
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/banzaicloud/pipeline/cluster"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 func TestClusterCreatedEvent(t *testing.T) {
@@ -45,7 +46,7 @@ func TestClusterCreatedEvent(t *testing.T) {
 }
 
 func TestClusterDeletedEvent(t *testing.T) {
-	oid := uint(1)
+	oid := pkgAuth.OrganizationID(1)
 	cname := "clustername"
 
 	clusterEventBus := evbus.New()
@@ -53,7 +54,7 @@ func TestClusterDeletedEvent(t *testing.T) {
 
 	ok := false
 	listener := NewClusterEvents(clusterEventBus)
-	listener.NotifyClusterDeleted(func(orgID uint, clusterName string) {
+	listener.NotifyClusterDeleted(func(orgID pkgAuth.OrganizationID, clusterName string) {
 		if orgID == oid && clusterName == cname {
 			ok = true
 		}

--- a/internal/ark/restores_model.go
+++ b/internal/ark/restores_model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 // ClusterBackupRestoresModel describes an ARK restore model
@@ -42,7 +43,7 @@ type ClusterBackupRestoresModel struct {
 	Bucket         ClusterBackupBucketsModel `gorm:"foreignkey:BucketID"`
 	BucketID       uint                      `gorm:"index;not null"`
 	Cluster        model.ClusterModel        `gorm:"foreignkey:ClusterID"`
-	ClusterID      uint                      `gorm:"index;not null"`
+	ClusterID      pkgCluster.ClusterID      `gorm:"index;not null"`
 	Organization   auth.Organization         `gorm:"foreignkey:OrganizationID"`
 	OrganizationID pkgAuth.OrganizationID    `gorm:"index;not null"`
 

--- a/internal/ark/restores_model.go
+++ b/internal/ark/restores_model.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // ClusterBackupRestoresModel describes an ARK restore model
@@ -43,7 +44,7 @@ type ClusterBackupRestoresModel struct {
 	Cluster        model.ClusterModel        `gorm:"foreignkey:ClusterID"`
 	ClusterID      uint                      `gorm:"index;not null"`
 	Organization   auth.Organization         `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint                      `gorm:"index;not null"`
+	OrganizationID pkgAuth.OrganizationID    `gorm:"index;not null"`
 
 	Status        string
 	StatusMessage string `sql:"type:text;"`

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/spotguide"
 	"github.com/gin-gonic/gin"
@@ -132,7 +133,7 @@ func LogWriter(
 		}
 
 		user := auth.GetCurrentUser(c.Request)
-		var userID uint
+		var userID pkgAuth.UserID
 		if user != nil {
 			userID = user.ID
 		}

--- a/internal/audit/model_audit_event.go
+++ b/internal/audit/model_audit_event.go
@@ -14,7 +14,11 @@
 
 package audit
 
-import "time"
+import (
+	"time"
+
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // TableName constants
 const (
@@ -30,7 +34,7 @@ type AuditEvent struct {
 	UserAgent     string
 	Path          string `gorm:"size:8000"`
 	Method        string `gorm:"size:7"`
-	UserID        uint
+	UserID        pkgAuth.UserID
 	StatusCode    int
 	Body          *string `gorm:"type:json"`
 	Headers       string  `gorm:"type:json"`

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -14,6 +14,10 @@
 
 package auth
 
+import (
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
+
 // AccessManager is responsible for managing authorization rules.
 // NOTE:
 // Currently this implementation is a dummy one, and is a placeholder for a future implementation.
@@ -44,15 +48,15 @@ func (m *AccessManager) GrantDefaultAccessToVirtualUser(userID string) {
 }
 
 // AddOrganizationPolicies creates an organization role, by adding the default (*) org policies for the given organization.
-func (m *AccessManager) AddOrganizationPolicies(orgID uint) {
+func (m *AccessManager) AddOrganizationPolicies(orgID pkgAuth.OrganizationID) {
 }
 
 // GrantOrganizationAccessToUser adds a user to an organization by adding the associated organization role.
-func (m *AccessManager) GrantOrganizationAccessToUser(userID string, orgID uint) {
+func (m *AccessManager) GrantOrganizationAccessToUser(userID string, orgID pkgAuth.OrganizationID) {
 }
 
 // RevokeOrganizationAccessFromUser removes a user from an organization by removing the associated organization role.
-func (m *AccessManager) RevokeOrganizationAccessFromUser(userID string, orgID uint) {
+func (m *AccessManager) RevokeOrganizationAccessFromUser(userID string, orgID pkgAuth.OrganizationID) {
 }
 
 // RevokeAllAccessFromUser removes all roles for a given user.

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -35,7 +35,7 @@ func newOrg(t *testing.T, db *gorm.DB, id uint, name string) *auth.Organization 
 }
 
 func newUser(t *testing.T, db *gorm.DB, id uint, login string) *auth.User {
-	user := auth.User{ID: id, Login: login}
+	user := auth.User{ID: pkgAuth.UserID(id), Login: login}
 	db.AutoMigrate(user)
 	if err := db.FirstOrCreate(&user).Error; err != nil {
 		t.Fatal(err)

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/stretchr/testify/assert"
 )
 
 func newOrg(t *testing.T, db *gorm.DB, id uint, name string) *auth.Organization {
-	org := auth.Organization{ID: id, Name: name}
+	org := auth.Organization{ID: pkgAuth.OrganizationID(id), Name: name}
 	db.AutoMigrate(org)
 	if err := db.FirstOrCreate(&org).Error; err != nil {
 		t.Fatal(err)

--- a/internal/cloudinfo/machine_types.go
+++ b/internal/cloudinfo/machine_types.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/goph/emperror"
 	"github.com/spf13/viper"
@@ -58,7 +60,7 @@ type MachineDetails struct {
 
 type VMKey struct {
 	cloud        string
-	service      string
+	service      pkgCluster.DistributionID
 	region       string
 	instanceType string
 }
@@ -66,7 +68,7 @@ type VMKey struct {
 // nolint: gochecknoglobals
 var instanceTypeMap = make(map[VMKey]MachineDetails)
 
-func fetchMachineTypes(cloud string, service string, region string) error {
+func fetchMachineTypes(cloud string, service pkgCluster.DistributionID, region string) error {
 	cloudInfoEndPoint := viper.GetString(config.CloudInfoEndPoint)
 	if len(cloudInfoEndPoint) == 0 {
 		return emperror.With(errors.New("missing config"), "propertyName", config.CloudInfoEndPoint)
@@ -103,7 +105,7 @@ func fetchMachineTypes(cloud string, service string, region string) error {
 }
 
 //GetMachineDetails returns machine resource details, like cpu/gpu/memory etc. either from local cache or CloudInfo
-func GetMachineDetails(cloud string, service string, region string, instanceType string) (*MachineDetails, error) {
+func GetMachineDetails(cloud string, service pkgCluster.DistributionID, region string, instanceType string) (*MachineDetails, error) {
 
 	vmKey := VMKey{
 		cloud,

--- a/internal/cluster/cluster_model.go
+++ b/internal/cluster/cluster_model.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gofrs/uuid"
 	"github.com/jinzhu/gorm"
@@ -48,9 +49,9 @@ type ClusterModel struct {
 	Cloud          string
 	Distribution   string
 	OrganizationID pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
-	SecretID       string
-	ConfigSecretID string
-	SSHSecretID    string
+	SecretID       pkgSecret.SecretID
+	ConfigSecretID pkgSecret.SecretID
+	SSHSecretID    pkgSecret.SecretID
 	Status         string
 	RbacEnabled    bool
 	Monitoring     bool

--- a/internal/cluster/cluster_model.go
+++ b/internal/cluster/cluster_model.go
@@ -37,8 +37,8 @@ const (
 
 // ClusterModel describes the common cluster model.
 type ClusterModel struct {
-	ID  uint   `gorm:"primary_key"`
-	UID string `gorm:"unique_index:idx_uid"`
+	ID  pkgCluster.ClusterID `gorm:"primary_key"`
+	UID string               `gorm:"unique_index:idx_uid"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/cluster/cluster_model.go
+++ b/internal/cluster/cluster_model.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gofrs/uuid"
@@ -47,7 +48,7 @@ type ClusterModel struct {
 	Name           string `gorm:"unique_index:idx_unique_id"`
 	Location       string
 	Cloud          string
-	Distribution   string
+	Distribution   pkgCluster.DistributionID
 	OrganizationID pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
 	SecretID       pkgSecret.SecretID
 	ConfigSecretID pkgSecret.SecretID

--- a/internal/cluster/cluster_model.go
+++ b/internal/cluster/cluster_model.go
@@ -41,7 +41,7 @@ type ClusterModel struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time `gorm:"unique_index:idx_unique_id" sql:"index"`
-	CreatedBy uint
+	CreatedBy pkgAuth.UserID
 
 	Name           string `gorm:"unique_index:idx_unique_id"`
 	Location       string

--- a/internal/cluster/cluster_model.go
+++ b/internal/cluster/cluster_model.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gofrs/uuid"
 	"github.com/jinzhu/gorm"
@@ -46,7 +47,7 @@ type ClusterModel struct {
 	Location       string
 	Cloud          string
 	Distribution   string
-	OrganizationID uint `gorm:"unique_index:idx_unique_id"`
+	OrganizationID pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
 	SecretID       string
 	ConfigSecretID string
 	SSHSecretID    string

--- a/internal/cluster/cluster_status_history_model.go
+++ b/internal/cluster/cluster_status_history_model.go
@@ -16,6 +16,8 @@ package cluster
 
 import (
 	"time"
+
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 const (
@@ -26,9 +28,9 @@ const (
 type StatusHistoryModel struct {
 	ID uint `gorm:"primary_key"`
 
-	ClusterID   uint      `gorm:"not null"`
-	ClusterName string    `gorm:"not null"`
-	CreatedAt   time.Time `gorm:"not null"`
+	ClusterID   pkgCluster.ClusterID `gorm:"not null"`
+	ClusterName string               `gorm:"not null"`
+	CreatedAt   time.Time            `gorm:"not null"`
 
 	FromStatus        string `gorm:"not null"`
 	FromStatusMessage string `sql:"type:text;" gorm:"not null"`

--- a/internal/cluster/clusters.go
+++ b/internal/cluster/clusters.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"github.com/banzaicloud/pipeline/model"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ func NewClusters(db *gorm.DB) *Clusters {
 }
 
 // Exists checks if a given cluster exists within an organization.
-func (c *Clusters) Exists(organizationID uint, name string) (bool, error) {
+func (c *Clusters) Exists(organizationID pkgAuth.OrganizationID, name string) (bool, error) {
 	var existingCluster ClusterModel
 
 	err := c.db.First(&existingCluster, map[string]interface{}{"name": name, "organization_id": organizationID}).Error
@@ -58,7 +59,7 @@ func (c *Clusters) All() ([]*model.ClusterModel, error) {
 }
 
 // FindByOrganization returns all cluster instances for an organization.
-func (c *Clusters) FindByOrganization(organizationID uint) ([]*model.ClusterModel, error) {
+func (c *Clusters) FindByOrganization(organizationID pkgAuth.OrganizationID) ([]*model.ClusterModel, error) {
 	var clusters []*model.ClusterModel
 
 	err := c.db.Find(&clusters, map[string]interface{}{"organization_id": organizationID}).Error
@@ -70,18 +71,18 @@ func (c *Clusters) FindByOrganization(organizationID uint) ([]*model.ClusterMode
 }
 
 // FindOneByID returns a cluster instance for an organization by cluster ID.
-func (c *Clusters) FindOneByID(organizationID uint, clusterID uint) (*model.ClusterModel, error) {
+func (c *Clusters) FindOneByID(organizationID pkgAuth.OrganizationID, clusterID uint) (*model.ClusterModel, error) {
 	return c.findOneBy(organizationID, "id", clusterID)
 }
 
 // FindOneByName returns a cluster instance for an organization by cluster name.
-func (c *Clusters) FindOneByName(organizationID uint, clusterName string) (*model.ClusterModel, error) {
+func (c *Clusters) FindOneByName(organizationID pkgAuth.OrganizationID, clusterName string) (*model.ClusterModel, error) {
 	return c.findOneBy(organizationID, "name", clusterName)
 }
 
 type clusterModelNotFoundError struct {
 	cluster        interface{}
-	organizationID uint
+	organizationID pkgAuth.OrganizationID
 }
 
 func (e *clusterModelNotFoundError) Error() string {
@@ -100,7 +101,7 @@ func (e *clusterModelNotFoundError) NotFound() bool {
 }
 
 // findOneBy returns a cluster instance for an organization by cluster name.
-func (c *Clusters) findOneBy(organizationID uint, field string, criteria interface{}) (*model.ClusterModel, error) {
+func (c *Clusters) findOneBy(organizationID pkgAuth.OrganizationID, field string, criteria interface{}) (*model.ClusterModel, error) {
 	cluster := model.ClusterModel{
 		OrganizationId: organizationID,
 	}
@@ -141,7 +142,7 @@ func (c *Clusters) findOneBy(organizationID uint, field string, criteria interfa
 }
 
 // FindBySecret returns all cluster instances for an organization filtered by secret.
-func (c *Clusters) FindBySecret(organizationID uint, secretID string) ([]*model.ClusterModel, error) {
+func (c *Clusters) FindBySecret(organizationID pkgAuth.OrganizationID, secretID string) ([]*model.ClusterModel, error) {
 	var clusters []*model.ClusterModel
 
 	err := c.db.Find(
@@ -159,7 +160,7 @@ func (c *Clusters) FindBySecret(organizationID uint, secretID string) ([]*model.
 }
 
 // GetConfigSecretIDByClusterID returns the kubeconfig's secretID stored in DB
-func (c *Clusters) GetConfigSecretIDByClusterID(organizationID, clusterID uint) (string, error) {
+func (c *Clusters) GetConfigSecretIDByClusterID(organizationID pkgAuth.OrganizationID, clusterID uint) (string, error) {
 	cluster := model.ClusterModel{ID: clusterID}
 
 	if err := c.db.Where(cluster).Select("config_secret_id").First(&cluster).Error; err != nil {

--- a/internal/cluster/clusters.go
+++ b/internal/cluster/clusters.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -142,7 +143,7 @@ func (c *Clusters) findOneBy(organizationID pkgAuth.OrganizationID, field string
 }
 
 // FindBySecret returns all cluster instances for an organization filtered by secret.
-func (c *Clusters) FindBySecret(organizationID pkgAuth.OrganizationID, secretID string) ([]*model.ClusterModel, error) {
+func (c *Clusters) FindBySecret(organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) ([]*model.ClusterModel, error) {
 	var clusters []*model.ClusterModel
 
 	err := c.db.Find(
@@ -160,7 +161,7 @@ func (c *Clusters) FindBySecret(organizationID pkgAuth.OrganizationID, secretID 
 }
 
 // GetConfigSecretIDByClusterID returns the kubeconfig's secretID stored in DB
-func (c *Clusters) GetConfigSecretIDByClusterID(organizationID pkgAuth.OrganizationID, clusterID uint) (string, error) {
+func (c *Clusters) GetConfigSecretIDByClusterID(organizationID pkgAuth.OrganizationID, clusterID uint) (pkgSecret.SecretID, error) {
 	cluster := model.ClusterModel{ID: clusterID}
 
 	if err := c.db.Where(cluster).Select("config_secret_id").First(&cluster).Error; err != nil {

--- a/internal/cluster/clusters.go
+++ b/internal/cluster/clusters.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"github.com/banzaicloud/pipeline/model"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
@@ -114,7 +115,7 @@ func (c *Clusters) findOneBy(organizationID pkgAuth.OrganizationID, field string
 			return nil, errors.New("criteria is not a valid uint value for id")
 		}
 
-		cluster.ID = id
+		cluster.ID = pkgCluster.ClusterID(id)
 
 	case "name":
 		name, ok := criteria.(string)
@@ -161,7 +162,7 @@ func (c *Clusters) FindBySecret(organizationID pkgAuth.OrganizationID, secretID 
 }
 
 // GetConfigSecretIDByClusterID returns the kubeconfig's secretID stored in DB
-func (c *Clusters) GetConfigSecretIDByClusterID(organizationID pkgAuth.OrganizationID, clusterID uint) (pkgSecret.SecretID, error) {
+func (c *Clusters) GetConfigSecretIDByClusterID(organizationID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID) (pkgSecret.SecretID, error) {
 	cluster := model.ClusterModel{ID: clusterID}
 
 	if err := c.db.Where(cluster).Select("config_secret_id").First(&cluster).Error; err != nil {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/config"
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/k8sutil"
@@ -33,7 +34,7 @@ import (
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/cache"
@@ -78,18 +79,18 @@ type Status struct {
 }
 
 type Cluster struct {
-	Name                string    `json:"name"`
-	Id                  string    `json:"id"`
-	Status              string    `json:"status"`
-	Distribution        string    `json:"distribution"`
-	StatusMessage       string    `json:"statusMessage"`
-	Cloud               string    `json:"cloud"`
-	CreatedAt           time.Time `json:"createdAt"`
-	Region              string    `json:"region"`
-	Nodes               []Node    `json:"nodes"`
-	CpuUsagePercent     float64   `json:"cpuUsagePercent"`
-	StorageUsagePercent float64   `json:"storageUsagePercent"`
-	MemoryUsagePercent  float64   `json:"memoryUsagePercent"`
+	Name                string                    `json:"name"`
+	Id                  string                    `json:"id"`
+	Status              string                    `json:"status"`
+	Distribution        pkgCluster.DistributionID `json:"distribution"`
+	StatusMessage       string                    `json:"statusMessage"`
+	Cloud               string                    `json:"cloud"`
+	CreatedAt           time.Time                 `json:"createdAt"`
+	Region              string                    `json:"region"`
+	Nodes               []Node                    `json:"nodes"`
+	CpuUsagePercent     float64                   `json:"cpuUsagePercent"`
+	StorageUsagePercent float64                   `json:"storageUsagePercent"`
+	MemoryUsagePercent  float64                   `json:"memoryUsagePercent"`
 }
 
 // GetDashboardResponse Api object to be mapped to Get dashboard request

--- a/internal/monitor/cluster_subscriber.go
+++ b/internal/monitor/cluster_subscriber.go
@@ -28,6 +28,7 @@ import (
 	pipCluster "github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/dns"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	pipSecret "github.com/banzaicloud/pipeline/secret"
 	promconfig "github.com/banzaicloud/prometheus-config"
@@ -180,7 +181,7 @@ func (s *clusterSubscriber) Register(events clusterEvents) {
 type scrapeConfigParameters struct {
 	orgID           pkgAuth.OrganizationID
 	orgName         string
-	clusterID       uint
+	clusterID       pkgCluster.ClusterID
 	clusterName     string
 	endpoint        string
 	tlsConfig       *scrapeTLSConfig

--- a/internal/monitor/cluster_subscriber.go
+++ b/internal/monitor/cluster_subscriber.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/pipeline/cluster"
 	pipCluster "github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/dns"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	pipSecret "github.com/banzaicloud/pipeline/secret"
 	promconfig "github.com/banzaicloud/prometheus-config"
@@ -35,8 +36,8 @@ import (
 	"github.com/pkg/errors"
 	promCommon "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v2"
-	"k8s.io/api/core/v1"
+	yaml "gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -177,7 +178,7 @@ func (s *clusterSubscriber) Register(events clusterEvents) {
 }
 
 type scrapeConfigParameters struct {
-	orgID           uint
+	orgID           pkgAuth.OrganizationID
 	orgName         string
 	clusterID       uint
 	clusterName     string
@@ -257,7 +258,7 @@ func (s *clusterSubscriber) AddClusterToPrometheusConfig(clusterID uint) {
 	}
 }
 
-func (s *clusterSubscriber) RemoveClusterFromPrometheusConfig(orgID uint, clusterName string) {
+func (s *clusterSubscriber) RemoveClusterFromPrometheusConfig(orgID pkgAuth.OrganizationID, clusterName string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -317,7 +318,7 @@ func (s *clusterSubscriber) getClusterAndOrganization(clusterID uint) (cluster.C
 	return c, org, err
 }
 
-func (s *clusterSubscriber) getOrganization(orgID uint) (*auth.Organization, error) {
+func (s *clusterSubscriber) getOrganization(orgID pkgAuth.OrganizationID) (*auth.Organization, error) {
 	org := auth.Organization{
 		ID: orgID,
 	}

--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -14,6 +14,8 @@
 
 package objectstore
 
+import pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+
 // ObjectStoreService is the interface that cloud specific object store implementation
 // must implement
 type ObjectStoreService interface {
@@ -29,12 +31,12 @@ type BucketInfo struct {
 	Name            string                    `json:"name"  binding:"required"`
 	Managed         bool                      `json:"managed" binding:"required"`
 	Location        string                    `json:"location,omitempty"`
-	SecretRef       string                    `json:"secretId,omitempty"`
+	SecretRef       pkgSecret.SecretID        `json:"secretId,omitempty"`
 	Cloud           string                    `json:"cloud,omitempty"`
 	Azure           *BlobStoragePropsForAzure `json:"aks,omitempty"`
 	Status          string                    `json:"status"`
 	StatusMsg       string                    `json:"statusMsg"`
-	AccessSecretRef string                    `json:"accessSecretId"`
+	AccessSecretRef pkgSecret.SecretID        `json:"accessSecretId"`
 }
 
 // BlobStoragePropsForAzure describes the Azure specific properties

--- a/internal/providers/alibaba/objectstore_model.go
+++ b/internal/providers/alibaba/objectstore_model.go
@@ -14,7 +14,10 @@
 
 package alibaba
 
-import "github.com/banzaicloud/pipeline/auth"
+import (
+	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // TableName constants
 const (
@@ -23,10 +26,10 @@ const (
 
 // ObjectStoreBucketModel is the schema for the DB
 type ObjectStoreBucketModel struct {
-	ID           uint              `gorm:"primary_key"`
-	Organization auth.Organization `gorm:"foreignkey:OrgID"`
-	OrgID        uint              `gorm:"index;not null"`
-	Name         string            `gorm:"unique_index:idx_bucket_name"`
+	ID           uint                   `gorm:"primary_key"`
+	Organization auth.Organization      `gorm:"foreignkey:OrgID"`
+	OrgID        pkgAuth.OrganizationID `gorm:"index;not null"`
+	Name         string                 `gorm:"unique_index:idx_bucket_name"`
 	Region       string
 	SecretRef    string
 

--- a/internal/providers/alibaba/objectstore_model.go
+++ b/internal/providers/alibaba/objectstore_model.go
@@ -17,6 +17,7 @@ package alibaba
 import (
 	"github.com/banzaicloud/pipeline/auth"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // TableName constants
@@ -31,7 +32,7 @@ type ObjectStoreBucketModel struct {
 	OrgID        pkgAuth.OrganizationID `gorm:"index;not null"`
 	Name         string                 `gorm:"unique_index:idx_bucket_name"`
 	Region       string
-	SecretRef    string
+	SecretRef    pkgSecret.SecretID
 
 	Status    string
 	StatusMsg string `sql:"type:text;"`

--- a/internal/providers/amazon/objectstore.go
+++ b/internal/providers/amazon/objectstore.go
@@ -110,10 +110,8 @@ func getProviderObjectStore(secret *secret.SecretItemResponse, region string) (a
 }
 
 func (s *objectStore) getLogger() logrus.FieldLogger {
-	var sId string
-	if s.secret == nil {
-		sId = ""
-	} else {
+	var sId pkgSecret.SecretID
+	if s.secret != nil {
 		sId = s.secret.ID
 	}
 

--- a/internal/providers/amazon/objectstore_model.go
+++ b/internal/providers/amazon/objectstore_model.go
@@ -17,6 +17,7 @@ package amazon
 import (
 	"github.com/banzaicloud/pipeline/auth"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // TableName constants
@@ -34,7 +35,7 @@ type ObjectStoreBucketModel struct {
 	Name   string `gorm:"unique_index:idx_bucket_name"`
 	Region string
 
-	SecretRef string
+	SecretRef pkgSecret.SecretID
 	Status    string
 	StatusMsg string `sql:"type:text;"`
 }

--- a/internal/providers/amazon/objectstore_model.go
+++ b/internal/providers/amazon/objectstore_model.go
@@ -14,7 +14,10 @@
 
 package amazon
 
-import "github.com/banzaicloud/pipeline/auth"
+import (
+	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // TableName constants
 const (
@@ -25,8 +28,8 @@ const (
 type ObjectStoreBucketModel struct {
 	ID uint `gorm:"primary_key"`
 
-	Organization   auth.Organization `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint              `gorm:"index;not null"`
+	Organization   auth.Organization      `gorm:"foreignkey:OrganizationID"`
+	OrganizationID pkgAuth.OrganizationID `gorm:"index;not null"`
 
 	Name   string `gorm:"unique_index:idx_bucket_name"`
 	Region string

--- a/internal/providers/azure/objectstore.go
+++ b/internal/providers/azure/objectstore.go
@@ -156,10 +156,8 @@ func getProviderObjectStore(secret *secret.SecretItemResponse, resourceGroup, st
 }
 
 func (s *ObjectStore) getLogger() logrus.FieldLogger {
-	var sId string
-	if s.secret == nil {
-		sId = ""
-	} else {
+	var sId pkgSecret.SecretID
+	if s.secret != nil {
 		sId = s.secret.ID
 	}
 
@@ -252,9 +250,9 @@ func (s *ObjectStore) CreateBucket(bucketName string) error {
 	return nil
 }
 
-func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (string, string, error) {
+func (s *ObjectStore) createUpdateStorageAccountSecret(accesskey string) (pkgSecret.SecretID, string, error) {
 
-	var secretId string
+	var secretId pkgSecret.SecretID
 	storageAccountName := alfanumericRegexp.ReplaceAllString(s.storageAccount, "-")
 	secretName := fmt.Sprintf("%v-key", storageAccountName)
 

--- a/internal/providers/azure/objectstore_model.go
+++ b/internal/providers/azure/objectstore_model.go
@@ -17,6 +17,7 @@ package azure
 import (
 	"github.com/banzaicloud/pipeline/auth"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // TableName constants
@@ -36,10 +37,10 @@ type ObjectStoreBucketModel struct {
 	StorageAccount string `gorm:"unique_index:idx_bucket_name"`
 	Location       string
 
-	SecretRef       string
+	SecretRef       pkgSecret.SecretID
 	Status          string
 	StatusMsg       string `sql:"type:text;"`
-	AccessSecretRef string
+	AccessSecretRef pkgSecret.SecretID
 }
 
 // TableName changes the default table name.

--- a/internal/providers/azure/objectstore_model.go
+++ b/internal/providers/azure/objectstore_model.go
@@ -14,7 +14,10 @@
 
 package azure
 
-import "github.com/banzaicloud/pipeline/auth"
+import (
+	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // TableName constants
 const (
@@ -25,8 +28,8 @@ const (
 type ObjectStoreBucketModel struct {
 	ID uint `gorm:"primary_key"`
 
-	Organization   auth.Organization `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint              `gorm:"index;not null"`
+	Organization   auth.Organization      `gorm:"foreignkey:OrganizationID"`
+	OrganizationID pkgAuth.OrganizationID `gorm:"index;not null"`
 
 	Name           string `gorm:"unique_index:idx_bucket_name"`
 	ResourceGroup  string `gorm:"unique_index:idx_bucket_name"`

--- a/internal/providers/google/gke_cluster_model.go
+++ b/internal/providers/google/gke_cluster_model.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/jinzhu/gorm"
 )
 
@@ -106,7 +107,7 @@ func (m GKEClusterModel) String() string {
 type GKENodePoolModel struct {
 	ID        uint `gorm:"primary_key"`
 	CreatedAt time.Time
-	CreatedBy uint
+	CreatedBy pkgAuth.UserID
 
 	ClusterID uint `gorm:"unique_index:idx_cluster_id_name"`
 

--- a/internal/providers/google/gke_cluster_model.go
+++ b/internal/providers/google/gke_cluster_model.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/jinzhu/gorm"
 )
 
@@ -34,7 +35,7 @@ const (
 type GKEClusterModel struct {
 	ID        uint                 `gorm:"primary_key"`
 	Cluster   cluster.ClusterModel `gorm:"foreignkey:ClusterID"`
-	ClusterID uint
+	ClusterID pkgCluster.ClusterID
 
 	MasterVersion string
 	NodeVersion   string

--- a/internal/providers/google/objectstore.go
+++ b/internal/providers/google/objectstore.go
@@ -119,10 +119,8 @@ func getProviderObjectStore(secret *secret.SecretItemResponse, location string) 
 }
 
 func (s *ObjectStore) getLogger() logrus.FieldLogger {
-	var sId string
-	if s.secret == nil {
-		sId = ""
-	} else {
+	var sId pkgSecret.SecretID
+	if s.secret != nil {
 		sId = s.secret.ID
 	}
 

--- a/internal/providers/google/objectstore_model.go
+++ b/internal/providers/google/objectstore_model.go
@@ -17,6 +17,7 @@ package google
 import (
 	"github.com/banzaicloud/pipeline/auth"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // TableName constants
@@ -34,7 +35,7 @@ type ObjectStoreBucketModel struct {
 	Name     string `gorm:"unique_index:idx_bucket_name"`
 	Location string
 
-	SecretRef string
+	SecretRef pkgSecret.SecretID
 	Status    string
 	StatusMsg string `sql:"type:text;"`
 }

--- a/internal/providers/google/objectstore_model.go
+++ b/internal/providers/google/objectstore_model.go
@@ -14,7 +14,10 @@
 
 package google
 
-import "github.com/banzaicloud/pipeline/auth"
+import (
+	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+)
 
 // TableName constants
 const (
@@ -25,8 +28,8 @@ const (
 type ObjectStoreBucketModel struct {
 	ID uint `gorm:"primary_key"`
 
-	Organization   auth.Organization `gorm:"foreignkey:OrganizationID"`
-	OrganizationID uint              `gorm:"index;not null"`
+	Organization   auth.Organization      `gorm:"foreignkey:OrganizationID"`
+	OrganizationID pkgAuth.OrganizationID `gorm:"index;not null"`
 
 	Name     string `gorm:"unique_index:idx_bucket_name"`
 	Location string

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -112,10 +112,8 @@ func getProviderObjectStore(secret *secret.SecretItemResponse, location string) 
 
 // getLogger initializes and gives back a logger instance with some basic fields
 func (o *ObjectStore) getLogger() logrus.FieldLogger {
-	var sId string
-	if o.secret == nil {
-		sId = ""
-	} else {
+	var sId pkgSecret.SecretID
+	if o.secret != nil {
 		sId = o.secret.ID
 	}
 

--- a/internal/providers/oracle/objectstore_model.go
+++ b/internal/providers/oracle/objectstore_model.go
@@ -17,6 +17,7 @@ package oracle
 import (
 	"github.com/banzaicloud/pipeline/auth"
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 // TableName constants
@@ -35,7 +36,7 @@ type ObjectStoreBucketModel struct {
 	Name          string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 	Location      string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 
-	SecretRef string
+	SecretRef pkgSecret.SecretID
 	Status    string
 	StatusMsg string `sql:"type:text;"`
 }

--- a/internal/providers/oracle/objectstore_model.go
+++ b/internal/providers/oracle/objectstore_model.go
@@ -16,6 +16,7 @@ package oracle
 
 import (
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 // TableName constants
@@ -27,8 +28,8 @@ const (
 type ObjectStoreBucketModel struct {
 	ID uint `gorm:"primary_key"`
 
-	Organization auth.Organization `gorm:"foreignkey:OrgID"`
-	OrgID        uint              `gorm:"index;not null"`
+	Organization auth.Organization      `gorm:"foreignkey:OrgID"`
+	OrgID        pkgAuth.OrganizationID `gorm:"index;not null"`
 
 	CompartmentID string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 	Name          string `gorm:"unique_index:idx_bucket_name_location_compartment"`

--- a/internal/providers/pke/ec2_cluster_model.go
+++ b/internal/providers/pke/ec2_cluster_model.go
@@ -16,6 +16,7 @@ package pke
 
 import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
 )
@@ -23,7 +24,7 @@ import (
 type EC2PKEClusterModel struct {
 	ID                 uint                 `gorm:"primary_key"`
 	Cluster            cluster.ClusterModel `gorm:"foreignkey:ClusterID"`
-	ClusterID          uint
+	ClusterID          pkgCluster.ClusterID
 	MasterInstanceType string
 	MasterImage        string
 

--- a/internal/providers/pke/model.go
+++ b/internal/providers/pke/model.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
@@ -27,7 +28,7 @@ import (
 type Model struct {
 	ID        uint `gorm:"primary_key"`
 	CreatedAt time.Time
-	CreatedBy uint
+	CreatedBy pkgAuth.UserID
 
 	ClusterID uint `gorm:"foreignkey:ClusterID"`
 }

--- a/internal/providers/pke/nodepool.go
+++ b/internal/providers/pke/nodepool.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 )
 
 type NodePools []NodePool
@@ -27,7 +29,7 @@ type NodePools []NodePool
 type NodePool struct {
 	NodePoolID uint `gorm:"primary_key;name:id"`
 	CreatedAt  time.Time
-	CreatedBy  uint
+	CreatedBy  pkgAuth.UserID
 
 	ClusterID uint `gorm:"foreignkey:ClusterIDl;association_foreignkey:ClusterID;unique_index:idx_cluster_id_name"`
 
@@ -124,7 +126,7 @@ type Hosts []Host
 type Host struct {
 	ID        uint `gorm:"primary_key"`
 	CreatedAt time.Time
-	CreatedBy uint
+	CreatedBy pkgAuth.UserID
 
 	NodePoolID uint `gorm:"name:nodepool_id;foreignkey:NodePoolID"`
 

--- a/internal/providers/pke/nodepool.go
+++ b/internal/providers/pke/nodepool.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 type NodePools []NodePool
@@ -31,7 +32,7 @@ type NodePool struct {
 	CreatedAt  time.Time
 	CreatedBy  pkgAuth.UserID
 
-	ClusterID uint `gorm:"foreignkey:ClusterIDl;association_foreignkey:ClusterID;unique_index:idx_cluster_id_name"`
+	ClusterID pkgCluster.ClusterID `gorm:"foreignkey:ClusterIDl;association_foreignkey:ClusterID;unique_index:idx_cluster_id_name"`
 
 	Name           string           `yaml:"name" gorm:"unique_index:idx_cluster_id_name"`
 	Roles          Roles            `yaml:"roles" gorm:"type:varchar(255)"`

--- a/internal/security/anchore.go
+++ b/internal/security/anchore.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"path"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/goph/emperror"
@@ -75,7 +76,7 @@ type anchoreUserPostBody struct {
 
 // AnchoreRequest anchore API request
 type AnchoreRequest struct {
-	OrgID     uint
+	OrgID     pkgAuth.OrganizationID
 	ClusterID string
 	Method    string
 	URL       string
@@ -202,7 +203,7 @@ func anchoreUserEndPoint(username string) string {
 }
 
 //SetupAnchoreUser sets up a new user in Anchore Postgres DB & creates / updates a secret containng user name /password.
-func SetupAnchoreUser(orgId uint, clusterId string) (*User, error) {
+func SetupAnchoreUser(orgId pkgAuth.OrganizationID, clusterId string) (*User, error) {
 	anchoreUserName := fmt.Sprintf("%v-anchore-user", clusterId)
 	var user User
 	if checkAnchoreUser(anchoreUserName, http.MethodGet) != http.StatusOK {
@@ -261,7 +262,7 @@ func SetupAnchoreUser(orgId uint, clusterId string) (*User, error) {
 	return &user, nil
 }
 
-func RemoveAnchoreUser(orgId uint, clusterId string) {
+func RemoveAnchoreUser(orgId pkgAuth.OrganizationID, clusterId string) {
 
 	anchorUserName := fmt.Sprintf("%v-anchore-user", clusterId)
 

--- a/issue/github.go
+++ b/issue/github.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/banzaicloud/pipeline/auth"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/google/go-github/github"
 	"github.com/goph/emperror"
 	"github.com/spf13/viper"
@@ -47,7 +48,7 @@ const issueTemplate = `
 %s`
 
 // CreateIssue creates an issue on GitHub
-func (gi GitHubIssuer) CreateIssue(userID uint, organization, title, text string, userLabels []string) error {
+func (gi GitHubIssuer) CreateIssue(userID pkgAuth.UserID, organization, title, text string, userLabels []string) error {
 
 	githubClient := auth.NewGithubClient(viper.GetString("github.token"))
 

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -16,6 +16,7 @@ package issue
 import (
 	"github.com/pkg/errors"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/spf13/viper"
 )
 
@@ -26,7 +27,7 @@ type VersionInformation struct {
 }
 
 type Issuer interface {
-	CreateIssue(userID uint, organization, title, body string, userLabels []string) error
+	CreateIssue(userID pkgAuth.UserID, organization, title, body string, userLabels []string) error
 }
 
 func NewIssuer(version VersionInformation) (Issuer, error) {

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -53,8 +53,8 @@ const (
 //ClusterModel describes the common cluster model
 // Note: this model is being moved to github.com/banzaicloud/pipeline/pkg/model.ClusterModel
 type ClusterModel struct {
-	ID             uint   `gorm:"primary_key"`
-	UID            string `gorm:"unique_index:idx_uid"`
+	ID             pkgCluster.ClusterID `gorm:"primary_key"`
+	UID            string               `gorm:"unique_index:idx_uid"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      *time.Time `gorm:"unique_index:idx_unique_id" sql:"index"`
@@ -117,7 +117,7 @@ type ACSKNodePoolModel struct {
 
 // ACSKClusterModel describes the Alibaba Cloud CS cluster model
 type ACSKClusterModel struct {
-	ID                       uint `gorm:"primary_key"`
+	ID                       pkgCluster.ClusterID `gorm:"primary_key"`
 	ProviderClusterID        string
 	RegionID                 string
 	ZoneID                   string
@@ -231,8 +231,8 @@ type EKSSubnetModel struct {
 
 //EKSClusterModel describes the EKS cluster model
 type EKSClusterModel struct {
-	ID        uint `gorm:"primary_key"`
-	ClusterID uint `gorm:"unique_index:ux_cluster_id"`
+	ID        uint                 `gorm:"primary_key"`
+	ClusterID pkgCluster.ClusterID `gorm:"unique_index:ux_cluster_id"`
 
 	Version      string
 	NodePools    []*AmazonNodePoolsModel `gorm:"foreignkey:ClusterID"`
@@ -244,7 +244,7 @@ type EKSClusterModel struct {
 
 //AKSClusterModel describes the aks cluster model
 type AKSClusterModel struct {
-	ID                uint `gorm:"primary_key"`
+	ID                pkgCluster.ClusterID `gorm:"primary_key"`
 	ResourceGroup     string
 	KubernetesVersion string
 	NodePools         []*AKSNodePoolModel `gorm:"foreignkey:ClusterID"`
@@ -267,16 +267,16 @@ type AKSNodePoolModel struct {
 
 // DummyClusterModel describes the dummy cluster model
 type DummyClusterModel struct {
-	ID                uint `gorm:"primary_key"`
+	ID                pkgCluster.ClusterID `gorm:"primary_key"`
 	KubernetesVersion string
 	NodeCount         int
 }
 
 //KubernetesClusterModel describes the build your own cluster model
 type KubernetesClusterModel struct {
-	ID          uint              `gorm:"primary_key"`
-	Metadata    map[string]string `gorm:"-"`
-	MetadataRaw []byte            `gorm:"meta_data"`
+	ID          pkgCluster.ClusterID `gorm:"primary_key"`
+	Metadata    map[string]string    `gorm:"-"`
+	MetadataRaw []byte               `gorm:"meta_data"`
 }
 
 func (cs *ClusterModel) BeforeCreate() (err error) {

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -24,6 +24,7 @@ import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	modelOracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/utils"
 	"github.com/gofrs/uuid"
 	"github.com/goph/emperror"
@@ -62,9 +63,9 @@ type ClusterModel struct {
 	Cloud          string
 	Distribution   string
 	OrganizationId pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
-	SecretId       string
-	ConfigSecretId string
-	SshSecretId    string
+	SecretId       pkgSecret.SecretID
+	ConfigSecretId pkgSecret.SecretID
+	SshSecretId    pkgSecret.SecretID
 	Status         string
 	RbacEnabled    bool
 	Monitoring     bool
@@ -500,13 +501,13 @@ func (cs *ClusterModel) UpdateStatus(status, statusMessage string) error {
 }
 
 // UpdateConfigSecret updates the model's config secret id in database
-func (cs *ClusterModel) UpdateConfigSecret(configSecretId string) error {
+func (cs *ClusterModel) UpdateConfigSecret(configSecretId pkgSecret.SecretID) error {
 	cs.ConfigSecretId = configSecretId
 	return cs.Save()
 }
 
 // UpdateSshSecret updates the model's ssh secret id in database
-func (cs *ClusterModel) UpdateSshSecret(sshSecretId string) error {
+func (cs *ClusterModel) UpdateSshSecret(sshSecretId pkgSecret.SecretID) error {
 	cs.SshSecretId = sshSecretId
 	return cs.Save()
 }

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -61,7 +61,7 @@ type ClusterModel struct {
 	Name           string     `gorm:"unique_index:idx_unique_id"`
 	Location       string
 	Cloud          string
-	Distribution   string
+	Distribution   pkgCluster.DistributionID
 	OrganizationId pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
 	SecretId       pkgSecret.SecretID
 	ConfigSecretId pkgSecret.SecretID

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/config"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	modelOracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
 	"github.com/banzaicloud/pipeline/utils"
@@ -60,7 +61,7 @@ type ClusterModel struct {
 	Location       string
 	Cloud          string
 	Distribution   string
-	OrganizationId uint `gorm:"unique_index:idx_unique_id"`
+	OrganizationId pkgAuth.OrganizationID `gorm:"unique_index:idx_unique_id"`
 	SecretId       string
 	ConfigSecretId string
 	SshSecretId    string

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -79,7 +79,7 @@ type ClusterModel struct {
 	Dummy          DummyClusterModel      `gorm:"foreignkey:ID"`
 	Kubernetes     KubernetesClusterModel `gorm:"foreignkey:ID"`
 	OKE            modelOracle.Cluster
-	CreatedBy      uint
+	CreatedBy      pkgAuth.UserID
 }
 
 // ScaleOptions describes scale options
@@ -99,7 +99,7 @@ type ScaleOptions struct {
 type ACSKNodePoolModel struct {
 	ID                           uint `gorm:"primary_key"`
 	CreatedAt                    time.Time
-	CreatedBy                    uint
+	CreatedBy                    pkgAuth.UserID
 	ClusterID                    uint   `gorm:"unique_index:idx_cluster_id_name"`
 	Name                         string `gorm:"unique_index:idx_cluster_id_name"`
 	InstanceType                 string
@@ -134,7 +134,7 @@ type ACSKClusterModel struct {
 type AmazonNodePoolsModel struct {
 	ID               uint `gorm:"primary_key"`
 	CreatedAt        time.Time
-	CreatedBy        uint
+	CreatedBy        pkgAuth.UserID
 	ClusterID        uint   `gorm:"unique_index:idx_cluster_id_name"`
 	Name             string `gorm:"unique_index:idx_cluster_id_name"`
 	NodeSpotPrice    string
@@ -253,7 +253,7 @@ type AKSClusterModel struct {
 type AKSNodePoolModel struct {
 	ID               uint `gorm:"primary_key"`
 	CreatedAt        time.Time
-	CreatedBy        uint
+	CreatedBy        pkgAuth.UserID
 	ClusterID        uint   `gorm:"unique_index:idx_cluster_id_name"`
 	Name             string `gorm:"unique_index:idx_cluster_id_name"`
 	Autoscaling      bool

--- a/model/cluster_status_history_model.go
+++ b/model/cluster_status_history_model.go
@@ -17,6 +17,8 @@ package model
 
 import (
 	"time"
+
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 const (
@@ -28,9 +30,9 @@ const (
 type StatusHistoryModel struct {
 	ID uint `gorm:"primary_key"`
 
-	ClusterID   uint      `gorm:"not null"`
-	ClusterName string    `gorm:"not null"`
-	CreatedAt   time.Time `gorm:"not null"`
+	ClusterID   pkgCluster.ClusterID `gorm:"not null"`
+	ClusterName string               `gorm:"not null"`
+	CreatedAt   time.Time            `gorm:"not null"`
 
 	FromStatus        string `gorm:"not null"`
 	FromStatusMessage string `sql:"type:text;" gorm:"not null"`

--- a/model/defaults/aks.go
+++ b/model/defaults/aks.go
@@ -98,7 +98,7 @@ func (d *AKSProfile) GetCloud() string {
 }
 
 // GetDistribution returns profile's distribution type
-func (d *AKSProfile) GetDistribution() string {
+func (d *AKSProfile) GetDistribution() pkgCluster.DistributionID {
 	return pkgCluster.AKS
 }
 

--- a/model/defaults/base.go
+++ b/model/defaults/base.go
@@ -70,7 +70,7 @@ type ClusterProfile interface {
 	IsDefinedBefore() bool
 	SaveInstance() error
 	GetCloud() string
-	GetDistribution() string
+	GetDistribution() pkgCluster.DistributionID
 	GetProfile() *pkgCluster.ClusterProfileResponse
 	UpdateProfile(*pkgCluster.ClusterProfileRequest, bool) error
 	DeleteProfile() error
@@ -126,7 +126,7 @@ func GetDefaultProfiles() []ClusterProfile {
 }
 
 // GetAllProfiles loads all saved cluster profile from database by given cloud type
-func GetAllProfiles(distribution string) ([]ClusterProfile, error) {
+func GetAllProfiles(distribution pkgCluster.DistributionID) ([]ClusterProfile, error) {
 
 	var defaults []ClusterProfile
 	db := config.DB()
@@ -169,7 +169,7 @@ func GetAllProfiles(distribution string) ([]ClusterProfile, error) {
 }
 
 // GetProfile finds cluster profile from database by given name and cloud type
-func GetProfile(distribution string, name string) (ClusterProfile, error) {
+func GetProfile(distribution pkgCluster.DistributionID, name string) (ClusterProfile, error) {
 	db := config.DB()
 
 	switch distribution {

--- a/model/defaults/eks.go
+++ b/model/defaults/eks.go
@@ -76,7 +76,7 @@ func (d *EKSProfile) GetCloud() string {
 }
 
 // GetDistribution returns profile's distribution type
-func (d *EKSProfile) GetDistribution() string {
+func (d *EKSProfile) GetDistribution() pkgCluster.DistributionID {
 	return pkgCluster.EKS
 }
 

--- a/model/defaults/gke.go
+++ b/model/defaults/gke.go
@@ -99,7 +99,7 @@ func (d *GKEProfile) GetCloud() string {
 }
 
 // GetDistribution returns profile's distribution type
-func (d *GKEProfile) GetDistribution() string {
+func (d *GKEProfile) GetDistribution() pkgCluster.DistributionID {
 	return pkgCluster.GKE
 }
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Banzai Cloud
+// Copyright © 2019 Banzai Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package auth
 
-import (
-	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
-	"github.com/banzaicloud/pipeline/secret"
-)
-
-type AKSCluster interface {
-	Cluster
-	GetResourceGroupName() string
-}
-
-// Cluster interface for cluster implementations
-type Cluster interface {
-	GetID() uint
-	GetName() string
-	GetOrganizationId() pkgAuth.OrganizationID
-	GetCloud() string
-	GetDistribution() string
-	GetK8sConfig() ([]byte, error)
-	GetSecretWithValidation() (*secret.SecretItemResponse, error)
-	GetLocation() string
-	RbacEnabled() bool
-}
+// OrganizationID represents the identifier of an organization
+type OrganizationID uint

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -16,3 +16,6 @@ package auth
 
 // OrganizationID represents the identifier of an organization
 type OrganizationID uint
+
+// UserID represents the identifier of a user
+type UserID uint

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -59,15 +59,18 @@ const (
 	Oracle     = "oracle"
 )
 
+// DistributionID represents the identifier of a distribution
+type DistributionID string
+
 // Distribution constants
 const (
-	ACSK    = "acsk"
-	EKS     = "eks"
-	AKS     = "aks"
-	GKE     = "gke"
-	OKE     = "oke"
-	PKE     = "pke"
-	Unknown = "unknown"
+	ACSK    DistributionID = "acsk"
+	EKS     DistributionID = "eks"
+	AKS     DistributionID = "aks"
+	GKE     DistributionID = "gke"
+	OKE     DistributionID = "oke"
+	PKE     DistributionID = "pke"
+	Unknown DistributionID = "unknown"
 )
 
 // constants for posthooks
@@ -186,7 +189,7 @@ type GetClusterStatusResponse struct {
 	Name          string                     `json:"name"`
 	Location      string                     `json:"location"`
 	Cloud         string                     `json:"cloud"`
-	Distribution  string                     `json:"distribution"`
+	Distribution  DistributionID             `json:"distribution"`
 	Spot          bool                       `json:"spot,omitempty"`
 	Logging       bool                       `json:"logging"`
 	Monitoring    bool                       `json:"monitoring"`
@@ -231,7 +234,7 @@ type GetNodePoolsResponse struct {
 	ClusterDesiredResources map[string]float64               `json:"clusterDesiredResources,omitempty"`
 	ClusterStatus           string                           `json:"status,omitempty"`
 	Cloud                   string                           `json:"cloud"`
-	Distribution            string                           `json:"distribution"`
+	Distribution            DistributionID                   `json:"distribution"`
 	Location                string                           `json:"location"`
 }
 

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -111,6 +111,9 @@ const (
 	KeyWordImage             = "image"
 )
 
+// ClusterID represents the identifier of a cluster
+type ClusterID uint
+
 // CreateClusterRequest describes a create cluster request
 type CreateClusterRequest struct {
 	Name         string                   `json:"name" yaml:"name" binding:"required"`
@@ -196,7 +199,7 @@ type GetClusterStatusResponse struct {
 	ServiceMesh   bool                       `json:"servicemesh"`
 	SecurityScan  bool                       `json:"securityscan"`
 	Version       string                     `json:"version,omitempty"`
-	ResourceID    uint                       `json:"id"`
+	ResourceID    ClusterID                  `json:"id"`
 	NodePools     map[string]*NodePoolStatus `json:"nodePools"`
 	pkgCommon.CreatorBaseFields
 
@@ -556,8 +559,8 @@ type SupportedClusterItem struct {
 
 // CreateClusterResponse describes Pipeline's CreateCluster API response
 type CreateClusterResponse struct {
-	Name       string `json:"name"`
-	ResourceID uint   `json:"id"`
+	Name       string    `json:"name"`
+	ResourceID ClusterID `json:"id"`
 }
 
 // PodDetailsResponse describes a pod

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster/acsk"
 	"github.com/banzaicloud/pipeline/pkg/cluster/aks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/dummy"
@@ -495,9 +496,9 @@ type ClusterProfileProperties struct {
 
 // CloudInfoRequest describes Cloud info requests
 type CloudInfoRequest struct {
-	OrganizationId uint             `json:"-"`
-	SecretId       string           `json:"secretId,omitempty"`
-	Filter         *CloudInfoFilter `json:"filter,omitempty"`
+	OrganizationId pkgAuth.OrganizationID `json:"-"`
+	SecretId       string                 `json:"secretId,omitempty"`
+	Filter         *CloudInfoFilter       `json:"filter,omitempty"`
 }
 
 // CloudInfoFilter describes a filter in cloud info

--- a/pkg/cluster/eks/action/actions.go
+++ b/pkg/cluster/eks/action/actions.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/banzaicloud/pipeline/model"
 	"github.com/banzaicloud/pipeline/pkg/amazon"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgEks "github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/pkg/common"
@@ -407,12 +408,12 @@ var _ utils.RevocableAction = (*GenerateVPCConfigRequestAction)(nil)
 type GenerateVPCConfigRequestAction struct {
 	context        *EksClusterCreateUpdateContext
 	stackName      string
-	organizationID uint
+	organizationID pkgAuth.OrganizationID
 	log            logrus.FieldLogger
 }
 
 // NewGenerateVPCConfigRequestAction creates a new GenerateVPCConfigRequestAction
-func NewGenerateVPCConfigRequestAction(log logrus.FieldLogger, creationContext *EksClusterCreateUpdateContext, stackName string, orgID uint) *GenerateVPCConfigRequestAction {
+func NewGenerateVPCConfigRequestAction(log logrus.FieldLogger, creationContext *EksClusterCreateUpdateContext, stackName string, orgID pkgAuth.OrganizationID) *GenerateVPCConfigRequestAction {
 	return &GenerateVPCConfigRequestAction{
 		context:        creationContext,
 		stackName:      stackName,
@@ -1054,12 +1055,12 @@ var _ utils.RevocableAction = (*PersistClusterUserAccessKeyAction)(nil)
 // PersistClusterUserAccessKeyAction describes the cluster user access key to be persisted
 type PersistClusterUserAccessKeyAction struct {
 	context        *EksClusterCreateUpdateContext
-	organizationID uint
+	organizationID pkgAuth.OrganizationID
 	log            logrus.FieldLogger
 }
 
 // NewPersistClusterUserAccessKeyAction creates a new PersistClusterUserAccessKeyAction
-func NewPersistClusterUserAccessKeyAction(log logrus.FieldLogger, context *EksClusterCreateUpdateContext, orgID uint) *PersistClusterUserAccessKeyAction {
+func NewPersistClusterUserAccessKeyAction(log logrus.FieldLogger, context *EksClusterCreateUpdateContext, orgID pkgAuth.OrganizationID) *PersistClusterUserAccessKeyAction {
 	return &PersistClusterUserAccessKeyAction{
 		context:        context,
 		organizationID: orgID,
@@ -1079,7 +1080,7 @@ func getSecretName(userName string) string {
 
 // GetClusterUserAccessKeyIdAndSecretVault returns the AWS access key and access key secret from Vault
 // for cluster user name
-func GetClusterUserAccessKeyIdAndSecretVault(organizationID uint, userName string) (string, string, error) {
+func GetClusterUserAccessKeyIdAndSecretVault(organizationID pkgAuth.OrganizationID, userName string) (string, string, error) {
 	secretName := getSecretName(userName)
 	secretItem, err := secret.Store.GetByName(organizationID, secretName)
 	if err != nil {
@@ -1347,12 +1348,12 @@ var _ utils.Action = (*DeleteClusterUserAccessKeySecretAction)(nil)
 // DeleteClusterUserAccessKeySecretAction deletes cluster user access key from Vault
 type DeleteClusterUserAccessKeySecretAction struct {
 	context        *EksClusterDeletionContext
-	organizationID uint
+	organizationID pkgAuth.OrganizationID
 	log            logrus.FieldLogger
 }
 
 // NewDeleteClusterUserAccessKeySecretAction creates a new DeleteClusterUserAccessKeySecretAction
-func NewDeleteClusterUserAccessKeySecretAction(log logrus.FieldLogger, context *EksClusterDeletionContext, orgID uint) *DeleteClusterUserAccessKeySecretAction {
+func NewDeleteClusterUserAccessKeySecretAction(log logrus.FieldLogger, context *EksClusterDeletionContext, orgID pkgAuth.OrganizationID) *DeleteClusterUserAccessKeySecretAction {
 	return &DeleteClusterUserAccessKeySecretAction{
 		context:        context,
 		organizationID: orgID,

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
@@ -41,9 +42,9 @@ type ErrorResponse struct {
 
 // CreatorBaseFields describes all field which contains info about who created the cluster/application etc
 type CreatorBaseFields struct {
-	CreatedAt   time.Time `json:"createdAt,omitempty"`
-	CreatorName string    `json:"creatorName,omitempty"`
-	CreatorId   uint      `json:"creatorId,omitempty"`
+	CreatedAt   time.Time      `json:"createdAt,omitempty"`
+	CreatorName string         `json:"creatorName,omitempty"`
+	CreatorId   pkgAuth.UserID `json:"creatorId,omitempty"`
 }
 
 // NodeNames describes node names

--- a/pkg/providers/oracle/model/cluster.go
+++ b/pkg/providers/oracle/model/cluster.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/config"
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -43,7 +44,7 @@ type Cluster struct {
 	OCID           string `gorm:"column:ocid"`
 	ClusterModelID uint
 	NodePools      []*NodePool
-	CreatedBy      uint
+	CreatedBy      pkgAuth.UserID
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	Delete         bool   `gorm:"-"`
@@ -62,7 +63,7 @@ type NodePool struct {
 	ClusterID         uint   `gorm:"unique_index:idx_cluster_id_name"`
 	Subnets           []*NodePoolSubnet
 	Labels            []*NodePoolLabel
-	CreatedBy         uint
+	CreatedBy         pkgAuth.UserID
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 	Delete            bool `gorm:"-"`
@@ -109,7 +110,7 @@ func (NodePoolLabel) TableName() string {
 }
 
 // CreateModelFromCreateRequest create model from create request
-func CreateModelFromCreateRequest(r *pkgCluster.CreateClusterRequest, userId uint) (cluster Cluster, err error) {
+func CreateModelFromCreateRequest(r *pkgCluster.CreateClusterRequest, userId pkgAuth.UserID) (cluster Cluster, err error) {
 
 	cluster.Name = r.Name
 
@@ -117,13 +118,12 @@ func CreateModelFromCreateRequest(r *pkgCluster.CreateClusterRequest, userId uin
 }
 
 // CreateModelFromUpdateRequest create model from update request
-func CreateModelFromUpdateRequest(current Cluster, r *pkgCluster.UpdateClusterRequest, userId uint) (cluster Cluster, err error) {
-
+func CreateModelFromUpdateRequest(current Cluster, r *pkgCluster.UpdateClusterRequest, userId pkgAuth.UserID) (cluster Cluster, err error) {
 	return CreateModelFromRequest(current, r.UpdateProperties.OKE, userId)
 }
 
 // CreateModelFromRequest creates model from request
-func CreateModelFromRequest(model Cluster, r *cluster.Cluster, userID uint) (cluster Cluster, err error) {
+func CreateModelFromRequest(model Cluster, r *cluster.Cluster, userID pkgAuth.UserID) (cluster Cluster, err error) {
 
 	model.Version = r.Version
 	model.CreatedBy = userID

--- a/pkg/providers/oracle/model/cluster.go
+++ b/pkg/providers/oracle/model/cluster.go
@@ -42,7 +42,7 @@ type Cluster struct {
 	LBSubnetID1    string
 	LBSubnetID2    string
 	OCID           string `gorm:"column:ocid"`
-	ClusterModelID uint
+	ClusterModelID pkgCluster.ClusterID
 	NodePools      []*NodePool
 	CreatedBy      pkgAuth.UserID
 	CreatedAt      time.Time

--- a/pkg/providers/oracle/model/profile.go
+++ b/pkg/providers/oracle/model/profile.go
@@ -113,7 +113,7 @@ func (d *Profile) GetCloud() string {
 }
 
 // GetDistribution returns profile's distribution type
-func (d *Profile) GetDistribution() string {
+func (d *Profile) GetDistribution() pkgCluster.DistributionID {
 	return pkgCluster.OKE
 }
 

--- a/pkg/providers/secret.go
+++ b/pkg/providers/secret.go
@@ -15,12 +15,13 @@
 package providers
 
 import (
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/pkg/errors"
 )
 
 type secretStore interface {
-	Get(organizationID uint, secretID string) (*secret.SecretItemResponse, error)
+	Get(organizationID pkgAuth.OrganizationID, secretID string) (*secret.SecretItemResponse, error)
 }
 
 type secretValidator struct {
@@ -33,7 +34,7 @@ func NewSecretValidator(secrets secretStore) *secretValidator {
 }
 
 // ValidateSecretType validates that a secret belongs to a cloud provider.
-func (v *secretValidator) ValidateSecretType(organizationID uint, secretID string, provider string) error {
+func (v *secretValidator) ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID string, provider string) error {
 	s, err := v.secrets.Get(organizationID, secretID)
 	if err == secret.ErrSecretNotExists {
 		return errors.Wrap(err, "error during secret validation")

--- a/pkg/providers/secret.go
+++ b/pkg/providers/secret.go
@@ -16,12 +16,13 @@ package providers
 
 import (
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/pkg/errors"
 )
 
 type secretStore interface {
-	Get(organizationID pkgAuth.OrganizationID, secretID string) (*secret.SecretItemResponse, error)
+	Get(organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID) (*secret.SecretItemResponse, error)
 }
 
 type secretValidator struct {
@@ -34,7 +35,7 @@ func NewSecretValidator(secrets secretStore) *secretValidator {
 }
 
 // ValidateSecretType validates that a secret belongs to a cloud provider.
-func (v *secretValidator) ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID string, provider string) error {
+func (v *secretValidator) ValidateSecretType(organizationID pkgAuth.OrganizationID, secretID pkgSecret.SecretID, provider string) error {
 	s, err := v.secrets.Get(organizationID, secretID)
 	if err == secret.ErrSecretNotExists {
 		return errors.Wrap(err, "error during secret validation")

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -18,6 +18,9 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
+// SecretID represents the identifier of a secret
+type SecretID string
+
 // FieldMeta describes how a secret field should be validated
 type FieldMeta struct {
 	Name        string `json:"name"`
@@ -296,10 +299,10 @@ var DefaultRules = map[string]Meta{
 
 // ListSecretsQuery represent a secret listing filter
 type ListSecretsQuery struct {
-	Type   string   `form:"type" json:"type"`
-	IDs    []string `form:"ids" json:"ids"`
-	Tags   []string `form:"tags" json:"tags"`
-	Values bool     `form:"values" json:"values"`
+	Type   string     `form:"type" json:"type"`
+	IDs    []SecretID `form:"ids" json:"ids"`
+	Tags   []string   `form:"tags" json:"tags"`
+	Values bool       `form:"values" json:"values"`
 }
 
 // InstallSecretsToClusterRequest describes an InstallSecretToCluster request
@@ -322,4 +325,12 @@ const (
 type K8SSourceMeta struct {
 	Name     string         `json:"name"`
 	Sourcing SourcingMethod `json:"sourcing"`
+}
+
+func StringsToSecretIDs(secretIDs []string) []SecretID {
+	res := make([]SecretID, len(secretIDs))
+	for i, id := range secretIDs {
+		res[i] = SecretID(id)
+	}
+	return res
 }

--- a/secret/restricted_store.go
+++ b/secret/restricted_store.go
@@ -44,7 +44,7 @@ func (s *restrictedSecretStore) List(orgid pkgAuth.OrganizationID, query *secret
 	return newResponseItems, nil
 }
 
-func (s *restrictedSecretStore) Update(organizationID pkgAuth.OrganizationID, secretID string, value *CreateSecretRequest) error {
+func (s *restrictedSecretStore) Update(organizationID pkgAuth.OrganizationID, secretID secretTypes.SecretID, value *CreateSecretRequest) error {
 	if err := s.checkBlockingTags(organizationID, secretID); err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (s *restrictedSecretStore) Update(organizationID pkgAuth.OrganizationID, se
 	return s.secretStore.Update(organizationID, secretID, value)
 }
 
-func (s *restrictedSecretStore) Delete(organizationID pkgAuth.OrganizationID, secretID string) error {
+func (s *restrictedSecretStore) Delete(organizationID pkgAuth.OrganizationID, secretID secretTypes.SecretID) error {
 	if err := s.checkBlockingTags(organizationID, secretID); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (s *restrictedSecretStore) Delete(organizationID pkgAuth.OrganizationID, se
 	return s.secretStore.Delete(organizationID, secretID)
 }
 
-func (s *restrictedSecretStore) checkBlockingTags(organizationID pkgAuth.OrganizationID, secretID string) error {
+func (s *restrictedSecretStore) checkBlockingTags(organizationID pkgAuth.OrganizationID, secretID secretTypes.SecretID) error {
 
 	secretItem, err := s.secretStore.Get(organizationID, secretID)
 	if err != nil {
@@ -80,7 +80,7 @@ func (s *restrictedSecretStore) checkBlockingTags(organizationID pkgAuth.Organiz
 	return nil
 }
 
-func (s *restrictedSecretStore) checkForbiddenTags(organizationID pkgAuth.OrganizationID, secretID string) error {
+func (s *restrictedSecretStore) checkForbiddenTags(organizationID pkgAuth.OrganizationID, secretID secretTypes.SecretID) error {
 	secretItem, err := s.secretStore.Get(organizationID, secretID)
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (s *restrictedSecretStore) isSecretReadOnly(secretItem *SecretItemResponse)
 
 // ReadOnlyError describes a secret error where it contains read only tag
 type ReadOnlyError struct {
-	SecretID string
+	SecretID secretTypes.SecretID
 }
 
 func (roe ReadOnlyError) Error() string {

--- a/secret/restricted_store.go
+++ b/secret/restricted_store.go
@@ -17,6 +17,7 @@ package secret
 import (
 	"fmt"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
@@ -26,7 +27,7 @@ type restrictedSecretStore struct {
 	*secretStore
 }
 
-func (s *restrictedSecretStore) List(orgid uint, query *secretTypes.ListSecretsQuery) ([]*SecretItemResponse, error) {
+func (s *restrictedSecretStore) List(orgid pkgAuth.OrganizationID, query *secretTypes.ListSecretsQuery) ([]*SecretItemResponse, error) {
 	responseItems, err := s.secretStore.List(orgid, query)
 	if err != nil {
 		return nil, err
@@ -43,7 +44,7 @@ func (s *restrictedSecretStore) List(orgid uint, query *secretTypes.ListSecretsQ
 	return newResponseItems, nil
 }
 
-func (s *restrictedSecretStore) Update(organizationID uint, secretID string, value *CreateSecretRequest) error {
+func (s *restrictedSecretStore) Update(organizationID pkgAuth.OrganizationID, secretID string, value *CreateSecretRequest) error {
 	if err := s.checkBlockingTags(organizationID, secretID); err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func (s *restrictedSecretStore) Update(organizationID uint, secretID string, val
 	return s.secretStore.Update(organizationID, secretID, value)
 }
 
-func (s *restrictedSecretStore) Delete(organizationID uint, secretID string) error {
+func (s *restrictedSecretStore) Delete(organizationID pkgAuth.OrganizationID, secretID string) error {
 	if err := s.checkBlockingTags(organizationID, secretID); err != nil {
 		return err
 	}
@@ -59,7 +60,7 @@ func (s *restrictedSecretStore) Delete(organizationID uint, secretID string) err
 	return s.secretStore.Delete(organizationID, secretID)
 }
 
-func (s *restrictedSecretStore) checkBlockingTags(organizationID uint, secretID string) error {
+func (s *restrictedSecretStore) checkBlockingTags(organizationID pkgAuth.OrganizationID, secretID string) error {
 
 	secretItem, err := s.secretStore.Get(organizationID, secretID)
 	if err != nil {
@@ -79,7 +80,7 @@ func (s *restrictedSecretStore) checkBlockingTags(organizationID uint, secretID 
 	return nil
 }
 
-func (s *restrictedSecretStore) checkForbiddenTags(organizationID uint, secretID string) error {
+func (s *restrictedSecretStore) checkForbiddenTags(organizationID pkgAuth.OrganizationID, secretID string) error {
 	secretItem, err := s.secretStore.Get(organizationID, secretID)
 	if err != nil {
 		return err

--- a/secret/ssh.go
+++ b/secret/ssh.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"golang.org/x/crypto/ssh"
 )
@@ -50,7 +51,7 @@ func NewSSHKeyPair(s *SecretItemResponse) *SSHKeyPair {
 }
 
 // StoreSSHKeyPair to store SSH Key to Bank Vaults
-func StoreSSHKeyPair(key *SSHKeyPair, organizationID pkgAuth.OrganizationID, clusterID uint, clusterName string, clusterUID string) (secretID secretTypes.SecretID, err error) {
+func StoreSSHKeyPair(key *SSHKeyPair, organizationID pkgAuth.OrganizationID, clusterID pkgCluster.ClusterID, clusterName string, clusterUID string) (secretID secretTypes.SecretID, err error) {
 	log.Info("Store SSH Key to Bank Vaults")
 	var createSecretRequest CreateSecretRequest
 	createSecretRequest.Type = secretTypes.SSHSecretType

--- a/secret/ssh.go
+++ b/secret/ssh.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	pkgAuth "github.com/banzaicloud/pipeline/pkg/auth"
 	secretTypes "github.com/banzaicloud/pipeline/pkg/secret"
 	"golang.org/x/crypto/ssh"
 )
@@ -49,7 +50,7 @@ func NewSSHKeyPair(s *SecretItemResponse) *SSHKeyPair {
 }
 
 // StoreSSHKeyPair to store SSH Key to Bank Vaults
-func StoreSSHKeyPair(key *SSHKeyPair, organizationID uint, clusterID uint, clusterName string, clusterUID string) (secretID string, err error) {
+func StoreSSHKeyPair(key *SSHKeyPair, organizationID pkgAuth.OrganizationID, clusterID uint, clusterName string, clusterUID string) (secretID string, err error) {
 	log.Info("Store SSH Key to Bank Vaults")
 	var createSecretRequest CreateSecretRequest
 	createSecretRequest.Type = secretTypes.SSHSecretType

--- a/secret/ssh.go
+++ b/secret/ssh.go
@@ -50,7 +50,7 @@ func NewSSHKeyPair(s *SecretItemResponse) *SSHKeyPair {
 }
 
 // StoreSSHKeyPair to store SSH Key to Bank Vaults
-func StoreSSHKeyPair(key *SSHKeyPair, organizationID pkgAuth.OrganizationID, clusterID uint, clusterName string, clusterUID string) (secretID string, err error) {
+func StoreSSHKeyPair(key *SSHKeyPair, organizationID pkgAuth.OrganizationID, clusterID uint, clusterName string, clusterUID string) (secretID secretTypes.SecretID, err error) {
 	log.Info("Store SSH Key to Bank Vaults")
 	var createSecretRequest CreateSecretRequest
 	createSecretRequest.Type = secretTypes.SSHSecretType

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -200,7 +200,7 @@ func (s *SpotguideManager) ScrapeSharedSpotguides() error {
 	return s.scrapeSpotguides(s.sharedLibraryOrganization, githubClient)
 }
 
-func (s *SpotguideManager) ScrapeSpotguides(orgID pkgAuth.OrganizationID, userID uint) error {
+func (s *SpotguideManager) ScrapeSpotguides(orgID pkgAuth.OrganizationID, userID pkgAuth.UserID) error {
 	githubClient, err := auth.NewGithubClientForUser(userID)
 	if err != nil {
 		return emperror.Wrap(err, "failed to create GitHub client")
@@ -508,7 +508,7 @@ func getSpotguideContent(githubClient *github.Client, request *LaunchRequest, so
 	return entries, nil
 }
 
-func createGithubRepo(githubClient *github.Client, request *LaunchRequest, userID uint, sourceRepo *SpotguideRepo) error {
+func createGithubRepo(githubClient *github.Client, request *LaunchRequest, userID pkgAuth.UserID, sourceRepo *SpotguideRepo) error {
 
 	repo := github.Repository{
 		Name:        github.String(request.RepoName),
@@ -532,7 +532,7 @@ func createGithubRepo(githubClient *github.Client, request *LaunchRequest, userI
 	return nil
 }
 
-func addSpotguideContent(githubClient *github.Client, request *LaunchRequest, userID uint, sourceRepo *SpotguideRepo) error {
+func addSpotguideContent(githubClient *github.Client, request *LaunchRequest, userID pkgAuth.UserID, sourceRepo *SpotguideRepo) error {
 
 	// An initial files have to be created with the API to be able to use the fresh repo
 	createFile := &github.RepositoryContentFileOptions{
@@ -592,7 +592,7 @@ func addSpotguideContent(githubClient *github.Client, request *LaunchRequest, us
 	return nil
 }
 
-func createSecrets(request *LaunchRequest, orgID pkgAuth.OrganizationID, userID uint) error {
+func createSecrets(request *LaunchRequest, orgID pkgAuth.OrganizationID, userID pkgAuth.UserID) error {
 
 	repoTag := "repo:" + request.RepoFullname()
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Untyped (uint, string) IDs get their own defined types.


### Why?
Defined types provide better type safety, plus, using non-global types promote better package architecture by revealing cyclic dependencies.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)