### PR TITLE
Don't send empty fields with BucketInfo

### DIFF
--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -32,9 +32,9 @@ type BucketInfo struct {
 	SecretRef       string                    `json:"secretId,omitempty"`
 	Cloud           string                    `json:"cloud,omitempty"`
 	Azure           *BlobStoragePropsForAzure `json:"aks,omitempty"`
-	Status          string                    `json:"status"`
-	StatusMsg       string                    `json:"statusMsg"`
-	AccessSecretRef string                    `json:"accessSecretId"`
+	Status          string                    `json:"status,omitempty"`
+	StatusMsg       string                    `json:"statusMsg,omitempty"`
+	AccessSecretRef string                    `json:"accessSecretId,omitempty"`
 }
 
 // BlobStoragePropsForAzure describes the Azure specific properties


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add `omitempty` tag to `status`, `statusMsg`, `accessSecretId` fields to `BucketInfo` struct


### Why?
Don't send empty fields. Current JSON response for bucket list:

```
[
  {
    "name": "bucket1",
    "managed": false,
    "location": "eu-central-1",
    "status": "",
    "statusMsg": "",
    "accessSecretId": ""
  },
  {
    "name": "bucket2",
    "managed": false,
    "location": "eu-west-1",
    "status": "",
    "statusMsg": "",
    "accessSecretId": ""
  }
]
```

After this change:
```
[
  {
    "name": "bucket1",
    "managed": false,
    "location": "eu-central-1"
  },
  {
    "name": "bucket2",
    "managed": false,
    "location": "eu-west-1"
  }
]
```


### Checklist
- [x] Implementation tested (with at least one cloud provider)
