### PR TITLE
Get location for bucket(s) in case of backup enable/create

### DIFF
--- a/api/ark/common/common.go
+++ b/api/ark/common/common.go
@@ -17,7 +17,10 @@ package common
 import (
 	"net/http"
 
+	"github.com/banzaicloud/pipeline/internal/providers"
+	"github.com/banzaicloud/pipeline/secret"
 	"github.com/gin-gonic/gin"
+	"github.com/goph/emperror"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -45,4 +48,14 @@ func ErrorResponse(c *gin.Context, err error) {
 	}
 
 	pkgCommon.ErrorResponseWithStatus(c, status, err)
+}
+
+func GetBucketLocation(cloud string, bucketName string, secretId string, organizationID uint, logger logrus.FieldLogger) (string, error) {
+
+	bucketSecret, err := secret.RestrictedStore.Get(organizationID, secretId)
+	if err != nil {
+		return "", emperror.WrapWith(err, "error during getting secret", "secretId", secretId)
+	}
+
+	return providers.GetBucketLocation(cloud, bucketSecret, bucketName, organizationID, logger)
 }

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Masterminds/semver"
 	securityV1Alpha "github.com/banzaicloud/anchore-image-validator/pkg/apis/security/v1alpha1"
 	securityClientV1Alpha "github.com/banzaicloud/anchore-image-validator/pkg/clientset/v1alpha1"
+	"github.com/banzaicloud/pipeline/internal/providers"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
@@ -46,8 +47,6 @@ import (
 	"github.com/banzaicloud/pipeline/helm"
 	"github.com/banzaicloud/pipeline/internal/ark"
 	arkAPI "github.com/banzaicloud/pipeline/internal/ark/api"
-	alibabaObjectstore "github.com/banzaicloud/pipeline/internal/providers/alibaba"
-	amazonObjectstore "github.com/banzaicloud/pipeline/internal/providers/amazon"
 	anchore "github.com/banzaicloud/pipeline/internal/security"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
@@ -221,8 +220,7 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 
 		if len(loggingParam.Region) == 0 {
 			// region field is empty in request, get bucket region
-			defaultRegion := viper.GetString(pipConfig.AmazonInitializeRegionKey)
-			region, err := amazonObjectstore.GetBucketRegion(logSecret, loggingParam.BucketName, defaultRegion, cluster.GetOrganizationId(), log)
+			region, err := providers.GetBucketLocation(pkgCluster.Amazon, logSecret, loggingParam.BucketName, cluster.GetOrganizationId(), log)
 			if err != nil {
 				return emperror.WrapWith(err, "failed to get S3 bucket region", "bucket", loggingParam.BucketName)
 			}
@@ -272,8 +270,7 @@ func InstallLogging(cluster CommonCluster, param pkgCluster.PostHookParam) error
 
 		if len(loggingParam.Region) == 0 {
 			// region field is empty in request, get bucket region
-			defaultRegion := viper.GetString(pipConfig.AlibabaInitializeRegionKey)
-			region, err := alibabaObjectstore.GetBucketLocation(logSecret, loggingParam.BucketName, defaultRegion, cluster.GetOrganizationId(), log)
+			region, err := providers.GetBucketLocation(pkgCluster.Alibaba, logSecret, loggingParam.BucketName, cluster.GetOrganizationId(), log)
 			if err != nil {
 				return emperror.WrapWith(err, "failed to get OSS bucket region", "bucket", loggingParam.BucketName)
 			}

--- a/internal/providers/objectstore.go
+++ b/internal/providers/objectstore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // ObjectStoreContext describes all parameters necessary to create a cloud provider agnostic object store instance.
@@ -70,4 +71,21 @@ func NewObjectStore(ctx *ObjectStoreContext, logger logrus.FieldLogger) (objects
 	default:
 		return nil, pkgErrors.ErrorNotSupportedCloudType
 	}
+}
+
+func GetBucketLocation(provider string, secret *secret.SecretItemResponse, bucketName string, orgID uint, log logrus.FieldLogger) (string, error) {
+
+	switch provider {
+	case providers.Alibaba:
+		defaultRegion := viper.GetString(config.AlibabaInitializeRegionKey)
+		return alibaba.GetBucketLocation(secret, bucketName, defaultRegion, orgID, log)
+
+	case providers.Amazon:
+		defaultRegion := viper.GetString(config.AmazonInitializeRegionKey)
+		return amazon.GetBucketRegion(secret, bucketName, defaultRegion, orgID, log)
+
+	default:
+		return "", pkgErrors.ErrorNotSupportedCloudType
+	}
+
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Get bucket location in backup services if `location` field is empty in request

### Why?
In case of empty location field we cannot enable backup

<img width="507" alt="Screenshot 2019-03-21 at 14 25 37" src="https://user-images.githubusercontent.com/6968817/54755018-388efe00-4be5-11e9-8de4-26c6b04ada94.png">


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
