### PR TITLE
fixing mysql/postgres text vs. varchar type mismatch issues

### DIFF
--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -38,7 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const pkeVersion = "0.4.7"
+const pkeVersion = "0.4.8"
 const MasterNodeTaint = pkgPKE.TaintKeyMaster + ":" + string(corev1.TaintEffectNoSchedule)
 
 func MakeAzurePKEClusterCreator(logger logrus.FieldLogger, store pke.AzurePKEClusterStore, workflowClient client.Client, pipelineExternalURL string, pipelineExternalURLInsecure bool) AzurePKEClusterCreator {

--- a/internal/providers/pke/config.go
+++ b/internal/providers/pke/config.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+
+	"github.com/spf13/cast"
 )
 
 type Config map[string]interface{}
@@ -37,5 +39,9 @@ var _ sql.Scanner = (*Config)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *Config) Scan(src interface{}) error {
-	return json.Unmarshal([]byte(string(src.([]uint8))), &n)
+	value, err := cast.ToStringE(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(value), &n)
 }

--- a/internal/providers/pke/cri.go
+++ b/internal/providers/pke/cri.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+
+	"github.com/spf13/cast"
 )
 
 // CRI is the schema for the DB.
@@ -63,6 +65,7 @@ var _ sql.Scanner = (*Runtime)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *Runtime) Scan(src interface{}) error {
-	*n = Runtime(string(src.([]uint8)))
-	return nil
+	value, err := cast.ToStringE(src)
+	*n = Runtime(value)
+	return err
 }

--- a/internal/providers/pke/kubeadm.go
+++ b/internal/providers/pke/kubeadm.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/jinzhu/gorm"
+	"github.com/spf13/cast"
 )
 
 // KubeADM is the schema for the DB.
@@ -105,6 +106,7 @@ var _ sql.Scanner = (*ExtraArg)(nil)
 
 // Scan implements the sql.Scanner interface
 func (e *ExtraArg) Scan(src interface{}) error {
-	*e = ExtraArg(string(src.([]uint8)))
-	return nil
+	value, err := cast.ToStringE(src)
+	*e = ExtraArg(value)
+	return err
 }

--- a/internal/providers/pke/network.go
+++ b/internal/providers/pke/network.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+
+	"github.com/spf13/cast"
 )
 
 // Network is the schema for the DB.
@@ -69,8 +71,9 @@ var _ sql.Scanner = (*NetworkProvider)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *NetworkProvider) Scan(src interface{}) error {
-	*n = NetworkProvider(string(src.([]uint8)))
-	return nil
+	value, err := cast.ToStringE(src)
+	*n = NetworkProvider(value)
+	return err
 }
 
 // NetworkProvider is the schema for the DB.
@@ -91,6 +94,7 @@ var _ sql.Scanner = (*CloudNetworkProvider)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *CloudNetworkProvider) Scan(src interface{}) error {
-	*n = CloudNetworkProvider(string(src.([]uint8)))
-	return nil
+	value, err := cast.ToStringE(src)
+	*n = CloudNetworkProvider(value)
+	return err
 }

--- a/internal/providers/pke/nodepool.go
+++ b/internal/providers/pke/nodepool.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/spf13/cast"
 )
 
 type NodePools []NodePool
@@ -76,8 +78,9 @@ var _ sql.Scanner = (*NodePoolProvider)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *NodePoolProvider) Scan(src interface{}) error {
-	*n = NodePoolProvider(string(src.([]uint8)))
-	return nil
+	value, err := cast.ToStringE(src)
+	*n = NodePoolProvider(value)
+	return err
 }
 
 type Roles []Role
@@ -104,7 +107,11 @@ var _ sql.Scanner = (*Roles)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *Roles) Scan(src interface{}) error {
-	return json.Unmarshal([]byte(string(src.([]uint8))), &n)
+	value, err := cast.ToStringE(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(value), &n)
 }
 
 var _ driver.Valuer = (*Role)(nil)
@@ -177,7 +184,11 @@ var _ sql.Scanner = (*Labels)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *Labels) Scan(src interface{}) error {
-	return json.Unmarshal([]byte(string(src.([]uint8))), &n)
+	value, err := cast.ToStringE(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(value), &n)
 }
 
 type Taints []Taint
@@ -198,5 +209,9 @@ var _ sql.Scanner = (*Taints)(nil)
 
 // Scan implements the sql.Scanner interface
 func (n *Taints) Scan(src interface{}) error {
-	return json.Unmarshal([]byte(string(src.([]uint8))), &n)
+	value, err := cast.ToStringE(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(value), &n)
 }

--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -24,7 +24,7 @@ import (
 )
 
 const CreateClusterWorkflowName = "pke-create-cluster"
-const pkeVersion = "0.4.7"
+const pkeVersion = "0.4.8"
 
 func getDefaultImageID(region, kubernetesVersion string) string {
 	switch kubernetesVersion {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Implementing a more DB neutral Scan method. Also bump PKE version (TLS insecure fix).


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The MySQL driver scans strings as `[]uint8`, the Postgres driver scans them as `string`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
