### PR TITLE
Fix: unhandled error if no watcher for persistent volumes can be created

### DIFF
--- a/internal/cluster/workflow/wait_pvs_deletion_activity.go
+++ b/internal/cluster/workflow/wait_pvs_deletion_activity.go
@@ -63,6 +63,9 @@ func (a WaitPersistentVolumesDeletionActivity) Execute(ctx context.Context, inpu
 
 	// watch persistent volumes
 	watcher, err := client.CoreV1().PersistentVolumes().Watch(metav1.ListOptions{})
+	if err = emperror.Wrap(err, "failed start watcher for persistent volumes") ;err != nil {
+		return
+	}
 	defer watcher.Stop()
 
 	pvcList, err := client.CoreV1().PersistentVolumeClaims(corev1.NamespaceAll).List(metav1.ListOptions{})

--- a/internal/cluster/workflow/wait_pvs_deletion_activity.go
+++ b/internal/cluster/workflow/wait_pvs_deletion_activity.go
@@ -63,7 +63,7 @@ func (a WaitPersistentVolumesDeletionActivity) Execute(ctx context.Context, inpu
 
 	// watch persistent volumes
 	watcher, err := client.CoreV1().PersistentVolumes().Watch(metav1.ListOptions{})
-	if err = emperror.Wrap(err, "failed start watcher for persistent volumes") ;err != nil {
+	if err = emperror.Wrap(err, "failed start watcher for persistent volumes"); err != nil {
 		return
 	}
 	defer watcher.Stop()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In case the cluster deletion is re-executed on a cluster that is in an incomplete state creating a watcher for persistent volumes may fail. This error must be handled gracefully.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
