### PR TITLE
Set cluster status

### DIFF
--- a/cluster/acsk.go
+++ b/cluster/acsk.go
@@ -497,11 +497,6 @@ func getConnectionInfo(client *cs.Client, clusterID string) (inf alibabaConnecti
 	return
 }
 
-func (c *ACSKCluster) Persist(status, statusMessage string) error {
-	c.log.Infof("Model before save: %v", c.modelCluster)
-	return c.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 func (c *ACSKCluster) DownloadK8sConfig() ([]byte, error) {
 	cfg := sdk.NewConfig()
 	cfg.AutoRetry = false
@@ -819,7 +814,8 @@ func (c *ACSKCluster) GetOrganizationId() uint {
 	return c.modelCluster.OrganizationId
 }
 
-func (c *ACSKCluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *ACSKCluster) SetStatus(status, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -413,11 +413,6 @@ func isRoleAssigned(roleAssignments []authorization.RoleAssignment, scope, roleI
 	return false
 }
 
-// Persist saves the cluster model
-func (c *AKSCluster) Persist(status, statusMessage string) error {
-	return c.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 // GetResourceGroupName return the resource group's name the cluster belongs in
 func (c *AKSCluster) GetResourceGroupName() string {
 	return c.modelCluster.AKS.ResourceGroup
@@ -807,8 +802,8 @@ func GetKubernetesVersion(orgID uint, secretID string, location string) ([]strin
 	return cc.GetContainerServicesClient().ListKubernetesVersions(context.TODO(), location)
 }
 
-// UpdateStatus updates cluster status in database
-func (c *AKSCluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *AKSCluster) SetStatus(status, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -58,8 +58,6 @@ type CommonCluster interface {
 	GetSecretWithValidation() (*secret.SecretItemResponse, error)
 
 	// Persistence
-	Persist(string, string) error
-	UpdateStatus(string, string) error
 	DeleteFromDatabase() error
 
 	// Cluster management
@@ -98,6 +96,8 @@ type CommonCluster interface {
 	SetMonitoring(m bool)
 	GetServiceMesh() bool
 	SetServiceMesh(m bool)
+
+	SetStatus(status, statusMessage string) error
 }
 
 // CommonClusterBase holds the fields that is common to all cluster types

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -55,12 +55,6 @@ func (c *DummyCluster) CreateCluster() error {
 	return nil
 }
 
-//Persist save the cluster model
-func (c *DummyCluster) Persist(status, statusMessage string) error {
-	log.Infof("Model before save: %v", c.modelCluster)
-	return c.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 // DownloadK8sConfig downloads the kubeconfig file from cloud
 func (c *DummyCluster) DownloadK8sConfig() ([]byte, error) {
 	return yaml.Marshal(createDummyConfig())
@@ -249,8 +243,8 @@ func CreateDummyClusterFromModel(clusterModel *model.ClusterModel) (*DummyCluste
 	return &dummyCluster, nil
 }
 
-// UpdateStatus updates cluster status in database
-func (c *DummyCluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster' status
+func (c *DummyCluster) SetStatus(status, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -217,12 +217,8 @@ func (c *EC2ClusterPKE) GetSecretWithValidation() (*secret.SecretItemResponse, e
 	return c.CommonClusterBase.getSecret(c)
 }
 
-func (c *EC2ClusterPKE) Persist(string, string) error {
-	err := c.db.Save(c.model).Error
-	return err
-}
-
-func (c *EC2ClusterPKE) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *EC2ClusterPKE) SetStatus(status, statusMessage string) error {
 	originalStatus := c.model.Cluster.Status
 	originalStatusMessage := c.model.Cluster.StatusMessage
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -363,12 +363,6 @@ func (c *EKSCluster) generateIAMRoleNameForCluster() string {
 	return "pipeline-eks-" + c.modelCluster.Name
 }
 
-// Persist saves the cluster model
-func (c *EKSCluster) Persist(status, statusMessage string) error {
-	c.log.Infof("Model before save: %v", c.modelCluster)
-	return c.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 // GetName returns the name of the cluster
 func (c *EKSCluster) GetName() string {
 	return c.modelCluster.Name
@@ -1012,8 +1006,8 @@ func (c *EKSCluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) 
 	return
 }
 
-// UpdateStatus updates cluster status in database
-func (c *EKSCluster) UpdateStatus(status string, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *EKSCluster) SetStatus(status, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -134,6 +134,10 @@ func (r dbGKEClusterRepository) DeleteNodePool(model *google.GKENodePoolModel) e
 	return r.db.Delete(model).Error
 }
 
+func (r dbGKEClusterRepository) SaveClusterModel(model *cluster.ClusterModel) error {
+	return r.db.Save(model).Error
+}
+
 func (r dbGKEClusterRepository) SaveModel(model *google.GKEClusterModel) error {
 	return r.db.Save(model).Error
 }
@@ -157,6 +161,7 @@ type GKEClusterRepository interface {
 	DeleteClusterModel(model *cluster.ClusterModel) error
 	DeleteModel(model *google.GKEClusterModel) error
 	DeleteNodePool(model *google.GKENodePoolModel) error
+	SaveClusterModel(model *cluster.ClusterModel) error
 	SaveModel(model *google.GKEClusterModel) error
 	SaveStatusHistory(model *cluster.StatusHistoryModel) error
 }
@@ -1904,7 +1909,7 @@ func (c *GKECluster) SetStatus(status, statusMessage string) error {
 	c.model.Cluster.Status = status
 	c.model.Cluster.StatusMessage = statusMessage
 
-	if err := c.repository.SaveModel(c.model); err != nil {
+	if err := c.repository.SaveClusterModel(&c.model.Cluster); err != nil {
 		return emperror.Wrap(err, "failed to update cluster status")
 	}
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -338,20 +338,6 @@ func (c *GKECluster) updateCurrentVersions(gkeCluster *gke.Cluster) {
 	}
 }
 
-//Persist save the cluster model
-func (c *GKECluster) Persist(status, statusMessage string) error {
-	c.log.Infof("Model before save: %v", c.model)
-	c.model.Cluster.Status = status
-	c.model.Cluster.StatusMessage = statusMessage
-
-	err := c.repository.SaveModel(c.model)
-	if err != nil {
-		return errors.Wrap(err, "failed to persist cluster")
-	}
-
-	return nil
-}
-
 // DownloadK8sConfig downloads the kubeconfig file from cloud
 func (c *GKECluster) DownloadK8sConfig() ([]byte, error) {
 
@@ -1894,8 +1880,8 @@ func (c *GKECluster) getProjectId() (string, error) {
 	return s.GetValue(pkgSecret.ProjectId), nil
 }
 
-// UpdateStatus updates cluster status in database
-func (c *GKECluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *GKECluster) SetStatus(status, statusMessage string) error {
 	originalStatus := c.model.Cluster.Status
 	originalStatusMessage := c.model.Cluster.StatusMessage
 

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -164,7 +164,7 @@ type ErrorHandler struct {
 }
 
 func (*ErrorHandler) Error(c CommonCluster, err error) {
-	c.UpdateStatus(pkgCluster.Error, err.Error())
+	c.SetStatus(pkgCluster.Error, err.Error())
 }
 
 // Priority can be used to run post hooks in a specific order

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -74,7 +74,7 @@ func RunPostHooks(postHooks []PostFunctioner, cluster CommonCluster) error {
 				return err
 			}
 
-			if err := cluster.UpdateStatus(pkgCluster.Creating, statusMsg); err != nil {
+			if err := cluster.SetStatus(pkgCluster.Creating, statusMsg); err != nil {
 				return emperror.Wrap(err, "failed to write status to db")
 			}
 		}
@@ -82,7 +82,7 @@ func RunPostHooks(postHooks []PostFunctioner, cluster CommonCluster) error {
 
 	log.Info("all posthooks ran successfully")
 
-	if err := cluster.UpdateStatus(pkgCluster.Running, pkgCluster.RunningMessage); err != nil {
+	if err := cluster.SetStatus(pkgCluster.Running, pkgCluster.RunningMessage); err != nil {
 		log.Errorf("Error during posthook status update in db: %s", err.Error())
 		return err
 	}

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -74,11 +74,6 @@ func (c *KubeCluster) CreateCluster() error {
 	return nil
 }
 
-// Persist save the cluster model
-func (c *KubeCluster) Persist(status, statusMessage string) error {
-	return c.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 // createDefaultStorageClass creates a default storage class as some clusters are not created with
 // any storage classes or with default one
 func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provisioner string, volumeBindingMode storagev1.VolumeBindingMode) error {
@@ -251,8 +246,8 @@ func CreateKubernetesClusterFromModel(clusterModel *model.ClusterModel) (*KubeCl
 	return &kubeCluster, nil
 }
 
-// UpdateStatus updates cluster status in database
-func (c *KubeCluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (c *KubeCluster) SetStatus(status, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/cluster/manager_common_creator.go
+++ b/cluster/manager_common_creator.go
@@ -44,7 +44,7 @@ func (c *commonCreator) Validate(ctx context.Context) error {
 
 // Prepare implements the clusterCreator interface.
 func (c *commonCreator) Prepare(ctx context.Context) (CommonCluster, error) {
-	return c.cluster, c.cluster.Persist(pkgCluster.Creating, pkgCluster.CreatingMessage)
+	return c.cluster, c.cluster.SetStatus(pkgCluster.Creating, pkgCluster.CreatingMessage)
 }
 
 // Create implements the clusterCreator interface.

--- a/cluster/manager_common_nodepool_updater.go
+++ b/cluster/manager_common_nodepool_updater.go
@@ -93,7 +93,7 @@ func (c *commonNodepoolUpdater) Validate(ctx context.Context) error {
 
 // Prepare implements the clusterUpdater interface.
 func (c *commonNodepoolUpdater) Prepare(ctx context.Context) (CommonCluster, error) {
-	return c.cluster, c.cluster.Persist(cluster.Updating, cluster.UpdatingMessage)
+	return c.cluster, c.cluster.SetStatus(cluster.Updating, cluster.UpdatingMessage)
 }
 
 // Update implements the clusterUpdater interface.

--- a/cluster/manager_common_updater.go
+++ b/cluster/manager_common_updater.go
@@ -114,7 +114,7 @@ func (c *commonUpdater) Prepare(ctx context.Context) (CommonCluster, error) {
 		}
 	}
 
-	return c.cluster, c.cluster.Persist(cluster.Updating, cluster.UpdatingMessage)
+	return c.cluster, c.cluster.SetStatus(cluster.Updating, cluster.UpdatingMessage)
 }
 
 // Update implements the clusterUpdater interface.

--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -130,7 +130,7 @@ func (m *Manager) CreateCluster(ctx context.Context, creationCtx CreationContext
 		return nil, err
 	}
 
-	if err := cluster.UpdateStatus(pkgCluster.Creating, pkgCluster.CreatingMessage); err != nil {
+	if err := cluster.SetStatus(pkgCluster.Creating, pkgCluster.CreatingMessage); err != nil {
 		return nil, err
 	}
 
@@ -178,23 +178,23 @@ func (m *Manager) createCluster(
 
 		sshKey, err := secret.GenerateSSHKeyPair()
 		if err != nil {
-			cluster.UpdateStatus(pkgCluster.Error, "internal error")
+			cluster.SetStatus(pkgCluster.Error, "internal error")
 			return emperror.Wrap(err, "failed to generate SSH key")
 		}
 
 		sshSecretId, err := secret.StoreSSHKeyPair(sshKey, cluster.GetOrganizationId(), cluster.GetID(), cluster.GetName(), cluster.GetUID())
 		if err != nil {
-			cluster.UpdateStatus(pkgCluster.Error, "internal error")
+			cluster.SetStatus(pkgCluster.Error, "internal error")
 			return emperror.Wrap(err, "failed to store SSH key")
 		}
 
 		if err := cluster.SaveSshSecretId(sshSecretId); err != nil {
-			cluster.UpdateStatus(pkgCluster.Error, "internal error")
+			cluster.SetStatus(pkgCluster.Error, "internal error")
 			return emperror.Wrap(err, "failed to save SSH key secret ID")
 		}
 	}
 	if err := creator.Create(ctx); err != nil {
-		cluster.UpdateStatus(pkgCluster.Error, err.Error())
+		cluster.SetStatus(pkgCluster.Error, err.Error())
 		return err
 	}
 

--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -267,7 +267,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 
 	logger.Info("deleting cluster")
 
-	err := cluster.UpdateStatus(pkgCluster.Deleting, pkgCluster.DeletingMessage)
+	err := cluster.SetStatus(pkgCluster.Deleting, pkgCluster.DeletingMessage)
 	if err != nil {
 		return emperror.With(
 			emperror.Wrap(err, "cluster status update failed"),
@@ -282,7 +282,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 			if err = cls.DeleteFromDatabase(); err != nil {
 				err = emperror.Wrap(err, "failed to delete from the database")
 				if !force {
-					cls.UpdateStatus(pkgCluster.Error, err.Error())
+					cls.SetStatus(pkgCluster.Error, err.Error())
 					return err
 				}
 				logger.Error(err)
@@ -308,7 +308,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 		err = emperror.Wrap(err, "cannot access Kubernetes cluster")
 
 		if !force {
-			cluster.UpdateStatus(pkgCluster.Error, err.Error())
+			cluster.SetStatus(pkgCluster.Error, err.Error())
 
 			return err
 		}
@@ -324,7 +324,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 			err = emperror.Wrap(err, "failed to delete deployments")
 
 			if !force {
-				cluster.UpdateStatus(pkgCluster.Error, err.Error())
+				cluster.SetStatus(pkgCluster.Error, err.Error())
 
 				return err
 			}
@@ -337,7 +337,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 			err = emperror.Wrap(err, "failed to delete Kubernetes resources")
 
 			if !force {
-				cluster.UpdateStatus(pkgCluster.Error, err.Error())
+				cluster.SetStatus(pkgCluster.Error, err.Error())
 
 				return err
 			}
@@ -365,7 +365,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 	if err != nil {
 		err = emperror.Wrap(err, "failed to delete cluster from the provider")
 		if !force {
-			cluster.UpdateStatus(pkgCluster.Error, err.Error())
+			cluster.SetStatus(pkgCluster.Error, err.Error())
 			return err
 		}
 		logger.Error(err)
@@ -378,7 +378,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 	if err != nil {
 		err = emperror.Wrap(err, "failed to delete unused cluster secrets")
 		if !force {
-			cluster.UpdateStatus(pkgCluster.Error, err.Error())
+			cluster.SetStatus(pkgCluster.Error, err.Error())
 			return err
 		}
 		logger.Error(err)
@@ -391,7 +391,7 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 	if err != nil {
 		err = emperror.Wrap(err, "failed to delete from the database")
 		if !force {
-			cluster.UpdateStatus(pkgCluster.Error, err.Error())
+			cluster.SetStatus(pkgCluster.Error, err.Error())
 			return err
 		}
 		logger.Error(err)

--- a/cluster/manager_update.go
+++ b/cluster/manager_update.go
@@ -77,7 +77,7 @@ func (m *Manager) UpdateCluster(ctx context.Context, updateCtx UpdateContext, up
 		return err
 	}
 
-	if err := cluster.UpdateStatus(pkgCluster.Updating, pkgCluster.UpdatingMessage); err != nil {
+	if err := cluster.SetStatus(pkgCluster.Updating, pkgCluster.UpdatingMessage); err != nil {
 		return emperror.With(err, "could not update cluster status")
 	}
 
@@ -108,12 +108,12 @@ func (m *Manager) updateCluster(ctx context.Context, updateCtx UpdateContext, cl
 
 	err := updater.Update(ctx)
 	if err != nil {
-		cluster.UpdateStatus(pkgCluster.Warning, err.Error())
+		cluster.SetStatus(pkgCluster.Warning, err.Error())
 
 		return emperror.Wrap(err, "error updating cluster")
 	}
 
-	if err := cluster.UpdateStatus(pkgCluster.Running, pkgCluster.RunningMessage); err != nil {
+	if err := cluster.SetStatus(pkgCluster.Running, pkgCluster.RunningMessage); err != nil {
 		return emperror.Wrap(err, "could not update cluster status")
 	}
 

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -176,12 +176,6 @@ func (o *OKECluster) DeleteCluster() error {
 	return nil
 }
 
-//Persist save the cluster model
-func (o *OKECluster) Persist(status, statusMessage string) error {
-
-	return o.modelCluster.UpdateStatus(status, statusMessage)
-}
-
 // DownloadK8sConfig downloads the kubeconfig file from cloud
 func (o *OKECluster) DownloadK8sConfig() ([]byte, error) {
 
@@ -345,8 +339,8 @@ func (o *OKECluster) SaveSshSecretId(sshSecretId string) error {
 	return o.modelCluster.UpdateSshSecret(sshSecretId)
 }
 
-// UpdateStatus updates cluster status in database
-func (o *OKECluster) UpdateStatus(status, statusMessage string) error {
+// SetStatus sets the cluster's status
+func (o *OKECluster) SetStatus(status, statusMessage string) error {
 	return o.modelCluster.UpdateStatus(status, statusMessage)
 }
 

--- a/internal/providers/pke/pkeworkflow/cluster.go
+++ b/internal/providers/pke/pkeworkflow/cluster.go
@@ -29,7 +29,7 @@ type Cluster interface {
 	GetUID() string
 	GetName() string
 	GetOrganizationId() uint
-	UpdateStatus(string, string) error
+	SetStatus(status string, statusMessage string) error
 	GetNodePools() []NodePool
 	GetSshPublicKey() (string, error)
 	GetLocation() string

--- a/internal/providers/pke/pkeworkflow/update_cluster_status_activity.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster_status_activity.go
@@ -42,5 +42,5 @@ func (a *UpdateClusterStatusActivity) Execute(ctx context.Context, input UpdateC
 		return err
 	}
 
-	return c.UpdateStatus(input.Status, input.StatusMessage)
+	return c.SetStatus(input.Status, input.StatusMessage)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
Rename `CommonCluster.UpdateStatus` to `SetStatus` to better convey its function. Remove the `Persist` method because it was neves supposed to be there (when the internal state is persisted should be at the discretion of the cluster object) and it was always used like `UpdateStatus` whose function it mostly duplicated. Also, fix the status update logic in GKE, because of the order of instructions the condition never allowed the status change to be recorded in the history. 

### Why?
Spring cleaning. 🌱

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
