### PR TITLE
don't use database user role by default

### DIFF
--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -23,7 +23,7 @@ dialect = "mysql"
 host = "localhost"
 port = 3306
 user = "sparky"
-role = "pipeline"
+role = ""
 password = "sparky123"
 dbname = "pipeline"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults/issues/178
| License         | Apache 2.0


### What's in this PR?
Until https://github.com/banzaicloud/bank-vaults/issues/178 gets fixed, don't use the DB role based authentication.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
