### PR TITLE
Fix GKE secret validation error handling

### DIFF
--- a/secret/verify/google.go
+++ b/secret/verify/google.go
@@ -17,19 +17,18 @@ package verify
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
-	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/goph/emperror"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/serviceusage/v1"
+
+	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 )
 
 const (
@@ -77,8 +76,7 @@ func checkRequiredServices(serviceAccount *ServiceAccount) ([]string, error) {
 
 	enabledServices, err := listEnabledServices(serviceAccount)
 	if err != nil {
-		logrus.Error(err)
-		return nil, errors.New("list enabled services failed")
+		return nil, emperror.Wrap(err, "list enabled services failed")
 	}
 
 	var missingServices []string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Fixes GKE secret validation error handling

### Why?

Useful information was lost, because new error was created instead of wrapping the raised provider error.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)