### PR TITLE
Azure PKE master HA user data script fix

### DIFF
--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -495,6 +495,7 @@ pke install master --pipeline-url="{{ .PipelineURL }}" \
 --kubernetes-api-server={{ .PublicAddress }}:6443 \
 --kubernetes-infrastructure-cidr={{ .InfraCIDR }} \
 --kubernetes-version={{ .KubernetesVersion }} \
+--kubernetes-master-mode={{ .KubernetesMasterMode }} \
 --kubernetes-api-server-cert-sans={{ .PublicAddress }}`
 
 const workerUserDataScriptTemplate = `#!/bin/sh

--- a/internal/providers/azure/pke/driver/common.go
+++ b/internal/providers/azure/pke/driver/common.go
@@ -59,6 +59,8 @@ func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMach
 
 	userDataScriptTemplate := workerUserDataScriptTemplate
 
+	k8sMasterMode := "default"
+
 	if np.hasRole(pkgPKE.RoleMaster) {
 		bapn = pke.GetBackendAddressPoolName()
 		inpn = pke.GetInboundNATPoolName()
@@ -74,6 +76,10 @@ func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMach
 		}
 
 		userDataScriptTemplate = masterUserDataScriptTemplate
+
+		if np.Count > 1 {
+			k8sMasterMode = "ha"
+		}
 	}
 
 	if np.hasRole(pkgPKE.RolePipelineSystem) {
@@ -123,6 +129,7 @@ func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMach
 				"PipelineToken":         "<not yet set>",
 				"PKEVersion":            pkeVersion,
 				"KubernetesVersion":     f.KubernetesVersion,
+				"KubernetesMasterMode":  k8sMasterMode,
 				"PublicAddress":         "<not yet set>",
 				"RouteTableName":        f.RouteTableName,
 				"SubnetName":            np.Subnet.Name,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Add the `kubernetes-master-mode` command line argument to the user data script of Azure PKE cluster master nodes.

### Checklist
- [x] Implementation tested (with at least one cloud provider)
