### PR TITLE
Ack parallel crud nodepool operation

### DIFF
--- a/cluster/ack.go
+++ b/cluster/ack.go
@@ -136,6 +136,7 @@ func (c *ACKCluster) ListNodeNames() (pkgCommon.NodeNames, error) {
 	request.SetScheme(requests.HTTPS)
 	request.SetDomain(fmt.Sprintf(ack.AlibabaESSEndPointFmt, c.modelCluster.ACK.RegionID))
 	request.SetContentType(requests.Json)
+
 	nodes := make(pkgCommon.NodeNames, 0)
 	for _, nodepool := range c.modelCluster.ACK.NodePools {
 		request.ScalingGroupId = nodepool.AsgID
@@ -1130,6 +1131,7 @@ func createAlibabaCSClient(auth *credentials.AccessKeyCredential, regionID strin
 
 	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
 	client, err := cs.NewClientWithOptions(regionID, cfg, cred)
+	client.SetReadTimeout(ack.ACKRequestReadTimeout)
 	return client, emperror.Wrap(err, "could not create Alibaba CSClient")
 }
 
@@ -1140,6 +1142,7 @@ func createAlibabaECSClient(auth *credentials.AccessKeyCredential, regionID stri
 
 	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
 	client, err := ecs.NewClientWithOptions(regionID, cfg, cred)
+	client.SetReadTimeout(ack.ACKRequestReadTimeout)
 	return client, emperror.Wrap(err, "could not create Alibaba ECSClient")
 }
 
@@ -1149,6 +1152,7 @@ func createAlibabaESSClient(auth *credentials.AccessKeyCredential, regionID stri
 	}
 	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
 	client, err := ess.NewClientWithOptions(regionID, cfg, cred)
+	client.SetReadTimeout(ack.ACKRequestReadTimeout)
 	return client, emperror.Wrap(err, "could not create Alibaba ESSClient")
 }
 
@@ -1158,6 +1162,7 @@ func createAlibabaVPCClient(auth *credentials.AccessKeyCredential, regionID stri
 	}
 	cred := credentials.NewAccessKeyCredential(auth.AccessKeyId, auth.AccessKeySecret)
 	client, err := vpc.NewClientWithOptions(regionID, cfg, cred)
+	client.SetReadTimeout(ack.ACKRequestReadTimeout)
 	return client, emperror.Wrap(err, "could not create Alibaba VPCClient")
 }
 

--- a/pkg/cluster/ack/action/action_create_nodepool.go
+++ b/pkg/cluster/ack/action/action_create_nodepool.go
@@ -69,9 +69,7 @@ func (a *CreateACKNodePoolAction) ExecuteAction(input interface{}) (interface{},
 	defer close(instanceIdsChan)
 
 	for _, nodePool := range a.nodePools {
-		// TODO: run node pool creation in parallel once Alibaba ESS API permits running multiple CreateScalingGroupRequest in parallel
-		// TODO: Currently running multiple CreateScalingGroupRequest in parallel may fail with throttling error
-		createNodePool(a.log, nodePool, a.context.ESSClient, cluster, instanceIdsChan, errChan)
+		go createNodePool(a.log, nodePool, a.context.ESSClient, cluster, instanceIdsChan, errChan)
 	}
 
 	caughtErrors := emperror.NewMultiErrorBuilder()

--- a/pkg/cluster/ack/action/action_delete_ssh_key.go
+++ b/pkg/cluster/ack/action/action_delete_ssh_key.go
@@ -53,6 +53,7 @@ func (a *DeleteSSHKeyAction) ExecuteAction(input interface{}) (interface{}, erro
 
 	req := ecs.CreateDeleteKeyPairsRequest()
 	req.SetScheme(requests.HTTPS)
+
 	jsonData := []string{a.sshKeyName}
 	marshaledValue, err := json.Marshal(jsonData)
 	if err != nil {

--- a/pkg/cluster/ack/action/action_update_nodepool.go
+++ b/pkg/cluster/ack/action/action_update_nodepool.go
@@ -72,8 +72,7 @@ func (a *UpdateACKNodePoolAction) ExecuteAction(input interface{}) (interface{},
 		defer close(createdInstanceIdsChan)
 
 		for _, nodePool := range a.nodePools {
-			// TODO: update node pools in parallel once Alibaba ESS API permits running multiple ModifyScalingGroupRequest in parallel
-			updateNodePool(a.log, nodePool, a.context.ESSClient, a.region, a.clusterName, createdInstanceIdsChan, errChan)
+			go updateNodePool(a.log, nodePool, a.context.ESSClient, a.region, a.clusterName, createdInstanceIdsChan, errChan)
 		}
 
 		caughtErrors := emperror.NewMultiErrorBuilder()

--- a/pkg/cluster/ack/action/action_utils.go
+++ b/pkg/cluster/ack/action/action_utils.go
@@ -152,6 +152,7 @@ func deleteNodePool(log logrus.FieldLogger, nodePool *model.ACKNodePoolModel, es
 	deleteSGRequest.SetScheme(requests.HTTPS)
 	deleteSGRequest.SetDomain(fmt.Sprintf(ack.AlibabaESSEndPointFmt, regionId))
 	deleteSGRequest.SetContentType(requests.Json)
+
 	if nodePool.AsgID == "" {
 		// Asg could not be created nothing to remove
 		errChan <- nil

--- a/pkg/cluster/ack/action/action_utils.go
+++ b/pkg/cluster/ack/action/action_utils.go
@@ -132,9 +132,7 @@ func deleteNodePools(log logrus.FieldLogger, nodePools []*model.ACKNodePoolModel
 	defer close(errChan)
 
 	for _, nodePool := range nodePools {
-		// TODO: run node pool deletion in parallel once Alibaba ESS API permits running multiple DeleteScalingGroup requests in parallel
-		// TODO: Currently running DeleteScalingGroup requests in parallel may fail with throttling error
-		deleteNodePool(log, nodePool, essClient, regionId, errChan)
+		go deleteNodePool(log, nodePool, essClient, regionId, errChan)
 	}
 	var err error
 	caughtErrors := emperror.NewMultiErrorBuilder()

--- a/pkg/cluster/ack/defaults.go
+++ b/pkg/cluster/ack/defaults.go
@@ -14,6 +14,8 @@
 
 package ack
 
+import "time"
+
 const (
 	AlibabaClusterStateRunning      = "running"
 	AlibabaClusterStateFailed       = "failed"
@@ -32,4 +34,7 @@ const (
 	AlibabaESSEndPointFmt           = "ess.%s.aliyuncs.com"
 	AlibabaMaxNodePoolSize          = 20
 	AlibabaDefaultImageId           = "centos_7_06_64_20G_alibase_20190218.vhd"
+
+	// ACKRequestReadTimeout is the read timeout setting for ACK rest API calls
+	ACKRequestReadTimeout = 30 * time.Second
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Enable parallel execution of node pool creation as ACK API supports this now.
Increase ACK Rest API call read timeout setting to 30seconds


### Why?
The parallel execution of node pool creation speeds up cluster creation.
The increased ACK Rest API call read timeout setting mitigates cases when the API is slow to respond and times out while the server still continues to process the request.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)