### PR TITLE
The generated secret name for EKS cluster user access key should be a…

### DIFF
--- a/pkg/cluster/eks/action/actions.go
+++ b/pkg/cluster/eks/action/actions.go
@@ -1057,7 +1057,7 @@ func (a *PersistClusterUserAccessKeyAction) GetName() string {
 
 // getSecretName returns the name that identifies the  cluster user access key in Vault
 func getSecretName(userName string) string {
-	return fmt.Sprintf("%s-key", userName)
+	return fmt.Sprintf("%s-key", strings.ToLower(userName))
 }
 
 // GetClusterUserAccessKeyIdAndSecretVault returns the AWS access key and access key secret from Vault


### PR DESCRIPTION
Cherry-pick https://github.com/banzaicloud/pipeline/commit/1f952946b866d61e5d59c79e9a3be78c498fd53c

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| License         | Apache 2.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
