### PR TITLE
Publish OKE VCN params

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-5f188ff5e87bc81c83bf8758b96eb983510e3c5ab6167e0b4af8fbe2499b40ae  docs/openapi/pipeline.yaml
+2feea30329fb987f45d4462957e23688a690efdd8a13a038ba3ed874b4c8690e  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -5949,6 +5949,12 @@ components:
         labels:
           additionalProperties:
             $ref: '#/components/schemas/LabelsOracle'
+        subnetIds:
+          items:
+            example: ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx
+            type: string
+          maxItems: 3
+          type: array
       type: object
     LabelsOracle:
       example: labelValue
@@ -9773,6 +9779,15 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/NodePoolsOracle'
           type: object
+        vcnId:
+          example: ocid1.vcn.oc1.iad.aaaaaaaapt4vnv6vhy4nxwxfq7e5hji44ugdz3dqpffxk77gurec7skjbcyq
+          type: string
+        lbSubnetId1:
+          example: ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx
+          type: string
+        lbSubnetId2:
+          example: ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx
+          type: string
       required:
       - nodePools
       - version

--- a/client/docs/CreateUpdateOkePropertiesOke.md
+++ b/client/docs/CreateUpdateOkePropertiesOke.md
@@ -5,6 +5,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Version** | **string** |  | 
 **NodePools** | [**map[string]NodePoolsOracle**](NodePoolsOracle.md) |  | 
+**VcnId** | **string** |  | [optional] 
+**LbSubnetId1** | **string** |  | [optional] 
+**LbSubnetId2** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/docs/NodePoolsOracle.md
+++ b/client/docs/NodePoolsOracle.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Image** | **string** |  | [optional] 
 **Shape** | **string** |  | [optional] 
 **Labels** | **map[string]string** |  | [optional] 
+**SubnetIds** | **[]string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_create_update_oke_properties_oke.go
+++ b/client/model_create_update_oke_properties_oke.go
@@ -12,6 +12,9 @@
 package client
 
 type CreateUpdateOkePropertiesOke struct {
-	Version   string                     `json:"version"`
-	NodePools map[string]NodePoolsOracle `json:"nodePools"`
+	Version     string                     `json:"version"`
+	NodePools   map[string]NodePoolsOracle `json:"nodePools"`
+	VcnId       string                     `json:"vcnId,omitempty"`
+	LbSubnetId1 string                     `json:"lbSubnetId1,omitempty"`
+	LbSubnetId2 string                     `json:"lbSubnetId2,omitempty"`
 }

--- a/client/model_node_pools_oracle.go
+++ b/client/model_node_pools_oracle.go
@@ -12,9 +12,10 @@
 package client
 
 type NodePoolsOracle struct {
-	Version string            `json:"version,omitempty"`
-	Count   int32             `json:"count,omitempty"`
-	Image   string            `json:"image,omitempty"`
-	Shape   string            `json:"shape,omitempty"`
-	Labels  map[string]string `json:"labels,omitempty"`
+	Version   string            `json:"version,omitempty"`
+	Count     int32             `json:"count,omitempty"`
+	Image     string            `json:"image,omitempty"`
+	Shape     string            `json:"shape,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	SubnetIds []string          `json:"subnetIds,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -5680,6 +5680,15 @@ components:
                             type: object
                             additionalProperties:
                                 $ref: '#/components/schemas/NodePoolsOracle'
+                        vcnId:
+                            type: string
+                            example: "ocid1.vcn.oc1.iad.aaaaaaaapt4vnv6vhy4nxwxfq7e5hji44ugdz3dqpffxk77gurec7skjbcyq"
+                        lbSubnetId1:
+                            type: string
+                            example: "ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx"
+                        lbSubnetId2:
+                            type: string
+                            example: "ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx"
 
         NodePoolsOracle:
             type: object
@@ -5699,6 +5708,13 @@ components:
                 labels:
                     additionalProperties:
                         $ref: '#/components/schemas/LabelsOracle'
+                subnetIds:
+                    type: array
+                    items:
+                        type: string
+                        example: "ocid1.subnet.oc1.iad.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx"
+                    maxItems: 3
+
 
         LabelsOracle:
             type: string

--- a/pkg/providers/oracle/cluster/cluster.go
+++ b/pkg/providers/oracle/cluster/cluster.go
@@ -26,9 +26,9 @@ type Cluster struct {
 	Version   string               `json:"version" yaml:"version"`
 	NodePools map[string]*NodePool `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
 
-	vcnID       string
-	lbSubnetID1 string
-	lbSubnetID2 string
+	VCNID       string `json:"vcnId,omitempty" yaml:"vcnId,omitempty"`
+	LBSubnetID1 string `json:"lbSubnetId1,omitempty" yaml:"lbSubnetId2,omitempty"`
+	LBSubnetID2 string `json:"lbSubnetId2,omitempty" yaml:"lbSubnetId2,omitempty"`
 }
 
 // NodePool describes Oracle's node fields of a Create/Update request
@@ -39,44 +39,44 @@ type NodePool struct {
 	Image   string            `json:"image,omitempty" yaml:"image,omitempty"`
 	Shape   string            `json:"shape,omitempty" yaml:"shape,omitempty"`
 
-	subnetIds         []string
+	SubnetIDs         []string `json:"subnetIds,omitempty" yaml:"subnetIds,omitempty"`
 	quantityPerSubnet uint
 }
 
 // SetVCNID sets VCNID
 func (c *Cluster) SetVCNID(id string) {
 
-	c.vcnID = id
+	c.VCNID = id
 }
 
 // GetVCNID gets VCNID
 func (c *Cluster) GetVCNID() (id string) {
 
-	return c.vcnID
+	return c.VCNID
 }
 
 // SetLBSubnetID1 sets LBSubnetID1
 func (c *Cluster) SetLBSubnetID1(id string) {
 
-	c.lbSubnetID1 = id
+	c.LBSubnetID1 = id
 }
 
 // GetLBSubnetID1 gets LBSubnetID1
 func (c *Cluster) GetLBSubnetID1() (id string) {
 
-	return c.lbSubnetID1
+	return c.LBSubnetID1
 }
 
 // SetLBSubnetID2 sets LBSubnetID2
 func (c *Cluster) SetLBSubnetID2(id string) {
 
-	c.lbSubnetID2 = id
+	c.LBSubnetID2 = id
 }
 
 // GetLBSubnetID2 gets LBSubnetID2
 func (c *Cluster) GetLBSubnetID2() (id string) {
 
-	return c.lbSubnetID2
+	return c.LBSubnetID2
 }
 
 // SetQuantityPerSubnet sets QuantityPerSubnet
@@ -94,13 +94,13 @@ func (np *NodePool) GetQuantityPerSubnet() (q uint) {
 // SetSubnetIDs sets SubnetIDs
 func (np *NodePool) SetSubnetIDs(ids []string) {
 
-	np.subnetIds = ids
+	np.SubnetIDs = ids
 }
 
 // GetSubnetIDs gets SubnetIDs
 func (np *NodePool) GetSubnetIDs() (ids []string) {
 
-	return np.subnetIds
+	return np.SubnetIDs
 }
 
 // AddDefaults adds default values to the request


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | BC only
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Make OKE VCN cluster creation/update parameters (VCN ID, subnet IDs) public and (de)serializable.

### Why?
Currently, these parameters are not accessible from the API.


### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
