### PR TITLE
Add cluster name and id to install service mesh posthook logs

### DIFF
--- a/cluster/hooks_istio.go
+++ b/cluster/hooks_istio.go
@@ -19,6 +19,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/goph/emperror"
+	"github.com/sirupsen/logrus"
 )
 
 // InstallServiceMeshParams describes InstallServiceMesh posthook params
@@ -38,6 +39,8 @@ func InstallServiceMesh(cluster CommonCluster, param cluster.PostHookParam) erro
 	if err != nil {
 		return emperror.Wrap(err, "failed to cast posthook param")
 	}
+
+	log := log.WithFields(logrus.Fields{"cluster": cluster.GetName(), "clusterID": cluster.GetID()})
 
 	log.Infof("istio params: %#v", params)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add cluster name and cluster id to the log context of service mesh install post hook.


### Why?
The additional log context helps to identify easier which cluster a failed service mesh install is related to. 

