### PR TITLE
Add repoConfig to error if spotguide config fails to marshall

### DIFF
--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -587,7 +587,7 @@ func createCICDRepoConfig(pipelineYAML []byte, request *LaunchRequest, platformD
 
 	repoConfig := new(cicdRepoConfig)
 	if err := yaml.Unmarshal(buffer.Bytes(), repoConfig); err != nil {
-		return nil, emperror.Wrap(err, "failed to unmarshal initial config")
+		return nil, emperror.WrapWith(err, "failed to unmarshal initial config", "repoConfig", base64.StdEncoding.EncodeToString(buffer.Bytes()))
 	}
 
 	// Configure cluster


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
This PR adds the repoconfig in base64 format to error context, to ease debugging

### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)