### PR TITLE
PKE on AWS: add cloudformation stack failure events to the error mess…

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
+++ b/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 )
@@ -72,9 +73,6 @@ func (a *DeleteVPCActivity) Execute(ctx context.Context, input DeleteVPCActivity
 	}
 
 	err = cfClient.WaitUntilStackDeleteCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{StackName: &stackName})
-	if err != nil {
-		return emperror.Wrap(err, "waiting for termination")
-	}
 
-	return nil
+	return emperror.Wrap(pkgCloudformation.NewAwsStackFailure(err, stackName, cfClient), "waiting for termination")
 }

--- a/internal/providers/pke/pkeworkflow/wait_for_cf_completion_activity.go
+++ b/internal/providers/pke/pkeworkflow/wait_for_cf_completion_activity.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	"github.com/goph/emperror"
 )
 
@@ -51,7 +52,7 @@ func (a *WaitCFCompletionActivity) Execute(ctx context.Context, input WaitCFComp
 
 	err = cfClient.WaitUntilStackCreateCompleteWithContext(ctx, describeStacksInput)
 	if err != nil {
-		return nil, emperror.Wrap(err, "error waiting Cloud Formation template")
+		return nil, emperror.Wrap(pkgCloudformation.NewAwsStackFailure(err, input.StackID, cfClient), "error waiting Cloud Formation template")
 	}
 
 	output, err := cfClient.DescribeStacks(describeStacksInput)

--- a/pkg/providers/amazon/cloudformation/cloudformation.go
+++ b/pkg/providers/amazon/cloudformation/cloudformation.go
@@ -15,7 +15,13 @@
 package cloudformation
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
+	"github.com/goph/emperror"
 )
 
 // GetExistingTaggedStackNames gives back existing CF stacks which have the given tags
@@ -53,4 +59,77 @@ func getFlattenedTags(tags []*cloudformation.Tag) map[string]string {
 	}
 
 	return t
+}
+
+type awsStackFailedError struct {
+	awsStackError   error
+	stackName       string
+	failedEventsMsg []string
+}
+
+func (e awsStackFailedError) Error() string {
+	hdr := "stack " + e.stackName
+	if len(e.failedEventsMsg) > 0 {
+		return hdr + "\n" + strings.Join(e.failedEventsMsg, "\n")
+	}
+
+	return hdr + e.awsStackError.Error()
+}
+
+func (e awsStackFailedError) Cause() error {
+	return e.awsStackError
+}
+
+func NewAwsStackFailure(awsStackError error, stackName string, cloudformationSrv *cloudformation.CloudFormation) error {
+	if awsStackError == nil {
+		return nil
+	}
+
+	failedStackEvents, err := collectFailedStackEvents(stackName, cloudformationSrv)
+	if err != nil {
+		caughtErrors := emperror.NewMultiErrorBuilder()
+		caughtErrors.Add(awsStackError)
+		caughtErrors.Add(emperror.Wrap(err, "could not retrieve stack events with 'FAILED' state"))
+
+		return pkgErrors.NewMultiErrorWithFormatter(caughtErrors.ErrOrNil())
+	}
+
+	if len(failedStackEvents) > 0 {
+		var failedEventsMsg []string
+
+		for _, event := range failedStackEvents {
+			msg := fmt.Sprintf("%v %v %v", aws.StringValue(event.LogicalResourceId), aws.StringValue(event.ResourceStatus), aws.StringValue(event.ResourceStatusReason))
+			failedEventsMsg = append(failedEventsMsg, msg)
+		}
+
+		return awsStackFailedError{
+			awsStackError:   awsStackError,
+			stackName:       stackName,
+			failedEventsMsg: failedEventsMsg,
+		}
+	}
+
+	return awsStackError
+}
+
+func collectFailedStackEvents(stackName string, cloudformationSrv *cloudformation.CloudFormation) ([]*cloudformation.StackEvent, error) {
+	var failedStackEvents []*cloudformation.StackEvent
+
+	describeStackEventsInput := &cloudformation.DescribeStackEventsInput{StackName: aws.String(stackName)}
+	err := cloudformationSrv.DescribeStackEventsPages(describeStackEventsInput,
+		func(page *cloudformation.DescribeStackEventsOutput, lastPage bool) bool {
+
+			for _, event := range page.StackEvents {
+				if strings.HasSuffix(*event.ResourceStatus, "FAILED") {
+					failedStackEvents = append(failedStackEvents, event)
+				}
+			}
+
+			return true
+		})
+	if err != nil {
+		return nil, emperror.WrapWith(err, "failed to describe CloudFormation stack events", "stackName", aws.String(stackName))
+	}
+
+	return failedStackEvents, nil
 }


### PR DESCRIPTION
…age returned in case of failure

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Collect CloudFormation stack failure events as that provides information on what caused a CloudFormation stack failure and propagate these events into the error that is returned to the user. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When a CloudFormation stack creation fails the user only receives the high-level error message that says that the stack failed but not the root cause. The root cause can be found among the failure events (e.g. quota limit exceeded) linked to the CloudFormation stack, thus these should be propagated back to the user.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
