### PR TITLE
Use errorHandler instead of simple log.error in case of LaunchSpotguide

### DIFF
--- a/api/spotguide.go
+++ b/api/spotguide.go
@@ -159,7 +159,8 @@ func (s *SpotguideAPI) LaunchSpotguide(c *gin.Context) {
 
 	err := s.spotguide.LaunchSpotguide(&launchRequest, org, user)
 	if err != nil {
-		log.Errorf("failed to Launch spotguide %s: %s", launchRequest.RepoFullname(), err.Error())
+		log.Errorf("failed to Launch spotguide %s", launchRequest.RepoFullname())
+		s.errorHandler.Handle(err)
 		c.JSON(http.StatusInternalServerError, pkgCommon.ErrorResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "error launching spotguide",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |no|
| New feature?    |yes|
| License         | Apache 2.0


### What's in this PR?
Use errorHandler instead of simple log.error to display available contexts.


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)