### PR TITLE
clustergroup deployments: fix merge problem when global values are nil

### DIFF
--- a/internal/clustergroup/deployment/deployment.go
+++ b/internal/clustergroup/deployment/deployment.go
@@ -57,13 +57,15 @@ type DeploymentInfo struct {
 func (c *DeploymentInfo) GetValuesForCluster(clusterName string) ([]byte, error) {
 	// copy c.values into a new map before merging
 	values := make(map[string]interface{})
-	m, err := json.Marshal(c.Values)
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(m, &values)
-	if err != nil {
-		return nil, err
+	if c.Values != nil {
+		m, err := json.Marshal(c.Values)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(m, &values)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	clusterSpecificOverrides, exists := c.ValueOverrides[clusterName]

--- a/internal/clustergroup/deployment/manager.go
+++ b/internal/clustergroup/deployment/manager.go
@@ -366,6 +366,9 @@ func (m CGDeploymentManager) updateDeploymentModel(clusterGroup *api.ClusterGrou
 				if err != nil {
 					return err
 				}
+				if currentValues == nil {
+					currentValues = make(map[string]interface{})
+				}
 				valuesOverride = helm.MergeValues(currentValues, valuesOverride)
 			}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no|yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

