### PR TITLE
quick fix for GKE cluster creation in case of its status is ERROR

### DIFF
--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -61,6 +61,7 @@ import (
 const (
 	statusRunning = "RUNNING"
 	statusDone    = "DONE"
+	statusError   = "ERROR"
 )
 
 const (
@@ -319,6 +320,10 @@ func (c *GKECluster) CreateCluster() error {
 	if err != nil {
 		be := getBanzaiErrorFromError(err)
 		// TODO status code !?
+		return errors.New(be.Message)
+	}
+	if gkeCluster.Status == statusError {
+		be := getBanzaiErrorFromError(err)
 		return errors.New(be.Message)
 	}
 

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -323,8 +323,7 @@ func (c *GKECluster) CreateCluster() error {
 		return errors.New(be.Message)
 	}
 	if gkeCluster.Status == statusError {
-		be := getBanzaiErrorFromError(err)
-		return errors.New(be.Message)
+		return errors.New(gkeCluster.StatusMessage)
 	}
 
 	c.googleCluster = gkeCluster


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2055
| License         | Apache 2.0


### What's in this PR?
Return error if the cluster status after GKE cluster creation is ERROR 
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
