### PR TITLE
worker: create domain on startup if it didn't exist

### DIFF
--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -138,4 +138,6 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	_ = v.BindEnv("cadence.host")
 	v.SetDefault("cadence.port", 7933)
 	v.SetDefault("cadence.domain", "pipeline")
+	v.SetDefault("cadence.createNonexistentDomain", true)
+	v.SetDefault("cadence.workflowExecutionRetentionPeriodInDays", 3)
 }

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -203,3 +203,5 @@ path = "config/certs"
 host = "127.0.0.1"
 port = 7933
 domain = "pipeline"
+createNonexistentDomain = true
+workflowExecutionRetentionPeriodInDays = 3

--- a/internal/platform/cadence/config.go
+++ b/internal/platform/cadence/config.go
@@ -26,7 +26,9 @@ type Config struct {
 	Host string
 	Port int
 
-	Domain string
+	Domain                                 string
+	WorkflowExecutionRetentionPeriodInDays int32
+	CreateNonexistentDomain                bool
 
 	// Client identity (not used for now; falls back to machine host name)
 	Identity string

--- a/internal/platform/cadence/worker.go
+++ b/internal/platform/cadence/worker.go
@@ -32,7 +32,8 @@ func NewWorker(config Config, taskList string, logger *zap.Logger) (worker.Worke
 	}
 
 	if config.CreateNonexistentDomain {
-		ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
 		err := serviceClient.RegisterDomain(ctx, &shared.RegisterDomainRequest{
 			Name:                                   &config.Domain,
 			WorkflowExecutionRetentionPeriodInDays: &config.WorkflowExecutionRetentionPeriodInDays,

--- a/internal/platform/cadence/worker.go
+++ b/internal/platform/cadence/worker.go
@@ -15,7 +15,11 @@
 package cadence
 
 import (
+	"context"
+	"time"
+
 	"github.com/goph/emperror"
+	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/worker"
 	"go.uber.org/zap"
 )
@@ -25,6 +29,21 @@ func NewWorker(config Config, taskList string, logger *zap.Logger) (worker.Worke
 	serviceClient, err := newServiceClient("cadence-worker", config, logger)
 	if err != nil {
 		return nil, emperror.Wrap(err, "could not create cadence worker client")
+	}
+
+	if config.CreateNonexistentDomain {
+		ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
+		err := serviceClient.RegisterDomain(ctx, &shared.RegisterDomainRequest{
+			Name:                                   &config.Domain,
+			WorkflowExecutionRetentionPeriodInDays: &config.WorkflowExecutionRetentionPeriodInDays,
+		})
+		if _, ok := err.(*shared.DomainAlreadyExistsError); ok {
+			logger.Info("Cadence domain already exists")
+		} else if err != nil {
+			return nil, emperror.Wrap(err, "failed to register Cadence domain")
+		} else {
+			logger.Info("Created Cadence domain")
+		}
 	}
 
 	return worker.New(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1839 
| License         | Apache 2.0


### What's in this PR?
Create the Cadence domain at worker startup if it does not exist.

### Why?
The domain's existence is a hard dependency of the worker's startup (unlike in the case of pipeline).


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)