### PR TITLE
remove AvailabilityZone parameter from instance definition

### DIFF
--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -90,7 +90,6 @@ Resources:
             PkeCommand: !Ref PkeCommand,
             }
       SubnetId: !Ref SubnetId
-      AvailabilityZone: !Ref AvailabilityZone
       Tags:
       - Key: ClusterName
         Value: !Ref ClusterName


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?
Specifying Subnet and AZ can lead to a condition where the master instance is unable to fulfil. To prevent this we will only use subnet as parameter.
