### PR TITLE
PKE on AWS: support creating node pools across different subnets of existing VPC

### DIFF
--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -862,8 +862,8 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url string, urlInsecur
 		subcommand = "master" // TODO remove this if not needed anymore
 	}
 
-	providerConfig := internalPke.NodePoolProviderConfigAmazon{}
-	err := mapstructure.Decode(np.ProviderConfig, &providerConfig)
+	nodePoolAmazonConfig := internalPke.NodePoolProviderConfigAmazon{}
+	err := mapstructure.Decode(np.ProviderConfig, &nodePoolAmazonConfig)
 	if err != nil {
 		return "", emperror.WrapWith(err, "failed to decode providerconfig", "cluster", c.model.Cluster.Name)
 	}
@@ -876,39 +876,39 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url string, urlInsecur
 		version = version[1:]
 	}
 	infrastructureCIDR := ""
-	cloudProvider, _, subnets, err := c.GetNetworkCloudProvider()
-	if err != nil {
-		return "", err
-	}
-	switch cloudProvider {
-	case string(internalPke.CNPAmazon):
-		subnetId := ""
-		if len(providerConfig.AutoScalingGroup.Subnets) > 0 {
-			subnetId = string(providerConfig.AutoScalingGroup.Subnets[0])
-		} else if len(subnets) > 0 {
-			idx := 0
-			if nodePoolName != "master" && len(subnets) > 1 {
-				idx = 1
-			}
-			subnetId = subnets[idx]
+
+	// determine the CIDR of the subnet of the node pool
+	subnetId := ""
+	if len(nodePoolAmazonConfig.AutoScalingGroup.Subnets) > 0 {
+		subnetId = string(nodePoolAmazonConfig.AutoScalingGroup.Subnets[0])
+	} else {
+		// subnet not provided for nodepool. fall back to global provider network config
+		_, _, subnets, err := c.GetNetworkCloudProvider()
+		if err != nil {
+			return "", emperror.Wrap(err, "couldn't get cloud provider network config")
 		}
 
-		if subnetId != "" {
-			// query subnet CIDR from amazon
-			client, err := c.GetAWSClient()
-			if err != nil {
-				return "", err
-			}
-			netSvc := pkgEC2.NewNetworkSvc(ec2.New(client), c.log)
-			infrastructureCIDR, err = netSvc.GetSubnetCidr(subnetId)
-			if err != nil {
-				return "", emperror.Wrapf(err, "couldn't get CIDR for subnet %q", subnetId)
-			}
+		if len(subnets) > 0 {
+			subnetId = subnets[0]
+		}
+	}
+
+	if subnetId != "" {
+		// query subnet CIDR from amazon
+		awsClient, err := c.GetAWSClient()
+		if err != nil {
+			return "", err
 		}
 
+		netSvc := pkgEC2.NewNetworkSvc(ec2.New(awsClient), NewLogurLogger(c.log))
+		infrastructureCIDR, err = netSvc.GetSubnetCidr(subnetId)
+		if err != nil {
+			return "", emperror.Wrapf(err, "couldn't get CIDR for subnet %q", subnetId)
+		}
 	}
+
 	if infrastructureCIDR == "" {
-		return "", errors.New("cloud not query nodepool subnet")
+		return "", emperror.Wrapf(err, "couldn't get CIDR for subnet %q", subnetId)
 	}
 
 	apiAddress, _, err := c.GetNetworkApiServerAddress()
@@ -919,7 +919,7 @@ func (c *EC2ClusterPKE) GetBootstrapCommand(nodePoolName, url string, urlInsecur
 	// master
 	if subcommand == "master" {
 		masterMode := "default"
-		if providerConfig.AutoScalingGroup.Size.Max > 1 {
+		if nodePoolAmazonConfig.AutoScalingGroup.Size.Max > 1 {
 			masterMode = "ha"
 		}
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -1116,7 +1116,7 @@ func (c *EKSCluster) ValidateCreationFields(r *pkgCluster.CreateClusterRequest) 
 		return emperror.Wrap(err, "failed to create AWS session")
 	}
 
-	netSvc := pkgEC2.NewNetworkSvc(ec2.New(session), c.log)
+	netSvc := pkgEC2.NewNetworkSvc(ec2.New(session), NewLogurLogger(c.log))
 	if r.Properties.CreateClusterEKS.Vpc != nil {
 
 		if r.Properties.CreateClusterEKS.Vpc.VpcId != "" && r.Properties.CreateClusterEKS.Vpc.Cidr != "" {

--- a/cluster/log.go
+++ b/cluster/log.go
@@ -16,6 +16,8 @@ package cluster
 
 import (
 	"github.com/banzaicloud/pipeline/config"
+	"github.com/goph/logur"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,4 +26,21 @@ var log logrus.FieldLogger
 
 func init() {
 	log = config.Logger()
+}
+
+func NewLogurLogger(fl logrus.FieldLogger) logur.Logger {
+	var logger logur.Logger
+
+	if l, ok := fl.(*logrus.Logger); ok {
+		return logrusadapter.New(l)
+	}
+
+	entry, ok := fl.(*logrus.Entry)
+	if !ok {
+		entry = fl.WithFields(logrus.Fields{})
+	}
+
+	logger = logrusadapter.New(entry.Logger)
+
+	return logur.WithFields(logger, entry.Data)
 }

--- a/cluster/log.go
+++ b/cluster/log.go
@@ -29,8 +29,6 @@ func init() {
 }
 
 func NewLogurLogger(fl logrus.FieldLogger) logur.Logger {
-	var logger logur.Logger
-
 	if l, ok := fl.(*logrus.Logger); ok {
 		return logrusadapter.New(l)
 	}
@@ -40,7 +38,7 @@ func NewLogurLogger(fl logrus.FieldLogger) logur.Logger {
 		entry = fl.WithFields(logrus.Fields{})
 	}
 
-	logger = logrusadapter.New(entry.Logger)
+	logger := logrusadapter.New(entry.Logger)
 
 	return logur.WithFields(logger, entry.Data)
 }

--- a/cmd/worker/aws.go
+++ b/cmd/worker/aws.go
@@ -38,6 +38,9 @@ func registerAwsWorkflows(clusters *pkeworkflowadapter.ClusterManagerAdapter, to
 	createPKEVPCActivity := pkeworkflow.NewCreateVPCActivity(awsClientFactory)
 	activity.RegisterWithOptions(createPKEVPCActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateVPCActivityName})
 
+	getVpcDefaultSecurityGroupActivity := pkeworkflow.NewGetVpcDefaultSecurityGroupActivity(awsClientFactory)
+	activity.RegisterWithOptions(getVpcDefaultSecurityGroupActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.GetVpcDefaultSecurityGroupActivityName})
+
 	updateClusterStatusActivitiy := pkeworkflow.NewUpdateClusterStatusActivity(clusters)
 	activity.RegisterWithOptions(updateClusterStatusActivitiy.Execute, activity.RegisterOptions{Name: pkeworkflow.UpdateClusterStatusActivityName})
 

--- a/internal/providers/pke/pkeworkflow/cluster.go
+++ b/internal/providers/pke/pkeworkflow/cluster.go
@@ -56,4 +56,5 @@ type NodePool struct {
 	AvailabilityZones []string
 	ImageID           string
 	SpotPrice         string
+	Subnets           []string
 }

--- a/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
+++ b/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
@@ -44,16 +44,17 @@ func NewCreateWorkerPoolActivity(clusters Clusters, tokenGenerator TokenGenerato
 }
 
 type CreateWorkerPoolActivityInput struct {
-	ClusterID               uint
-	Pool                    NodePool
-	VPCID                   string
-	SubnetID                string
-	WorkerInstanceProfile   string
-	ClusterSecurityGroup    string
-	ExternalBaseUrl         string
-	ExternalBaseUrlInsecure bool
-	ImageID                 string
-	SSHKeyName              string
+	ClusterID                 uint
+	Pool                      NodePool
+	VPCID                     string
+	VPCDefaultSecurityGroupID string
+	SubnetID                  string
+	WorkerInstanceProfile     string
+	ClusterSecurityGroup      string
+	ExternalBaseUrl           string
+	ExternalBaseUrlInsecure   bool
+	ImageID                   string
+	SSHKeyName                string
 }
 
 func (a *CreateWorkerPoolActivity) Execute(ctx context.Context, input CreateWorkerPoolActivityInput) (string, error) {
@@ -149,6 +150,10 @@ func (a *CreateWorkerPoolActivity) Execute(ctx context.Context, input CreateWork
 			{
 				ParameterKey:   aws.String("VPCId"),
 				ParameterValue: &input.VPCID,
+			},
+			{
+				ParameterKey:   aws.String("VPCDefaultSecurityGroupId"),
+				ParameterValue: &input.VPCDefaultSecurityGroupID,
 			},
 			{
 				ParameterKey:   aws.String("SubnetIds"),

--- a/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
+++ b/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
@@ -216,7 +216,7 @@ func (a *CreateWorkerPoolActivity) Execute(ctx context.Context, input CreateWork
 
 	err = cfClient.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{StackName: aws.String(stackName)})
 	if err != nil {
-		emperror.Wrap(pkgCloudformation.NewAwsStackFailure(err, stackName, cfClient), "waiting for stack creation")
+		return "", emperror.Wrap(pkgCloudformation.NewAwsStackFailure(err, stackName, cfClient), "waiting for stack creation")
 	}
 
 	if output.StackId != nil {

--- a/internal/providers/pke/pkeworkflow/create_master_activity.go
+++ b/internal/providers/pke/pkeworkflow/create_master_activity.go
@@ -42,16 +42,17 @@ func NewCreateMasterActivity(clusters Clusters, tokenGenerator TokenGenerator) *
 }
 
 type CreateMasterActivityInput struct {
-	ClusterID               uint
-	AvailabilityZone        string
-	VPCID                   string
-	SubnetID                string
-	MultiMaster             bool
-	MasterInstanceProfile   string
-	ExternalBaseUrl         string
-	ExternalBaseUrlInsecure bool
-	Pool                    NodePool
-	SSHKeyName              string
+	ClusterID                 uint
+	AvailabilityZone          string
+	VPCID                     string
+	VPCDefaultSecurityGroupID string
+	SubnetID                  string
+	MultiMaster               bool
+	MasterInstanceProfile     string
+	ExternalBaseUrl           string
+	ExternalBaseUrlInsecure   bool
+	Pool                      NodePool
+	SSHKeyName                string
 
 	EIPAllocationID string
 
@@ -127,6 +128,10 @@ func (a *CreateMasterActivity) Execute(ctx context.Context, input CreateMasterAc
 		{
 			ParameterKey:   aws.String("VPCId"),
 			ParameterValue: &input.VPCID,
+		},
+		{
+			ParameterKey:   aws.String("VPCDefaultSecurityGroupId"),
+			ParameterValue: &input.VPCDefaultSecurityGroupID,
 		},
 		{
 			ParameterKey:   aws.String("PkeCommand"),

--- a/internal/providers/pke/pkeworkflow/get_vpc_default_sg_activity.go
+++ b/internal/providers/pke/pkeworkflow/get_vpc_default_sg_activity.go
@@ -1,0 +1,62 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkeworkflow
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
+	"github.com/goph/emperror"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/cadence/activity"
+)
+
+const GetVpcDefaultSecurityGroupActivityName = "pke-get-vpc-default-sg-activity"
+
+type GetVpcDefaultSecurityGroupActivity struct {
+	awsClientFactory *AWSClientFactory
+}
+
+type GetVpcDefaultSecurityGroupActivityInput struct {
+	AWSActivityInput
+	ClusterID uint
+	VpcID     string
+}
+
+func NewGetVpcDefaultSecurityGroupActivity(awsClientFactory *AWSClientFactory) *GetVpcDefaultSecurityGroupActivity {
+	return &GetVpcDefaultSecurityGroupActivity{
+		awsClientFactory: awsClientFactory,
+	}
+}
+
+func (a *GetVpcDefaultSecurityGroupActivity) Execute(ctx context.Context, input GetVpcDefaultSecurityGroupActivityInput) (string, error) {
+	logger := activity.GetLogger(ctx).Sugar().With("clusterID", input.ClusterID, "vpcId", input.VpcID)
+
+	client, err := a.awsClientFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err != nil {
+		return "", err
+	}
+
+	netSvc := pkgEC2.NewNetworkSvc(ec2.New(client), logrus.New())
+	sgID, err := netSvc.GetVpcDefaultSecurityGroup(input.VpcID)
+
+	logger.Debug("getting VPC's default security group")
+	if err != nil {
+		return "", emperror.WrapWith(err, "couldn't get the default security group of the VPC", "clusterID", input.ClusterID, "vpcId", input.VpcID)
+	}
+
+	return sgID, nil
+}

--- a/internal/providers/pke/pkeworkflow/pkeworkflowadapter/cluster_manager.go
+++ b/internal/providers/pke/pkeworkflow/pkeworkflowadapter/cluster_manager.go
@@ -79,6 +79,7 @@ func (c *Cluster) GetNodePools() []pkeworkflow.NodePool {
 			AvailabilityZones: np.AvailabilityZones,
 			ImageID:           np.ImageID,
 			SpotPrice:         np.SpotPrice,
+			Subnets:           np.Subnets,
 		}
 	}
 	return nodePools

--- a/internal/providers/pke/pkeworkflow/update_cluster.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster.go
@@ -84,10 +84,6 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 		return err
 	}
 
-	if vpcDefaultSecurityGroupID == "" {
-		return errors.Errorf("couldn't get the default security group of the VPC %q", input.VPCID)
-	}
-
 	// delete removed nodepools
 	for _, np := range input.NodePoolsToDelete {
 		if np.Master || !np.Worker {

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -20,6 +20,10 @@ Parameters:
   VPCId:
     Type: 'AWS::EC2::VPC::Id'
     Description: Specify VPC Id for Autoscaling
+  VPCDefaultSecurityGroupId:
+    Type: String
+    Description: Default security group of the VPC
+    Default: ""
   SubnetId:
     Type: 'AWS::EC2::Subnet::Id'
     Description: Specify Subnet Id for Autoscaling
@@ -45,8 +49,9 @@ Resources:
       ImageId: !Ref ImageId
       IamInstanceProfile: !Ref IamInstanceProfile
       SecurityGroupIds:
-      - !Ref MasterSecurityGroup
-      - !Ref ClusterSecurityGroup
+        - !Ref MasterSecurityGroup
+        - !Ref ClusterSecurityGroup
+        - !Ref VPCDefaultSecurityGroupId
       BlockDeviceMappings:
       - DeviceName: /dev/sda1
         Ebs:

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -23,7 +23,6 @@ Parameters:
   VPCDefaultSecurityGroupId:
     Type: String
     Description: Default security group of the VPC
-    Default: ""
   SubnetId:
     Type: 'AWS::EC2::Subnet::Id'
     Description: Specify Subnet Id for Autoscaling

--- a/templates/pke/masters.cf.yaml
+++ b/templates/pke/masters.cf.yaml
@@ -28,6 +28,9 @@ Parameters:
   VPCId:
     Type: 'AWS::EC2::VPC::Id'
     Description: Specify VPC Id for Autoscaling
+  VPCDefaultSecurityGroupId:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: Default security group of the VPC
   SubnetIds:
     Type: 'List<AWS::EC2::Subnet::Id>'
     Description: Specify Subnet Id for Autoscaling
@@ -96,6 +99,7 @@ Resources:
       SecurityGroups:
       - !Ref MasterSecurityGroup
       - !Ref ClusterSecurityGroup
+      - !Ref VPCDefaultSecurityGroupId
       BlockDeviceMappings:
       - DeviceName: /dev/sda1
         Ebs:

--- a/templates/pke/worker.cf.yaml
+++ b/templates/pke/worker.cf.yaml
@@ -25,6 +25,9 @@ Parameters:
   SubnetIds:
     Type: 'List<AWS::EC2::Subnet::Id>'
     Description: Specify Subnet Id for Autoscaling
+  VPCDefaultSecurityGroupId:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: Default security group of the VPC
   IamInstanceProfile:
     Type: String
   ClusterSecurityGroup:
@@ -73,6 +76,7 @@ Resources:
       SecurityGroups:
       - !Ref SecurityGroup
       - !Ref ClusterSecurityGroup
+      - !Ref VPCDefaultSecurityGroupId
       BlockDeviceMappings:
       - DeviceName: /dev/sda1
         Ebs:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Support of creating the node pools of a cluster in different subnets of an existing VPC.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In order to be able to deploy certain nodes to private subnets we need to support deploying nodepools into a specific subnet of an existing VPC.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
An example create a request for deploying a cluster where the master nodes are in a different subnet than the worker nodes that belong to pool1 using `banzai cli`.
```
banzai cluster create <<EOF
{
  "name": "pke-cluster1",
  "location": "eu-west-1",
  "cloud": "amazon",
  "secretId": "<aws-credentials-secret-id>",
  "properties": {
    "pke": {
      "nodepools": [
        {
          "name": "master",
          "roles": [
            "master"
          ],
          "provider": "amazon",
          "autoscaling": false,
          "providerConfig": {
            "autoScalingGroup": {
              "name": "master",
              "zones": [
                "eu-west-1a"
              ],
              "instanceType": "c5.large",
              "launchConfigurationName": "master",
              "spotPrice": "",
              "size": {
                "desired": 3,
                "min": 3,
                "max": 3
              },
              "vpcID": "vpc-0c41ea5f47cd8367a",
              "subnets": [
                "subnet-09eff8c8a494604b1"
              ]
            }
          }
        },
        {
          "name": "pool1",
          "roles": [
            "worker"
          ],
          "provider": "amazon",
          "autoscaling": true,
          "providerConfig": {
            "autoScalingGroup": {
              "name": "pool1",
              "zones": [
                "eu-west-1a"
              ],
              "instanceType": "t2.large",
              "launchConfigurationName": "pool1",
              "spotPrice": "0.1008",
              "size": {
                "desired": 1,
                "min": 1,
                "max": 3
              },
              "vpcID": "vpc-0c41ea5f47cd8367a",
              "subnets": [
                "subnet-035c209ead4be1222"
              ]
            }
          }
        }
      ],
      "kubernetes": {
        "version": "1.14.2",
        "rbac": {
          "enabled": true
        }
      },
      "cri": {
        "runtime": "containerd"
      },
      "network": {
        "cloudProviderConfig": {
          "vpcID": "vpc-0c41ea5f47cd8367a",
          "subnets": [
            "subnet-035c209ead4be1222"
          ]
        }
      }
    }
  }
}
EOF
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)