### PR TITLE
Increase Azure API operation polling duration time

### DIFF
--- a/pkg/providers/azure/cloud.go
+++ b/pkg/providers/azure/cloud.go
@@ -15,6 +15,8 @@
 package azure
 
 import (
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
@@ -51,6 +53,9 @@ func NewCloudConnection(env *azure.Environment, creds *Credentials) (*CloudConne
 		creds:  *creds,
 		client: autorest.NewClientWithUserAgent(userAgent),
 	}
+
+	cc.client.PollingDuration = 30 * time.Minute
+
 	var err error
 	cc.client.Authorizer, err = GetAuthorizer(&creds.ServicePrincipal, env)
 	if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1782
| License         | Apache 2.0




### Why?
The default operation polling period of 15 min is too low as the cluster create/delete operations often take longer than 15 mins. This leads to Pipeline receiving an error that the operation did not succeed while the operation continues to run on the cloud provider side and eventually complete.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)