### PR TITLE
Add tags field to SecretCreateResponse

### DIFF
--- a/api/secrets.go
+++ b/api/secrets.go
@@ -191,6 +191,7 @@ func AddSecrets(c *gin.Context) {
 		UpdatedAt: s.UpdatedAt,
 		UpdatedBy: s.UpdatedBy,
 		Version:   int32(s.Version),
+		Tags:      s.Tags,
 	})
 }
 

--- a/client/SHA256SUMS
+++ b/client/SHA256SUMS
@@ -1,1 +1,1 @@
-b7dbf248d654c592c795c9e2b267cd0ab4bd3901a3b457cadfbfd01ec1bb9430  docs/openapi/pipeline.yaml
+a2af78868d125998211ddebb7bc330e7002b3d47f4e814ee19b742eec285ca3d  docs/openapi/pipeline.yaml

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -10262,6 +10262,9 @@ components:
         error: Validation failed
         version: 1
         updatedAt: 2000-01-23T04:56:07.000+00:00
+        tags:
+        - repo:pipeline
+        - tag2
       properties:
         name:
           example: My-google-secret
@@ -10285,6 +10288,13 @@ components:
           example: 1
           format: int32
           type: integer
+        tags:
+          example:
+          - repo:pipeline
+          - tag2
+          items:
+            type: string
+          type: array
       required:
       - id
       - name

--- a/client/docs/CreateSecretResponse.md
+++ b/client/docs/CreateSecretResponse.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **UpdatedAt** | [**time.Time**](time.Time.md) |  | [optional] 
 **UpdatedBy** | **string** |  | [optional] 
 **Version** | **int32** |  | [optional] 
+**Tags** | **[]string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_create_secret_response.go
+++ b/client/model_create_secret_response.go
@@ -23,4 +23,5 @@ type CreateSecretResponse struct {
 	UpdatedAt time.Time `json:"updatedAt,omitempty"`
 	UpdatedBy string    `json:"updatedBy,omitempty"`
 	Version   int32     `json:"version,omitempty"`
+	Tags      []string  `json:"tags,omitempty"`
 }

--- a/docs/openapi/pipeline.yaml
+++ b/docs/openapi/pipeline.yaml
@@ -9310,6 +9310,11 @@ components:
                 version:
                     type: integer
                     example: 1
+                tags:
+                    type: array
+                    items:
+                        type: string
+                    example: [ "repo:pipeline", "tag2" ]
 
         CreateSecretRequest:
             type: object


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2097 
| License         | Apache 2.0


### What's in this PR?
Add `tags` field to SecretCreateResponse struct


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
