### PR TITLE
Support helm upgrade in Istio clustergroup feature

### DIFF
--- a/internal/istio/istiofeature/reconcile_istio_operator.go
+++ b/internal/istio/istiofeature/reconcile_istio_operator.go
@@ -88,13 +88,14 @@ func (m *MeshReconciler) installIstioOperator(c cluster.CommonCluster, logger lo
 		return emperror.Wrap(err, "could not marshal chart value overrides")
 	}
 
-	err = installDeployment(
+	err = installOrUpgradeDeployment(
 		c,
 		istioOperatorNamespace,
 		pkgHelm.BanzaiRepository+"/"+viper.GetString(pConfig.IstioOperatorChartName),
 		istioOperatorReleaseName,
 		valuesOverride,
 		viper.GetString(pConfig.IstioOperatorChartVersion),
+		true,
 		true,
 	)
 	if err != nil {

--- a/internal/istio/istiofeature/reconcile_uistio.go
+++ b/internal/istio/istiofeature/reconcile_uistio.go
@@ -165,13 +165,14 @@ func (m *MeshReconciler) installUistio(c cluster.CommonCluster, monitoring monit
 		return emperror.Wrap(err, "could not marshal chart value overrides")
 	}
 
-	err = installDeployment(
+	err = installOrUpgradeDeployment(
 		c,
 		uistioNamespace,
 		pkgHelm.BanzaiRepository+"/"+viper.GetString(pConfig.UistioChartName),
 		uistioReleaseName,
 		valuesOverride,
 		viper.GetString(pConfig.UistioChartVersion),
+		true,
 		true,
 	)
 	if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?

Adds support for helm package upgrade in Istio cluster group feature reconcile logic

### Why?

We must support package upgrade to deploy newer version of an already deployed chart to the cluster

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
