### PR TITLE
 Bump external dns chart default version to 1.6.2 and introduce image version

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -1032,6 +1032,9 @@ func RegisterDomainPostHook(commonCluster CommonCluster) error {
 		"rbac": map[string]bool{
 			"create": commonCluster.RbacEnabled() == true,
 		},
+		"image": map[string]string{
+			"tag": viper.GetString(pipConfig.DNSExternalDnsImageVersion),
+		},
 		"aws": map[string]string{
 			"secretKey": route53Secret.Values[pkgSecret.AwsSecretAccessKey],
 			"accessKey": route53Secret.Values[pkgSecret.AwsAccessKeyId],

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -40,8 +40,11 @@ const (
 	// DNSGcLogLevel configuration key for the DNS garbage collector logging level default value: "debug"
 	DNSGcLogLevel = "dns.gcLogLevel"
 
-	// DNSExternalDnsChartVersion set the external-dns chart version default value: "0.5.4"
+	// DNSExternalDnsChartVersion set the external-dns chart version default value: "1.6.2"
 	DNSExternalDnsChartVersion = "dns.externalDnsChartVersion"
+
+	// DNSExternalDnsImageVersion set the external-dns image version
+	DNSExternalDnsImageVersion = "dns.externalDnsImageVersion"
 
 	// Route53MaintenanceWndMinute configuration key for the maintenance window for Route53.
 	// This is the maintenance window before the next AWS Route53 pricing period starts
@@ -206,7 +209,8 @@ func init() {
 	viper.SetDefault("tls.validity", "8760h") // 1 year
 	viper.SetDefault(DNSBaseDomain, "example.org")
 	viper.SetDefault(DNSGcIntervalMinute, 1)
-	viper.SetDefault(DNSExternalDnsChartVersion, "0.7.5")
+	viper.SetDefault(DNSExternalDnsChartVersion, "1.6.2")
+	viper.SetDefault(DNSExternalDnsImageVersion, "v0.5.11")
 	viper.SetDefault(DNSGcLogLevel, "debug")
 	viper.SetDefault(Route53MaintenanceWndMinute, 15)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
External dns chart version bump to 1.6.2


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Bump external dns chart version because of a bug we encountered on EKS clusters

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
