### PR TITLE
Keep node pool label tables for backward compatibility

### DIFF
--- a/database/migrations/1550784299_node_pool_label_tables.down.sql
+++ b/database/migrations/1550784299_node_pool_label_tables.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS `amazon_node_pool_labels`;
+
+DROP TABLE IF EXISTS `google_gke_node_pool_labels`;
+
+DROP TABLE IF EXISTS `oracle_oke_node_pool_labels`;

--- a/database/migrations/1550784299_node_pool_label_tables.up.sql
+++ b/database/migrations/1550784299_node_pool_label_tables.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE `oracle_oke_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `amazon_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`),
+  KEY `idx_amazon_node_pool_labels_node_pool_id` (`node_pool_id`),
+  CONSTRAINT `fk_amazon_node_pool_labels_node_pool_id` FOREIGN KEY (`node_pool_id`) REFERENCES `amazon_node_pools` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `google_gke_node_pool_labels` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `node_pool_id` int(10) unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/1550784299_node_pool_label_tables.up.sql
+++ b/database/migrations/1550784299_node_pool_label_tables.up.sql
@@ -17,9 +17,7 @@ CREATE TABLE `amazon_node_pool_labels` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`),
-  KEY `idx_amazon_node_pool_labels_node_pool_id` (`node_pool_id`),
-  CONSTRAINT `fk_amazon_node_pool_labels_node_pool_id` FOREIGN KEY (`node_pool_id`) REFERENCES `amazon_node_pools` (`id`)
+  UNIQUE KEY `idx_node_pool_id_name` (`name`,`node_pool_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `google_gke_node_pool_labels` (

--- a/internal/providers/google/gke_cluster_model.go
+++ b/internal/providers/google/gke_cluster_model.go
@@ -28,6 +28,7 @@ import (
 const (
 	gkeClusterModelTableName  = "google_gke_clusters"
 	gkeNodePoolModelTableName = "google_gke_node_pools"
+	gkeNodePoolLabelTableName = "google_gke_node_pool_labels"
 )
 
 // GKEClusterModel is the schema for the DB.
@@ -149,5 +150,32 @@ func (m GKENodePoolModel) String() string {
 		m.NodeMinCount,
 		m.NodeMaxCount,
 		m.NodeCount,
+	)
+}
+
+// GKENodePoolLabelModel stores labels for node pools
+type GKENodePoolLabelModel struct {
+	ID         uint   `gorm:"primary_key"`
+	Name       string `gorm:"unique_index:idx_node_pool_id_name"`
+	Value      string
+	NodePoolID uint `gorm:"unique_index:idx_node_pool_id_name"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// TableName changes the default table name.
+func (GKENodePoolLabelModel) TableName() string {
+	return gkeNodePoolLabelTableName
+}
+
+func (m GKENodePoolLabelModel) String() string {
+	return fmt.Sprintf(
+		"ID: %d, Name: %s, Value: %s, NodePoolID: %d, createdAt: %v, UpdatedAt: %v",
+		m.ID,
+		m.Name,
+		m.Value,
+		m.NodePoolID,
+		m.CreatedAt,
+		m.UpdatedAt,
 	)
 }

--- a/internal/providers/google/model.go
+++ b/internal/providers/google/model.go
@@ -31,6 +31,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 
 		&GKEClusterModel{},
 		&GKENodePoolModel{},
+		&GKENodePoolLabelModel{},
 	}
 
 	var tableNames string

--- a/internal/providers/oracle/model.go
+++ b/internal/providers/oracle/model.go
@@ -34,6 +34,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&model.Profile{},
 		&model.ProfileNodePool{},
 		&model.ProfileNodePoolLabel{},
+		&model.NodePoolLabel{},
 	}
 
 	var tableNames string

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -46,6 +46,7 @@ const (
 	tableNameDummyProperties      = "dummy_clusters"
 	tableNameKubernetesProperties = "kubernetes_clusters"
 	tableNameEKSSubnets           = "amazon_eks_subnets"
+	tableNameAmazonNodePoolLabels = "amazon_node_pool_labels"
 )
 
 //ClusterModel describes the common cluster model
@@ -457,4 +458,33 @@ func (cs *ClusterModel) UpdateConfigSecret(configSecretId pkgSecret.SecretID) er
 func (cs *ClusterModel) UpdateSshSecret(sshSecretId pkgSecret.SecretID) error {
 	cs.SshSecretId = sshSecretId
 	return cs.Save()
+}
+
+// AmazonNodePoolLabelModel stores labels for node pools
+type AmazonNodePoolLabelModel struct {
+	ID         uint   `gorm:"primary_key"`
+	Name       string `gorm:"unique_index:idx_node_pool_id_name"`
+	Value      string
+	NodePoolID uint `gorm:"unique_index:idx_node_pool_id_name"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+
+	Delete bool `gorm:"-"`
+}
+
+// TableName changes the default table name.
+func (AmazonNodePoolLabelModel) TableName() string {
+	return tableNameAmazonNodePoolLabels
+}
+
+func (m AmazonNodePoolLabelModel) String() string {
+	return fmt.Sprintf(
+		"ID: %d, Name: %s, Value: %s, NodePoolID: %d, createdAt: %v, UpdatedAt: %v",
+		m.ID,
+		m.Name,
+		m.Value,
+		m.NodePoolID,
+		m.CreatedAt,
+		m.UpdatedAt,
+	)
 }

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -36,6 +36,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&AKSNodePoolModel{},
 		&DummyClusterModel{},
 		&KubernetesClusterModel{},
+		&AmazonNodePoolLabelModel{},
 	}
 
 	var tableNames string

--- a/pkg/providers/oracle/model/cluster.go
+++ b/pkg/providers/oracle/model/cluster.go
@@ -29,6 +29,7 @@ const (
 	clustersTableName                = "oracle_oke_clusters"
 	clustersNodePoolsTableName       = "oracle_oke_node_pools"
 	clustersNodePoolSubnetsTableName = "oracle_oke_node_pool_subnets"
+	clustersNodePoolLabelsTableName  = "oracle_oke_node_pool_labels"
 )
 
 // Cluster describes the Oracle cluster model
@@ -246,4 +247,19 @@ func (c *Cluster) GetClusterRequestFromModel() *cluster.Cluster {
 		Version:   c.Version,
 		NodePools: nodePools,
 	}
+}
+
+// NodePoolLabel stores labels for node pools
+type NodePoolLabel struct {
+	ID         uint   `gorm:"primary_key"`
+	Name       string `gorm:"unique_index:idx_node_pool_id_name"`
+	Value      string
+	NodePoolID uint `gorm:"unique_index:idx_node_pool_id_name"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// TableName sets the NodePoolLabels table name
+func (NodePoolLabel) TableName() string {
+	return clustersNodePoolLabelsTableName
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Keep the node pool labels table for backward compatibility until a Pipeline version not using it is released.


### Why?
New database changes have to be backwards compatible with current Pipeline release.
These tables should be removed once a version of the Pipeline is released that is not using these.
