### PR TITLE
Remove break which prevented to collect all tagged deployments

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -278,7 +278,6 @@ func ListDeployments(filter *string, tagFilter string, kubeConfig []byte) (*rls.
 			if DeploymentHasTag(deployment.Deployment, tagFilter) {
 				filteredResp.Releases = append(filteredResp.Releases, deployment.Release)
 				filteredResp.Count++
-				break
 			}
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove break which prevented to collect all tagged deployment which caused errors in Spotguide when trying to list notes.txt on a deployment which does not have one.
