### PR TITLE
Revert "Remove break which prevented to collect all tagged deployments"

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -278,6 +278,7 @@ func ListDeployments(filter *string, tagFilter string, kubeConfig []byte) (*rls.
 			if DeploymentHasTag(deployment.Deployment, tagFilter) {
 				filteredResp.Releases = append(filteredResp.Releases, deployment.Release)
 				filteredResp.Count++
+				break
 			}
 		}
 


### PR DESCRIPTION
Reverts banzaicloud/pipeline#1936
We need to add Spotguide specific helm chart tags to all Spotguides before merging this commit. Ci client tags all deployments even the ones in the requirements which can cause unnecessary Spotguide summary if the requirements has a notes.txt.