### PR TITLE
fix regexp match indexing in AKS subnet validation

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-9852b4695bdc4ab16a0629acc8f1df190d9e41911c49cb376fd32da2d5ba758b  docs/openapi/pipeline.yaml
+3f9863f5760f01d289a93af4ae055b2d7588af7c338420b32436f9ee94baf3ce  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -8778,6 +8778,17 @@ components:
           example: 2
           format: int32
           type: integer
+        instanceType:
+          example: Standard_B2ms
+          type: string
+        labels:
+          additionalProperties:
+            example: '{"example.io/label1":"value1"}'
+            type: string
+          type: object
+        vnetSubnetID:
+          example: /subscriptions/12345678-1234-5678-1234-123456789abc/resourceGroups/your-resource-group-name/providers/Microsoft.Network/virtualNetworks/your-vnet-name/subnets/your-vnet-subnet-name
+          type: string
       required:
       - count
       type: object

--- a/client/docs/UpdateNodePoolsAzure.md
+++ b/client/docs/UpdateNodePoolsAzure.md
@@ -7,6 +7,9 @@ Name | Type | Description | Notes
 **Count** | **int32** |  | 
 **MinCount** | **int32** |  | [optional] 
 **MaxCount** | **int32** |  | [optional] 
+**InstanceType** | **string** |  | [optional] 
+**Labels** | **map[string]string** |  | [optional] 
+**VnetSubnetID** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_update_node_pools_azure.go
+++ b/client/model_update_node_pools_azure.go
@@ -12,8 +12,11 @@
 package client
 
 type UpdateNodePoolsAzure struct {
-	Autoscaling bool  `json:"autoscaling,omitempty"`
-	Count       int32 `json:"count"`
-	MinCount    int32 `json:"minCount,omitempty"`
-	MaxCount    int32 `json:"maxCount,omitempty"`
+	Autoscaling  bool              `json:"autoscaling,omitempty"`
+	Count        int32             `json:"count"`
+	MinCount     int32             `json:"minCount,omitempty"`
+	MaxCount     int32             `json:"maxCount,omitempty"`
+	InstanceType string            `json:"instanceType,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	VnetSubnetID string            `json:"vnetSubnetID,omitempty"`
 }

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -1236,18 +1236,18 @@ func (c *AKSCluster) collectActivityLogsWithErrors(filter string) ([]insights.Ev
 var vnetSubnetIDRegexp = regexp.MustCompile("/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft.Network/virtualNetworks/([^/]+)/subnets/([^/]+)")
 
 func validateVNetSubnet(cc *pkgAzure.CloudConnection, resourceGroupName, vnetSubnetID string) error {
-	if len(vnetSubnetID) != 0 {
+	if vnetSubnetID != "" {
 		matches := vnetSubnetIDRegexp.FindStringSubmatch(vnetSubnetID)
 		if matches == nil {
 			return errors.New("virtual network subnet ID format is invalid")
 		}
-		if matches[0] != cc.GetSubscriptionID() {
+		if matches[1] != cc.GetSubscriptionID() {
 			return errors.New("virtual network subnet is not from same subscription")
 		}
-		if matches[1] != resourceGroupName {
+		if matches[2] != resourceGroupName {
 			return errors.New("virtual network subnet is not from same resource group")
 		}
-		_, err := cc.GetSubnetsClient().Get(context.TODO(), matches[1], matches[2], matches[3], "")
+		_, err := cc.GetSubnetsClient().Get(context.TODO(), matches[2], matches[3], matches[4], "")
 		if err != nil {
 			return emperror.Wrap(err, "request to retreive subnet failed")
 		}

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -7871,6 +7871,18 @@ components:
                 maxCount:
                     type: integer
                     example: 2
+                instanceType:
+                    type: string
+                    example: "Standard_B2ms"
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                        example:
+                            example.io/label1: value1
+                vnetSubnetID:
+                    type: string
+                    example: "/subscriptions/12345678-1234-5678-1234-123456789abc/resourceGroups/your-resource-group-name/providers/Microsoft.Network/virtualNetworks/your-vnet-name/subnets/your-vnet-subnet-name"
 
         UpdateGoogleProperties:
             type: object


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
Fixing the regexp match indexing in the AKS subnet validation logic.

### Why?
Off-by-one error that hasn't manifested yet because apparently the web UI never posted the subnet field (in the right place).

### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- [x] implement related fix in web UI
