### PR TITLE
Schedule tiller pod to desired node using node affinity

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Masterminds/semver"
 	securityV1Alpha "github.com/banzaicloud/anchore-image-validator/pkg/apis/security/v1alpha1"
 	securityClientV1Alpha "github.com/banzaicloud/anchore-image-validator/pkg/clientset/v1alpha1"
+	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
@@ -138,7 +139,7 @@ func getHeadNodeTolerations() []v1.Toleration {
 	}
 	return []v1.Toleration{
 		{
-			Key:      pkgCommon.HeadNodeTaintKey,
+			Key:      pkgCommon.NodePoolNameTaintKey,
 			Operator: v1.TolerationOpEqual,
 			Value:    headNodePoolName,
 		},
@@ -618,15 +619,53 @@ func InstallHelmPostHook(cluster CommonCluster) error {
 		Upgrade:        true,
 	}
 
-	headNodePoolName := viper.GetString(pipConfig.PipelineHeadNodePoolName)
-	if len(headNodePoolName) > 0 {
-		if cluster.NodePoolExists(headNodePoolName) {
-			helmInstall.TargetNodePool = headNodePoolName
-		} else {
-			log.Warnf("head node pool %v not found, tiller deployment is not targeted to any node pool.", headNodePoolName)
+	if cluster.GetDistribution() == pkgCluster.PKE {
+		// add toleration for master node
+		helmInstall.Tolerations = []v1.Toleration{
+			{
+				Key:      pke.TaintKeyMaster,
+				Operator: v1.TolerationOpExists,
+			},
+		}
+
+		// try to schedule to master or master-worker node
+		helmInstall.NodeAffinity = &v1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: v1.NodeSelectorTerm{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      pke.TaintKeyMaster,
+								Operator: v1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+				{
+					Weight: 100,
+					Preference: v1.NodeSelectorTerm{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      pke.NodeLabelKeyMasterWorker,
+								Operator: v1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+		}
+	} else {
+		headNodePoolName := viper.GetString(pipConfig.PipelineHeadNodePoolName)
+		if len(headNodePoolName) > 0 {
+			if cluster.NodePoolExists(headNodePoolName) {
+				helmInstall.Tolerations = getHeadNodeTolerations()                   // add toleration for system node
+				helmInstall.NodeAffinity = getHeadNodeAffinity(cluster).NodeAffinity // try to schedule to system node
+			} else {
+				log.Warnf("head node pool %v not found, tiller deployment is not targeted to any node pool.", headNodePoolName)
+			}
 		}
 	}
-
 	kubeconfig, err := cluster.GetK8sConfig()
 	if err != nil {
 		return err
@@ -929,13 +968,13 @@ func taintNodes(commonCluster CommonCluster, client *kubernetes.Clientset, nodeP
 		// https://github.com/Azure/AKS/issues/363
 		if commonCluster.GetCloud() == pkgCluster.Azure {
 			taints = append(taints, v1.Taint{
-				Key:    pkgCommon.HeadNodeTaintKey,
+				Key:    pkgCommon.NodePoolNameTaintKey,
 				Value:  nodePoolName,
 				Effect: v1.TaintEffectPreferNoSchedule,
 			})
 		} else {
 			taints = append(taints, v1.Taint{
-				Key:    pkgCommon.HeadNodeTaintKey,
+				Key:    pkgCommon.NodePoolNameTaintKey,
 				Value:  nodePoolName,
 				Effect: v1.TaintEffectNoSchedule,
 			})

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -657,12 +657,12 @@ func InstallHelmPostHook(cluster CommonCluster) error {
 		}
 	} else {
 		headNodePoolName := viper.GetString(pipConfig.PipelineHeadNodePoolName)
-		if len(headNodePoolName) > 0 {
+		if headNodePoolName != "" {
 			if cluster.NodePoolExists(headNodePoolName) {
 				helmInstall.Tolerations = getHeadNodeTolerations()                   // add toleration for system node
 				helmInstall.NodeAffinity = getHeadNodeAffinity(cluster).NodeAffinity // try to schedule to system node
 			} else {
-				log.Warnf("head node pool %v not found, tiller deployment is not targeted to any node pool.", headNodePoolName)
+				log.Warnf("head node pool %q not found, tiller deployment is not targeted to any node pool.", headNodePoolName)
 			}
 		}
 	}

--- a/helm/install.go
+++ b/helm/install.go
@@ -322,20 +322,20 @@ func Install(log logrus.FieldLogger, helmInstall *phelm.Install, kubeConfig []by
 	}
 
 	for i := range helmInstall.Tolerations {
-		if len(helmInstall.Tolerations[i].Key) > 0 {
-			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%v].key=%v", i, helmInstall.Tolerations[i].Key))
+		if helmInstall.Tolerations[i].Key != "" {
+			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%d].key=%s", i, helmInstall.Tolerations[i].Key))
 		}
 
-		if len(helmInstall.Tolerations[i].Operator) > 0 {
-			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%v].operator=%v", i, helmInstall.Tolerations[i].Operator))
+		if helmInstall.Tolerations[i].Operator != "" {
+			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%d].operator=%s", i, helmInstall.Tolerations[i].Operator))
 		}
 
-		if len(helmInstall.Tolerations[i].Value) > 0 {
-			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%v].value=%v", i, helmInstall.Tolerations[i].Value))
+		if helmInstall.Tolerations[i].Value != "" {
+			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%d].value=%s", i, helmInstall.Tolerations[i].Value))
 		}
 
-		if len(helmInstall.Tolerations[i].Effect) > 0 {
-			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%v].effect=%v", i, helmInstall.Tolerations[i].Effect))
+		if helmInstall.Tolerations[i].Effect != "" {
+			opts.Values = append(opts.Values, fmt.Sprintf("spec.template.spec.tolerations[%d].effect=%s", i, helmInstall.Tolerations[i].Effect))
 		}
 	}
 
@@ -343,19 +343,19 @@ func Install(log logrus.FieldLogger, helmInstall *phelm.Install, kubeConfig []by
 		for i := range helmInstall.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 			preferredSchedulingTerm := helmInstall.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i]
 
-			schedulingTermString := fmt.Sprintf("spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[%v]", i)
-			opts.Values = append(opts.Values, fmt.Sprintf("%s.weight=%v", schedulingTermString, preferredSchedulingTerm.Weight))
+			schedulingTermString := fmt.Sprintf("spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d]", i)
+			opts.Values = append(opts.Values, fmt.Sprintf("%s.weight=%d", schedulingTermString, preferredSchedulingTerm.Weight))
 
 			for j := range preferredSchedulingTerm.Preference.MatchExpressions {
 				matchExpression := preferredSchedulingTerm.Preference.MatchExpressions[j]
 
-				matchExpressionString := fmt.Sprintf("%s.preference.matchExpressions[%v]", schedulingTermString, j)
+				matchExpressionString := fmt.Sprintf("%s.preference.matchExpressions[%d]", schedulingTermString, j)
 
-				opts.Values = append(opts.Values, fmt.Sprintf("%s.key=%v", matchExpressionString, matchExpression.Key))
-				opts.Values = append(opts.Values, fmt.Sprintf("%s.operator=%v", matchExpressionString, matchExpression.Operator))
+				opts.Values = append(opts.Values, fmt.Sprintf("%s.key=%s", matchExpressionString, matchExpression.Key))
+				opts.Values = append(opts.Values, fmt.Sprintf("%s.operator=%s", matchExpressionString, matchExpression.Operator))
 
 				for k := range matchExpression.Values {
-					opts.Values = append(opts.Values, fmt.Sprintf("%s.values[%v]=%v", matchExpressionString, k, matchExpression.Values[i]))
+					opts.Values = append(opts.Values, fmt.Sprintf("%s.values[%d]=%v", matchExpressionString, k, matchExpression.Values[i]))
 				}
 			}
 		}

--- a/helm/install.go
+++ b/helm/install.go
@@ -361,16 +361,6 @@ func Install(log logrus.FieldLogger, helmInstall *phelm.Install, kubeConfig []by
 		}
 	}
 
-	/*if len(helmInstall.TargetNodePool) > 0 {
-		opts.Values = []string{
-			fmt.Sprintf("spec.template.spec.tolerations[0].key=%v", pkgCommon.HeadNodeTaintKey),
-			"spec.template.spec.tolerations[0].operator=Equal",
-			fmt.Sprintf("spec.template.spec.tolerations[0].value=%v", helmInstall.TargetNodePool),
-		}
-		// TODO check why this even needed? Soft affinity would be better here.
-		//opts.NodeSelectors = fmt.Sprintf("%s=%s", pkgCommon.LabelKey, helmInstall.TargetNodePool)
-	}*/
-
 	kubeClient, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
 	if err != nil {
 		return err

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -43,7 +43,7 @@ import (
 )
 
 const pkeVersion = "0.4.6"
-const MasterNodeTaint = "node-role.kubernetes.io/master:" + string(corev1.TaintEffectNoSchedule)
+const MasterNodeTaint = pkgPKE.TaintKeyMaster + ":" + string(corev1.TaintEffectNoSchedule)
 
 func MakeAzurePKEClusterCreator(logger logrus.FieldLogger, store pke.AzurePKEClusterStore, workflowClient client.Client, pipelineExternalURL string) AzurePKEClusterCreator {
 	return AzurePKEClusterCreator{
@@ -237,7 +237,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 			nsgn = params.Name + "-worker-nsg"
 			azureRole = "Contributor"
 			if npLen > 1 && np.hasRole(pkgPKE.RolePipelineSystem) {
-				taints = fmt.Sprintf("%s=%s:%s", pkgCommon.HeadNodeTaintKey, np.Name, corev1.TaintEffectPreferNoSchedule)
+				taints = fmt.Sprintf("%s=%s:%s", pkgCommon.NodePoolNameTaintKey, np.Name, corev1.TaintEffectPreferNoSchedule)
 			}
 			userDataScriptTemplate = workerUserDataScriptTemplate
 

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -85,9 +85,11 @@ type Roles []Role
 type Role string
 
 const (
-	RoleMaster         Role = "master"
-	RoleWorker         Role = "worker"
-	RolePipelineSystem Role = "pipeline-system"
+	RoleMaster               Role   = "master"
+	RoleWorker               Role   = "worker"
+	RolePipelineSystem       Role   = "pipeline-system"
+	TaintKeyMaster           string = "node-role.kubernetes.io/master"
+	NodeLabelKeyMasterWorker string = "node-role.kubernetes.io/master-worker"
 )
 
 type Hosts []Host

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -89,7 +89,7 @@ const (
 
 // Constant for tainting head node
 const (
-	HeadNodeTaintKey = "nodepool.banzaicloud.io/name"
+	NodePoolNameTaintKey = "nodepool.banzaicloud.io/name"
 )
 
 const (

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/technosophos/moniker"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ### [ Constants to helm]
@@ -58,8 +59,11 @@ type Install struct {
 	// Limit the maximum number of revisions saved per release. Use 0 for no limit.
 	MaxHistory int `json:"history_max"`
 
-	// TargetNodePool
-	TargetNodePool string `json:"targetNodePool"`
+	// Tolerations to be applied onto the pod
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// NodeAffinity
+	NodeAffinity *corev1.NodeAffinity `json:"nodeAffinity,omitempty"`
 }
 
 // EndpointResponse describes a service public endpoints


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Use node affinity instead of node selector to schedule tiller pod master or system node where available as node affinity allows soft placement rule.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This allows for scheduling tiller for a non-worker node to ensure that tiller is scheduled to a node that has enough resources. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
