### PR TITLE
dex: propagate client delete error

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_dex_client.go
+++ b/internal/providers/pke/pkeworkflow/delete_dex_client.go
@@ -16,10 +16,9 @@ package pkeworkflow
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/banzaicloud/pipeline/internal/cluster/auth"
-	"github.com/pkg/errors"
+	"github.com/goph/emperror"
 )
 
 const DeleteDexClientActivityName = "pke-delete-dex-client-activity"
@@ -48,7 +47,7 @@ func (a *DeleteDexClientActivity) Execute(ctx context.Context, input DeleteDexCl
 
 	err = a.clusterAuthService.UnRegisterCluster(ctx, cluster.GetUID())
 	if err != nil {
-		return errors.New(fmt.Sprintf("can't delete dex client for cluster %t", cluster))
+		return emperror.Wrapf(err, "can't delete dex client for cluster: %d", input.ClusterID)
 	}
 
 	return nil

--- a/internal/providers/pke/pkeworkflow/delete_dex_client.go
+++ b/internal/providers/pke/pkeworkflow/delete_dex_client.go
@@ -47,7 +47,7 @@ func (a *DeleteDexClientActivity) Execute(ctx context.Context, input DeleteDexCl
 
 	err = a.clusterAuthService.UnRegisterCluster(ctx, cluster.GetUID())
 	if err != nil {
-		return emperror.Wrapf(err, "can't delete dex client for cluster: %d", input.ClusterID)
+		return emperror.Wrap(err, "can't delete dex client for cluster")
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Propagate low-level dex error correctly from the activity.


### Why?
To see the root cause of deletion issues.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
