### PR TITLE
The generated secret name for EKS cluster user access key should be a…

### DIFF
--- a/pkg/cluster/eks/action/actions.go
+++ b/pkg/cluster/eks/action/actions.go
@@ -1063,7 +1063,7 @@ func (a *PersistClusterUserAccessKeyAction) GetName() string {
 
 // getSecretName returns the name that identifies the  cluster user access key in Vault
 func getSecretName(userName string) string {
-	return fmt.Sprintf("%s-key", userName)
+	return fmt.Sprintf("%s-key", strings.ToLower(userName))
 }
 
 // GetClusterUserAccessKeyIdAndSecretVault returns the AWS access key and access key secret from Vault


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Lowercase the secret name generated for the EKS cluster user credentials.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The secret name generated for storing EKS cluster user credentials is based on the cluster name. If the cluster name contains uppercases than the generated secret name will be rejected as it's not valid


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

-[x] Implementation tested (with at least one cloud provider)
