### PR TITLE
[WIP] Rename network API provider parameter

### DIFF
--- a/api/network.go
+++ b/api/network.go
@@ -269,7 +269,7 @@ func (a *NetworkAPI) ListRouteTables(ctx *gin.Context) {
 }
 
 func getRequiredProviderFromContext(ctx *gin.Context, logger logrus.FieldLogger) (string, bool) {
-	provider, ok := ginutils.RequiredQueryOrAbort(ctx, "cloudType")
+	provider, ok := ginutils.RequiredQueryOrAbort(ctx, "provider")
 	return provider, ok
 }
 

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-33e2d65073e5eebe710f75015c95f5865eb3861bb43b67b89a1e1c1bc8988c76  docs/openapi/pipeline.yaml
+e0bc8bf14bb43bc697658198d9134b844ebe0c1988231a726d0118f99bf20e23  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -4702,7 +4702,7 @@ paths:
       - description: Identifies the cloud provider
         explode: true
         in: query
-        name: cloudType
+        name: provider
         required: true
         schema:
           enum:
@@ -4713,7 +4713,7 @@ paths:
           - alibaba
           type: string
         style: form
-      - description: Identifies the region of the VPC network (required when cloudType != azure)
+      - description: Identifies the region of the VPC network (required when provider != azure)
         explode: true
         in: query
         name: region
@@ -4721,7 +4721,7 @@ paths:
         schema:
           type: string
         style: form
-      - description: Identifies the resource group of the Azure virtual network (required when cloudType == azure)
+      - description: Identifies the resource group of the Azure virtual network (required when provider == azure)
         explode: true
         in: query
         name: resourceGroup
@@ -4792,7 +4792,7 @@ paths:
       - description: Identifies the cloud provider
         explode: true
         in: query
-        name: cloudType
+        name: provider
         required: true
         schema:
           enum:
@@ -4884,7 +4884,7 @@ paths:
       - description: Identifies the cloud provider
         explode: true
         in: query
-        name: cloudType
+        name: provider
         required: true
         schema:
           enum:

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -35,7 +35,7 @@ List route tables of the given VPC network
  * @param orgId Organization identification
  * @param networkId VPC network identification
  * @param secretId Secret identification
- * @param cloudType Identifies the cloud provider
+ * @param provider Identifies the cloud provider
  * @param optional nil or *ListRouteTablesOpts - Optional Parameters:
  * @param "Region" (optional.String) -  Identifies the region of the VPC network (required when cloudType != azure)
  * @param "ResourceGroup" (optional.String) -  Identifies the resource group of the Azure virtual network (required when cloudType == azure)
@@ -47,7 +47,7 @@ type ListRouteTablesOpts struct {
 	ResourceGroup optional.String
 }
 
-func (a *NetworkApiService) ListRouteTables(ctx context.Context, orgId int32, networkId string, secretId string, cloudType string, localVarOptionals *ListRouteTablesOpts) ([]RouteTableInfo, *http.Response, error) {
+func (a *NetworkApiService) ListRouteTables(ctx context.Context, orgId int32, networkId string, secretId string, provider string, localVarOptionals *ListRouteTablesOpts) ([]RouteTableInfo, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
@@ -66,7 +66,7 @@ func (a *NetworkApiService) ListRouteTables(ctx context.Context, orgId int32, ne
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("cloudType", parameterToString(cloudType, ""))
+	localVarQueryParams.Add("provider", parameterToString(provider, ""))
 	if localVarOptionals != nil && localVarOptionals.Region.IsSet() {
 		localVarQueryParams.Add("region", parameterToString(localVarOptionals.Region.Value(), ""))
 	}
@@ -173,10 +173,10 @@ List VPC networks accessible by the organization.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orgId Organization identification
  * @param secretId Secret identification
- * @param cloudType Identifies the cloud provider
+ * @param provider Identifies the cloud provider
  * @param optional nil or *ListVPCNetworksOpts - Optional Parameters:
- * @param "Region" (optional.String) -  Identifies the region of the VPC network (required when cloudType != azure)
- * @param "ResourceGroup" (optional.String) -  Identifies the resource group of the Azure virtual network (required when cloudType == azure)
+ * @param "Region" (optional.String) -  Identifies the region of the VPC network (required when provider != azure)
+ * @param "ResourceGroup" (optional.String) -  Identifies the resource group of the Azure virtual network (required when provider == azure)
 @return []VpcNetworkInfo
 */
 
@@ -185,7 +185,7 @@ type ListVPCNetworksOpts struct {
 	ResourceGroup optional.String
 }
 
-func (a *NetworkApiService) ListVPCNetworks(ctx context.Context, orgId int32, secretId string, cloudType string, localVarOptionals *ListVPCNetworksOpts) ([]VpcNetworkInfo, *http.Response, error) {
+func (a *NetworkApiService) ListVPCNetworks(ctx context.Context, orgId int32, secretId string, provider string, localVarOptionals *ListVPCNetworksOpts) ([]VpcNetworkInfo, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
@@ -203,7 +203,7 @@ func (a *NetworkApiService) ListVPCNetworks(ctx context.Context, orgId int32, se
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("cloudType", parameterToString(cloudType, ""))
+	localVarQueryParams.Add("provider", parameterToString(provider, ""))
 	if localVarOptionals != nil && localVarOptionals.Region.IsSet() {
 		localVarQueryParams.Add("region", parameterToString(localVarOptionals.Region.Value(), ""))
 	}
@@ -311,7 +311,7 @@ List subnetworks of the given VPC network
  * @param orgId Organization identification
  * @param networkId VPC network identification
  * @param secretId Secret identification
- * @param cloudType Identifies the cloud provider
+ * @param provider Identifies the cloud provider
  * @param optional nil or *ListVPCSubnetsOpts - Optional Parameters:
  * @param "Region" (optional.String) -  Identifies the region of the VPC network (required when cloudType != azure)
  * @param "ResourceGroup" (optional.String) -  Identifies the resource group of the Azure virtual network (required when cloudType == azure)
@@ -323,7 +323,7 @@ type ListVPCSubnetsOpts struct {
 	ResourceGroup optional.String
 }
 
-func (a *NetworkApiService) ListVPCSubnets(ctx context.Context, orgId int32, networkId string, secretId string, cloudType string, localVarOptionals *ListVPCSubnetsOpts) ([]SubnetInfo, *http.Response, error) {
+func (a *NetworkApiService) ListVPCSubnets(ctx context.Context, orgId int32, networkId string, secretId string, provider string, localVarOptionals *ListVPCSubnetsOpts) ([]SubnetInfo, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
@@ -342,7 +342,7 @@ func (a *NetworkApiService) ListVPCSubnets(ctx context.Context, orgId int32, net
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("cloudType", parameterToString(cloudType, ""))
+	localVarQueryParams.Add("provider", parameterToString(provider, ""))
 	if localVarOptionals != nil && localVarOptionals.Region.IsSet() {
 		localVarQueryParams.Add("region", parameterToString(localVarOptionals.Region.Value(), ""))
 	}

--- a/client/docs/NetworkApi.md
+++ b/client/docs/NetworkApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 
 
 # **ListRouteTables**
-> []RouteTableInfo ListRouteTables(ctx, orgId, networkId, secretId, cloudType, optional)
+> []RouteTableInfo ListRouteTables(ctx, orgId, networkId, secretId, provider, optional)
 List VPC route tables
 
 List route tables of the given VPC network
@@ -23,7 +23,7 @@ Name | Type | Description  | Notes
   **orgId** | **int32**| Organization identification | 
   **networkId** | **string**| VPC network identification | 
   **secretId** | **string**| Secret identification | 
-  **cloudType** | **string**| Identifies the cloud provider | 
+  **provider** | **string**| Identifies the cloud provider | 
  **optional** | ***ListRouteTablesOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -54,7 +54,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListVPCNetworks**
-> []VpcNetworkInfo ListVPCNetworks(ctx, orgId, secretId, cloudType, optional)
+> []VpcNetworkInfo ListVPCNetworks(ctx, orgId, secretId, provider, optional)
 List VPC networks
 
 List VPC networks accessible by the organization.
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
  **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **orgId** | **int32**| Organization identification | 
   **secretId** | **string**| Secret identification | 
-  **cloudType** | **string**| Identifies the cloud provider | 
+  **provider** | **string**| Identifies the cloud provider | 
  **optional** | ***ListVPCNetworksOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -77,8 +77,8 @@ Name | Type | Description  | Notes
 
 
 
- **region** | **optional.String**| Identifies the region of the VPC network (required when cloudType !&#x3D; azure) | 
- **resourceGroup** | **optional.String**| Identifies the resource group of the Azure virtual network (required when cloudType &#x3D;&#x3D; azure) | 
+ **region** | **optional.String**| Identifies the region of the VPC network (required when provider !&#x3D; azure) | 
+ **resourceGroup** | **optional.String**| Identifies the resource group of the Azure virtual network (required when provider &#x3D;&#x3D; azure) | 
 
 ### Return type
 
@@ -96,7 +96,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListVPCSubnets**
-> []SubnetInfo ListVPCSubnets(ctx, orgId, networkId, secretId, cloudType, optional)
+> []SubnetInfo ListVPCSubnets(ctx, orgId, networkId, secretId, provider, optional)
 List VPC subnetworks
 
 List subnetworks of the given VPC network
@@ -109,7 +109,7 @@ Name | Type | Description  | Notes
   **orgId** | **int32**| Organization identification | 
   **networkId** | **string**| VPC network identification | 
   **secretId** | **string**| Secret identification | 
-  **cloudType** | **string**| Identifies the cloud provider | 
+  **provider** | **string**| Identifies the cloud provider | 
  **optional** | ***ListVPCSubnetsOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -4512,7 +4512,7 @@ paths:
                     schema:
                         type: string
                 -
-                    name: cloudType
+                    name: provider
                     description: Identifies the cloud provider
                     in: query
                     required: true
@@ -4521,14 +4521,14 @@ paths:
                         enum: [amazon, google, azure, oracle, alibaba]
                 -
                     name: region
-                    description: Identifies the region of the VPC network (required when cloudType != azure)
+                    description: Identifies the region of the VPC network (required when provider != azure)
                     in: query
                     required: false
                     schema:
                         type: string
                 -
                     name: resourceGroup
-                    description: Identifies the resource group of the Azure virtual network (required when cloudType == azure)
+                    description: Identifies the resource group of the Azure virtual network (required when provider == azure)
                     in: query
                     required: false
                     schema:
@@ -4592,7 +4592,7 @@ paths:
                     schema:
                         type: string
                 -
-                    name: cloudType
+                    name: provider
                     description: Identifies the cloud provider
                     in: query
                     required: true
@@ -4674,7 +4674,7 @@ paths:
                     schema:
                         type: string
                 -
-                    name: cloudType
+                    name: provider
                     description: Identifies the cloud provider
                     in: query
                     required: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Rename `cloudType` parameter of network API queries to `providers`, because it better describes its purpose.

### Why?
It looks better this way.

### Checklist
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)