### PR TITLE
update ubercadence/server:0.5.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
         image: cassandra:3.11
 
     cadence:
-        image: ubercadence/server:0.5.1
+        image: ubercadence/server:0.5.5
         environment:
             - "LOG_LEVEL=debug,info"
             - "CASSANDRA_SEEDS=cassandra"


### PR DESCRIPTION
### What's in this PR?
Upgrade cadence in compose that reduces Docker image size from 800Mb to 130Mb