### PR TITLE
Fix anchore user manipulation fv's return values in case of error

### DIFF
--- a/internal/security/anchore.go
+++ b/internal/security/anchore.go
@@ -130,7 +130,7 @@ func checkAnchoreUser(username string, method string) int {
 	response, err := DoAnchoreRequest(anchoreRequest)
 	if err != nil {
 		logger.Error(err)
-		return response.StatusCode
+		return http.StatusInternalServerError
 	}
 	return response.StatusCode
 }
@@ -153,7 +153,7 @@ func deleteAnchoreAccount(account string) int {
 	response, err := DoAnchoreRequest(anchoreRequest)
 	if err != nil {
 		logger.Error(err)
-		return response.StatusCode
+		return http.StatusInternalServerError
 	}
 
 	anchoreRequest = AnchoreRequest{
@@ -165,7 +165,7 @@ func deleteAnchoreAccount(account string) int {
 	response, err = DoAnchoreRequest(anchoreRequest)
 	if err != nil {
 		logger.Error(err)
-		return response.StatusCode
+		return http.StatusInternalServerError
 	}
 	return response.StatusCode
 }
@@ -186,7 +186,7 @@ func getAnchoreUserCredentials(username string) (string, int) {
 	response, err := DoAnchoreRequest(anchoreRequest)
 	if err != nil {
 		logger.Error(err)
-		return "", response.StatusCode
+		return "", http.StatusInternalServerError
 	}
 	defer response.Body.Close()
 	var usercreds userCred
@@ -347,7 +347,7 @@ func DoAnchoreRequest(req AnchoreRequest) (*http.Response, error) {
 
 	response, err := client.Do(request)
 	if err != nil {
-		return response, emperror.Wrap(err, "anchore request failed")
+		return nil, emperror.Wrap(err, "anchore request failed")
 	}
 
 	return response, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fix anchore user manipulation fv's return values in case of error

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
