### PR TITLE
dex: make insecure configurable in ClusterAuthAPI as well

### DIFF
--- a/api/cluster_auth.go
+++ b/api/cluster_auth.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -55,12 +56,22 @@ func NewClusterAuthAPI(
 	clusterAuthService auth.ClusterAuthService,
 	tokenSigningKey string,
 	issuerURL string,
+	insecureSkipVerify bool,
 	redirectURI string,
 ) (*ClusterAuthAPI, error) {
 
+	httpClient := http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify,
+			},
+		},
+	}
+
 	a := ClusterAuthAPI{
 		tokenSigningKey:    []byte(tokenSigningKey),
-		client:             http.DefaultClient,
+		client:             &httpClient,
 		clusterGetter:      clusterGetter,
 		clusterAuthService: clusterAuthService,
 		redirectURI:        redirectURI,

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -502,6 +502,7 @@ func main() {
 				clusterAuthService,
 				viper.GetString("auth.tokensigningkey"),
 				viper.GetString("auth.dexURL"),
+				viper.GetBool("auth.dexInsecure"),
 				pipelineExternalURL.String(),
 			)
 			emperror.Panic(emperror.Wrap(err, "failed to create ClusterAuthAPI"))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | completion of #2043 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
