### PR TITLE
Fix posthook panic when posthooks are not configured

### DIFF
--- a/cluster/manager_create.go
+++ b/cluster/manager_create.go
@@ -214,6 +214,10 @@ func (m *Manager) createCluster(
 		return err
 	}
 
+	if postHooks == nil {
+		postHooks = make(pkgCluster.PostHooks)
+	}
+
 	postHooks[pkgCluster.SetupNodePoolLabelsSet] = NodePoolLabelParam{
 		Labels: labelsMap,
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Fix a panic when cluster create does not receive any posthooks.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
