### PR TITLE
Add tags field to update secret response

### DIFF
--- a/api/secrets.go
+++ b/api/secrets.go
@@ -288,6 +288,7 @@ func UpdateSecrets(c *gin.Context) {
 		UpdatedAt: s.UpdatedAt,
 		UpdatedBy: s.UpdatedBy,
 		Version:   int32(s.Version),
+		Tags:      s.Tags,
 	})
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add tags field to update secret response

### Why?
In case of secret update the `tags` field is missing

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)

