### PR TITLE
Remove the remains of casbin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -355,29 +355,6 @@
   version = "v3.1.1"
 
 [[projects]]
-  digest = "1:d7149665a6945aa722d14922377a6d428dc0793d39977cd0ebed2e9263972760"
-  name = "github.com/casbin/casbin"
-  packages = [
-    "config",
-    "log",
-    "model",
-    "persist",
-    "rbac",
-    "util",
-  ]
-  pruneopts = "NUT"
-  revision = "4aa316fb68d44d4cc5ddd98d7e9ec80bc0a8b081"
-  version = "v1.8.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:3786e4321be0a37718a04c51e3ba6dc0182efd2f617bacf934aa8b44012531ee"
-  name = "github.com/casbin/gorm-adapter"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "5f0f4b5ecad7f5259de033c2765c1e9399b23034"
-
-[[projects]]
   digest = "1:65b0d980b428a6ad4425f2df4cd5410edd81f044cf527bd1c345368444649e58"
   name = "github.com/census-instrumentation/opencensus-proto"
   packages = [
@@ -1106,17 +1083,6 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "0bc2a4274cd0f8baa49f2d598df5ef0cc3069c80"
-
-[[projects]]
-  digest = "1:4d5fa9f49e5bf3d55c16ff562af9e3231f9ac5ccf495927fd0555f4607c15475"
-  name = "github.com/lib/pq"
-  packages = [
-    ".",
-    "oid",
-  ]
-  pruneopts = "NUT"
-  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:35e5598ba3bc950039e13d91958ce37f675264735907cada569d11b243e5cacb"
@@ -2705,7 +2671,6 @@
     "github.com/banzaicloud/logrus-runtime-formatter",
     "github.com/banzaicloud/nodepool-labels-operator/pkg/npls",
     "github.com/banzaicloud/prometheus-config",
-    "github.com/casbin/gorm-adapter",
     "github.com/dgrijalva/jwt-go",
     "github.com/didip/tollbooth",
     "github.com/docker/libcompose/yaml",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -159,10 +159,6 @@ required = [ "github.com/apache/thrift/lib/go/thrift"]
 
 [[constraint]]
   branch = "master"
-  name = "github.com/casbin/gorm-adapter"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/banzaicloud/logrus-runtime-formatter"
 
 [[constraint]]

--- a/auth/migrate.go
+++ b/auth/migrate.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	gormadapter "github.com/casbin/gorm-adapter"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
@@ -31,7 +30,6 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&User{},
 		&UserOrganization{},
 		&Organization{},
-		&gormadapter.CasbinRule{},
 	}
 
 	var tableNames string

--- a/database/migrations/1551260857_drop_casbin_rule_table.down.sql
+++ b/database/migrations/1551260857_drop_casbin_rule_table.down.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `casbin_rule` (
+   `p_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v0` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v1` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v2` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v3` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v4` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   `v5` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/1551260857_drop_casbin_rule_table.up.sql
+++ b/database/migrations/1551260857_drop_casbin_rule_table.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `casbin_rule`;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related #1758, related #1764
| License         | Apache 2.0


### What's in this PR?

This PR removes the last remains of Casbin.


### Why?

Earlier we decided to remove Casbin and replace it with a simple, custom implementation. However, because of our migration policy we couldn't remove the database tables in a single step.
