### PR TITLE
0.18: hotfix duplicate default storageclass on aws/pke

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -207,7 +207,7 @@ func CreateDefaultStorageclass(commonCluster CommonCluster) error {
 	distro := commonCluster.GetDistribution()
 	provider := commonCluster.GetCloud()
 
-	if distro != pkgCluster.PKE || provider == pkgCluster.Azure {
+	if true {
 		log.Infof("Not creating storageclass for %s on %s ", distro, provider)
 		return nil
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
pke-tool creates a default storageclass by default, and the posthook creates one more. there shouldn't be more than one.

### To Do
- long-term solution
