### PR TITLE
Pass k8s config secret IDs to activities instead of k8s configs

### DIFF
--- a/internal/cluster/workflow/common.go
+++ b/internal/cluster/workflow/common.go
@@ -1,0 +1,19 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+type K8sConfigGetter interface {
+	Get(organizationID uint, k8sSecretID string) ([]byte, error)
+}

--- a/internal/cluster/workflow/delete_helm_deployments_activity.go
+++ b/internal/cluster/workflow/delete_helm_deployments_activity.go
@@ -27,20 +27,26 @@ const DeleteHelmDeploymentsActivityName = "delete-helm-deployments"
 type DeleteHelmDeploymentsActivityInput struct {
 	OrganizationID uint
 	ClusterName    string
-	K8sConfig      []byte
+	K8sSecretID    string
 }
 
 type DeleteHelmDeploymentsActivity struct {
-	logger logrus.FieldLogger
+	k8sConfigGetter K8sConfigGetter
+	logger          logrus.FieldLogger
 }
 
-func MakeDeleteHelmDeploymentsActivity(logger logrus.FieldLogger) DeleteHelmDeploymentsActivity {
+func MakeDeleteHelmDeploymentsActivity(k8sConfigGetter K8sConfigGetter, logger logrus.FieldLogger) DeleteHelmDeploymentsActivity {
 	return DeleteHelmDeploymentsActivity{
-		logger: logger,
+		k8sConfigGetter: k8sConfigGetter,
+		logger:          logger,
 	}
 }
 
 func (a DeleteHelmDeploymentsActivity) Execute(ctx context.Context, input DeleteHelmDeploymentsActivityInput) error {
 	logger := a.logger.WithField("organizationID", input.OrganizationID).WithField("clusterName", input.ClusterName)
-	return emperror.Wrap(helm.DeleteAllDeployment(logger, input.K8sConfig), "failed to delete all Helm deployments")
+	k8sConfig, err := a.k8sConfigGetter.Get(input.OrganizationID, input.K8sSecretID)
+	if err != nil {
+		return emperror.Wrap(err, "failed to get k8s config")
+	}
+	return emperror.Wrap(helm.DeleteAllDeployment(logger, k8sConfig), "failed to delete all Helm deployments")
 }

--- a/internal/cluster/workflow/delete_k8s_resources.go
+++ b/internal/cluster/workflow/delete_k8s_resources.go
@@ -27,7 +27,7 @@ const DeleteK8sResourcesWorkflowName = "delete-k8s-resources"
 type DeleteK8sResourcesWorkflowInput struct {
 	OrganizationID uint
 	ClusterName    string
-	K8sConfig      []byte
+	K8sSecretID    string
 }
 
 func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWorkflowInput) error {
@@ -47,7 +47,7 @@ func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWo
 		activityInput := DeleteHelmDeploymentsActivityInput{
 			OrganizationID: input.OrganizationID,
 			ClusterName:    input.ClusterName,
-			K8sConfig:      input.K8sConfig,
+			K8sSecretID:    input.K8sSecretID,
 		}
 		if err := workflow.ExecuteActivity(ctx, DeleteHelmDeploymentsActivityName, activityInput).Get(ctx, nil); err != nil {
 			if strings.Contains(err.Error(), "could not find tiller") {
@@ -65,7 +65,7 @@ func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWo
 		activityInput := DeleteUserNamespacesActivityInput{
 			OrganizationID: input.OrganizationID,
 			ClusterName:    input.ClusterName,
-			K8sConfig:      input.K8sConfig,
+			K8sSecretID:    input.K8sSecretID,
 		}
 		if err := workflow.ExecuteActivity(ctx, DeleteUserNamespacesActivityName, activityInput).Get(ctx, &deleteUserNamespacesOutput); err != nil {
 			logger.Info(emperror.Wrap(err, "failed to delete user namespaces")) // retry later after resource deletion
@@ -77,7 +77,7 @@ func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWo
 		activityInput := DeleteNamespaceResourcesActivityInput{
 			OrganizationID: input.OrganizationID,
 			ClusterName:    input.ClusterName,
-			K8sConfig:      input.K8sConfig,
+			K8sSecretID:    input.K8sSecretID,
 			Namespace:      ns,
 		}
 		if err := workflow.ExecuteActivity(ctx, DeleteNamespaceResourcesActivityName, activityInput).Get(ctx, nil); err != nil {
@@ -90,7 +90,7 @@ func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWo
 		activityInput := DeleteNamespaceServicesActivityInput{
 			OrganizationID: input.OrganizationID,
 			ClusterName:    input.ClusterName,
-			K8sConfig:      input.K8sConfig,
+			K8sSecretID:    input.K8sSecretID,
 			Namespace:      ns,
 		}
 		if err := workflow.ExecuteActivity(ctx, DeleteNamespaceServicesActivityName, activityInput).Get(ctx, nil); err != nil {
@@ -101,7 +101,9 @@ func DeleteK8sResourcesWorkflow(ctx workflow.Context, input DeleteK8sResourcesWo
 	// delete user namespaces
 	{
 		activityInput := DeleteUserNamespacesActivityInput{
-			K8sConfig: input.K8sConfig,
+			OrganizationID: input.OrganizationID,
+			ClusterName:    input.ClusterName,
+			K8sSecretID:    input.K8sSecretID,
 		}
 		if err := workflow.ExecuteActivity(ctx, DeleteUserNamespacesActivityName, activityInput).Get(ctx, nil); err != nil {
 			return emperror.Wrap(err, "failed to delete user namespaces")

--- a/internal/cluster/workflow/delete_namespace_services_activity.go
+++ b/internal/cluster/workflow/delete_namespace_services_activity.go
@@ -25,24 +25,30 @@ const DeleteNamespaceServicesActivityName = "delete-namespace-services"
 type DeleteNamespaceServicesActivityInput struct {
 	OrganizationID uint
 	ClusterName    string
-	K8sConfig      []byte
+	K8sSecretID    string
 	Namespace      string
 }
 
 type DeleteNamespaceServicesActivity struct {
-	deleter NamespaceServicesDeleter
+	deleter         NamespaceServicesDeleter
+	k8sConfigGetter K8sConfigGetter
 }
 
 type NamespaceServicesDeleter interface {
 	Delete(organizationID uint, clusterName string, k8sConfig []byte, namespace string) error
 }
 
-func MakeDeleteNamespaceServicesActivity(deleter NamespaceServicesDeleter) DeleteNamespaceServicesActivity {
+func MakeDeleteNamespaceServicesActivity(deleter NamespaceServicesDeleter, k8sConfigGetter K8sConfigGetter) DeleteNamespaceServicesActivity {
 	return DeleteNamespaceServicesActivity{
-		deleter: deleter,
+		deleter:         deleter,
+		k8sConfigGetter: k8sConfigGetter,
 	}
 }
 
 func (a DeleteNamespaceServicesActivity) Execute(ctx context.Context, input DeleteNamespaceServicesActivityInput) error {
-	return emperror.Wrapf(a.deleter.Delete(input.OrganizationID, input.ClusterName, input.K8sConfig, input.Namespace), "failed to delete services in namespace %q", input.Namespace)
+	k8sConfig, err := a.k8sConfigGetter.Get(input.OrganizationID, input.K8sSecretID)
+	if err != nil {
+		return emperror.Wrap(err, "failed to get k8s config")
+	}
+	return emperror.Wrapf(a.deleter.Delete(input.OrganizationID, input.ClusterName, k8sConfig, input.Namespace), "failed to delete services in namespace %q", input.Namespace)
 }

--- a/internal/providers/azure/pke/workflow/delete_cluster.go
+++ b/internal/providers/azure/pke/workflow/delete_cluster.go
@@ -32,7 +32,7 @@ type DeleteClusterWorkflowInput struct {
 	ClusterID            uint
 	ClusterName          string
 	ClusterUID           string
-	K8sConfig            []byte
+	K8sSecretID          string
 	ResourceGroupName    string
 	LoadBalancerName     string
 	PublicIPAddressNames []string
@@ -60,11 +60,11 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	ctx = workflow.WithChildOptions(workflow.WithActivityOptions(ctx, ao), cwo)
 
 	// delete k8s resources
-	if len(input.K8sConfig) > 0 {
+	if input.K8sSecretID != "" {
 		wfInput := intClusterWorkflow.DeleteK8sResourcesWorkflowInput{
 			OrganizationID: input.OrganizationID,
 			ClusterName:    input.ClusterName,
-			K8sConfig:      input.K8sConfig,
+			K8sSecretID:    input.K8sSecretID,
 		}
 		if err := workflow.ExecuteChildWorkflow(ctx, intClusterWorkflow.DeleteK8sResourcesWorkflowName, wfInput).Get(ctx, nil); err != nil {
 			if input.Forced {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Pass k8s config secret IDs to activities instead of k8s configs.

### Why?
Security reasons.

### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
