### PR TITLE
Add example.com default to the auto dns check

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -364,7 +364,7 @@ func main() {
 	}
 
 	spotguidePlatformData := spotguide.PlatformData{
-		AutoDNSEnabled: viper.GetString(config.DNSBaseDomain) != "",
+		AutoDNSEnabled: viper.GetString(config.DNSBaseDomain) != "" && viper.GetString(config.DNSBaseDomain) != "example.com",
 	}
 
 	spotguideManager := spotguide.NewSpotguideManager(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Add `example.com` check to the decision whether auto DNS is enabled or not.


### Why?

`example.com` is the default external DNS domain. In order to make auto DNS opt-in.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
