### PR TITLE
Fix: cluster deletion failes if route53 domain name is empty

### DIFF
--- a/dns/route53/route53.go
+++ b/dns/route53/route53.go
@@ -911,7 +911,7 @@ func (dns *awsRoute53) startNewWorker() chan workerTask {
 				var err error
 				var domain, hostedZoneId string
 				domain, err = dns.getOrgDomain(task.organisationId)
-				if err == nil {
+				if err == nil && domain != "" {
 					hostedZoneId, err = dns.hostedZoneExistsByDomain(domain)
 					if err == nil && hostedZoneId != "" {
 						err = dns.deleteHostedZoneResourceRecordSetsOwnedBy(aws.String(hostedZoneId), aws.StringValue(task.dnsRecordownerId))


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
