### PR TITLE
Check enable/create backup request location field just in case of Ama…

### DIFF
--- a/api/ark/backupservice/enable.go
+++ b/api/ark/backupservice/enable.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/auth"
+	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/gin-gonic/gin"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
@@ -61,7 +62,7 @@ func Enable(c *gin.Context) {
 		return
 	}
 
-	if len(request.Location) == 0 {
+	if len(request.Location) == 0 && (request.Cloud == providers.Alibaba || request.Cloud == providers.Amazon) {
 		// location field is empty in request, get bucket location
 		organizationID := auth.GetCurrentOrganization(c.Request).ID
 

--- a/api/ark/buckets/create.go
+++ b/api/ark/buckets/create.go
@@ -17,6 +17,7 @@ package buckets
 import (
 	"net/http"
 
+	"github.com/banzaicloud/pipeline/pkg/providers"
 	"github.com/jinzhu/gorm"
 
 	"github.com/gin-gonic/gin"
@@ -46,7 +47,7 @@ func Create(c *gin.Context) {
 
 	org := auth.GetCurrentOrganization(c.Request)
 
-	if len(request.Location) == 0 {
+	if len(request.Location) == 0 && (request.Cloud == providers.Alibaba || request.Cloud == providers.Amazon) {
 		// location field is empty in request, get bucket location
 		location, err := common.GetBucketLocation(request.Cloud, request.BucketName, request.SecretID, org.ID, logger)
 		if err != nil {


### PR DESCRIPTION
…zon and Alibaba

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Check enable/create backup request location field just in case of Amazon and Alibaba


### Why?
The enable/create backup requests failed due to location check. This check is necessary just in case of Amazon and Alibaba

### Checklist

- [x] Implementation tested (with at least one cloud provider)
