### PR TITLE
Speed up storage listing in case of Amazon & Alibaba

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/pipeline/auth"
+	pipConfig "github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/internal/objectstore"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
@@ -35,6 +36,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -108,15 +110,10 @@ func ListBuckets(c *gin.Context) {
 	}
 
 	switch cloudType {
-	case pkgProviders.Alibaba, pkgProviders.Amazon:
-		location, ok := ginutils.RequiredQueryOrAbort(c, "location")
-		if !ok {
-			logger.Debug("missing location")
-
-			return
-		}
-
-		objectStoreCtx.Location = location
+	case pkgProviders.Amazon:
+		objectStoreCtx.Location = viper.GetString(pipConfig.AmazonInitializeRegionKey)
+	case pkgProviders.Alibaba:
+		objectStoreCtx.Location = viper.GetString(pipConfig.AlibabaInitializeRegionKey)
 	}
 
 	objectStore, err := providers.NewObjectStore(objectStoreCtx, logger)

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-4fea1564ffc5b613da38f2a9b3600e6fbd0cf991eb918d29e6e6510cc82fb559  docs/openapi/pipeline.yaml
+59e364af908d72159bd34922aec65a9de0ff63314be7f22a6bd240788531988f  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -4066,14 +4066,6 @@ paths:
           - secret
           type: string
         style: form
-      - description: Identifies the cloud region. Required by Amazon only.
-        explode: true
-        in: query
-        name: location
-        required: false
-        schema:
-          type: string
-        style: form
       responses:
         200:
           content:

--- a/client/api_storage.go
+++ b/client/api_storage.go
@@ -514,7 +514,6 @@ List object store buckets accessible by the credentials referenced by the given 
  * @param "SecretId" (optional.String) -  Secret identification. If not provided only the managed buckets (those created via pipeline) are listed
  * @param "CloudType" (optional.String) -  Identifies the cloud provider - mandatory if secretId header is provided
  * @param "Include" (optional.String) -  Signals whether the secret name is to be returned
- * @param "Location" (optional.String) -  Identifies the cloud region. Required by Amazon only.
 @return []BucketInfo
 */
 
@@ -522,7 +521,6 @@ type ListObjectStoreBucketsOpts struct {
 	SecretId  optional.String
 	CloudType optional.String
 	Include   optional.String
-	Location  optional.String
 }
 
 func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId int32, localVarOptionals *ListObjectStoreBucketsOpts) ([]BucketInfo, *http.Response, error) {
@@ -548,9 +546,6 @@ func (a *StorageApiService) ListObjectStoreBuckets(ctx context.Context, orgId in
 	}
 	if localVarOptionals != nil && localVarOptionals.Include.IsSet() {
 		localVarQueryParams.Add("include", parameterToString(localVarOptionals.Include.Value(), ""))
-	}
-	if localVarOptionals != nil && localVarOptionals.Location.IsSet() {
-		localVarQueryParams.Add("location", parameterToString(localVarOptionals.Location.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}

--- a/client/docs/StorageApi.md
+++ b/client/docs/StorageApi.md
@@ -198,7 +198,6 @@ Name | Type | Description  | Notes
  **secretId** | **optional.String**| Secret identification. If not provided only the managed buckets (those created via pipeline) are listed | 
  **cloudType** | **optional.String**| Identifies the cloud provider - mandatory if secretId header is provided | 
  **include** | **optional.String**| Signals whether the secret name is to be returned | 
- **location** | **optional.String**| Identifies the cloud region. Required by Amazon only. | 
 
 ### Return type
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -1961,7 +1961,7 @@ func (c *GKECluster) IsReady() (bool, error) {
 		return false, err
 	}
 
-	c.log.Debug("Get gke cluster with name %s", c.model.Cluster.Name)
+	c.log.Debug("Get gke cluster")
 	cl, err := svc.Projects.Zones.Clusters.Get(secretItem.GetValue(pkgSecret.ProjectId), c.model.Cluster.Location, c.model.Cluster.Name).Context(context.Background()).Do()
 	if err != nil {
 		apiError := getBanzaiErrorFromError(err)

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -205,3 +205,11 @@ port = 7933
 domain = "pipeline"
 createNonexistentDomain = true
 workflowExecutionRetentionPeriodInDays = 3
+
+[amazon]
+# default Amazon region to initialize client
+defaultApiRegion = "us-west-1"
+
+[alibaba]
+# default Alibaba region to initialize client
+defaultApiRegion = "eu-central-1"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -151,6 +151,10 @@ const (
 	PrometheusServiceName    = "prometheus.serviceName"
 	PrometheusServiceContext = "prometheus.serviceContext"
 	PrometheusLocalPort      = "prometheus.localPort"
+
+	// Default regions config keys to initialize clients
+	AmazonInitializeRegionKey  = "amazon.defaultApiRegion"
+	AlibabaInitializeRegionKey = "alibaba.defaultApiRegion"
 )
 
 //Init initializes the configurations
@@ -289,6 +293,9 @@ func init() {
 	// Cadence config
 	viper.SetDefault("cadence.port", 7933)
 	viper.SetDefault("cadence.domain", "pipeline")
+
+	viper.SetDefault(AmazonInitializeRegionKey, "us-west-1")
+	viper.SetDefault(AlibabaInitializeRegionKey, "eu-central-1")
 
 	// Prometheus service defaults
 	viper.SetDefault(PrometheusServiceName, "monitor-prometheus-server")

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -3949,12 +3949,6 @@ paths:
                         enum: [secret]
                     required: false
                     description: Signals whether the secret name is to be returned
-                -
-                    name: location
-                    in: query
-                    schema:
-                        type: string
-                    description: Identifies the cloud region. Required by Amazon only.
             responses:
                 '200':
                     description: "Storage buckets listed"

--- a/docs/postman/e2e_test.postman_collection.json
+++ b/docs/postman/e2e_test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d79480b2-e93c-4065-bd60-66e602de12f3",
+		"_postman_id": "3c37dc30-ac98-4db4-8efe-275196af4e4d",
 		"name": "End2End TEST Organizations",
 		"description": "Collection for K8S Cluster CRUD operations through the Banzai Cloud Pipeline API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -360,14 +360,14 @@
 									],
 									"variable": [
 										{
-											"description": "Organization identifier",
 											"key": "orgId",
-											"value": "{{orgId}}"
+											"value": "{{orgId}}",
+											"description": "Organization identifier"
 										},
 										{
-											"description": "Cluster identifier",
 											"key": "clusterId",
-											"value": "{{clusterId}}"
+											"value": "{{clusterId}}",
+											"description": "Cluster identifier"
 										}
 									]
 								},
@@ -7339,6 +7339,48 @@
 					"response": []
 				},
 				{
+					"name": "CreateBuckets Alibaba",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "secretId",
+								"value": "{{secretIdAlibaba}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"secretId\": \"{{secretIdAlibaba}}\",\n\t\"name\": \"\",\n\t\"properties\": {\n\t\t\"alibaba\": {\n\t\t\t\"location\": \"eu-central-1\"\n\t\t}\n\t}\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/orgs/:orgId/buckets",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								":orgId",
+								"buckets"
+							],
+							"variable": [
+								{
+									"key": "orgId",
+									"value": "{{orgId}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "CreateBuckets Azure",
 					"request": {
 						"method": "POST",
@@ -7480,7 +7522,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/orgs/:orgId/buckets?cloudType=amazon&location={{amLocation}}",
+							"raw": "{{url}}/api/v1/orgs/:orgId/buckets?cloudType=amazon",
 							"host": [
 								"{{url}}"
 							],
@@ -7496,11 +7538,6 @@
 									"key": "cloudType",
 									"value": "amazon",
 									"description": "Bucket's cloud: Amazon"
-								},
-								{
-									"key": "location",
-									"value": "{{amLocation}}",
-									"description": "Location of the buckets"
 								}
 							],
 							"variable": [
@@ -7508,6 +7545,49 @@
 									"key": "orgId",
 									"value": "{{orgId}}",
 									"description": "Organization identifier"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ListBuckets Alibaba",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "secretId",
+								"value": "{{secretIdAlibaba}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/orgs/:orgId/buckets?cloudType=alibaba",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								":orgId",
+								"buckets"
+							],
+							"query": [
+								{
+									"key": "cloudType",
+									"value": "alibaba"
+								}
+							],
+							"variable": [
+								{
+									"key": "orgId",
+									"value": "{{orgId}}"
 								}
 							]
 						}
@@ -7863,95 +7943,6 @@
 									"key": "bucketName",
 									"value": "{{bucketName}}",
 									"description": "Bucket name"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "CreateBuckets Alibaba",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "secretId",
-								"value": "{{secretIdAlibaba}}",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"secretId\": \"{{secretIdAlibaba}}\",\n\t\"name\": \"\",\n\t\"properties\": {\n\t\t\"alibaba\": {\n\t\t\t\"location\": \"eu-central-1\"\n\t\t}\n\t}\n}"
-						},
-						"url": {
-							"raw": "{{url}}/api/v1/orgs/:orgId/buckets",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"orgs",
-								":orgId",
-								"buckets"
-							],
-							"variable": [
-								{
-									"key": "orgId",
-									"value": "{{orgId}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "ListBuckets Alibaba",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "secretId",
-								"value": "{{secretIdAlibaba}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{url}}/api/v1/orgs/:orgId/buckets?cloudType=alibaba&location=eu-central-1",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"orgs",
-								":orgId",
-								"buckets"
-							],
-							"query": [
-								{
-									"key": "cloudType",
-									"value": "alibaba"
-								},
-								{
-									"key": "location",
-									"value": "eu-central-1"
-								}
-							],
-							"variable": [
-								{
-									"key": "orgId",
-									"value": "{{orgId}}"
 								}
 							]
 						}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- In case of (non managed) storages we don't add location field to the response items. 
- In install logging posthook check the region field, if it's empty we send a get region request to cloud and set the region field
- To initialize Amazon & Alibaba clients we use default regions
- Make configurable these default regions


### Why?
The current storage listing is extremly slow (compared to other providers). These numbers are depend on how many storage we have.

In case of 95 Amazon storage it takes `~8 sec` to get a response.
In case of 8 Alibaba storage it takes `~10-12 sec` to get a response.

With this solution:
In case of 95 Amazon storage it takes `~1-2 sec` to get a response.
In case of 8 Alibaba storage it takes `~1-2 sec` to get a response.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
