### PR TITLE
Update versions, change default helm cache path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+/bin/
+/build/
+/var/
+
 _state*
 .DS_Store
 .pipeline
@@ -8,13 +12,10 @@ vault/*
 config/config.toml
 config/dex.yml
 *.swp
-orgs/
 *.pem
 !config/certs/*.pem
 */main/main.go
 test.txt
-/bin/
-/build/
 /vendor/
 /.docker/
 /docker-compose.override.yml

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -86,8 +86,8 @@ setCookieDomain = false
 [helm]
 retryAttempt = 30
 retrySleepSeconds = 15
-tillerVersion = "v2.11.0"
-path = "./orgs"
+tillerVersion = "v2.12.2"
+path = "./var/cache"
 
 #helm repo URLs
 stableRepositoryURL = "https://kubernetes-charts.storage.googleapis.com"
@@ -103,10 +103,10 @@ grafanaAdminUsername = "admin"
 
 [loggingOperator]
 chartVersion = ""
-imageTag = "0.0.4"
+imageTag = "0.1.2"
 
 [servicemesh]
-istioOperatorChartVersion = "0.0.2"
+istioOperatorChartVersion = "0.0.3"
 grafanaDashboardLocation = "https://raw.githubusercontent.com/banzaicloud/banzai-charts/master/istio/deps/grafana/dashboards"
 
 # DNS service settings


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Update the default version for the following components in the default dev config:

- Tiller
- Logging Operator image
- Istio Operator chart

Also, relocated the default path for the helm cache.