### PR TITLE
Use zoneId in location field in case of ACK

### DIFF
--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -308,7 +308,7 @@ func CreateACSKClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgI
 
 	cluster.modelCluster = &model.ClusterModel{
 		Name:           request.Name,
-		Location:       request.Properties.CreateClusterACSK.RegionID,
+		Location:       request.Properties.CreateClusterACSK.ZoneID,
 		Cloud:          request.Cloud,
 		Distribution:   pkgCluster.ACSK,
 		OrganizationId: orgId,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In case of ACK we should return ZoneId in the Location field.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This is required by the UI.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)