### PR TITLE
import user name as organization during org sync

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -67,6 +67,13 @@ const SessionCookieHTTPOnly = true
 // SessionCookieName is the name of the token that is stored in the session cookie
 const SessionCookieName = "Pipeline session token"
 
+// Auth provider names
+const (
+	ProviderDexGithub = "dex:github"
+	ProviderGithub    = "github"
+	ProviderUser      = "user"
+)
+
 // Init authorization
 // nolint: gochecknoglobals
 var (

--- a/auth/github.go
+++ b/auth/github.go
@@ -88,7 +88,7 @@ func getGithubOrganizations(token string) ([]organization, error) {
 
 	memberships, _, err := githubClient.Organizations.ListOrgMemberships(oauth2.NoContext, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list organization memberships")
+		return nil, errors.Wrap(err, "failed to list organization memberships from github")
 	}
 
 	var orgs []organization
@@ -102,6 +102,19 @@ func getGithubOrganizations(token string) ([]organization, error) {
 
 		orgs = append(orgs, org)
 	}
+
+	user, _, err := githubClient.Users.Get(context.Background(), "")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch user from github")
+	}
+
+	userOrg := organization{
+		name:     *user.Login,
+		role:     "admin",
+		provider: "user",
+	}
+
+	orgs = append(orgs, userOrg)
 
 	return orgs, nil
 }

--- a/auth/github.go
+++ b/auth/github.go
@@ -97,7 +97,7 @@ func getGithubOrganizations(token string) ([]organization, error) {
 			name:     membership.GetOrganization().GetLogin(),
 			id:       membership.GetOrganization().GetID(),
 			role:     membership.GetRole(),
-			provider: "github",
+			provider: ProviderGithub,
 		}
 
 		orgs = append(orgs, org)
@@ -111,7 +111,7 @@ func getGithubOrganizations(token string) ([]organization, error) {
 	userOrg := organization{
 		name:     *user.Login,
 		role:     "admin",
-		provider: "user",
+		provider: ProviderUser,
 	}
 
 	orgs = append(orgs, userOrg)

--- a/auth/user.go
+++ b/auth/user.go
@@ -293,7 +293,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 	// Until https://github.com/dexidp/dex/issues/1076 gets resolved we need to use a manual
 	// GitHub API query to get the user login and image to retain compatibility for now
 	var githubUserMeta *githubUserMeta
-	if schema.Provider == "dex:github" {
+	if schema.Provider == ProviderDexGithub {
 
 		githubUserMeta, err = getGithubUserMeta(schema)
 		if err != nil {
@@ -327,7 +327,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 	// When a user registers a default organization is created in which he/she is admin
 	userOrg := Organization{
 		Name:     currentUser.Login,
-		Provider: "user",
+		Provider: ProviderUser,
 	}
 	currentUser.Organizations = []Organization{userOrg}
 
@@ -347,7 +347,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 	bus.events.OrganizationRegistered(currentUser.Organizations[0].ID, currentUser.ID)
 
 	// Import Github organizations in case of GitHub
-	if schema.Provider == "dex:github" {
+	if schema.Provider == ProviderDexGithub {
 		err = bus.githubImporter.ImportOrganizationsFromDex(currentUser, organizations)
 	}
 
@@ -465,7 +465,7 @@ func (i *GithubImporter) ImportOrganizationsFromGithub(currentUser *User, github
 func (i *GithubImporter) ImportOrganizationsFromDex(currentUser *User, organizations []string) error {
 	var orgs []organization
 	for _, org := range organizations {
-		orgs = append(orgs, organization{name: org, provider: "github"})
+		orgs = append(orgs, organization{name: org, provider: ProviderGithub})
 	}
 
 	return i.ImportGithubOrganizations(currentUser, orgs)

--- a/database/migrations/1551105244_set_spotguides_org_provider.down..sql
+++ b/database/migrations/1551105244_set_spotguides_org_provider.down..sql
@@ -1,0 +1,1 @@
+UPDATE organizations SET provider = "" WHERE name = "spotguides";

--- a/database/migrations/1551105244_set_spotguides_org_provider.down..sql
+++ b/database/migrations/1551105244_set_spotguides_org_provider.down..sql
@@ -1,1 +1,0 @@
-UPDATE organizations SET provider = "" WHERE name = "spotguides";

--- a/database/migrations/1551105244_set_spotguides_org_provider.down.sql
+++ b/database/migrations/1551105244_set_spotguides_org_provider.down.sql
@@ -1,0 +1,1 @@
+UPDATE organizations SET provider = "" WHERE name = "spotguides";

--- a/database/migrations/1551105244_set_spotguides_org_provider.up.sql
+++ b/database/migrations/1551105244_set_spotguides_org_provider.up.sql
@@ -1,0 +1,1 @@
+UPDATE organizations SET provider = "github" WHERE name = "spotguides";

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -146,7 +146,7 @@ func CreateSharedSpotguideOrganization(db *gorm.DB, sharedLibraryGitHubOrganizat
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to query shared Github organization")
 	}
-	sharedOrg = &auth.Organization{Name: *githubOrg.Login, GithubID: githubOrg.ID}
+	sharedOrg = &auth.Organization{Name: *githubOrg.Login, GithubID: githubOrg.ID, Provider: "github"}
 	if err := db.Where(sharedOrg).FirstOrCreate(sharedOrg).Error; err != nil {
 		return nil, emperror.Wrap(err, "failed to create shared organization")
 	}

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -146,7 +146,7 @@ func CreateSharedSpotguideOrganization(db *gorm.DB, sharedLibraryGitHubOrganizat
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to query shared Github organization")
 	}
-	sharedOrg = &auth.Organization{Name: *githubOrg.Login, GithubID: githubOrg.ID, Provider: "github"}
+	sharedOrg = &auth.Organization{Name: *githubOrg.Login, GithubID: githubOrg.ID, Provider: auth.ProviderGithub}
 	if err := db.Where(sharedOrg).FirstOrCreate(sharedOrg).Error; err != nil {
 		return nil, emperror.Wrap(err, "failed to create shared organization")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
If a user logs in with some other provider than GitHub it's convenient to have its user name synced into an org when the Sync Orgs feature is called.


### Why?
To enable CI/CD for non through-GitHub registered users.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
