### PR TITLE
route53: set low NTTL value to hosted zone's soa

### DIFF
--- a/dns/route53/route53.go
+++ b/dns/route53/route53.go
@@ -50,6 +50,7 @@ const (
 	iamUserNameTemplate                = "%s.r53.%s"
 	hostedZoneAccessPolicyNameTemplate = "%s.r53.%s"
 	IAMUserAccessKeySecretName         = "route53"
+	soaNTTL                            = 60 // negative-cache TTL to set in the SOA record of the created hosted zone
 )
 
 func loggerWithFields(fields logrus.Fields) *logrus.Entry {
@@ -314,6 +315,10 @@ func (dns *awsRoute53) registerDomain(orgId uint, domain string) error {
 
 		hostedZoneIdShort = stripHostedZoneId(aws.StringValue(hostedZone.Id))
 		hostedZoneId = aws.StringValue(hostedZone.Id)
+
+		if err := dns.setHostedZoneSoaNTTL(hostedZone.Id, soaNTTL); err != nil {
+			log.Errorf("could not set NTTL: %v", err)
+		}
 
 	} else {
 		log.Infof("skip creating hosted zone in route53 as it already exists with id: '%s'", hostedZoneIdShort)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Set a low NTTL value of 60 seconds to the created hosted zones' soa record.

### Why?

If we create an ingress, and the end user tries to load the page earlier than the correct record is synced to route53, the negative response will be cached by the caching recursors or the user's machine for `min(SOA.ttl=900, SOA.nttl=86400)=900` seconds by default.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
