### PR TITLE
[WIP] PKE cluster create API v2

### DIFF
--- a/api/cluster/requests.go
+++ b/api/cluster/requests.go
@@ -1,0 +1,338 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/banzaicloud/pipeline/pkg/providers"
+	"github.com/banzaicloud/pipeline/secret"
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/banzaicloud/pipeline/cluster"
+	internalCluster "github.com/banzaicloud/pipeline/internal/cluster"
+	internalPKE "github.com/banzaicloud/pipeline/internal/providers/pke"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
+	pkgClusterPKE "github.com/banzaicloud/pipeline/pkg/cluster/pke"
+	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+)
+
+// CreateClusterRequest defines the common interface of cluster creation requests
+type CreateClusterRequest interface {
+	CreateCluster(ctx context.Context, organizationID uint, userID uint) (cluster.Cluster, *pkgCommon.ErrorResponse)
+}
+
+// CreateClusterRequestBase describes the common base of cluster creation requests
+type CreateClusterRequestBase struct {
+	Name       string               `json:"name" yaml:"name" binding:"required"`
+	PostHooks  pkgCluster.PostHooks `json:"postHooks" yaml:"postHooks"`
+	SecretID   string               `json:"secretId" yaml:"secretId"`
+	SecretIDs  []string             `json:"secretIds,omitempty" yaml:"secretIds,omitempty"`
+	SecretName string               `json:"secretName" yaml:"secretName"`
+	Type       string               `json:"type" yaml:"type" binding:"required"`
+}
+
+func getSecretByID(organizationID uint, secretID string) (*secret.SecretItemResponse, *pkgCommon.ErrorResponse) {
+	if secretID == "" {
+		return nil, nil
+	}
+	sir, err := secret.Store.Get(organizationID, secretID)
+	if err == nil {
+		return sir, nil
+	}
+	if err == secret.ErrSecretNotExists {
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: "no secret exists with the specified ID",
+			Error:   err.Error(),
+		}
+	}
+	return nil, &pkgCommon.ErrorResponse{
+		Code:    http.StatusInternalServerError,
+		Message: "failed to retreive secret by ID",
+		Error:   err.Error(),
+	}
+}
+
+func getSecretByName(organizationID uint, secretName string) (*secret.SecretItemResponse, *pkgCommon.ErrorResponse) {
+	if secretName == "" {
+		return nil, nil
+	}
+	sir, err := secret.Store.GetByName(organizationID, secretName)
+	if err == nil {
+		return sir, nil
+	}
+	if err == secret.ErrSecretNotExists {
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: "no secret exists with the specified name",
+			Error:   err.Error(),
+		}
+	}
+	return nil, &pkgCommon.ErrorResponse{
+		Code:    http.StatusInternalServerError,
+		Message: "failed to retreive secret by name",
+		Error:   err.Error(),
+	}
+}
+
+func getSecretWithType(organizationID uint, secretIDs []string, secretType string) (*secret.SecretItemResponse, *pkgCommon.ErrorResponse) {
+	for _, id := range secretIDs {
+		sir, err := secret.Store.Get(organizationID, id)
+		if err == nil && sir.Type == secretType {
+			return sir, nil
+		}
+		if err != secret.ErrSecretNotExists {
+			return nil, &pkgCommon.ErrorResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to retreive secret by ID",
+				Error:   err.Error(),
+			}
+		}
+	}
+	return nil, nil
+}
+
+func getSecretFromRequest(orgID uint, req CreateClusterRequestBase, providerID string) (*secret.SecretItemResponse, *pkgCommon.ErrorResponse) {
+	sir, errRes := getSecretByID(orgID, req.SecretID)
+	if errRes != nil {
+		return nil, errRes
+	}
+	if sir == nil {
+		sir, errRes = getSecretByName(orgID, req.SecretName)
+	}
+	if errRes != nil {
+		return nil, errRes
+	}
+	if sir == nil {
+		sir, errRes = getSecretWithType(orgID, req.SecretIDs, providerID)
+	}
+	if errRes != nil {
+		return nil, errRes
+	}
+	if sir == nil {
+		msg := "no suitable secret provided in request"
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: msg,
+			Error:   msg,
+		}
+	}
+	return sir, nil
+}
+
+// CreatePKEAWSClusterRequest represents a PKE-on-AWS cluster creation request
+type CreatePKEAWSClusterRequest struct {
+	CreateClusterRequestBase
+	Region     string
+	Network    pkgClusterPKE.Network    `json:"network,omitempty" yaml:"network,omitempty" binding:"required"`
+	NodePools  pkgClusterPKE.NodePools  `json:"nodepools,omitempty" yaml:"nodepools,omitempty" binding:"required"`
+	Kubernetes pkgClusterPKE.Kubernetes `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty" binding:"required"`
+	KubeADM    pkgClusterPKE.KubeADM    `json:"kubeadm,omitempty" yaml:"kubeadm,omitempty"`
+	CRI        pkgClusterPKE.CRI        `json:"cri,omitempty" yaml:"cri,omitempty" binding:"required"`
+}
+
+func (req CreatePKEAWSClusterRequest) GetProviderID() string {
+	return providers.Amazon
+}
+
+func createEC2PKENetworkFromRequest(network pkgClusterPKE.Network, userID uint) internalPKE.Network {
+	n := internalPKE.Network{
+		ServiceCIDR:      network.ServiceCIDR,
+		PodCIDR:          network.PodCIDR,
+		Provider:         internalPKE.NetworkProvider(network.Provider),
+		APIServerAddress: network.APIServerAddress,
+	}
+	n.CreatedBy = userID
+	return n
+}
+
+func convertRoles(roles pkgClusterPKE.Roles) internalPKE.Roles {
+	result := make(internalPKE.Roles, len(roles))
+	for i, role := range roles {
+		result[i] = internalPKE.Role(role)
+	}
+	return result
+}
+
+func convertLabels(labels pkgClusterPKE.Labels) internalPKE.Labels {
+	result := make(internalPKE.Labels, len(labels))
+	for i, label := range labels {
+		result[i] = label
+	}
+	return result
+}
+
+func convertTaints(taints pkgClusterPKE.Taints) internalPKE.Taints {
+	result := make(internalPKE.Taints, len(taints))
+	for i, taint := range taints {
+		result[i] = internalPKE.Taint(taint)
+	}
+	return result
+}
+
+func convertHosts(hosts pkgClusterPKE.Hosts) internalPKE.Hosts {
+	result := make(internalPKE.Hosts, len(hosts))
+	for i, host := range hosts {
+		result[i] = internalPKE.Host{
+			Name:             host.Name,
+			PrivateIP:        host.PrivateIP,
+			NetworkInterface: host.NetworkInterface,
+			Roles:            convertRoles(host.Roles),
+			Labels:           convertLabels(host.Labels),
+			Taints:           convertTaints(host.Taints),
+		}
+	}
+	return result
+}
+
+func convertNodePoolProvider(provider pke.NodePoolProvider) internalPKE.NodePoolProvider {
+	return internalPKE.NodePoolProvider(provider)
+}
+
+func createEC2ClusterPKENodePoolsFromRequest(pools pkgClusterPKE.NodePools, userID uint) internalPKE.NodePools {
+	result := make(internalPKE.NodePools, len(pools))
+	for i, pool := range pools {
+		np := internalPKE.NodePool{
+			Name:           pool.Name,
+			Roles:          convertRoles(pool.Roles),
+			Hosts:          convertHosts(pool.Hosts),
+			Provider:       convertNodePoolProvider(pool.Provider),
+			ProviderConfig: pool.ProviderConfig,
+		}
+		np.CreatedBy = userID
+		result[i] = np
+	}
+	return result
+}
+
+func createEC2ClusterPKEFromRequest(kubernetes pkgClusterPKE.Kubernetes, userID uint) internalPKE.Kubernetes {
+	k := internalPKE.Kubernetes{
+		Version: kubernetes.Version,
+		RBAC:    internalPKE.RBAC{Enabled: kubernetes.RBAC.Enabled},
+	}
+	k.CreatedBy = userID
+	return k
+}
+
+func convertExtraArgs(extraArgs pkgClusterPKE.ExtraArgs) internalPKE.ExtraArgs {
+	result := make(internalPKE.ExtraArgs, len(extraArgs))
+	for i, arg := range extraArgs {
+		result[i] = internalPKE.ExtraArg(arg)
+	}
+	return result
+}
+
+func createEC2ClusterPKEKubeADMFromRequest(kubernetes pkgClusterPKE.KubeADM, userID uint) internalPKE.KubeADM {
+	a := internalPKE.KubeADM{
+		ExtraArgs: convertExtraArgs(kubernetes.ExtraArgs),
+	}
+	a.CreatedBy = userID
+	return a
+}
+
+func createEC2ClusterPKECRIFromRequest(cri pkgClusterPKE.CRI, userID uint) internalPKE.CRI {
+	c := internalPKE.CRI{
+		Runtime:       internalPKE.Runtime(cri.Runtime),
+		RuntimeConfig: cri.RuntimeConfig,
+	}
+	c.CreatedBy = userID
+	return c
+}
+
+func getMasterInstanceTypeAndImageFromNodePools(nodepools internalPKE.NodePools) (masterInstanceType string, masterImage string, err error) {
+	for _, nodepool := range nodepools {
+		for _, role := range nodepool.Roles {
+			if role == internalPKE.RoleMaster {
+				switch nodepool.Provider {
+				case internalPKE.NPPAmazon:
+					var providerConfig internalPKE.NodePoolProviderConfigAmazon
+					if err = mapstructure.Decode(nodepool.ProviderConfig, &providerConfig); err != nil {
+						return
+					}
+					masterInstanceType = providerConfig.AutoScalingGroup.InstanceType
+					masterImage = providerConfig.AutoScalingGroup.Image
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// CreateCluster creates a new PKE-on-AWS cluster based on the request
+func (req CreatePKEAWSClusterRequest) CreateCluster(ctx context.Context, organizationID uint, userID uint) (cluster.Cluster, *pkgCommon.ErrorResponse) {
+	sir, errRes := getSecretFromRequest(organizationID, req.CreateClusterRequestBase, req.GetProviderID())
+	if errRes != nil {
+		return nil, errRes
+	}
+
+	var (
+		network    = createEC2PKENetworkFromRequest(req.Network, userID)
+		nodepools  = createEC2ClusterPKENodePoolsFromRequest(req.NodePools, userID)
+		kubernetes = createEC2ClusterPKEFromRequest(req.Kubernetes, userID)
+		kubeADM    = createEC2ClusterPKEKubeADMFromRequest(req.KubeADM, userID)
+		cri        = createEC2ClusterPKECRIFromRequest(req.CRI, userID)
+	)
+
+	instanceType, image, err := getMasterInstanceTypeAndImageFromNodePools(nodepools)
+	if err != nil {
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: "failed to parse node pool provider config",
+			Error:   err.Error(),
+		}
+	}
+
+	c, err := cluster.CreateEC2ClusterPKEFromClusterModel(&internalPKE.EC2PKEClusterModel{
+		Cluster: internalCluster.ClusterModel{
+			Name:           req.Name,
+			Location:       req.Region,
+			Cloud:          string(req.GetProviderID()),
+			Distribution:   pkgCluster.PKE,
+			OrganizationID: organizationID,
+			RbacEnabled:    kubernetes.RBAC.Enabled,
+			CreatedBy:      userID,
+			SecretID:       sir.ID,
+		},
+		MasterInstanceType: instanceType,
+		MasterImage:        image,
+		Network:            network,
+		NodePools:          nodepools,
+		Kubernetes:         kubernetes,
+		KubeADM:            kubeADM,
+		CRI:                cri,
+	})
+	if err != nil {
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "failed to create PKE-on-AWS cluster from cluster model",
+			Error:   err.Error(),
+		}
+	}
+	return c, nil
+}
+
+// CreateCustomClusterRequest represents a custom cluster creation request
+type CreateCustomClusterRequest struct {
+	CreateClusterRequestBase
+}
+
+// CreateCluster creates a new custom cluster based on the request
+func (req CreateCustomClusterRequest) CreateCluster(ctx context.Context, organizationID uint, userID uint) (cluster.Cluster, *pkgCommon.ErrorResponse) {
+	return nil, nil // TODO
+}

--- a/api/cluster_create.go
+++ b/api/cluster_create.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/goph/emperror"
+
+	clusterAPI "github.com/banzaicloud/pipeline/api/cluster"
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
@@ -30,12 +33,91 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func (a *ClusterAPI) onParseError(ctx *gin.Context, err error) {
+	msg := "Error parsing request"
+
+	a.logger.Error(emperror.Wrap(err, msg))
+	ginutils.ReplyWithErrorResponse(ctx, &pkgCommon.ErrorResponse{
+		Code:    http.StatusBadRequest,
+		Message: msg,
+		Error:   err.Error(),
+	})
+}
+
+func (a *ClusterAPI) parseCreatePKEAWSClusterRequest(ctx *gin.Context) (req clusterAPI.CreatePKEAWSClusterRequest, err error) {
+	if err = ctx.BindJSON(&req); err != nil {
+		return req, emperror.Wrap(err, "failed to parse CreatePKEAWSClusterRequest")
+	}
+	return
+}
+
+func (a *ClusterAPI) parseCreateCustomClusterRequest(ctx *gin.Context) (req clusterAPI.CreateCustomClusterRequest, err error) {
+	if err = ctx.BindJSON(&req); err != nil {
+		return req, emperror.Wrap(err, "failed to parse CreateCustomClusterRequest")
+	}
+	return
+}
+
 //CreateClusterRequest gin handler
 func (a *ClusterAPI) CreateClusterRequest(c *gin.Context) {
 	a.logger.Info("Cluster creation started")
 
-	a.logger.Debug("Bind json into CreateClusterRequest struct")
-	// bind request body to struct
+	ctx := ginutils.Context(context.Background(), c)
+
+	orgID := auth.GetCurrentOrganization(c.Request).ID
+	userID := auth.GetCurrentUser(c.Request).ID
+
+	a.logger.Debug("Try to bind JSON to CreateClusterRequest struct")
+	var createClusterRequestBase clusterAPI.CreateClusterRequestBase
+	if err := c.ShouldBindJSON(&createClusterRequestBase); err == nil {
+		var createClusterRequest clusterAPI.CreateClusterRequest
+
+		switch createClusterRequestBase.Type {
+		case cluster.PKEAWS:
+			createClusterRequest, err = a.parseCreatePKEAWSClusterRequest(c)
+		case "custom":
+			createClusterRequest, err = a.parseCreateCustomClusterRequest(c)
+		default:
+			ginutils.ReplyWithErrorResponse(c, &pkgCommon.ErrorResponse{
+				Code:    http.StatusBadRequest,
+				Message: "unknown cluster type",
+			})
+			return
+		}
+
+		if err != nil {
+			a.onParseError(c, err)
+			return
+		}
+		cl, errResp := createClusterRequest.CreateCluster(ctx, orgID, userID)
+		if errResp != nil {
+			ginutils.ReplyWithErrorResponse(c, errResp)
+			return
+		}
+		// until this point, all request data should've been validated
+		// below this point, all errors are server errors (HTTP 5xx)
+		created, err := cl.Deploy(ctx)
+		if err = emperror.Wrap(err, "failed to "); err != nil {
+			a.logger.Error(err)
+			ginutils.ReplyWithErrorResponse(c, &pkgCommon.ErrorResponse{
+				Code:    http.StatusInternalServerError,
+				Message: err.Error(),
+				Error:   errors.Cause(err).Error(),
+			})
+			return
+		}
+		status := http.StatusOK
+		if created {
+			status = http.StatusCreated
+		}
+		c.JSON(status, pkgCluster.CreateClusterResponse{
+			Name:       cl.GetName(),
+			ResourceID: cl.GetID(),
+		})
+		return
+	}
+
+	a.logger.Debug("JSON didn't match V2 format, trying legacy format")
 	var createClusterRequest pkgCluster.CreateClusterRequest
 	if err := c.BindJSON(&createClusterRequest); err != nil {
 		a.logger.Error(errors.Wrap(err, "Error parsing request"))
@@ -59,11 +141,7 @@ func (a *ClusterAPI) CreateClusterRequest(c *gin.Context) {
 		createClusterRequest.SecretId = string(secret.GenerateSecretIDFromName(createClusterRequest.SecretName))
 	}
 
-	orgID := auth.GetCurrentOrganization(c.Request).ID
-	userID := auth.GetCurrentUser(c.Request).ID
-
 	ph := getPostHookFunctions(createClusterRequest.PostHooks)
-	ctx := ginutils.Context(context.Background(), c)
 	commonCluster, err := a.CreateCluster(ctx, &createClusterRequest, orgID, userID, ph)
 	if err != nil {
 		c.JSON(err.Code, err)

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -36,6 +37,23 @@ import (
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 )
+
+// Cluster defines the common interface of clusters
+type Cluster interface {
+	// Deploy ensures that the cluster has been fully realized on the provider, and returns false when the cluster has already been deployed
+	Deploy(ctx context.Context) (created bool, err error)
+	Dispose(ctx context.Context) error
+
+	GetCreatedBy() uint
+	GetCreationTime() time.Time
+	GetDistributionID() string
+	GetID() uint
+	GetName() string
+	GetOrganizationID() uint
+	GetProviderID() string
+	GetType() string
+	GetUUID() string
+}
 
 // CommonCluster interface for clusters.
 type CommonCluster interface {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | BC only
| Deprecations?   | yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
This PR implements part of the new cluster API (creation requests) for the PKE-on-AWS cluster type as an alternative to the legacy API. (Both work right now, the legacy API will be phased out eventually.)

### Why?
The current API is coupled too deeply with the business logic and data layers, which is bad. We should move toward a new API, building on a better architecture. 

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)