### PR TITLE
client: add version field to GetClusterStatusResponse

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-3fdfb723352c62d98b5aaf98119d18eb343e9461da9be47836fbbe801e1d8b45  docs/openapi/pipeline.yaml
+aecc8dbda6996b2807bd4e98667b0a8a0253db80bc4bf96d3fec3331c3740674  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -9342,6 +9342,7 @@ components:
         ttlMinutes: 120
         distribution: gke
         monitoring: true
+        version: 1.12.6-gke.10
         statusMessage: Cluster is running
         cloud: google
         createdAt: 2018-07-03T14:23:19+02:00
@@ -9372,6 +9373,9 @@ components:
           type: string
         distribution:
           example: gke
+          type: string
+        version:
+          example: 1.12.6-gke.10
           type: string
         spot:
           type: boolean

--- a/client/docs/GetClusterStatusResponse.md
+++ b/client/docs/GetClusterStatusResponse.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | [optional] 
 **Cloud** | **string** |  | [optional] 
 **Distribution** | **string** |  | [optional] 
+**Version** | **string** |  | [optional] 
 **Spot** | **bool** |  | [optional] 
 **Location** | **string** |  | [optional] 
 **Id** | **int32** |  | [optional] 

--- a/client/model_get_cluster_status_response.go
+++ b/client/model_get_cluster_status_response.go
@@ -17,6 +17,7 @@ type GetClusterStatusResponse struct {
 	Name          string `json:"name,omitempty"`
 	Cloud         string `json:"cloud,omitempty"`
 	Distribution  string `json:"distribution,omitempty"`
+	Version       string `json:"version,omitempty"`
 	Spot          bool   `json:"spot,omitempty"`
 	Location      string `json:"location,omitempty"`
 	Id            int32  `json:"id,omitempty"`

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -8424,6 +8424,9 @@ components:
                 distribution:
                     type: string
                     example: "gke"
+                version:
+                    type: string
+                    example: "1.12.6-gke.10"
                 spot:
                     type: boolean
                     example: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
The `version` field is returned by the API but it was missing from the OpenAPI descriptor, this PR adds it.


### Why?
We need this field to determine the cluster version and make decisions based on that in `ci-pipeline-client`, which parses responses with the help of the generated client library.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
