### PR TITLE
Dex cluster auth with PKE

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2094,7 +2094,7 @@
   revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
 
 [[projects]]
-  digest = "1:b140f21b83859b16d263fc34fc316076af1c3e1661d92018a105a8cbf2f24d1e"
+  digest = "1:8462458147dbb4b02e389c8081e235e2ea3023c9baa21f669e9d6a7c37e0c98d"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -2124,8 +2124,8 @@
     "transport",
   ]
   pruneopts = "NUT"
-  revision = "d89cded64628466c4ab532d1f0ba5c220459ebe8"
-  version = "v1.11.2"
+  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
+  version = "v1.11.3"
 
 [[projects]]
   branch = "v3"
@@ -2802,7 +2802,6 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/rbac/v1",
-    "k8s.io/api/rbac/v1beta1",
     "k8s.io/api/storage/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -420,6 +420,14 @@
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:6b2fc71062354c8eb3fa9d20a4b9adb7a9148706cecc9140db2c28b4f094b992"
+  name = "github.com/dexidp/dex"
+  packages = ["api"]
+  pruneopts = "NUT"
+  revision = "7bd4071b4c8ced39568fbc48332641b5cdcc164c"
+  version = "v2.15.0"
+
+[[projects]]
   digest = "1:2e08f767623936c719c07f52e1c89bb5d8597aac6b5fe669e6e851b92cebbe69"
   name = "github.com/dgrijalva/jwt-go"
   packages = [
@@ -2706,6 +2714,7 @@
     "github.com/banzaicloud/nodepool-labels-operator/pkg/npls",
     "github.com/banzaicloud/prometheus-config",
     "github.com/casbin/gorm-adapter",
+    "github.com/dexidp/dex/api",
     "github.com/dgrijalva/jwt-go",
     "github.com/didip/tollbooth",
     "github.com/docker/libcompose/yaml",
@@ -2786,6 +2795,8 @@
     "google.golang.org/api/serviceusage/v1",
     "google.golang.org/api/storage/v1",
     "google.golang.org/genproto/googleapis/iam/credentials/v1",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/credentials",
     "gopkg.in/yaml.v2",
     "k8s.io/api/autoscaling/v2beta1",
     "k8s.io/api/core/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@ required = [ "github.com/apache/thrift/lib/go/thrift"]
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "=v1.11.2"
+  version = "=v1.11.3"
 
 [[override]]
   name = "github.com/Azure/go-autorest"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@ required = [ "github.com/apache/thrift/lib/go/thrift"]
   name = "github.com/docker/docker"
   revision = "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 
-[[override]]
+[[constraint]]
   name = "google.golang.org/grpc"
   version = "=v1.11.2"
 
@@ -280,3 +280,7 @@ required = [ "github.com/apache/thrift/lib/go/thrift"]
 [[constraint]]
   name = "github.com/oklog/run"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/dexidp/dex"
+  version = "v2.15.0"

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -47,6 +47,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"go.uber.org/cadence/client"
 	"gopkg.in/yaml.v2"
 )
@@ -693,6 +694,10 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url, token string) (st
 	if err != nil {
 		return "", err
 	}
+
+	dexIssuerURL := viper.GetString("auth.dexURL")
+	dexClientID := c.GetUID()
+
 	// master
 	if subcommand == "master" {
 		return fmt.Sprintf("pke install %s "+
@@ -708,7 +713,9 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url, token string) (st
 			"--kubernetes-pod-network-cidr=10.20.0.0/16 "+
 			"--kubernetes-infrastructure-cidr=%q "+
 			"--kubernetes-api-server=%q "+
-			"--kubernetes-cluster-name=%q",
+			"--kubernetes-cluster-name=%q "+
+			"--kubernetes-oidc-issuer-url=%q "+
+			"--kubernetes-oidc-client-id=%q",
 			subcommand,
 			url,
 			token,
@@ -718,6 +725,8 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url, token string) (st
 			infrastructureCIDR,
 			apiAddress,
 			c.GetName(),
+			dexIssuerURL,
+			dexClientID,
 		), nil
 	}
 

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -112,8 +112,9 @@ var HookMap = map[string]PostFunctioner{
 		ErrorHandler: ErrorHandler{},
 	},
 	pkgCluster.CreateDefaultStorageclass: &BasePostFunction{
-		f:        CreateDefaultStorageclass,
-		Priority: Priority{5},
+		f:            CreateDefaultStorageclass,
+		Priority:     Priority{5},
+		ErrorHandler: ErrorHandler{},
 	},
 	pkgCluster.CreateClusterRoles: &BasePostFunction{
 		f:            CreateClusterRoles,

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -112,8 +112,11 @@ var HookMap = map[string]PostFunctioner{
 		ErrorHandler: ErrorHandler{},
 	},
 	pkgCluster.CreateDefaultStorageclass: &BasePostFunction{
-		f:            CreateDefaultStorageclass,
-		Priority:     Priority{5},
+		f:        CreateDefaultStorageclass,
+		Priority: Priority{5},
+	},
+	pkgCluster.CreateClusterRoles: &BasePostFunction{
+		f:            CreateClusterRoles,
 		ErrorHandler: ErrorHandler{},
 	},
 }

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -49,7 +49,6 @@ import (
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/api/rbac/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -563,7 +562,7 @@ func InstallKubernetesDashboardPostHook(cluster CommonCluster) error {
 
 		// cluster role based on https://github.com/helm/charts/blob/master/stable/kubernetes-dashboard/templates/role.yaml
 		clusterRoleName := k8sDashboardReleaseName
-		rules := []v1beta1.PolicyRule{
+		rules := []rbacv1.PolicyRule{
 			// Allow to list all
 			{
 				APIGroups: []string{"*"},
@@ -655,22 +654,20 @@ func setAdminRights(client *kubernetes.Clientset, userName string) (err error) {
 
 	log.Info("cluster role creating")
 
-	_, err = client.RbacV1beta1().ClusterRoleBindings().Create(
-		&v1beta1.ClusterRoleBinding{
+	_, err = client.RbacV1().ClusterRoleBindings().Create(
+		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Subjects: []v1beta1.Subject{
+			Subjects: []rbacv1.Subject{
 				{
-					Kind:     "User",
-					Name:     userName,
-					APIGroup: v1.GroupName,
+					Kind: "User",
+					Name: userName,
 				},
 			},
-			RoleRef: v1beta1.RoleRef{
-				Kind:     "ClusterRole",
-				Name:     "cluster-admin",
-				APIGroup: v1beta1.GroupName,
+			RoleRef: rbacv1.RoleRef{
+				Kind: "ClusterRole",
+				Name: "cluster-admin",
 			},
 		})
 
@@ -1367,7 +1364,7 @@ func CreateClusterRoles(cluster CommonCluster) error {
 
 	clusterRoleBinding := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: org.Name,
+			Name: org.Name + "-cluster-admin",
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind: "ClusterRole",

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -47,7 +47,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/api/rbac/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1339,5 +1340,50 @@ func initializeSpotConfigMap(client *kubernetes.Clientset, systemNs string) erro
 		}
 	}
 	log.Info("finished initializing spot ConfigMap")
+	return nil
+}
+
+// CreateClusterRoles creates the pre-defined ClusterRoles for a PKE cluster
+func CreateClusterRoles(cluster CommonCluster) error {
+	if distro := cluster.GetDistribution(); distro != pkgCluster.PKE {
+		log.Infof("Not creating ClusterRoleBindings for %s", distro)
+		return nil
+	}
+
+	kubeConfig, err := cluster.GetK8sConfig()
+	if err != nil {
+		return emperror.Wrap(err, "failed to get Kubernetes config")
+	}
+
+	client, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
+	if err != nil {
+		return emperror.Wrap(err, "failed to get Kubernetes clientset from kubeconfig")
+	}
+
+	org, err := auth.GetOrganizationById(cluster.GetOrganizationId())
+	if err != nil {
+		return emperror.Wrap(err, "failed to get organization of Kubernetes cluster")
+	}
+
+	clusterRoleBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: org.Name,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind: rbacv1.GroupKind,
+			Name: org.Name,
+		}},
+	}
+
+	_, err = client.RbacV1().ClusterRoleBindings().Create(&clusterRoleBinding)
+
+	if err != nil {
+		return emperror.WrapWith(err, "failed to ClusterRoleBinding", "name", clusterRoleBinding.Name)
+	}
+
 	return nil
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -25,6 +25,7 @@ import (
 	conf "github.com/banzaicloud/pipeline/config"
 	intAuth "github.com/banzaicloud/pipeline/internal/auth"
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
+	intClusterAuth "github.com/banzaicloud/pipeline/internal/cluster/auth"
 	"github.com/banzaicloud/pipeline/internal/cluster/clustersecret"
 	"github.com/banzaicloud/pipeline/internal/cluster/clustersecret/clustersecretadapter"
 	"github.com/banzaicloud/pipeline/internal/platform/buildinfo"
@@ -137,10 +138,15 @@ func main() {
 
 		clusters := pkeworkflowadapter.NewClusterManagerAdapter(clusterManager)
 
-		generateCertificatesActivity := pkeworkflow.NewGenerateCertificatesActivity(clustersecret.NewStore(
+		clusterSecretStore := clustersecret.NewStore(
 			clustersecretadapter.NewClusterManagerAdapter(clusterManager),
 			clustersecretadapter.NewSecretStore(secret.Store),
-		))
+		)
+
+		clusterAuthService, err := intClusterAuth.NewDexClusterAuthService(clusterSecretStore)
+		emperror.Panic(errors.Wrap(err, "failed to create DexClusterAuthService"))
+
+		generateCertificatesActivity := pkeworkflow.NewGenerateCertificatesActivity(clusterSecretStore)
 		activity.RegisterWithOptions(generateCertificatesActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.GenerateCertificatesActivityName})
 
 		awsClientFactory := pkeworkflow.NewAWSClientFactory(pkeworkflowadapter.NewSecretStore(secret.Store))
@@ -162,6 +168,9 @@ func main() {
 
 		createElasticIPActivity := pkeworkflow.NewCreateElasticIPActivity(awsClientFactory)
 		activity.RegisterWithOptions(createElasticIPActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateElasticIPActivityName})
+
+		createDexClientActivity := pkeworkflow.NewCreateDexClientActivity(clusters, clusterAuthService)
+		activity.RegisterWithOptions(createDexClientActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateDexClientActivityName})
 
 		createMasterActivity := pkeworkflow.NewCreateMasterActivity(clusters, tokenGenerator)
 		activity.RegisterWithOptions(createMasterActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateMasterActivityName})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -172,6 +172,9 @@ func main() {
 		createDexClientActivity := pkeworkflow.NewCreateDexClientActivity(clusters, clusterAuthService)
 		activity.RegisterWithOptions(createDexClientActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateDexClientActivityName})
 
+		deleteDexClientActivity := pkeworkflow.NewDeleteDexClientActivity(clusters, clusterAuthService)
+		activity.RegisterWithOptions(deleteDexClientActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteDexClientActivityName})
+
 		createMasterActivity := pkeworkflow.NewCreateMasterActivity(clusters, tokenGenerator)
 		activity.RegisterWithOptions(createMasterActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateMasterActivityName})
 

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -67,6 +67,7 @@ token = "YourPersonalAccessToken"
 clientid = "pipeline"
 clientsecret = "ZXhhbXBsZS1hcHAtc2VjcmV0"
 dexURL = "http://127.0.0.1:5556/dex"
+dexGrpcAddress = "127.0.0.1:5557"
 
 tokensigningkey = "Th1s!sMyR4Nd0MStri4gPleaseChangeIt"
 jwtissueer = "https://banzaicloud.com/"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -180,6 +180,8 @@ func init() {
 	viper.SetDefault("auth.secureCookie", true)
 	viper.SetDefault("auth.whitelistEnabled", false)
 	viper.SetDefault("auth.dexURL", "http://127.0.0.1:5556/dex")
+	viper.SetDefault("auth.dexGrpcAddress", "127.0.0.1:5557")
+	viper.SetDefault("auth.dexGrpcCaCert", "")
 	viper.SetDefault(SetCookieDomain, false)
 
 	viper.SetDefault("pipeline.bindaddr", "127.0.0.1:9090")

--- a/config/dex.yml.dist
+++ b/config/dex.yml.dist
@@ -26,8 +26,8 @@ telemetry:
 
 # Uncomment this block to enable the gRPC API. This values MUST be different
 # from the HTTP endpoints.
-# grpc:
-#   addr: 127.0.0.1:5557
+grpc:
+  addr: 0.0.0.0:5557
 #  tlsCert: examples/grpc-client/server.crt
 #  tlsKey: examples/grpc-client/server.key
 #  tlsClientCA: /etc/dex/client.crt

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -60,6 +60,7 @@ services:
     dex:
         ports:
             - 127.0.0.1:5556:5556
+            - 127.0.0.1:5557:5557
             - 127.0.0.1:5558:5558
         volumes:
             - ./.docker/volumes/dex:/dex

--- a/internal/cluster/auth/auth.go
+++ b/internal/cluster/auth/auth.go
@@ -1,0 +1,143 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/clustersecret"
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
+	"github.com/banzaicloud/pipeline/secret"
+	"github.com/dexidp/dex/api"
+	"github.com/goph/emperror"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type dexClient struct {
+	api.DexClient
+	grpcConn *grpc.ClientConn
+}
+
+func (d *dexClient) Close() error {
+	return d.grpcConn.Close()
+}
+
+func newDexClient(hostAndPort, caPath string) (*dexClient, error) {
+	dialOption := grpc.WithInsecure()
+	if caPath != "" {
+		creds, err := credentials.NewClientTLSFromFile(caPath, "")
+		if err != nil {
+			return nil, emperror.Wrapf(err, "loading dex CA cert failed")
+		}
+		dialOption = grpc.WithTransportCredentials(creds)
+	}
+	conn, err := grpc.Dial(hostAndPort, dialOption)
+	if err != nil {
+		return nil, emperror.Wrapf(err, "grpc dial failed")
+	}
+	return &dexClient{DexClient: api.NewDexClient(conn), grpcConn: conn}, nil
+}
+
+type ClusterAuthService interface {
+	RegisterCluster(context.Context, string, uint, string) error
+	UnRegisterCluster(context.Context, string) error
+}
+
+type noOpClusterAuthService struct {
+}
+
+func NewNoOpClusterAuthService() (ClusterAuthService, error) {
+	return &noOpClusterAuthService{}, nil
+}
+
+func (*noOpClusterAuthService) RegisterCluster(tx context.Context, clusterName string, clusterID uint, clusterUID string) error {
+	return nil
+}
+
+func (*noOpClusterAuthService) UnRegisterCluster(tx context.Context, clusterUID string) error {
+	return nil
+}
+
+type dexClusterAuthService struct {
+	dexClient   *dexClient
+	secretStore *clustersecret.Store
+}
+
+func NewDexClusterAuthService(secretStore *clustersecret.Store) (ClusterAuthService, error) {
+	client, err := newDexClient(viper.GetString("auth.dexGrpcAddress"), viper.GetString("auth.dexGrpcCaCert"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &dexClusterAuthService{
+		dexClient:   client,
+		secretStore: secretStore,
+	}, nil
+}
+
+func (a *dexClusterAuthService) RegisterCluster(ctx context.Context, clusterName string, clusterID uint, clusterUID string) error {
+
+	clientID := clusterUID
+	clientSecret, _ := secret.RandomString("randAlphaNum", 32)
+	redirectURI := "http://127.0.0.1:1848/dex/cluster/callback"
+
+	req := &api.CreateClientReq{
+		Client: &api.Client{
+			Id:           clientID,
+			Name:         clusterName,
+			Secret:       clientSecret,
+			RedirectUris: []string{redirectURI},
+		},
+	}
+
+	if _, err := a.dexClient.CreateClient(ctx, req); err != nil {
+		return emperror.Wrapf(err, "failed to create dex client for cluster: %s", clusterUID)
+	}
+
+	// save the secret to the secret store
+	secretRequest := clustersecret.SecretCreateRequest{
+		Type: pkgSecret.GenericSecret,
+		Name: "dex-client",
+		Values: map[string]string{
+			"clientID":     clientID,
+			"clientSecret": clientSecret,
+		},
+	}
+
+	_, err := a.secretStore.EnsureSecretExists(ctx, clusterID, secretRequest)
+
+	if err != nil {
+		return emperror.Wrapf(err, "failed to create secret for dex clientID/clientSecret for cluster: %s", clusterUID)
+	}
+
+	return nil
+}
+
+func (a *dexClusterAuthService) UnRegisterCluster(ctx context.Context, clusterUID string) error {
+
+	clientID := clusterUID
+
+	req := &api.DeleteClientReq{
+		Id: clientID,
+	}
+
+	if _, err := a.dexClient.DeleteClient(ctx, req); err != nil {
+		return emperror.Wrapf(err, "failed to delete dex client for cluster: %s", clusterUID)
+	}
+
+	return nil
+}

--- a/internal/cluster/auth/auth.go
+++ b/internal/cluster/auth/auth.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/banzaicloud/pipeline/internal/cluster/clustersecret"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
@@ -73,19 +74,28 @@ func (*noOpClusterAuthService) UnRegisterCluster(tx context.Context, clusterUID 
 }
 
 type dexClusterAuthService struct {
-	dexClient   *dexClient
-	secretStore *clustersecret.Store
+	dexClient           *dexClient
+	secretStore         *clustersecret.Store
+	pipelineRedirectURI string
 }
 
 func NewDexClusterAuthService(secretStore *clustersecret.Store) (ClusterAuthService, error) {
 	client, err := newDexClient(viper.GetString("auth.dexGrpcAddress"), viper.GetString("auth.dexGrpcCaCert"))
 	if err != nil {
-		return nil, err
+		return nil, emperror.Wrapf(err, "failed to create dex auth service")
 	}
 
+	pipelineExternalURL, err := url.Parse(viper.GetString("pipeline.externalURL"))
+	if err != nil {
+		return nil, emperror.Wrapf(err, "failed to parse pipeline externalURL")
+	}
+
+	pipelineExternalURL.Path = "/auth/dex/cluster/callback"
+
 	return &dexClusterAuthService{
-		dexClient:   client,
-		secretStore: secretStore,
+		dexClient:           client,
+		secretStore:         secretStore,
+		pipelineRedirectURI: pipelineExternalURL.String(),
 	}, nil
 }
 
@@ -93,14 +103,18 @@ func (a *dexClusterAuthService) RegisterCluster(ctx context.Context, clusterName
 
 	clientID := clusterUID
 	clientSecret, _ := secret.RandomString("randAlphaNum", 32)
-	redirectURI := "http://127.0.0.1:1848/dex/cluster/callback"
+	cliRedirectURI := "http://127.0.0.1:5555/auth/dex/cluster/callback"
+	pipelineRedirectURI := a.pipelineRedirectURI
 
 	req := &api.CreateClientReq{
 		Client: &api.Client{
-			Id:           clientID,
-			Name:         clusterName,
-			Secret:       clientSecret,
-			RedirectUris: []string{redirectURI},
+			Id:     clientID,
+			Name:   clusterName,
+			Secret: clientSecret,
+			RedirectUris: []string{
+				cliRedirectURI,
+				pipelineRedirectURI,
+			},
 		},
 	}
 

--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -191,6 +191,13 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		}
 	}
 
+	createDexClientActivityInput := CreateDexClientActivityInput{
+		ClusterID: input.ClusterID,
+	}
+	if err := workflow.ExecuteActivity(ctx, CreateDexClientActivityName, createDexClientActivityInput).Get(ctx, nil); err != nil {
+		return err
+	}
+
 	var masterAvailabilityZone string
 	var master NodePool
 	for _, np := range nodePools {

--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -186,16 +186,21 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		activityInput := UploadSSHKeyPairActivityInput{
 			ClusterID: input.ClusterID,
 		}
-		if err := workflow.ExecuteActivity(ctx, UploadSSHKeyPairActivityName, activityInput).Get(ctx, &keyOut); err != nil {
+		err := workflow.ExecuteActivity(ctx, UploadSSHKeyPairActivityName, activityInput).Get(ctx, &keyOut)
+		if err != nil {
 			return err
 		}
 	}
 
-	createDexClientActivityInput := CreateDexClientActivityInput{
-		ClusterID: input.ClusterID,
-	}
-	if err := workflow.ExecuteActivity(ctx, CreateDexClientActivityName, createDexClientActivityInput).Get(ctx, nil); err != nil {
-		return err
+	// Create dex client for the cluster
+	{
+		activityInput := CreateDexClientActivityInput{
+			ClusterID: input.ClusterID,
+		}
+		err := workflow.ExecuteActivity(ctx, CreateDexClientActivityName, activityInput).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	var masterAvailabilityZone string

--- a/internal/providers/pke/pkeworkflow/create_dex_client.go
+++ b/internal/providers/pke/pkeworkflow/create_dex_client.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkeworkflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/auth"
+	"github.com/pkg/errors"
+)
+
+const CreateDexClientActivityName = "pke-create-dex-client-activity"
+
+type CreateDexClientActivity struct {
+	clusters           Clusters
+	clusterAuthService auth.ClusterAuthService
+}
+
+func NewCreateDexClientActivity(clusters Clusters, clusterAuthService auth.ClusterAuthService) *CreateDexClientActivity {
+	return &CreateDexClientActivity{
+		clusters:           clusters,
+		clusterAuthService: clusterAuthService,
+	}
+}
+
+type CreateDexClientActivityInput struct {
+	ClusterID uint
+}
+
+func (a *CreateDexClientActivity) Execute(ctx context.Context, input CreateDexClientActivityInput) error {
+	cluster, err := a.clusters.GetCluster(ctx, input.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	err = a.clusterAuthService.RegisterCluster(ctx, cluster.GetName(), cluster.GetID(), cluster.GetUID())
+	if err != nil {
+		return errors.New(fmt.Sprintf("can't create dex client for cluster %v", cluster))
+	}
+
+	return nil
+}

--- a/internal/providers/pke/pkeworkflow/create_master_activity.go
+++ b/internal/providers/pke/pkeworkflow/create_master_activity.go
@@ -140,7 +140,7 @@ func (a *CreateMasterActivity) Execute(ctx context.Context, input CreateMasterAc
 			},
 			{
 				ParameterKey:   aws.String("PkeVersion"),
-				ParameterValue: aws.String("0.0.5"),
+				ParameterValue: aws.String("0.0.6"),
 			},
 			{
 				ParameterKey:   aws.String("KeyName"),

--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -110,6 +110,15 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		return err
 	}
 
+	// remove dex client (if we created it)
+
+	deleteDexClientActivityInput := &DeleteDexClientActivityInput{
+		ClusterID: input.ClusterID,
+	}
+	if err := workflow.ExecuteActivity(ctx, DeleteDexClientActivityName, deleteDexClientActivityInput).Get(ctx, nil); err != nil {
+		return err
+	}
+
 	// TODO: remove roles (probably not needed)
 
 	return nil

--- a/internal/providers/pke/pkeworkflow/delete_dex_client.go
+++ b/internal/providers/pke/pkeworkflow/delete_dex_client.go
@@ -29,7 +29,7 @@ type DeleteDexClientActivity struct {
 	clusterAuthService auth.ClusterAuthService
 }
 
-func DeleteCreateDexClientActivity(clusters Clusters, clusterAuthService auth.ClusterAuthService) *DeleteDexClientActivity {
+func NewDeleteDexClientActivity(clusters Clusters, clusterAuthService auth.ClusterAuthService) *DeleteDexClientActivity {
 	return &DeleteDexClientActivity{
 		clusters:           clusters,
 		clusterAuthService: clusterAuthService,

--- a/internal/providers/pke/pkeworkflow/delete_dex_client.go
+++ b/internal/providers/pke/pkeworkflow/delete_dex_client.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkeworkflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/auth"
+	"github.com/pkg/errors"
+)
+
+const DeleteDexClientActivityName = "pke-delete-dex-client-activity"
+
+type DeleteDexClientActivity struct {
+	clusters           Clusters
+	clusterAuthService auth.ClusterAuthService
+}
+
+func DeleteCreateDexClientActivity(clusters Clusters, clusterAuthService auth.ClusterAuthService) *DeleteDexClientActivity {
+	return &DeleteDexClientActivity{
+		clusters:           clusters,
+		clusterAuthService: clusterAuthService,
+	}
+}
+
+type DeleteDexClientActivityInput struct {
+	ClusterID uint
+}
+
+func (a *DeleteDexClientActivity) Execute(ctx context.Context, input DeleteDexClientActivityInput) error {
+	cluster, err := a.clusters.GetCluster(ctx, input.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	err = a.clusterAuthService.UnRegisterCluster(ctx, cluster.GetUID())
+	if err != nil {
+		return errors.New(fmt.Sprintf("can't delete dex client for cluster %t", cluster))
+	}
+
+	return nil
+}

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -93,6 +93,7 @@ const (
 	InstallNodePoolLabelSetOperator        = "InstallNodePoolLabelSetOperator"
 	SetupNodePoolLabelsSet                 = "SetupNodePoolLabelsSet"
 	CreateDefaultStorageclass              = "CreateDefaultStorageclass"
+	CreateClusterRoles                     = "CreateClusterRoles"
 )
 
 // Provider name regexp

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/rbac/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +31,10 @@ import (
 )
 
 // GetOrCreateClusterRole gets the cluster role with the given name if exists otherwise creates new one and returns it
-func GetOrCreateClusterRole(log logrus.FieldLogger, client *kubernetes.Clientset, name string, rules []v1beta1.PolicyRule) (*v1beta1.ClusterRole, error) {
+func GetOrCreateClusterRole(log logrus.FieldLogger, client *kubernetes.Clientset, name string, rules []rbacv1.PolicyRule) (*rbacv1.ClusterRole, error) {
 	fieldSelector := fields.SelectorFromSet(fields.Set{"metadata.name": name})
 
-	clusterRoles, err := client.RbacV1beta1().ClusterRoles().List(metav1.ListOptions{FieldSelector: fieldSelector.String()})
+	clusterRoles, err := client.RbacV1().ClusterRoles().List(metav1.ListOptions{FieldSelector: fieldSelector.String()})
 	if err != nil {
 		log.Errorf("querying cluster roles failed: %s", err.Error())
 		return nil, err
@@ -50,8 +50,8 @@ func GetOrCreateClusterRole(log logrus.FieldLogger, client *kubernetes.Clientset
 		return &clusterRoles.Items[0], nil
 	}
 
-	clusterRole, err := client.RbacV1beta1().ClusterRoles().Create(
-		&v1beta1.ClusterRole{
+	clusterRole, err := client.RbacV1().ClusterRoles().Create(
+		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -111,10 +111,10 @@ func GetOrCreateServiceAccount(log logrus.FieldLogger, client *kubernetes.Client
 func GetOrCreateClusterRoleBinding(log logrus.FieldLogger,
 	client *kubernetes.Clientset,
 	name string, serviceAccount *v1.ServiceAccount,
-	clusterRole *v1beta1.ClusterRole) (*v1beta1.ClusterRoleBinding, error) {
+	clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRoleBinding, error) {
 	fieldSelector := fields.SelectorFromSet(fields.Set{"metadata.name": name})
 
-	clusterRoleBindings, err := client.RbacV1beta1().ClusterRoleBindings().List(metav1.ListOptions{FieldSelector: fieldSelector.String()})
+	clusterRoleBindings, err := client.RbacV1().ClusterRoleBindings().List(metav1.ListOptions{FieldSelector: fieldSelector.String()})
 	if err != nil {
 		log.Errorf("querying cluster role bindings failed: %s", err.Error())
 		return nil, err
@@ -130,23 +130,21 @@ func GetOrCreateClusterRoleBinding(log logrus.FieldLogger,
 		return &clusterRoleBindings.Items[0], nil
 	}
 
-	clusterRoleBinding, err := client.RbacV1beta1().ClusterRoleBindings().Create(
-		&v1beta1.ClusterRoleBinding{
+	clusterRoleBinding, err := client.RbacV1().ClusterRoleBindings().Create(
+		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Subjects: []v1beta1.Subject{
+			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
 					Name:      serviceAccount.Name,
 					Namespace: serviceAccount.Namespace,
-					APIGroup:  v1.GroupName,
 				},
 			},
-			RoleRef: v1beta1.RoleRef{
-				Kind:     "ClusterRole",
-				Name:     clusterRole.Name,
-				APIGroup: v1beta1.GroupName,
+			RoleRef: rbacv1.RoleRef{
+				Kind: "ClusterRole",
+				Name: clusterRole.Name,
 			},
 		})
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pke/pull/7
| License         | Apache 2.0


### What's in this PR?
Dex based OIDC cluster authentication. This is the first part of a series of PRs, since this just integrates Dex client creation into the PKE install flow (and added the necessary flags to the `pke` command).

### Why?
To have more users other than the global admin user.

### Additional context
Maybe the clientID and clientSecret could be bundled into an OAuth secret type and the values could be generated inside the secret engine. Not sure.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
