### PR TITLE
bucketAPI: save namespace for Oracle buckets

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -56,15 +56,16 @@ type secretData struct {
 // BucketResponseItem encapsulates bucket and secret details to be returned
 // it's purpose is to properly format the response details - especially the secret details
 type BucketResponseItem struct {
-	Name       string                                `json:"name"  binding:"required"`
-	Managed    bool                                  `json:"managed" binding:"required"`
-	Location   string                                `json:"location,omitempty"`
-	Cloud      string                                `json:"cloud,omitempty"`
-	Notes      *string                               `json:"notes,omitempty"`
-	SecretInfo *secretData                           `json:"secret"`
-	Azure      *objectstore.BlobStoragePropsForAzure `json:"aks,omitempty"`
-	Status     string                                `json:"status"`
-	StatusMsg  string                                `json:"statusMessage"`
+	Name       string                                 `json:"name"  binding:"required"`
+	Managed    bool                                   `json:"managed" binding:"required"`
+	Location   string                                 `json:"location,omitempty"`
+	Cloud      string                                 `json:"cloud,omitempty"`
+	Notes      *string                                `json:"notes,omitempty"`
+	SecretInfo *secretData                            `json:"secret"`
+	Azure      *objectstore.BlobStoragePropsForAzure  `json:"aks,omitempty"`
+	Oracle     *objectstore.BlobStoragePropsForOracle `json:"oracle,omitempty"`
+	Status     string                                 `json:"status"`
+	StatusMsg  string                                 `json:"statusMessage"`
 }
 
 // ListAllBuckets handles 	bucket list requests. The handler method directs the flow to the appropriate retrieval
@@ -638,7 +639,7 @@ func GetBucket(c *gin.Context) {
 		return
 	}
 
-	if retBuckets, err := bc.filterBuckets(bucketList, bucketName, *qd); err == nil {
+	if retBuckets, err := bc.filterBuckets(bucketList, bucketName, *qd); err == nil && len(retBuckets) > 0 {
 		c.JSON(http.StatusOK, newBucketResponseItemFromBucketInfo(retBuckets[0], organization.ID, qd.withSecretName()))
 		return
 	}
@@ -713,6 +714,7 @@ func newBucketResponseItemFromBucketInfo(bi *objectstore.BucketInfo, orgid uint,
 		Managed:   bi.Managed,
 		Notes:     &notes,
 		Azure:     bi.Azure,
+		Oracle:    bi.Oracle,
 		SecretInfo: &secretData{
 			SecretName:       secretName,
 			SecretId:         bi.SecretRef,

--- a/database/migrations/mysql/1559301886_oracle_bucket_add_namespace.down.sql
+++ b/database/migrations/mysql/1559301886_oracle_bucket_add_namespace.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oracle_buckets DROP COLUMN namespace;
+

--- a/database/migrations/mysql/1559301886_oracle_bucket_add_namespace.up.sql
+++ b/database/migrations/mysql/1559301886_oracle_bucket_add_namespace.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `oracle_buckets` ADD COLUMN `namespace` varchar(255)  DEFAULT NULL;
+

--- a/database/migrations/postgres/1559301886_oracle_bucket_add_namespace.down.sql
+++ b/database/migrations/postgres/1559301886_oracle_bucket_add_namespace.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "oracle_buckets" DROP COLUMN "namespace";
+

--- a/database/migrations/postgres/1559301886_oracle_bucket_add_namespace.up.sql
+++ b/database/migrations/postgres/1559301886_oracle_bucket_add_namespace.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "oracle_buckets" ADD COLUMN "namespace" text;
+

--- a/internal/objectstore/objectstore.go
+++ b/internal/objectstore/objectstore.go
@@ -26,19 +26,25 @@ type ObjectStoreService interface {
 
 // BucketInfo describes a storage bucket
 type BucketInfo struct {
-	Name            string                    `json:"name"  binding:"required"`
-	Managed         bool                      `json:"managed" binding:"required"`
-	Location        string                    `json:"location,omitempty"`
-	SecretRef       string                    `json:"secretId,omitempty"`
-	Cloud           string                    `json:"cloud,omitempty"`
-	Azure           *BlobStoragePropsForAzure `json:"aks,omitempty"`
-	Status          string                    `json:"status,omitempty"`
-	StatusMsg       string                    `json:"statusMsg,omitempty"`
-	AccessSecretRef string                    `json:"accessSecretId,omitempty"`
+	Name            string                     `json:"name"  binding:"required"`
+	Managed         bool                       `json:"managed" binding:"required"`
+	Location        string                     `json:"location,omitempty"`
+	SecretRef       string                     `json:"secretId,omitempty"`
+	Cloud           string                     `json:"cloud,omitempty"`
+	Azure           *BlobStoragePropsForAzure  `json:"aks,omitempty"`
+	Oracle          *BlobStoragePropsForOracle `json:"oracle,omitempty"`
+	Status          string                     `json:"status,omitempty"`
+	StatusMsg       string                     `json:"statusMsg,omitempty"`
+	AccessSecretRef string                     `json:"accessSecretId,omitempty"`
 }
 
 // BlobStoragePropsForAzure describes the Azure specific properties
 type BlobStoragePropsForAzure struct {
 	ResourceGroup  string `json:"resourceGroup" binding:"required"`
 	StorageAccount string `json:"storageAccount" binding:"required"`
+}
+
+// BlobStoragePropsForOracle describes the Oracle specific properties
+type BlobStoragePropsForOracle struct {
+	Namespace string `json:"namespace"`
 }

--- a/internal/providers/oracle/objectstore.go
+++ b/internal/providers/oracle/objectstore.go
@@ -39,6 +39,8 @@ func (bucketNotFoundError) NotFound() bool { return true }
 
 type oracleObjectStore interface {
 	commonObjectstore.ObjectStore
+	// GetNamespace returns client namespace
+	GetNamespace() string
 }
 
 // ObjectStore stores all required parameters for container creation
@@ -160,6 +162,8 @@ func (o *ObjectStore) CreateBucket(bucketName string) error {
 	}
 
 	bucket.Status = providers.BucketCreated
+	// save Namespace
+	bucket.Namespace = o.objectStore.GetNamespace()
 	bucket.StatusMsg = "bucket successfully created"
 	if err := o.db.Save(bucket).Error; err != nil {
 		return o.createFailed(bucket, emperror.Wrap(err, "failed to save bucket"))
@@ -234,6 +238,9 @@ func (o *ObjectStore) ListManagedBuckets() ([]*objectstore.BucketInfo, error) {
 			Location:  bucket.Location,
 			SecretRef: bucket.SecretRef,
 			Cloud:     providers.Oracle,
+			Oracle: &objectstore.BlobStoragePropsForOracle{
+				Namespace: bucket.Namespace,
+			},
 			Status:    bucket.Status,
 			StatusMsg: bucket.StatusMsg,
 		})

--- a/internal/providers/oracle/objectstore_model.go
+++ b/internal/providers/oracle/objectstore_model.go
@@ -35,9 +35,9 @@ type ObjectStoreBucketModel struct {
 	Location      string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 
 	SecretRef string
-	Namespace string
 	Status    string
 	StatusMsg string `sql:"type:text;"`
+	Namespace string
 }
 
 // TableName changes the default table name.

--- a/internal/providers/oracle/objectstore_model.go
+++ b/internal/providers/oracle/objectstore_model.go
@@ -35,6 +35,7 @@ type ObjectStoreBucketModel struct {
 	Location      string `gorm:"unique_index:idx_bucket_name_location_compartment"`
 
 	SecretRef string
+	Namespace string
 	Status    string
 	StatusMsg string `sql:"type:text;"`
 }

--- a/pkg/providers/oracle/objectstore/objectstore.go
+++ b/pkg/providers/oracle/objectstore/objectstore.go
@@ -102,6 +102,11 @@ func (o *objectStore) CreateBucket(bucketName string) error {
 	return nil
 }
 
+// GetNamespace returns client namespace
+func (o *objectStore) GetNamespace() string {
+	return o.osClient.Namespace
+}
+
 // ListBuckets lists the current buckets in the object store
 func (o *objectStore) ListBuckets() ([]string, error) {
 	var keys []string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Add namespace field to Oracle bucket.


### Why?
Oracle buckets should be referred with namespace like bucketName@namespace at least when accessing through HDFS Connector for Object Storage which is used by Spark. When using Oracle storage buckets for Spark Event Logs we need to know the namespace for each bucket.





### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)