### PR TITLE
cli oidc login flow

### DIFF
--- a/auth/authn.go
+++ b/auth/authn.go
@@ -36,7 +36,6 @@ import (
 	"github.com/qor/auth"
 	"github.com/qor/auth/auth_identity"
 	"github.com/qor/auth/claims"
-	"github.com/qor/auth/providers/dex"
 	"github.com/qor/session"
 	"github.com/qor/session/gorilla"
 	"github.com/sirupsen/logrus"
@@ -219,7 +218,8 @@ func Init(db *gorm.DB, accessManager accessManager, orgImporter *OrgImporter) {
 		DeregisterHandler: NewBanzaiDeregisterHandler(accessManager),
 	})
 
-	dexProvider := dex.New(&dex.Config{
+	dexProvider := newDexProvider(&DexConfig{
+		PublicClientID:     viper.GetString("auth.publicclientid"),
 		ClientID:           viper.GetString("auth.clientid"),
 		ClientSecret:       viper.GetString("auth.clientsecret"),
 		IssuerURL:          viper.GetString("auth.dexURL"),
@@ -268,6 +268,7 @@ func Install(engine *gin.Engine, generateTokenHandler gin.HandlerFunc) {
 		authGroup.GET("/dex/logout", authHandler)
 		authGroup.GET("/dex/register", authHandler)
 		authGroup.GET("/dex/callback", authHandler)
+		authGroup.POST("/dex/callback", authHandler)
 		authGroup.POST("/tokens", generateTokenHandler)
 		authGroup.GET("/tokens", GetTokens)
 		authGroup.GET("/tokens/:id", GetTokens)

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package auth
 
 import (

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -1,0 +1,325 @@
+package auth
+
+import (
+	gocontext "context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	oidc "github.com/coreos/go-oidc"
+	"github.com/qor/auth"
+	"github.com/qor/auth/auth_identity"
+	"github.com/qor/auth/claims"
+	"github.com/qor/qor/utils"
+	"golang.org/x/oauth2"
+)
+
+// DexProvider provide login with dex method
+type DexProvider struct {
+	*DexConfig
+	provider *oidc.Provider
+}
+
+// DexConfig is the dex Config
+type DexConfig struct {
+	PublicClientID     string
+	ClientID           string
+	ClientSecret       string
+	IssuerURL          string
+	InsecureSkipVerify bool
+	RedirectURL        string
+	Scopes             []string
+	AuthorizeHandler   func(*auth.Context) (*claims.Claims, error)
+}
+
+func newDexProvider(config *DexConfig) *DexProvider {
+	if config == nil {
+		config = &DexConfig{}
+	}
+
+	provider := &DexProvider{DexConfig: config}
+
+	if config.ClientID == "" {
+		panic(errors.New("Dex's ClientID can't be blank"))
+	}
+
+	if config.ClientSecret == "" {
+		panic(errors.New("Dex's ClientSecret can't be blank"))
+	}
+
+	if config.IssuerURL == "" {
+		panic(errors.New("Dex's IssuerURL can't be blank"))
+	}
+
+	if config.Scopes == nil {
+		config.Scopes = []string{oidc.ScopeOpenID, "profile", "email", "groups", "federated:id"}
+	}
+
+	httpClient := http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: config.InsecureSkipVerify,
+			},
+		},
+	}
+	ctx := oidc.ClientContext(gocontext.Background(), &httpClient)
+	dexProvider, err := oidc.NewProvider(ctx, provider.IssuerURL)
+	if err != nil {
+		panic(fmt.Errorf("Failed to query provider %q: %s", provider.IssuerURL, err.Error()))
+	}
+
+	provider.provider = dexProvider
+
+	if config.AuthorizeHandler == nil {
+
+		config.AuthorizeHandler = func(context *auth.Context) (*claims.Claims, error) {
+			var (
+				schema       auth.Schema
+				authInfo     auth_identity.Basic
+				err          error
+				rawIDToken   string
+				token        *oauth2.Token
+				authIdentity = reflect.New(utils.ModelType(context.Auth.Config.AuthIdentityModel)).Interface()
+				req          = context.Request
+				tx           = context.Auth.GetDB(req)
+				w            = context.Writer
+				ok           bool
+			)
+
+			verifier := dexProvider.Verifier(&oidc.Config{ClientID: config.ClientID})
+
+			ctx := oidc.ClientContext(req.Context(), &httpClient)
+			oauth2Config := provider.OAuthConfig(context)
+
+			switch req.Method {
+			case "GET":
+				// Authorization redirect callback from OAuth2 auth flow.
+				if errMsg := req.FormValue("error"); errMsg != "" {
+					err = errors.New(errMsg + ": " + req.FormValue("error_description"))
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return nil, err
+				}
+
+				code := req.FormValue("code")
+				if code == "" {
+					err = fmt.Errorf("no code in request: %q", req.Form)
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return nil, err
+				}
+				state := req.FormValue("state")
+
+				var claims *claims.Claims
+
+				claims, err = context.Auth.SessionStorer.ValidateClaims(state)
+				if err != nil {
+					err = fmt.Errorf("failed to validate state claims: %s", err.Error())
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return nil, err
+				}
+
+				if err := claims.Valid(); err != nil {
+					err = fmt.Errorf("failed to validate state claims: %s", err.Error())
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return nil, err
+				}
+
+				if claims.Subject != "state" {
+					err = fmt.Errorf("state parameter doesn't match: %s", claims.Subject)
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return nil, err
+				}
+
+				token, err = oauth2Config.Exchange(ctx, code)
+				if err != nil {
+					err = fmt.Errorf("failed to get token: %s", err.Error())
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return nil, err
+				}
+
+				rawIDToken, ok = token.Extra("id_token").(string)
+				if !ok {
+					err = fmt.Errorf("no id_token in token response")
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return nil, err
+				}
+
+			case "POST":
+				// The Banzai CLI can send an id_token that it has requested from Dex
+				// we may consume that as well in a POST request.
+				rawIDToken = req.FormValue("id_token")
+				if rawIDToken != "" {
+					// The public CLI client's verifier is needed in this case
+					verifier = dexProvider.Verifier(&oidc.Config{ClientID: config.PublicClientID})
+
+				} else {
+					// Form request from frontend to refresh a token.
+					refresh := req.FormValue("refresh_token")
+					if refresh == "" {
+						err = fmt.Errorf("no refresh_token in request: %q", req.Form)
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return nil, err
+					}
+
+					t := &oauth2.Token{
+						RefreshToken: refresh,
+						Expiry:       time.Now().Add(-time.Hour),
+					}
+
+					token, err = oauth2Config.TokenSource(ctx, t).Token()
+					if err != nil {
+						err = fmt.Errorf("failed to get token: %s", err.Error())
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return nil, err
+					}
+
+					rawIDToken, ok = token.Extra("id_token").(string)
+					if !ok {
+						err = fmt.Errorf("no id_token in token response")
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return nil, err
+					}
+				}
+			default:
+				err = fmt.Errorf("method not implemented: %s", req.Method)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return nil, err
+			}
+
+			idToken, err := verifier.Verify(req.Context(), rawIDToken)
+			if err != nil {
+				err = fmt.Errorf("Failed to verify ID token: %s", err.Error())
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return nil, err
+			}
+
+			var claims struct {
+				Subject         string            `json:"sub"`
+				Name            string            `json:"name"`
+				Email           string            `json:"email"`
+				Verified        bool              `json:"email_verified"`
+				Groups          []string          `json:"groups"`
+				FederatedClaims map[string]string `json:"federated_claims"`
+			}
+
+			err = idToken.Claims(&claims)
+			if err != nil {
+				err = fmt.Errorf("failed to parse claims: %s", err.Error())
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return nil, err
+			}
+
+			// Check if authInfo exists with the backend connector already
+			authInfo.Provider = claims.FederatedClaims["connector_id"]
+			authInfo.UID = claims.FederatedClaims["user_id"]
+
+			if !tx.Model(authIdentity).Where(authInfo).Scan(&authInfo).RecordNotFound() {
+				return authInfo.ToClaims(), nil
+			}
+
+			// Check if authInfo exists with Dex
+			authInfo.Provider = "dex:" + claims.FederatedClaims["connector_id"]
+			authInfo.UID = claims.Subject
+
+			if !tx.Model(authIdentity).Where(authInfo).Scan(&authInfo).RecordNotFound() {
+				return authInfo.ToClaims(), nil
+			}
+
+			// Create a new account otherwise
+			context.Request = req.WithContext(gocontext.WithValue(req.Context(), SignUp, true))
+
+			{
+				schema.Provider = authInfo.Provider
+				schema.UID = claims.Subject
+				schema.Name = claims.Name
+				schema.Email = claims.Email
+				schema.RawInfo = claims
+			}
+			if _, userID, err := context.Auth.UserStorer.Save(&schema, context); err == nil {
+				if userID != "" {
+					authInfo.UserID = userID
+				}
+			} else {
+				return nil, err
+			}
+
+			if err = tx.Where(authInfo).FirstOrCreate(authIdentity).Error; err == nil {
+				return authInfo.ToClaims(), nil
+			}
+
+			return nil, err
+		}
+	}
+
+	return provider
+}
+
+// GetName return provider name
+func (DexProvider) GetName() string {
+	return "dex"
+}
+
+// ConfigAuth config auth
+func (provider DexProvider) ConfigAuth(*auth.Auth) {
+}
+
+// OAuthConfig return oauth config based on configuration
+func (provider DexProvider) OAuthConfig(context *auth.Context) *oauth2.Config {
+	var (
+		config = provider.DexConfig
+		req    = context.Request
+		scheme = req.URL.Scheme
+	)
+
+	if scheme == "" {
+		if req.TLS == nil {
+			scheme = "http://"
+		} else {
+			scheme = "https://"
+		}
+	}
+
+	return &oauth2.Config{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Endpoint:     provider.provider.Endpoint(),
+		RedirectURL:  scheme + req.Host + context.Auth.AuthURL("dex/callback"),
+		Scopes:       config.Scopes,
+	}
+}
+
+// Login implemented login with dex provider
+func (provider DexProvider) Login(context *auth.Context) {
+	claims := claims.Claims{}
+	claims.Subject = "state"
+	signedToken := context.Auth.SessionStorer.SignedToken(&claims)
+
+	url := provider.OAuthConfig(context).AuthCodeURL(signedToken)
+	http.Redirect(context.Writer, context.Request, url, http.StatusFound)
+}
+
+// Logout implemented logout with dex provider
+func (DexProvider) Logout(context *auth.Context) {
+}
+
+// Register implemented register with dex provider
+func (provider DexProvider) Register(context *auth.Context) {
+	provider.Login(context)
+}
+
+// Deregister implemented deregister with dex provider
+func (provider DexProvider) Deregister(context *auth.Context) {
+	panic("Not implemented")
+}
+
+// Callback implement Callback with dex provider
+func (provider DexProvider) Callback(context *auth.Context) {
+	context.Auth.LoginHandler(context, provider.AuthorizeHandler)
+}
+
+// ServeHTTP implement ServeHTTP with dex provider
+func (DexProvider) ServeHTTP(*auth.Context) {
+}

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -74,6 +74,7 @@ baseURL = "https://gitlab.com/"
 
 [auth]
 # Dex settings
+publicclientid = "banzai-cli"
 clientid = "pipeline"
 clientsecret = "ZXhhbXBsZS1hcHAtc2VjcmV0"
 dexURL = "http://127.0.0.1:5556/dex"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -210,6 +210,7 @@ func init() {
 	viper.SetDefault("auth.jwtissuer", "https://banzaicloud.com/")
 	viper.SetDefault("auth.jwtaudience", "https://pipeline.banzaicloud.com")
 	viper.SetDefault("auth.secureCookie", true)
+	viper.SetDefault("auth.publicclientid", "banzai-cli")
 	viper.SetDefault("auth.dexURL", "http://127.0.0.1:5556/dex")
 	viper.SetDefault("auth.dexInsecure", false)
 	viper.SetDefault("auth.dexGrpcAddress", "127.0.0.1:5557")
@@ -239,7 +240,7 @@ func init() {
 	viper.SetDefault(DBAutoMigrateEnabled, false)
 	viper.SetDefault("audit.enabled", true)
 	viper.SetDefault("audit.headers", []string{"secretId"})
-	viper.SetDefault("audit.skippaths", []string{"/auth/github/callback", "/pipeline/api"})
+	viper.SetDefault("audit.skippaths", []string{"/auth/dex/callback", "/pipeline/api"})
 	viper.SetDefault("tls.validity", "8760h") // 1 year
 	viper.SetDefault(DNSBaseDomain, "example.org")
 	viper.SetDefault(DNSGcIntervalMinute, 1)

--- a/config/dex.yml.dist
+++ b/config/dex.yml.dist
@@ -54,11 +54,16 @@ grpc:
 staticClients:
 - id: pipeline
   redirectURIs:
-  - 'http://127.0.0.1:5555/callback'
   - 'http://127.0.0.1:9090/auth/dex/callback'
   - 'http://localhost:9090/auth/dex/callback'
   name: 'Pipeline'
   secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+- id: banzai-cli
+  secret: banzai-cli-secret
+  public: true
+  redirectURIs:
+  - 'http://localhost:5555/callback'
+  name: 'Banzai CLI'
 
 connectors:
 - type: github

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
             RECOMMENDER_URL: https://beta.banzaicloud.io/recommender
 
     dex:
-        image: banzaicloud/dex-shim:0.3.5
+        image: banzaicloud/dex-shim:0.3.9
         command: serve /dex.yml
         volumes:
             - ./config/dex.yml:/dex.yml

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/gin-gonic/gin v1.3.1-0.20190402010134-2e915f4e5083
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logr/zapr v0.1.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/mock v1.2.0 // indirect
@@ -148,10 +149,7 @@ require (
 	k8s.io/cli-runtime v0.0.0-20190404071300-cbd7455f4bce // indirect
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/cluster-bootstrap v0.0.0-20190404071559-03c28a85c7b7
-	k8s.io/cluster-registry v0.0.6 // indirect
 	k8s.io/helm v2.12.2+incompatible
-	k8s.io/klog v0.2.0
-	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 	k8s.io/kubectl v0.0.0-20190523211420-5b63b0fd89bb // indirect
 	k8s.io/kubernetes v1.13.5
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da // indirect

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/go-openapi/swag v0.17.0 h1:iqrgMg7Q7SvtbWLlltPrkMs0UBJI6oTSs79JFRUi88
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stomp/stomp v2.0.2+incompatible h1:0yPknMJh32lE2xiCFGW5t/KgamhUC4OgCv10wIjx5aw=
 github.com/go-stomp/stomp v2.0.2+incompatible/go.mod h1:VqCtqNZv1226A1/79yh+rMiFUcfY3R109np+7ke4n0c=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
@@ -484,6 +486,7 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -916,20 +919,14 @@ k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUr
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/cluster-bootstrap v0.0.0-20190404071559-03c28a85c7b7 h1:APBDbohZArvzxW+eDNl8Xcv90EbQ/2b+BNNZeko97Po=
 k8s.io/cluster-bootstrap v0.0.0-20190404071559-03c28a85c7b7/go.mod h1:w2RvtPjvhWaadOLkhi5L5F9e1uYTpnF5TWYJA+MjIBQ=
-k8s.io/cluster-registry v0.0.6/go.mod h1:/F+o1rvzjBdLbg782rR8eKrOb20hPy7us+Zu/pjBtAY=
 k8s.io/helm v2.12.2+incompatible h1:xSDfcFN8X6lfMKWQB1GmU18pnzIthU+/c7kkcl8Xlb0=
 k8s.io/helm v2.12.2+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4 h1:gW+EUB2I96nbxVenV/8ctfbACsHP+yxlT2dhMCsiy+s=
 k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
-k8s.io/kube-openapi v0.0.0-20190208205540-d7c86cdc46e3 h1:exy9uNfm+xG+9rQsfPhmJQt+l/Pufd86hB9T/QrHeR4=
-k8s.io/kube-openapi v0.0.0-20190208205540-d7c86cdc46e3/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
-k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86FIDppkbrEXdXlxU3a3BMI=
-k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubectl v0.0.0-20190523211420-5b63b0fd89bb h1:g0hpLo7nnd6m3kiDNoScMy9xT3+ogpeygPtuq+SlgqQ=
 k8s.io/kubectl v0.0.0-20190523211420-5b63b0fd89bb/go.mod h1:EB+3ydgwGODs2kdxh8bSZwgE1veo9VehVcxOVjWl8sI=
-k8s.io/kubectl v0.0.0-20190602132707-7a653e992706 h1:iauj/V3gGPQez3P2Il/2KLtEAZznqUHoBHh/RokVW28=
 k8s.io/kubernetes v1.11.0 h1:PXuL6UuWlsyNTGEWNFsQPuZ4NHFT/KUKxiah/snvnaI=
 k8s.io/kubernetes v1.11.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.13.5 h1:nI5TsYNPpcXnPPptVx+OpoXdAckpq6omYLkDZy/WYuE=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/banzai-cli/pull/85
| License         | Apache 2.0


### What's in this PR?
This PR adds the ability to register and login from the `banzai` CLI tool with the `banzai login` subcommand. This is implemented mostly in the CLI, so it creates a web flow with the OIDC provider and posts the IDToken to Pipeline directly, which returns a Pipeline token which expires after 30 days automatically.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
https://github.com/banzaicloud/banzai-cli/pull/85

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
