### PR TITLE
Set taint on headnode through VMSS user datascript

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -843,10 +843,14 @@ func addLabelsToNode(client *kubernetes.Clientset, nodeName string, labels map[s
 
 // TaintHeadNodes add taints to the given node in nodepool
 func TaintHeadNodes(commonCluster CommonCluster) error {
-
 	headNodePoolName := viper.GetString(pipConfig.PipelineHeadNodePoolName)
 	if len(headNodePoolName) == 0 {
 		log.Infof("headNodePoolName not specified")
+		return nil
+	}
+
+	if commonCluster.GetCloud() == pkgCluster.Azure && commonCluster.GetDistribution() == pkgCluster.PKE {
+		log.Info("head node already tainted")
 		return nil
 	}
 

--- a/internal/providers/azure/pke/workflow/create_infra.go
+++ b/internal/providers/azure/pke/workflow/create_infra.go
@@ -275,8 +275,8 @@ func (p mapVMSSPrincipalIDProvider) Get(name string) string {
 func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateAzureInfrastructureWorkflowInput) error {
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Minute,
-		StartToCloseTimeout:    10 * time.Minute,
-		ScheduleToCloseTimeout: 15 * time.Minute,
+		StartToCloseTimeout:    15 * time.Minute,
+		ScheduleToCloseTimeout: 20 * time.Minute,
 		WaitForCancellation:    true,
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Pass initial node taints through the user data script instead of setting taints on already joined nodes. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Setting taints through user data script has the advantage of having those taints placed automatically on the new nodes are created by the VMSS.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
