### PR TITLE
Cluster deletion should wait for all PVs with delete reclaim policy c…

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -203,7 +203,7 @@ func main() {
 		deleteClusterDNSRecordsActivity := intClusterWorkflow.MakeDeleteClusterDNSRecordsActivity(clusterDNSRecordsDeleter)
 		activity.RegisterWithOptions(deleteClusterDNSRecordsActivity.Execute, activity.RegisterOptions{Name: intClusterWorkflow.DeleteClusterDNSRecordsActivityName})
 
-		waitPersistentVolumesDeletionActivity := intClusterWorkflow.MakeCollectPersistentVolumesActivity(k8sConfigGetter, conf.Logger())
+		waitPersistentVolumesDeletionActivity := intClusterWorkflow.MakeWaitPersistentVolumesDeletionActivity(k8sConfigGetter, conf.Logger())
 		activity.RegisterWithOptions(waitPersistentVolumesDeletionActivity.Execute, activity.RegisterOptions{Name: intClusterWorkflow.WaitPersistentVolumesDeletionActivityName})
 
 		var closeCh = make(chan struct{})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -203,6 +203,9 @@ func main() {
 		deleteClusterDNSRecordsActivity := intClusterWorkflow.MakeDeleteClusterDNSRecordsActivity(clusterDNSRecordsDeleter)
 		activity.RegisterWithOptions(deleteClusterDNSRecordsActivity.Execute, activity.RegisterOptions{Name: intClusterWorkflow.DeleteClusterDNSRecordsActivityName})
 
+		waitPersistentVolumesDeletionActivity := intClusterWorkflow.MakeCollectPersistentVolumesActivity(k8sConfigGetter, conf.Logger())
+		activity.RegisterWithOptions(waitPersistentVolumesDeletionActivity.Execute, activity.RegisterOptions{Name: intClusterWorkflow.WaitPersistentVolumesDeletionActivityName})
+
 		var closeCh = make(chan struct{})
 
 		group.Add(

--- a/internal/cluster/workflow/wait_pvs_deletion_activity.go
+++ b/internal/cluster/workflow/wait_pvs_deletion_activity.go
@@ -1,0 +1,120 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	"github.com/goph/emperror"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const WaitPersistentVolumesDeletionActivityName = "wait-persistent-volumes-deletion"
+
+type WaitPersistentVolumesDeletionActivityInput struct {
+	OrganizationID uint
+	ClusterName    string
+	K8sSecretID    string
+}
+
+// WaitPersistentVolumesDeletionActivity collects the PVs that were created through PVCs
+// and are expected to be deleted by Kubernetes upon cluster deletion.
+type WaitPersistentVolumesDeletionActivity struct {
+	k8sConfigGetter K8sConfigGetter
+	logger          logrus.FieldLogger
+}
+
+func MakeCollectPersistentVolumesActivity(k8sConfigGetter K8sConfigGetter, logger logrus.FieldLogger) WaitPersistentVolumesDeletionActivity {
+	return WaitPersistentVolumesDeletionActivity{
+		k8sConfigGetter: k8sConfigGetter,
+		logger:          logger,
+	}
+}
+
+func (a WaitPersistentVolumesDeletionActivity) Execute(ctx context.Context, input DeleteHelmDeploymentsActivityInput) (err error) {
+	logger := a.logger.WithField("organizationID", input.OrganizationID).WithField("clusterName", input.ClusterName)
+
+	k8sConfig, err := a.k8sConfigGetter.Get(input.OrganizationID, input.K8sSecretID)
+	if err = emperror.Wrap(err, "failed to get k8s config"); err != nil {
+		return
+	}
+
+	client, err := k8sclient.NewClientFromKubeConfig(k8sConfig)
+	if err = emperror.Wrap(err, "failed to instantiate k8s client"); err != nil {
+		return
+	}
+
+	// watch persistent volumes
+	watcher, err := client.CoreV1().PersistentVolumes().Watch(metav1.ListOptions{})
+	defer watcher.Stop()
+
+	pvcList, err := client.CoreV1().PersistentVolumeClaims(corev1.NamespaceAll).List(metav1.ListOptions{})
+	if err = emperror.Wrap(err, "failed to retrieve persistent volume claims"); err != nil {
+		return
+	}
+
+	pvList, err := client.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+	if err = emperror.Wrap(err, "failed to retrieve persistent volumes"); err != nil {
+		return
+	}
+
+	var pvsToWatch = make(map[types.UID]corev1.PersistentVolume)
+	for _, pvc := range pvcList.Items {
+		if pvc.Status.Phase == corev1.ClaimBound {
+			for _, pv := range pvList.Items {
+				if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.UID == pvc.UID && pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+					pvsToWatch[pv.UID] = pv
+					break
+				}
+			}
+		}
+	}
+
+	if len(pvsToWatch) == 0 {
+		logger.Info("no persistent volumes found to wait for")
+		return
+	}
+
+	for {
+		select {
+		case e := <-watcher.ResultChan():
+			if e.Object != nil {
+				pv, ok := e.Object.(*corev1.PersistentVolume)
+
+				if !ok {
+					continue
+				}
+
+				switch e.Type {
+				case watch.Deleted:
+					delete(pvsToWatch, pv.UID)
+
+					if len(pvsToWatch) == 0 { // all watched pvs deleted
+						logger.Debug("all watched persistent volumes have been deleted")
+						return
+					}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+
+	}
+}

--- a/internal/cluster/workflow/wait_pvs_deletion_activity.go
+++ b/internal/cluster/workflow/wait_pvs_deletion_activity.go
@@ -41,7 +41,7 @@ type WaitPersistentVolumesDeletionActivity struct {
 	logger          logrus.FieldLogger
 }
 
-func MakeCollectPersistentVolumesActivity(k8sConfigGetter K8sConfigGetter, logger logrus.FieldLogger) WaitPersistentVolumesDeletionActivity {
+func MakeWaitPersistentVolumesDeletionActivity(k8sConfigGetter K8sConfigGetter, logger logrus.FieldLogger) WaitPersistentVolumesDeletionActivity {
 	return WaitPersistentVolumesDeletionActivity{
 		k8sConfigGetter: k8sConfigGetter,
 		logger:          logger,


### PR DESCRIPTION
…reated by PVCs to be deleted

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Cluster deletion should wait for all PVs with delete reclaim policy created by PVCs to be deleted by Kubernetes controller before deleting the infrastructure of the cluster.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
