### PR TITLE
Check that the specified load balancer subnets are not the same

### DIFF
--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -536,8 +536,8 @@ func (o *OKECluster) PopulateNetworkValues(r *oracle.Cluster, VCNID string) (*or
 	}
 
 	r.SetVCNID(VCNID)
-	if len(networkValues.LBSubnetIDs) != 2 {
-		return r, errors.New("invalid network config: there must be 2 loadbalancer subnets")
+	if len(networkValues.LBSubnetIDs) != 2 || networkValues.LBSubnetIDs[0] == networkValues.LBSubnetIDs[1] {
+		return r, errors.New("invalid network config: there must be exactly 2 different load balancer subnets specified")
 	}
 	r.SetLBSubnetID1(networkValues.LBSubnetIDs[0])
 	r.SetLBSubnetID2(networkValues.LBSubnetIDs[1])


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Extend the check which verifies that there are exactly 2 load balancer subnets specified with a clause checking that the subnets are not the same.

### Why?
The 2 required load balancer subnets must not be the same.