### PR TITLE
Use client/CreateSecretResponse

### DIFF
--- a/api/secrets.go
+++ b/api/secrets.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/pipeline/auth"
+	"github.com/banzaicloud/pipeline/client"
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/config"
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
@@ -182,14 +183,14 @@ func AddSecrets(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, secret.CreateSecretResponse{
+	c.JSON(http.StatusCreated, client.CreateSecretResponse{
 		Name:      s.Name,
 		Type:      s.Type,
-		ID:        secretID,
+		Id:        secretID,
 		Error:     errorMsg,
 		UpdatedAt: s.UpdatedAt,
 		UpdatedBy: s.UpdatedBy,
-		Version:   s.Version,
+		Version:   int32(s.Version),
 	})
 }
 
@@ -278,14 +279,14 @@ func UpdateSecrets(c *gin.Context) {
 		errorMsg = validationError.Error()
 	}
 
-	c.JSON(http.StatusOK, secret.CreateSecretResponse{
+	c.JSON(http.StatusOK, client.CreateSecretResponse{
 		Name:      s.Name,
 		Type:      s.Type,
-		ID:        secretID,
+		Id:        secretID,
 		Error:     errorMsg,
 		UpdatedAt: s.UpdatedAt,
 		UpdatedBy: s.UpdatedBy,
-		Version:   s.Version,
+		Version:   int32(s.Version),
 	})
 }
 

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-02a1581d03d0f8973517f9f76134c3448cd4491a9cb637441f367277e1d329b6  docs/openapi/pipeline.yaml
+9e0f85fa1efaf6bb2f5319c308e350f560415ff2b65519fbf8473de88454f2b0  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -9911,7 +9911,7 @@ components:
         type: google
         error: Validation failed
         version: 1
-        updatedAt: 2018-07-01T08:27:23.2636996Z
+        updatedAt: 2000-01-23T04:56:07.000+00:00
       properties:
         name:
           example: My-google-secret
@@ -9926,7 +9926,7 @@ components:
           example: Validation failed
           type: string
         updatedAt:
-          example: 2018-07-01T08:27:23.2636996Z
+          format: date-time
           type: string
         updatedBy:
           example: username
@@ -9935,6 +9935,10 @@ components:
           example: 1
           format: int32
           type: integer
+      required:
+      - id
+      - name
+      - type
       type: object
     CreateSecretRequest:
       example:

--- a/client/docs/CreateSecretResponse.md
+++ b/client/docs/CreateSecretResponse.md
@@ -3,11 +3,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
-**Type** | **string** |  | [optional] 
-**Id** | **string** |  | [optional] 
+**Name** | **string** |  | 
+**Type** | **string** |  | 
+**Id** | **string** |  | 
 **Error** | **string** |  | [optional] 
-**UpdatedAt** | **string** |  | [optional] 
+**UpdatedAt** | [**time.Time**](time.Time.md) |  | [optional] 
 **UpdatedBy** | **string** |  | [optional] 
 **Version** | **int32** |  | [optional] 
 

--- a/client/model_create_secret_response.go
+++ b/client/model_create_secret_response.go
@@ -11,12 +11,16 @@
 
 package client
 
+import (
+	"time"
+)
+
 type CreateSecretResponse struct {
-	Name      string `json:"name,omitempty"`
-	Type      string `json:"type,omitempty"`
-	Id        string `json:"id,omitempty"`
-	Error     string `json:"error,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
-	UpdatedBy string `json:"updatedBy,omitempty"`
-	Version   int32  `json:"version,omitempty"`
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	Id        string    `json:"id"`
+	Error     string    `json:"error,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy string    `json:"updatedBy,omitempty"`
+	Version   int32     `json:"version,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -8945,6 +8945,10 @@ components:
 
         CreateSecretResponse:
             type: object
+            required:
+                - id
+                - name
+                - type
             properties:
                 name:
                     type: string
@@ -8960,6 +8964,7 @@ components:
                     example: "Validation failed"
                 updatedAt:
                     type: string
+                    format: date-time
                     example: "2018-07-01T08:27:23.2636996Z"
                 updatedBy:
                     type: string

--- a/secret/store.go
+++ b/secret/store.go
@@ -70,17 +70,6 @@ type secretStore struct {
 	Logical *vaultapi.Logical
 }
 
-// CreateSecretResponse API response for AddSecrets
-type CreateSecretResponse struct {
-	Name      string    `json:"name" binding:"required"`
-	Type      string    `json:"type" binding:"required"`
-	ID        string    `json:"id"`
-	Error     string    `json:"error,omitempty"`
-	UpdatedAt time.Time `json:"updatedAt,omitempty"`
-	UpdatedBy string    `json:"updatedBy,omitempty"`
-	Version   int       `json:"version,omitempty"`
-}
-
 // CreateSecretRequest param for Store.Store
 // Only fields with `mapstructure` tag are getting written to Vault
 type CreateSecretRequest struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Use the generated `CreateSecretResponse` type from the `client` package in the API instead of the one from the `secret`.

### Why?
It's redundant to have the type repeated. Also, the `secret` package in the project root should not exist, and this is a step toward removing it.

### Checklist
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
