### PR TITLE
update auth package to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -259,6 +259,6 @@ require (
 	vbom.ml/util v0.0.0-20170409195630-256737ac55c4 // indirect
 )
 
-replace github.com/qor/auth v0.0.0-20190103025640-46aae9fa92fa => github.com/banzaicloud/auth v0.0.0-20190129164927-922d5048ccd3
+replace github.com/qor/auth v0.0.0-20190103025640-46aae9fa92fa => github.com/banzaicloud/auth v0.1.0
 
 replace gopkg.in/yaml.v2 => github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/banzaicloud/anchore-image-validator v0.0.0-20181204185657-bf9806201a4
 github.com/banzaicloud/anchore-image-validator v0.0.0-20181204185657-bf9806201a4e/go.mod h1:VJiVAbcVK7jA47SF+VvQe5NK93vSMiumk7Cr8HK6cv4=
 github.com/banzaicloud/auth v0.0.0-20190129164927-922d5048ccd3 h1:ZppPubTYdo6IZLJgRGxP9oHZEC0GBmlP1Mxt2T1f6ag=
 github.com/banzaicloud/auth v0.0.0-20190129164927-922d5048ccd3/go.mod h1:oKSmpvPMCqencgRxTNadXspkyZYqpZcQV8yeo0VUxso=
+github.com/banzaicloud/auth v0.1.0 h1:rz0jgeu+sonxd9+oVv4IYArP0oHi4lPACBY+U0jkqnI=
+github.com/banzaicloud/auth v0.1.0/go.mod h1:oKSmpvPMCqencgRxTNadXspkyZYqpZcQV8yeo0VUxso=
 github.com/banzaicloud/bank-vaults v0.0.0-20181228154154-8f1348d7821a h1:UAAasJ268OWbYYz+2cLfo30diWRU3N+JkIR91kaLRU0=
 github.com/banzaicloud/bank-vaults v0.0.0-20181228154154-8f1348d7821a/go.mod h1:DCXyt+jITEQ5JUfxOWiYUKUE6ILZ5P4IU0MKgGcnmuc=
 github.com/banzaicloud/cicd-go v0.0.0-20190214150755-832df3e92677 h1:5q4Sv/DFbmiXNyelLCKwYGCUwulXmT1thgKzgWPMvLU=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no|yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
this version of the auth package returns an HTTP error in case the OAuth token is nil after the exchange procedure, instead of SIGSEGV-ing.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
