### PR TITLE
Fix alibaba sdk error when trying to get cluster details on a still c…

### DIFF
--- a/pkg/cluster/acsk/action/action_utils.go
+++ b/pkg/cluster/acsk/action/action_utils.go
@@ -480,6 +480,9 @@ func waitUntilClusterDeleteIsComplete(logger logrus.FieldLogger, clusterID strin
 
 // GetClusterDetails retrieves cluster details from cloud provider
 func GetClusterDetails(client *cs.Client, clusterID string) (r *acsk.AlibabaDescribeClusterResponse, err error) {
+	if clusterID == "" {
+		return nil, errors.New("could not get cluster details clusterId is empty")
+	}
 	req := cs.CreateDescribeClusterDetailRequest()
 	req.SetScheme(requests.HTTPS)
 	req.SetDomain(acsk.AlibabaApiDomain)


### PR DESCRIPTION
…reating cluster

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes an Alibaba SDK error which occurs when trying to get cluster details on a still creating cluster.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Cluster ID is only available in our DB when the cluster become functional. Alibaba only allows interaction with the clusters when it is running.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)