### PR TITLE
Filter out Unauthorized response code in case of Amazon specific errors

### DIFF
--- a/api/common_stuff.go
+++ b/api/common_stuff.go
@@ -76,7 +76,7 @@ func ErrorResponseFrom(err error) *pkgCommon.ErrorResponse {
 	// aws specific errors
 	if awsErr, ok := err.(awserr.Error); ok {
 		code := http.StatusBadRequest
-		if awsReqFailure, ok := err.(awserr.RequestFailure); ok {
+		if awsReqFailure, ok := err.(awserr.RequestFailure); ok && awsReqFailure.StatusCode() != http.StatusUnauthorized {
 			code = awsReqFailure.StatusCode()
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Filter out Unauthorized response code in case of Amazon specific errors

### Why?
We want to list Amazon networks: `{url}/pipeline/api/v1/orgs/{orgId}/networks?cloudType=amazon&region=us-west-2` with a wrong Amazon secret. Pipeline response (with 401 status code):
```
{
    "code": 401,
    "message": "AWS was not able to validate the provided access credentials",
    "error": "AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: 0cb63d3f-aa66-4647-81e6-2f24e51033a2"
}
```
The UI will logout the user after this request without any information. I think in these cases when we communicate with providers we should not send back 401 response code

After this change the response will look like this:
```
{
    "code": 400,
    "message": "AWS was not able to validate the provided access credentials",
    "error": "AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: 0cb63d3f-aa66-4647-81e6-2f24e51033a2"
}

```

### Checklist

- [x] Implementation tested (with at least one cloud provider)

