### PR TITLE
Fix delete all deployments

### DIFF
--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -319,7 +319,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 	}
 
 	if deleteResources {
-		err = helm.DeleteAllDeployment(config)
+		err = helm.DeleteAllDeployment(logger, config)
 		if err != nil {
 			err = emperror.Wrap(err, "failed to delete deployments")
 

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -184,7 +184,7 @@ func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte) error {
 	if err != nil {
 		return emperror.Wrap(err, "failed to get deployments")
 	}
-	log.Info("start deleting deployments")
+
 	if releaseResp != nil {
 		// the returned release items are unique by release name and status
 		// e.g. release name = release1, status = PENDING_UPGRADE
@@ -194,7 +194,9 @@ func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte) error {
 		deletedDeployments := make(map[string]bool)
 		for _, r := range releaseResp.Releases {
 			if _, ok := deletedDeployments[r.Name]; !ok {
-				log.Infoln("deleting deployment", r.Name)
+				log := log.WithField("deployment", r.Name)
+
+				log.Info("deleting deployment")
 
 				err := DeleteDeployment(r.Name, kubeconfig)
 				if err != nil {
@@ -202,7 +204,7 @@ func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte) error {
 				}
 				deletedDeployments[r.Name] = true
 
-				log.Infof("deployment %s successfully deleted", r.Name)
+				log.Info("deployment successfully deleted")
 			}
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes




### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If a helm upgrade of a deployment fails the deployment will have two states: the original state and a PENDING_UPGRADE state. This caused Pipeline to delete such deployments twice the second attempt failing since the first already deleted the deployment.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
