### PR TITLE
spotguide: gitlabTag.Release can be nil, use .Name instead

### DIFF
--- a/spotguide/scm/gitlab.go
+++ b/spotguide/scm/gitlab.go
@@ -108,8 +108,7 @@ func (scm *gitLabSCM) ListRepositoryReleases(owner, name string) ([]RepositoryRe
 
 		for _, gitlabTag := range gitlabTags {
 			release := RepositoryRelease{
-				tag:  gitlabTag.Release.TagName,
-				body: gitlabTag.Release.Description,
+				tag: gitlabTag.Name,
 			}
 			releases = append(releases, release)
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | See trace below. 👇 
| License         | Apache 2.0


### What's in this PR?
Fixing panic when gitlabTag is not tied to a gitlab release.

### Why?
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3044c71]

goroutine 108 [running]:
github.com/banzaicloud/pipeline/spotguide/scm.(*gitLabSCM).ListRepositoryReleases(0xc0000b8eb0, 0xc00082de10, 0xa, 0xc00123fcb0, 0xb, 0x0, 0xc000869440, 0x7, 0x8, 0x0)
	/build/spotguide/scm/gitlab.go:111 +0x181
github.com/banzaicloud/pipeline/spotguide.(*SpotguideManager).scrapeSpotguides(0xc000582300, 0xc000708480, 0x45fa680, 0xc0000b8eb0, 0x0, 0xc000809ec0)
	/build/spotguide/spotguide.go:258 +0x496
github.com/banzaicloud/pipeline/spotguide.(*SpotguideManager).ScrapeSharedSpotguides(0xc000582300, 0x1eb00000079, 0x181000000c0)
	/build/spotguide/spotguide.go:210 +0xbe
main.main.func2(0xc000582300, 0xc00057ed20)
	/build/cmd/pipeline/main.go:394 +0x35
created by main.main
	/build/cmd/pipeline/main.go:393 +0x2ef8
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
