### PR TITLE
Ignore namespace deletion error if namespace status transitioned into…

### DIFF
--- a/internal/cluster/kubernetes/user_namespace_deleter.go
+++ b/internal/cluster/kubernetes/user_namespace_deleter.go
@@ -82,8 +82,8 @@ func (d UserNamespaceDeleter) Delete(organizationID uint, clusterName string, k8
 		if err != nil {
 			return emperror.Wrap(err, "could not list remaining namespaces")
 		}
-		left = []string{}
-		gaveUp = []string{}
+		left = nil
+		gaveUp = nil
 		for _, ns := range namespaces.Items {
 			switch ns.Name {
 			case "default", "kube-system", "kube-public":

--- a/internal/cluster/kubernetes/user_namespace_deleter.go
+++ b/internal/cluster/kubernetes/user_namespace_deleter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,7 +63,7 @@ func (d UserNamespaceDeleter) Delete(organizationID uint, clusterName string, k8
 					return emperror.Wrapf(err, "failed to get %q namespace details", ns.Name)
 				}
 
-				if namespace.Status.Phase == v1.NamespaceTerminating {
+				if namespace.Status.Phase == corev1.NamespaceTerminating {
 					continue
 				}
 

--- a/internal/cluster/kubernetes/user_namespace_deleter.go
+++ b/internal/cluster/kubernetes/user_namespace_deleter.go
@@ -63,11 +63,9 @@ func (d UserNamespaceDeleter) Delete(organizationID uint, clusterName string, k8
 					return emperror.Wrapf(err, "failed to get %q namespace details", ns.Name)
 				}
 
-				if namespace.Status.Phase == corev1.NamespaceTerminating {
-					continue
+				if namespace.Status.Phase != corev1.NamespaceTerminating {
+					return emperror.Wrapf(err, "failed to delete %q namespace", ns.Name)
 				}
-
-				return emperror.Wrapf(err, "failed to delete %q namespace", ns.Name)
 			}
 		}
 		return nil


### PR DESCRIPTION
… 'Terminating' state

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
If namespace deletion returns with error but the namespace actually transitions into 'Terminating' status phase than ignore the error and continue with the deletion process.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When namespace deletion returns with an error that error may indicate that Kubernetes will delete the namespace at a later stage thus it's not a real error. (e.g. `Operation cannot be fulfilled on namespaces "....": The system is ensuring all content is removed from this namespace. Upon completion, this namespace will automatically be purged by the system.`)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
