### PR TITLE
Unrestricted CreateCluster request formats in OpenAPI

### DIFF
--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-6317331b4786a684251702a4394f7e9844ae5993faa031ed8909da8e6cfade85  docs/openapi/pipeline.yaml
+aa0cca21930b9ebfcd0ccdf6bd8659bebf4f0481f0606db2b5897a7a5719fdc0  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -272,7 +272,7 @@ paths:
                     gke:
                       $ref: '#/components/schemas/CreateGKEProperties'
             schema:
-              $ref: '#/components/schemas/CreateClusterRequest'
+              type: object
         required: true
       responses:
         202:

--- a/client/api_clusters.go
+++ b/client/api_clusters.go
@@ -105,10 +105,10 @@ ClustersApiService Create cluster
 Create a new K8S cluster in the cloud
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orgId Organization identification
- * @param createClusterRequest
+ * @param body
 @return CreateClusterResponse202
 */
-func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, createClusterRequest CreateClusterRequest) (CreateClusterResponse202, *http.Response, error) {
+func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, body map[string]interface{}) (CreateClusterResponse202, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Post")
 		localVarPostBody     interface{}
@@ -144,7 +144,7 @@ func (a *ClustersApiService) CreateCluster(ctx context.Context, orgId int32, cre
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &createClusterRequest
+	localVarPostBody = &body
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/client/docs/ClustersApi.md
+++ b/client/docs/ClustersApi.md
@@ -63,7 +63,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **CreateCluster**
-> CreateClusterResponse202 CreateCluster(ctx, orgId, createClusterRequest)
+> CreateClusterResponse202 CreateCluster(ctx, orgId, body)
 Create cluster
 
 Create a new K8S cluster in the cloud
@@ -74,7 +74,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **orgId** | **int32**| Organization identification | 
-  **createClusterRequest** | [**CreateClusterRequest**](CreateClusterRequest.md)|  | 
+  **body** | **map[string]interface{}**|  | 
 
 ### Return type
 

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -255,7 +255,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateClusterRequest'
+                            type: object
                             ## oneOf not properly supported by generator
                             #oneOf:
                             #    - $ref: '#/components/schemas/CreateClusterRequest'

--- a/spotguide/cicdconfig.go
+++ b/spotguide/cicdconfig.go
@@ -15,7 +15,6 @@
 package spotguide
 
 import (
-	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 	libcompose "github.com/docker/libcompose/yaml"
 	yaml2 "github.com/ghodss/yaml"
@@ -97,7 +96,7 @@ type cicdContainer struct {
 	Repo          *string                                `yaml:"repo,omitempty"`
 	Tags          *string                                `yaml:"tags,omitempty"`
 	Log           *string                                `yaml:"log,omitempty"`
-	Cluster       *pkgCluster.CreateClusterRequest       `yaml:"cluster,omitempty"`
+	Cluster       map[string]interface{}                 `yaml:"cluster,omitempty"`
 	Deployment    *pkgHelm.CreateUpdateDeploymentRequest `yaml:"deployment,omitempty"`
 	ClusterSecret map[string]interface{}                 `yaml:"cluster_secret,omitempty"`
 }

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -114,7 +114,7 @@ type LaunchRequest struct {
 	RepoName         string                        `json:"repoName" binding:"required"`
 	RepoPrivate      bool                          `json:"repoPrivate"`
 	RepoLatent       bool                          `json:"repoLatent"`
-	Cluster          *client.CreateClusterRequest  `json:"cluster" binding:"required"`
+	Cluster          map[string]interface{}        `json:"cluster" binding:"required"`
 	Secrets          []*secret.CreateSecretRequest `json:"secrets,omitempty"`
 	Pipeline         map[string]interface{}        `json:"pipeline,omitempty"`
 }

--- a/spotguide/spotguide_test.go
+++ b/spotguide/spotguide_test.go
@@ -188,7 +188,6 @@ pipeline:
               maxCount: 2
               minCount: 1
           nodeVersion: "1.10"
-          projectId: ""
       secretId: c8f9c9fc3835b9a3721165afea97ffb78e1375552ab112ed54aee30b29c962ae
       secretName: ""
     cluster_secret:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Do not restrict the format of the CreateCluster request to support the new request format in spotguides (i.e. to make it possible to create azure/pke clusters).


### Additional context

As oneOf is not supported by openapi-generator, and the possible request formats are
incompatible, we have to fall back to type:object (map[string]interface{}).

The request is composed by the UI during spotguide creation, by the same routines that submit requests for new clusters. The request format is validated at the end by Pipeline cluster API.

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)

See banzaicloud/ci-pipeline-client#83