### PR TITLE
Turn domain creation off by default

### DIFF
--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -138,6 +138,6 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	_ = v.BindEnv("cadence.host")
 	v.SetDefault("cadence.port", 7933)
 	v.SetDefault("cadence.domain", "pipeline")
-	v.SetDefault("cadence.createNonexistentDomain", true)
+	v.SetDefault("cadence.createNonexistentDomain", false)
 	v.SetDefault("cadence.workflowExecutionRetentionPeriodInDays", 3)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR turns off the cadence domain creation by default.


### Why?

Resource creation like this should be opt-in, not opt-out (see: database).

