### PR TITLE
PKE use a single subnet

### DIFF
--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -228,7 +228,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 				Pool:                  np,
 				WorkerInstanceProfile: rolesOutput["WorkerInstanceProfile"],
 				VPCID:                 vpcOutput["VpcId"],
-				SubnetID:              strings.Split(vpcOutput["SubnetIds"], ",")[1],
+				SubnetID:              strings.Split(vpcOutput["SubnetIds"], ",")[0],
 				ClusterSecurityGroup:  clusterSecurityGroup,
 				ExternalBaseUrl:       input.PipelineExternalURL,
 				SSHKeyName:            keyOut.KeyName,

--- a/templates/pke/vpc.cf.yaml
+++ b/templates/pke/vpc.cf.yaml
@@ -28,11 +28,6 @@ Parameters:
     Default: 192.168.64.0/20
     Description: CidrBlock for subnet 01 within the VPC
 
-  Subnet02Block:
-    Type: String
-    Default: 192.168.80.0/20
-    Description: CidrBlock for subnet 02 within the VPC
-
   Subnets:
     Description: The subnets where workers can be created.
     Type: String
@@ -54,7 +49,6 @@ Metadata:
           - RouteTableId
           - VpcBlock
           - Subnet01Block
-          - Subnet02Block
           - Subnets
 Conditions:
   CreateVpc: !Equals [ !Ref VpcId, "" ]
@@ -121,24 +115,6 @@ Resources:
       - Key: Name
         Value: !Sub "${AWS::StackName}-Subnet01"
 
-  Subnet02:
-    Type: "AWS::EC2::Subnet"
-    Condition: CreateSubnets
-    Metadata:
-      Comment: Subnet 02
-    Properties:
-      AvailabilityZone:
-        Fn::Select:
-        - '1'
-        - Fn::GetAZs:
-            Ref: AWS::Region
-      CidrBlock:
-        Ref: Subnet02Block
-      VpcId: !If [ CreateVpc, !Ref VPC,  !Ref VpcId ]
-      Tags:
-      - Key: Name
-        Value: !Sub "${AWS::StackName}-Subnet02"
-
   Subnet01RouteTableAssociation:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Condition: CreateSubnets
@@ -146,19 +122,12 @@ Resources:
       SubnetId: !Ref Subnet01
       RouteTableId: !If [ CreateVpc, !Ref RouteTable,  !Ref RouteTableId ]
 
-  Subnet02RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Condition: CreateSubnets
-    Properties:
-      SubnetId: !Ref Subnet02
-      RouteTableId: !If [ CreateVpc, !Ref RouteTable,  !Ref RouteTableId ]
-
 Outputs:
 
   SubnetIds:
     Description: All subnets in the VPC
-    Value:  !If [ CreateSubnets, !Join [ ",", [ !Ref Subnet01, !Ref Subnet02 ] ], !Ref Subnets ]
+    Value:  !If [ CreateSubnets, !Ref Subnet01, !Ref Subnets ]
 
   VpcId:
     Description: The VPC Id
-    Value: !If [ CreateVpc, !Ref VPC,  !Ref VpcId ]
+    Value: !If [ CreateVpc, !Ref VPC, !Ref VpcId ]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    |no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Allowing multiple subnets in PKE needs rethinking from API perspective. We will only use one subnet for now, until we come up with a more broad solution.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
