### PR TITLE
#1964. Change node pool labels to respect node restrictions

### DIFF
--- a/cluster/hooks_nodelabels.go
+++ b/cluster/hooks_nodelabels.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
 	"github.com/spf13/viper"
@@ -36,12 +37,18 @@ type nodePoolLabelSetOperatorConfig struct {
 
 type configuration struct {
 	// Labeler configuration
-	Labeler labelerConfig `mapstructure:"labeler"`
+	Labeler    labelerConfig    `mapstructure:"labeler"`
+	Controller controllerConfig `mapstructure:"controller"`
 }
 
 type labelerConfig struct {
 	// ForbiddenLabelDomains holds the forbidden domain names, the labeler won't set matching labels
 	ForbiddenLabelDomains []string `mapstructure:"forbiddenLabelDomains"`
+}
+
+type controllerConfig struct {
+	// NodepoolNameLabels holds the possible labels for node pool, as this might be different on PKE, GKE, AKS
+	NodepoolNameLabels []string `mapstructure:"nodepoolNameLabels"`
 }
 
 // InstallNodePoolLabelSetOperator deploys node pool label set operator.
@@ -61,6 +68,14 @@ func InstallNodePoolLabelSetOperator(cluster CommonCluster) error {
 		Configuration: configuration{
 			Labeler: labelerConfig{
 				ForbiddenLabelDomains: reservedNodeLabelDomains,
+			},
+			Controller: controllerConfig{
+				NodepoolNameLabels: []string{
+					common.LabelKey,
+					"nodepool.banzaicloud.io/name",
+					"cloud.google.com/gke-nodepool",
+					"agentpool",
+				},
 			},
 		},
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -81,7 +81,7 @@ const (
 
 // Constants for labeling cluster nodes
 const (
-	LabelKey                = "nodepool.banzaicloud.io/name"
+	LabelKey                = "node.kubernetes.io/poolname"
 	OnDemandLabelKey        = "node.banzaicloud.io/ondemand"
 	CloudInfoLabelKeyPrefix = "node.banzaicloud.io/"
 	HeadNodeLabelKey        = "nodepool.banzaicloud.io/head"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1964
| License         | Apache 2.0


### What's in this PR?
Pipeline node pool label key has been renamed to "node.kubernetes.io/poolname" to conform with new label scheme from Kubernetes v1.15.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] Related Helm chart(s) updated (if needed)

