### PR TITLE
#2125. Gather helm repo related functions behind a new interface Repo…

### DIFF
--- a/api/helm.go
+++ b/api/helm.go
@@ -178,7 +178,7 @@ func ListDeployments(c *gin.Context) {
 		return
 	}
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -189,7 +189,7 @@ func ListDeployments(c *gin.Context) {
 		return
 	}
 
-	chartsResponse, err := rs.ChartsGet("", "", "", "")
+	chartsResponse, err := rs.GetCharts("", "", "", "")
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -569,7 +569,7 @@ func parseCreateUpdateDeploymentRequest(c *gin.Context, commonCluster cluster.Co
 func HelmReposGet(c *gin.Context) {
 	log := logrusadapter.NewFromEntry(pipelineContext.LoggerWithCorrelationID(c, config.Logger()).WithFields(logrus.Fields{}))
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -580,7 +580,7 @@ func HelmReposGet(c *gin.Context) {
 		return
 	}
 
-	response, err := rs.ReposGet()
+	response, err := rs.GetRepos()
 	if err != nil {
 		log.Error(fmt.Sprint("error during get helm repo list:", err.Error()))
 		c.JSON(http.StatusInternalServerError, pkgCommmon.ErrorResponse{
@@ -610,7 +610,7 @@ func HelmReposAdd(c *gin.Context) {
 		return
 	}
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -621,7 +621,7 @@ func HelmReposAdd(c *gin.Context) {
 		return
 	}
 
-	_, err = rs.ReposAdd(r)
+	_, err = rs.AddRepo(r)
 	if err != nil {
 		log.Error(fmt.Sprint("error adding helm repo:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -643,7 +643,7 @@ func HelmReposDelete(c *gin.Context) {
 
 	repoName := c.Param("name")
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -654,7 +654,7 @@ func HelmReposDelete(c *gin.Context) {
 		return
 	}
 
-	err = rs.ReposDelete(repoName)
+	err = rs.DeleteRepo(repoName)
 	if err != nil {
 		log.Error(fmt.Sprint("error during get helm repo delete:", err.Error()))
 		if err.Error() == helm.ErrRepoNotFound.Error() {
@@ -697,7 +697,7 @@ func HelmReposModify(c *gin.Context) {
 		})
 		return
 	}
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -707,7 +707,7 @@ func HelmReposModify(c *gin.Context) {
 		})
 		return
 	}
-	errModify := rs.ReposModify(repoName, newRepo)
+	errModify := rs.ModifyRepo(repoName, newRepo)
 	if errModify != nil {
 		if errModify == helm.ErrRepoNotFound {
 			c.JSON(http.StatusNotFound, pkgCommmon.ErrorResponse{
@@ -738,7 +738,7 @@ func HelmReposUpdate(c *gin.Context) {
 
 	repoName := c.Param("name")
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -748,7 +748,7 @@ func HelmReposUpdate(c *gin.Context) {
 		})
 		return
 	}
-	errUpdate := rs.ReposUpdate(repoName)
+	errUpdate := rs.UpdateRepo(repoName)
 	if errUpdate != nil {
 		log.Error(fmt.Sprint("error during helm repo update:", errUpdate.Error()))
 		c.JSON(http.StatusNotFound, pkgCommmon.ErrorResponse{
@@ -781,7 +781,7 @@ func HelmCharts(c *gin.Context) {
 	}
 
 	log.Debug(fmt.Sprintf("%v", query))
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -791,7 +791,7 @@ func HelmCharts(c *gin.Context) {
 		})
 		return
 	}
-	response, err := rs.ChartsGet(query.Name, query.Repo, query.Version, query.Keyword)
+	response, err := rs.GetCharts(query.Name, query.Repo, query.Version, query.Keyword)
 	if err != nil {
 		log.Error(fmt.Sprint("error during get helm repo chart list:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -813,7 +813,7 @@ func HelmChart(c *gin.Context) {
 	chartName := c.Param("name")
 	chartVersion := c.DefaultQuery("version", "")
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("error listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -823,7 +823,7 @@ func HelmChart(c *gin.Context) {
 		})
 		return
 	}
-	response, err := rs.ChartGet(chartRepo, chartName, chartVersion)
+	response, err := rs.GetChart(chartRepo, chartName, chartVersion)
 	if err != nil {
 		log.Error(fmt.Sprint("error during get helm chart information:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -849,7 +849,7 @@ func HelmChart(c *gin.Context) {
 func sendResponseWithRepo(c *gin.Context, repoName string) {
 	log := logrusadapter.NewFromEntry(pipelineContext.LoggerWithCorrelationID(c, config.Logger()).WithFields(logrus.Fields{}))
 
-	rs, err := helm.GetDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
+	rs, err := helm.CreateDefaultRepoStore(auth.GetCurrentOrganization(c.Request).Name, log)
 	if err != nil {
 		log.Error(fmt.Sprint("Eerror listing charts for deployments:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{
@@ -860,7 +860,7 @@ func sendResponseWithRepo(c *gin.Context, repoName string) {
 		return
 	}
 
-	entries, err := rs.ReposGet()
+	entries, err := rs.GetRepos()
 	if err != nil {
 		log.Error(fmt.Sprint("error during getting helm repo:", err.Error()))
 		c.JSON(http.StatusBadRequest, pkgCommmon.ErrorResponse{

--- a/auth/user.go
+++ b/auth/user.go
@@ -29,6 +29,7 @@ import (
 	"github.com/banzaicloud/pipeline/helm"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/jinzhu/copier"
 	"github.com/jinzhu/gorm"
 	"github.com/mitchellh/mapstructure"
@@ -284,7 +285,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 		return nil, "", emperror.Wrap(err, "failed to create user organization")
 	}
 
-	_, err = helm.GetDefaultRepoStore(currentUser.Organizations[0].Name)
+	_, err = helm.GetDefaultRepoStore(currentUser.Organizations[0].Name, logrusadapter.New(config.Logger()))
 	if err != nil {
 		log.Errorf("Error during local helm install: %s", err.Error())
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -285,7 +285,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 		return nil, "", emperror.Wrap(err, "failed to create user organization")
 	}
 
-	_, err = helm.GetDefaultRepoStore(currentUser.Organizations[0].Name, logrusadapter.New(config.Logger()))
+	_, err = helm.CreateDefaultRepoStore(currentUser.Organizations[0].Name, logrusadapter.New(config.Logger()))
 	if err != nil {
 		log.Errorf("Error during local helm install: %s", err.Error())
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -284,7 +284,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 		return nil, "", emperror.Wrap(err, "failed to create user organization")
 	}
 
-	err = helm.InstallLocalHelm(helm.GenerateHelmRepoEnv(currentUser.Organizations[0].Name))
+	_, err = helm.GetDefaultRepoStore(currentUser.Organizations[0].Name)
 	if err != nil {
 		log.Errorf("Error during local helm install: %s", err.Error())
 	}

--- a/cluster/autoscale.go
+++ b/cluster/autoscale.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
 	"github.com/ghodss/yaml"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
@@ -349,6 +350,7 @@ func isAutoscalerDeployedAlready(releaseName string, kubeConfig []byte) bool {
 }
 
 func deployAutoscalerChart(cluster CommonCluster, nodeGroups []nodeGroup, kubeConfig []byte, action deploymentAction) error {
+	log := config.Logger()
 	var values *autoscalingInfo
 	switch cluster.GetDistribution() {
 	case pkgCluster.EKS:
@@ -385,9 +387,9 @@ func deployAutoscalerChart(cluster CommonCluster, nodeGroups []nodeGroup, kubeCo
 
 	switch action {
 	case install:
-		_, err = helm.CreateDeployment(org.Name, autoScalerChart, chartVersion, nil, helm.SystemNamespace, releaseName, false, nil, kubeConfig, k8sHelm.ValueOverrides(yamlValues))
+		_, err = helm.CreateDeployment(org.Name, autoScalerChart, chartVersion, nil, helm.SystemNamespace, releaseName, false, nil, kubeConfig, logrusadapter.New(log), k8sHelm.ValueOverrides(yamlValues))
 	case upgrade:
-		_, err = helm.UpgradeDeployment(org.Name, releaseName, autoScalerChart, chartVersion, nil, yamlValues, false, kubeConfig)
+		_, err = helm.UpgradeDeployment(org.Name, releaseName, autoScalerChart, chartVersion, nil, yamlValues, false, kubeConfig, logrusadapter.New(log))
 	default:
 		return err
 	}

--- a/cluster/autoscale.go
+++ b/cluster/autoscale.go
@@ -385,9 +385,9 @@ func deployAutoscalerChart(cluster CommonCluster, nodeGroups []nodeGroup, kubeCo
 
 	switch action {
 	case install:
-		_, err = helm.CreateDeployment(autoScalerChart, chartVersion, nil, helm.SystemNamespace, releaseName, false, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), k8sHelm.ValueOverrides(yamlValues))
+		_, err = helm.CreateDeployment(org.Name, autoScalerChart, chartVersion, nil, helm.SystemNamespace, releaseName, false, nil, kubeConfig, k8sHelm.ValueOverrides(yamlValues))
 	case upgrade:
-		_, err = helm.UpgradeDeployment(releaseName, autoScalerChart, chartVersion, nil, yamlValues, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+		_, err = helm.UpgradeDeployment(org.Name, releaseName, autoScalerChart, chartVersion, nil, yamlValues, false, kubeConfig)
 	default:
 		return err
 	}

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -145,6 +146,7 @@ func GetHeadNodeTolerations() []v1.Toleration {
 }
 
 func installDeployment(cluster CommonCluster, namespace string, deploymentName string, releaseName string, values []byte, chartVersion string, wait bool) error {
+	log := pipConfig.Logger()
 	// --- [ Get K8S Config ] --- //
 	kubeConfig, err := cluster.GetK8sConfig()
 	if err != nil {
@@ -193,7 +195,7 @@ func installDeployment(cluster CommonCluster, namespace string, deploymentName s
 		k8sHelm.InstallWait(wait),
 		k8sHelm.ValueOverrides(values),
 	}
-	_, err = helm.CreateDeployment(org.Name, deploymentName, chartVersion, nil, namespace, releaseName, false, nil, kubeConfig, options...)
+	_, err = helm.CreateDeployment(org.Name, deploymentName, chartVersion, nil, namespace, releaseName, false, nil, kubeConfig, logrusadapter.New(log), options...)
 	if err != nil {
 		log.Errorf("Deploying '%s' failed due to: %s", deploymentName, err.Error())
 		return err

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -193,7 +193,7 @@ func installDeployment(cluster CommonCluster, namespace string, deploymentName s
 		k8sHelm.InstallWait(wait),
 		k8sHelm.ValueOverrides(values),
 	}
-	_, err = helm.CreateDeployment(deploymentName, chartVersion, nil, namespace, releaseName, false, nil, kubeConfig, helm.GenerateHelmRepoEnv(org.Name), options...)
+	_, err = helm.CreateDeployment(org.Name, deploymentName, chartVersion, nil, namespace, releaseName, false, nil, kubeConfig, options...)
 	if err != nil {
 		log.Errorf("Deploying '%s' failed due to: %s", deploymentName, err.Error())
 		return err

--- a/cluster/hooks_tiller.go
+++ b/cluster/hooks_tiller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -49,7 +50,7 @@ func WaitingForTillerComeUp(log logrus.FieldLogger, kubeConfig []byte) error {
 		log.WithField("attempt", fmt.Sprintf("%d/%d", i, retryAttempts)).Info("waiting for tiller to come up")
 		i++
 
-		client, err := pkgHelm.NewClient(kubeConfig, log)
+		client, err := pkgHelm.NewClient(kubeConfig, logrusadapter.NewFromEntry(log.WithFields(logrus.Fields{})))
 		if err != nil {
 			log.Warnf("error during getting helm client: %s", err.Error())
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/goph/emperror v0.17.1
-	github.com/goph/logur v0.11.0
+	github.com/goph/logur v0.11.1
 	github.com/gorilla/sessions v0.0.0-20181208214519-12bd4761fc66
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/goph/emperror v0.17.1/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH
 github.com/goph/logur v0.9.0/go.mod h1:PfIUaGrVwMKoEWyHjPF4820Qcitq0xJNmje9Eh7eRJA=
 github.com/goph/logur v0.11.0 h1:nKVK6frr7dakIaUElQkkAN3yVHi9n/ulc1so1XnNAV8=
 github.com/goph/logur v0.11.0/go.mod h1:SUhs+0vskrKgPHfpceKH+bB9K6ceen8x3zAOqEWJWpA=
+github.com/goph/logur v0.11.1 h1:DFyCXGhMZJRcwRLSVuUQcq70eOlDQBx03UFTkkUTmRY=
+github.com/goph/logur v0.11.1/go.mod h1:SUhs+0vskrKgPHfpceKH+bB9K6ceen8x3zAOqEWJWpA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 h1:f0n1xnMSmBLzVfsMMvriDyA75NB/oBgILX2GcHXIQzY=

--- a/helm/file_repo_store.go
+++ b/helm/file_repo_store.go
@@ -1,0 +1,489 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/banzaicloud/pipeline/config"
+	phelm "github.com/banzaicloud/pipeline/pkg/helm"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"k8s.io/helm/pkg/downloader"
+	"k8s.io/helm/pkg/getter"
+	helmEnv "k8s.io/helm/pkg/helm/environment"
+	"k8s.io/helm/pkg/helm/helmpath"
+	"k8s.io/helm/pkg/repo"
+)
+
+type FileRepositoryStore struct {
+	Env helmEnv.EnvSettings
+}
+
+func NewFileRepositoryStore(orgName string) (*FileRepositoryStore, error) {
+	var helmPath = config.GetHelmPath(orgName)
+	env := createEnvSettings(fmt.Sprintf("%s/%s", helmPath, phelm.HelmPostFix))
+
+	repoStore := &FileRepositoryStore{Env: env}
+	err := repoStore.init()
+	if err != nil {
+		return nil, err
+	}
+	return repoStore, nil
+}
+
+// ReposGet returns repo
+func (s *FileRepositoryStore) ReposGet() ([]*repo.Entry, error) {
+
+	repoPath := s.Env.Home.RepositoryFile()
+	log.Debugf("Helm repo path: %s", repoPath)
+
+	f, err := repo.LoadRepositoriesFile(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(f.Repositories) == 0 {
+		return make([]*repo.Entry, 0), nil
+	}
+
+	return f.Repositories, nil
+}
+
+// ReposAdd adds repo(s)
+func (s *FileRepositoryStore) ReposAdd(Hrepo *repo.Entry) (bool, error) {
+	repoFile := s.Env.Home.RepositoryFile()
+	var f *repo.RepoFile
+	if _, err := os.Stat(repoFile); err != nil {
+		log.Infof("Creating %s", repoFile)
+		f = repo.NewRepoFile()
+	} else {
+		f, err = repo.LoadRepositoriesFile(repoFile)
+		if err != nil {
+			return false, errors.Wrap(err, "Cannot create a new ChartRepo")
+		}
+		log.Debugf("Profile file %q loaded.", repoFile)
+	}
+
+	for _, n := range f.Repositories {
+		log.Debugf("repo: %s", n.Name)
+		if n.Name == Hrepo.Name {
+			return false, nil
+		}
+	}
+
+	c := repo.Entry{
+		Name:  Hrepo.Name,
+		URL:   Hrepo.URL,
+		Cache: s.Env.Home.CacheIndex(Hrepo.Name),
+	}
+	r, err := repo.NewChartRepository(&c, getter.All(s.Env))
+	if err != nil {
+		return false, errors.Wrap(err, "Cannot create a new ChartRepo")
+	}
+	log.Debugf("New repo added: %s", Hrepo.Name)
+
+	errIdx := r.DownloadIndexFile("")
+	if errIdx != nil {
+		return false, errors.Wrap(errIdx, "Repo index download failed")
+	}
+	f.Add(&c)
+	if errW := f.WriteFile(repoFile, 0644); errW != nil {
+		return false, errors.Wrap(errW, "Cannot write helm repo profile file")
+	}
+	return true, nil
+}
+
+// ReposDelete deletes repo(s)
+func (s *FileRepositoryStore) ReposDelete(repoName string) error {
+	repoFile := s.Env.Home.RepositoryFile()
+	log.Debugf("Repo File: %s", repoFile)
+
+	r, err := repo.LoadRepositoriesFile(repoFile)
+	if err != nil {
+		return err
+	}
+
+	if !r.Remove(repoName) {
+		return ErrRepoNotFound
+	}
+	if err := r.WriteFile(repoFile, 0644); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(s.Env.Home.CacheIndex(repoName)); err == nil {
+		err = os.Remove(s.Env.Home.CacheIndex(repoName))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+// ReposModify modifies repo(s)
+func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) error {
+
+	log.Debug("ReposModify")
+	repoFile := s.Env.Home.RepositoryFile()
+	log.Debugf("Repo File: %s", repoFile)
+	log.Debugf("New repo content: %#v", newRepo)
+
+	f, err := repo.LoadRepositoriesFile(repoFile)
+	if err != nil {
+		return err
+	}
+
+	if !f.Has(repoName) {
+		return ErrRepoNotFound
+	}
+
+	var formerRepo *repo.Entry
+	repos := f.Repositories
+	for _, r := range repos {
+		if r.Name == repoName {
+			formerRepo = r
+		}
+	}
+
+	if formerRepo != nil {
+		if len(newRepo.Name) == 0 {
+			newRepo.Name = formerRepo.Name
+			log.Infof("new repo name field is empty, replaced with: %s", formerRepo.Name)
+		}
+
+		if len(newRepo.URL) == 0 {
+			newRepo.URL = formerRepo.URL
+			log.Infof("new repo url field is empty, replaced with: %s", formerRepo.URL)
+		}
+
+		if len(newRepo.Cache) == 0 {
+			newRepo.Cache = formerRepo.Cache
+			log.Infof("new repo cache field is empty, replaced with: %s", formerRepo.Cache)
+		}
+	}
+
+	f.Update(newRepo)
+
+	if errW := f.WriteFile(repoFile, 0644); errW != nil {
+		return errors.Wrap(errW, "Cannot write helm repo profile file")
+	}
+	return nil
+}
+
+// ReposUpdate updates a repo(s)
+func (s *FileRepositoryStore) ReposUpdate(repoName string) error {
+
+	repoFile := s.Env.Home.RepositoryFile()
+	log.Debugf("Repo File: %s", repoFile)
+
+	f, err := repo.LoadRepositoriesFile(repoFile)
+
+	if err != nil {
+		return errors.Wrap(err, "Load ChartRepo")
+	}
+
+	for _, cfg := range f.Repositories {
+		if cfg.Name == repoName {
+			c, err := repo.NewChartRepository(cfg, getter.All(s.Env))
+			if err != nil {
+				return errors.Wrap(err, "Cannot get ChartRepo")
+			}
+			errIdx := c.DownloadIndexFile("")
+			if errIdx != nil {
+				return errors.Wrap(errIdx, "Repo index download failed")
+			}
+			return nil
+
+		}
+	}
+
+	return ErrRepoNotFound
+}
+
+// ChartsGet returns chart list
+func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error) {
+	log.Debugf("Helm repo path %s", s.Env.Home.RepositoryFile())
+	f, err := repo.LoadRepositoriesFile(s.Env.Home.RepositoryFile())
+	if err != nil {
+		return nil, err
+	}
+	if len(f.Repositories) == 0 {
+		return nil, nil
+	}
+	cl := make([]ChartList, 0)
+
+	for _, r := range f.Repositories {
+
+		log.Debugf("Repository: %s", r.Name)
+		i, errIndx := repo.LoadIndexFile(r.Cache)
+		if errIndx != nil {
+			return nil, errIndx
+		}
+		repoMatched, _ := regexp.MatchString(queryRepo, strings.ToLower(r.Name))
+		if repoMatched || queryRepo == "" {
+			log.Debugf("Repository: %s Matched", r.Name)
+			c := ChartList{
+				Name:   r.Name,
+				Charts: make([]repo.ChartVersions, 0),
+			}
+			for n := range i.Entries {
+				log.Debugf("Chart: %s", n)
+				chartMatched, _ := regexp.MatchString("^"+queryName+"$", strings.ToLower(n))
+
+				kwString := strings.ToLower(strings.Join(i.Entries[n][0].Keywords, " "))
+				log.Debugf("kwString: %s", kwString)
+
+				kwMatched, _ := regexp.MatchString(queryKeyword, kwString)
+				if (chartMatched || queryName == "") && (kwMatched || queryKeyword == "") {
+					log.Debugf("Chart: %s Matched", n)
+					if queryVersion == "latest" {
+						c.Charts = append(c.Charts, repo.ChartVersions{i.Entries[n][0]})
+					} else {
+						c.Charts = append(c.Charts, i.Entries[n])
+					}
+				}
+
+			}
+			cl = append(cl, c)
+
+		}
+	}
+	return cl, nil
+}
+
+// ChartGet returns chart details
+func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error) {
+
+	repoPath := s.Env.Home.RepositoryFile()
+	log.Debugf("Helm repo path: %s", repoPath)
+	var f *repo.RepoFile
+	f, err = repo.LoadRepositoriesFile(repoPath)
+	if err != nil {
+		return
+	}
+
+	if len(f.Repositories) == 0 {
+		return
+	}
+
+	for _, repository := range f.Repositories {
+
+		log.Debugf("Repository: %s", repository.Name)
+
+		var i *repo.IndexFile
+		i, err = repo.LoadIndexFile(repository.Cache)
+		if err != nil {
+			return
+		}
+
+		details = &ChartDetails{
+			Name: chartName,
+			Repo: chartRepo,
+		}
+
+		if repository.Name == chartRepo {
+
+			for name, chartVersions := range i.Entries {
+				log.Debugf("Chart: %s", name)
+				if chartName == name {
+					for _, v := range chartVersions {
+
+						if v.Version == chartVersion || chartVersion == "" {
+
+							var ver *ChartVersion
+							ver, err = getChartVersion(v)
+							if err != nil {
+								return
+							}
+							details.Versions = []*ChartVersion{ver}
+
+							return
+						} else if chartVersion == versionAll {
+							var ver *ChartVersion
+							ver, err = getChartVersion(v)
+							if err != nil {
+								log.Warnf("error during getting chart[%s - %s]: %s", v.Name, v.Version, err.Error())
+							} else {
+								details.Versions = append(details.Versions, ver)
+							}
+
+						}
+
+					}
+					return
+				}
+
+			}
+
+		}
+	}
+	return
+}
+
+// DownloadChartFromRepo download a given chart
+func (s *FileRepositoryStore) DownloadChartFromRepo(name, version string) (string, error) {
+	dl := downloader.ChartDownloader{
+		HelmHome: s.Env.Home,
+		Getters:  getter.All(s.Env),
+	}
+	if _, err := os.Stat(s.Env.Home.Archive()); os.IsNotExist(err) {
+		log.Infof("Creating '%s' directory.", s.Env.Home.Archive())
+		os.MkdirAll(s.Env.Home.Archive(), 0744)
+	}
+
+	log.Infof("Downloading helm chart %q, version %q to %q", name, version, s.Env.Home.Archive())
+	filename, _, err := dl.DownloadTo(name, version, s.Env.Home.Archive())
+	if err == nil {
+		lname, err := filepath.Abs(filename)
+		if err != nil {
+			return filename, errors.Wrapf(err, "Could not create absolute path from %s", filename)
+		}
+		log.Debugf("Fetched helm chart %q, version %q to %q", name, version, filename)
+		return lname, nil
+	}
+
+	return filename, errors.Wrapf(err, "Failed to download chart %q, version %q", name, version)
+}
+
+func getChartVersion(v *repo.ChartVersion) (*ChartVersion, error) {
+	log.Infof("get chart[%s - %s]", v.Name, v.Version)
+
+	chartSource := v.URLs[0]
+	log.Debugf("chartSource: %s", chartSource)
+	reader, err := DownloadFile(chartSource)
+	if err != nil {
+		return nil, err
+	}
+	valuesStr, err := GetChartFile(reader, "values.yaml")
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("values hash: %s", valuesStr)
+
+	readmeStr, err := GetChartFile(reader, "README.md")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChartVersion{
+		Chart:  v,
+		Values: valuesStr,
+		Readme: readmeStr,
+	}, nil
+}
+
+// createEnvSettings Create env settings on a given path
+func createEnvSettings(helmRepoHome string) helmEnv.EnvSettings {
+	var settings helmEnv.EnvSettings
+	settings.Home = helmpath.Home(helmRepoHome)
+	return settings
+}
+
+// init Helm repository store
+func (s *FileRepositoryStore) init() error {
+	// check local helm
+	if _, err := os.Stat(s.Env.Home.String()); os.IsNotExist(err) {
+		log.Infof("Helm directories [%s] not exists", s.Env.Home.String())
+		err := s.installLocalHelm()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// InstallLocalHelm install helm into the given path
+func (s *FileRepositoryStore) installLocalHelm() error {
+	if err := s.installHelmClient(); err != nil {
+		return err
+	}
+	log.Info("Helm client install succeeded")
+
+	if err := s.ensureDefaultRepos(); err != nil {
+		return errors.Wrap(err, "Setting up default repos failed!")
+	}
+	return nil
+}
+
+func (s *FileRepositoryStore) ensureDefaultRepos() error {
+
+	stableRepositoryURL := viper.GetString("helm.stableRepositoryURL")
+	banzaiRepositoryURL := viper.GetString("helm.banzaiRepositoryURL")
+
+	log.Infof("Setting up default helm repos.")
+
+	_, err := s.ReposAdd(
+		&repo.Entry{
+			Name:  phelm.StableRepository,
+			URL:   stableRepositoryURL,
+			Cache: s.Env.Home.CacheIndex(phelm.StableRepository),
+		})
+	if err != nil {
+		return errors.Wrapf(err, "cannot init repo: %s", phelm.StableRepository)
+	}
+	_, err = s.ReposAdd(
+		&repo.Entry{
+			Name:  phelm.BanzaiRepository,
+			URL:   banzaiRepositoryURL,
+			Cache: s.Env.Home.CacheIndex(phelm.BanzaiRepository),
+		})
+	if err != nil {
+		return errors.Wrapf(err, "cannot init repo: %s", phelm.BanzaiRepository)
+	}
+	return nil
+}
+
+// installHelmClient Installs helm client on a given path
+func (s *FileRepositoryStore) installHelmClient() error {
+	if err := s.ensureDirectories(); err != nil {
+		return errors.Wrap(err, "Initializing helm directories failed!")
+	}
+
+	log.Info("Initializing helm client succeeded, happy helming!")
+	return nil
+}
+
+// ensureDirectories for helm repo local install
+func (s *FileRepositoryStore) ensureDirectories() error {
+	home := s.Env.Home
+	configDirectories := []string{
+		home.String(),
+		home.Repository(),
+		home.Cache(),
+		home.LocalRepository(),
+		home.Plugins(),
+		home.Starters(),
+		home.Archive(),
+	}
+
+	log.Info("Setting up helm directories.")
+
+	for _, p := range configDirectories {
+		if fi, err := os.Stat(p); err != nil {
+			log.Infof("Creating '%s'", p)
+			if err := os.MkdirAll(p, 0755); err != nil {
+				return errors.Wrapf(err, "Could not create '%s'", p)
+			}
+		} else if !fi.IsDir() {
+			return errors.Errorf("'%s' must be a directory", p)
+		}
+	}
+	return nil
+}

--- a/helm/file_repo_store.go
+++ b/helm/file_repo_store.go
@@ -40,7 +40,7 @@ type FileRepositoryStore struct {
 	log logur.Logger
 }
 
-func NewFileRepositoryStore(orgName string, log logur.Logger) (*FileRepositoryStore, error) {
+func newFileRepositoryStore(orgName string, log logur.Logger) (*FileRepositoryStore, error) {
 	var helmPath = config.GetHelmPath(orgName)
 	env := createEnvSettings(fmt.Sprintf("%s/%s", helmPath, phelm.HelmPostFix))
 
@@ -55,8 +55,8 @@ func NewFileRepositoryStore(orgName string, log logur.Logger) (*FileRepositorySt
 	return repoStore, nil
 }
 
-// ReposGet returns repo
-func (s *FileRepositoryStore) ReposGet() ([]*repo.Entry, error) {
+// GetRepos returns repo
+func (s *FileRepositoryStore) GetRepos() ([]*repo.Entry, error) {
 	repoPath := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repositoryFile": repoPath})
@@ -74,8 +74,8 @@ func (s *FileRepositoryStore) ReposGet() ([]*repo.Entry, error) {
 	return f.Repositories, nil
 }
 
-// ReposAdd adds repo(s)
-func (s *FileRepositoryStore) ReposAdd(helmChartRepo *repo.Entry) (bool, error) {
+// AddRepo adds repo(s)
+func (s *FileRepositoryStore) AddRepo(helmChartRepo *repo.Entry) (bool, error) {
 	repoFile := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repositoryFile": repoFile})
@@ -120,8 +120,8 @@ func (s *FileRepositoryStore) ReposAdd(helmChartRepo *repo.Entry) (bool, error) 
 	return true, nil
 }
 
-// ReposDelete deletes repo(s)
-func (s *FileRepositoryStore) ReposDelete(repoName string) error {
+// DeleteRepo deletes repo(s)
+func (s *FileRepositoryStore) DeleteRepo(repoName string) error {
 	log := logur.WithFields(s.log, logur.Fields{"repoName": repoName})
 
 	repoFile := s.Env.Home.RepositoryFile()
@@ -149,8 +149,8 @@ func (s *FileRepositoryStore) ReposDelete(repoName string) error {
 
 }
 
-// ReposModify modifies repo(s)
-func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) error {
+// ModifyRepo modifies repo(s)
+func (s *FileRepositoryStore) ModifyRepo(repoName string, newRepo *repo.Entry) error {
 	repoFile := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repoName": repoName, "repositoryFile": repoFile})
@@ -196,8 +196,8 @@ func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) 
 	return nil
 }
 
-// ReposUpdate updates a repo(s)
-func (s *FileRepositoryStore) ReposUpdate(repoName string) error {
+// UpdateRepo updates a repo(s)
+func (s *FileRepositoryStore) UpdateRepo(repoName string) error {
 	repoFile := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repoName": repoName, "repositoryFile": repoFile})
@@ -228,8 +228,8 @@ func (s *FileRepositoryStore) ReposUpdate(repoName string) error {
 	return ErrRepoNotFound
 }
 
-// ChartsGet returns chart list
-func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error) {
+// GetCharts returns chart list
+func (s *FileRepositoryStore) GetCharts(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error) {
 	repoFile := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repositoryFile": repoFile})
@@ -281,8 +281,8 @@ func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, quer
 	return cl, nil
 }
 
-// ChartGet returns chart details
-func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error) {
+// GetChart returns chart details
+func (s *FileRepositoryStore) GetChart(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error) {
 	repoPath := s.Env.Home.RepositoryFile()
 
 	log := logur.WithFields(s.log, logur.Fields{"repositoryFile": repoPath, "chartRepo": chartRepo, "chartName": chartName, "chartVersion": chartVersion})
@@ -351,8 +351,8 @@ func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string
 	return
 }
 
-// DownloadChartFromRepo download a given chart
-func (s *FileRepositoryStore) DownloadChartFromRepo(name, version string) (string, error) {
+// DownloadChart download a given chart
+func (s *FileRepositoryStore) DownloadChart(name, version string) (string, error) {
 	dl := downloader.ChartDownloader{
 		HelmHome: s.Env.Home,
 		Getters:  getter.All(s.Env),
@@ -447,7 +447,7 @@ func (s *FileRepositoryStore) ensureDefaultRepos() error {
 
 	s.log.Info("setting up default helm chart repos.")
 
-	_, err := s.ReposAdd(
+	_, err := s.AddRepo(
 		&repo.Entry{
 			Name:  phelm.StableRepository,
 			URL:   stableRepositoryURL,
@@ -456,7 +456,7 @@ func (s *FileRepositoryStore) ensureDefaultRepos() error {
 	if err != nil {
 		return errors.Wrapf(err, "cannot init repo: %s", phelm.StableRepository)
 	}
-	_, err = s.ReposAdd(
+	_, err = s.AddRepo(
 		&repo.Entry{
 			Name:  phelm.BanzaiRepository,
 			URL:   banzaiRepositoryURL,

--- a/helm/file_repo_store.go
+++ b/helm/file_repo_store.go
@@ -52,7 +52,7 @@ func NewFileRepositoryStore(orgName string) (*FileRepositoryStore, error) {
 func (s *FileRepositoryStore) ReposGet() ([]*repo.Entry, error) {
 
 	repoPath := s.Env.Home.RepositoryFile()
-	log.Debugf("Helm repo path: %s", repoPath)
+	log.Debugf("helm chart repo path: %s", repoPath)
 
 	f, err := repo.LoadRepositoriesFile(repoPath)
 	if err != nil {
@@ -66,45 +66,45 @@ func (s *FileRepositoryStore) ReposGet() ([]*repo.Entry, error) {
 }
 
 // ReposAdd adds repo(s)
-func (s *FileRepositoryStore) ReposAdd(Hrepo *repo.Entry) (bool, error) {
+func (s *FileRepositoryStore) ReposAdd(helmChartRepo *repo.Entry) (bool, error) {
 	repoFile := s.Env.Home.RepositoryFile()
 	var f *repo.RepoFile
 	if _, err := os.Stat(repoFile); err != nil {
-		log.Infof("Creating %s", repoFile)
+		log.Infof("creating %s", repoFile)
 		f = repo.NewRepoFile()
 	} else {
 		f, err = repo.LoadRepositoriesFile(repoFile)
 		if err != nil {
-			return false, errors.Wrap(err, "Cannot create a new ChartRepo")
+			return false, errors.Wrap(err, "cannot create a new ChartRepo")
 		}
-		log.Debugf("Profile file %q loaded.", repoFile)
+		log.Debugf("profile file %q loaded.", repoFile)
 	}
 
 	for _, n := range f.Repositories {
 		log.Debugf("repo: %s", n.Name)
-		if n.Name == Hrepo.Name {
+		if n.Name == helmChartRepo.Name {
 			return false, nil
 		}
 	}
 
 	c := repo.Entry{
-		Name:  Hrepo.Name,
-		URL:   Hrepo.URL,
-		Cache: s.Env.Home.CacheIndex(Hrepo.Name),
+		Name:  helmChartRepo.Name,
+		URL:   helmChartRepo.URL,
+		Cache: s.Env.Home.CacheIndex(helmChartRepo.Name),
 	}
 	r, err := repo.NewChartRepository(&c, getter.All(s.Env))
 	if err != nil {
-		return false, errors.Wrap(err, "Cannot create a new ChartRepo")
+		return false, errors.Wrap(err, "cannot create a new ChartRepo")
 	}
-	log.Debugf("New repo added: %s", Hrepo.Name)
+	log.Debugf("new repo added: %s", helmChartRepo.Name)
 
 	errIdx := r.DownloadIndexFile("")
 	if errIdx != nil {
-		return false, errors.Wrap(errIdx, "Repo index download failed")
+		return false, errors.Wrap(errIdx, "repo index download failed")
 	}
 	f.Add(&c)
 	if errW := f.WriteFile(repoFile, 0644); errW != nil {
-		return false, errors.Wrap(errW, "Cannot write helm repo profile file")
+		return false, errors.Wrap(errW, "cannot write helm chart repo profile file")
 	}
 	return true, nil
 }
@@ -112,7 +112,7 @@ func (s *FileRepositoryStore) ReposAdd(Hrepo *repo.Entry) (bool, error) {
 // ReposDelete deletes repo(s)
 func (s *FileRepositoryStore) ReposDelete(repoName string) error {
 	repoFile := s.Env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
+	log.Debugf("repo file: %s", repoFile)
 
 	r, err := repo.LoadRepositoriesFile(repoFile)
 	if err != nil {
@@ -139,10 +139,9 @@ func (s *FileRepositoryStore) ReposDelete(repoName string) error {
 // ReposModify modifies repo(s)
 func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) error {
 
-	log.Debug("ReposModify")
 	repoFile := s.Env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
-	log.Debugf("New repo content: %#v", newRepo)
+	log.Debugf("repo file: %s", repoFile)
+	log.Debugf("new repo content: %#v", newRepo)
 
 	f, err := repo.LoadRepositoriesFile(repoFile)
 	if err != nil {
@@ -181,7 +180,7 @@ func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) 
 	f.Update(newRepo)
 
 	if errW := f.WriteFile(repoFile, 0644); errW != nil {
-		return errors.Wrap(errW, "Cannot write helm repo profile file")
+		return errors.Wrap(errW, "cannot write helm chart repo profile file")
 	}
 	return nil
 }
@@ -190,23 +189,23 @@ func (s *FileRepositoryStore) ReposModify(repoName string, newRepo *repo.Entry) 
 func (s *FileRepositoryStore) ReposUpdate(repoName string) error {
 
 	repoFile := s.Env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
+	log.Debugf("repo file: %s", repoFile)
 
 	f, err := repo.LoadRepositoriesFile(repoFile)
 
 	if err != nil {
-		return errors.Wrap(err, "Load ChartRepo")
+		return errors.Wrap(err, "load helm chart repo")
 	}
 
 	for _, cfg := range f.Repositories {
 		if cfg.Name == repoName {
 			c, err := repo.NewChartRepository(cfg, getter.All(s.Env))
 			if err != nil {
-				return errors.Wrap(err, "Cannot get ChartRepo")
+				return errors.Wrap(err, "cannot get helm chart repo")
 			}
 			errIdx := c.DownloadIndexFile("")
 			if errIdx != nil {
-				return errors.Wrap(errIdx, "Repo index download failed")
+				return errors.Wrap(errIdx, "helm chart repo index download failed")
 			}
 			return nil
 
@@ -218,7 +217,7 @@ func (s *FileRepositoryStore) ReposUpdate(repoName string) error {
 
 // ChartsGet returns chart list
 func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error) {
-	log.Debugf("Helm repo path %s", s.Env.Home.RepositoryFile())
+	log.Debugf("helm chart repo path %s", s.Env.Home.RepositoryFile())
 	f, err := repo.LoadRepositoriesFile(s.Env.Home.RepositoryFile())
 	if err != nil {
 		return nil, err
@@ -230,20 +229,20 @@ func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, quer
 
 	for _, r := range f.Repositories {
 
-		log.Debugf("Repository: %s", r.Name)
+		log.Debugf("repository: %s", r.Name)
 		i, errIndx := repo.LoadIndexFile(r.Cache)
 		if errIndx != nil {
 			return nil, errIndx
 		}
 		repoMatched, _ := regexp.MatchString(queryRepo, strings.ToLower(r.Name))
 		if repoMatched || queryRepo == "" {
-			log.Debugf("Repository: %s Matched", r.Name)
+			log.Debugf("repository: %s Matched", r.Name)
 			c := ChartList{
 				Name:   r.Name,
 				Charts: make([]repo.ChartVersions, 0),
 			}
 			for n := range i.Entries {
-				log.Debugf("Chart: %s", n)
+				log.Debugf("chart: %s", n)
 				chartMatched, _ := regexp.MatchString("^"+queryName+"$", strings.ToLower(n))
 
 				kwString := strings.ToLower(strings.Join(i.Entries[n][0].Keywords, " "))
@@ -251,7 +250,7 @@ func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, quer
 
 				kwMatched, _ := regexp.MatchString(queryKeyword, kwString)
 				if (chartMatched || queryName == "") && (kwMatched || queryKeyword == "") {
-					log.Debugf("Chart: %s Matched", n)
+					log.Debugf("chart: %s Matched", n)
 					if queryVersion == "latest" {
 						c.Charts = append(c.Charts, repo.ChartVersions{i.Entries[n][0]})
 					} else {
@@ -271,7 +270,7 @@ func (s *FileRepositoryStore) ChartsGet(queryName, queryRepo, queryVersion, quer
 func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error) {
 
 	repoPath := s.Env.Home.RepositoryFile()
-	log.Debugf("Helm repo path: %s", repoPath)
+	log.Debugf("helm chart repo path: %s", repoPath)
 	var f *repo.RepoFile
 	f, err = repo.LoadRepositoriesFile(repoPath)
 	if err != nil {
@@ -284,7 +283,7 @@ func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string
 
 	for _, repository := range f.Repositories {
 
-		log.Debugf("Repository: %s", repository.Name)
+		log.Debugf("repository: %s", repository.Name)
 
 		var i *repo.IndexFile
 		i, err = repo.LoadIndexFile(repository.Cache)
@@ -300,7 +299,7 @@ func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string
 		if repository.Name == chartRepo {
 
 			for name, chartVersions := range i.Entries {
-				log.Debugf("Chart: %s", name)
+				log.Debugf("chart: %s", name)
 				if chartName == name {
 					for _, v := range chartVersions {
 
@@ -318,7 +317,7 @@ func (s *FileRepositoryStore) ChartGet(chartRepo, chartName, chartVersion string
 							var ver *ChartVersion
 							ver, err = getChartVersion(v)
 							if err != nil {
-								log.Warnf("error during getting chart[%s - %s]: %s", v.Name, v.Version, err.Error())
+								log.Warnf("error during getting helm chart[%s - %s]: %s", v.Name, v.Version, err.Error())
 							} else {
 								details.Versions = append(details.Versions, ver)
 							}
@@ -343,22 +342,22 @@ func (s *FileRepositoryStore) DownloadChartFromRepo(name, version string) (strin
 		Getters:  getter.All(s.Env),
 	}
 	if _, err := os.Stat(s.Env.Home.Archive()); os.IsNotExist(err) {
-		log.Infof("Creating '%s' directory.", s.Env.Home.Archive())
+		log.Infof("creating '%s' directory.", s.Env.Home.Archive())
 		os.MkdirAll(s.Env.Home.Archive(), 0744)
 	}
 
-	log.Infof("Downloading helm chart %q, version %q to %q", name, version, s.Env.Home.Archive())
+	log.Infof("downloading helm chart %q, version %q to %q", name, version, s.Env.Home.Archive())
 	filename, _, err := dl.DownloadTo(name, version, s.Env.Home.Archive())
 	if err == nil {
 		lname, err := filepath.Abs(filename)
 		if err != nil {
-			return filename, errors.Wrapf(err, "Could not create absolute path from %s", filename)
+			return filename, errors.Wrapf(err, "could not create absolute path from %s", filename)
 		}
-		log.Debugf("Fetched helm chart %q, version %q to %q", name, version, filename)
+		log.Debugf("fetched helm chart %q, version %q to %q", name, version, filename)
 		return lname, nil
 	}
 
-	return filename, errors.Wrapf(err, "Failed to download chart %q, version %q", name, version)
+	return filename, errors.Wrapf(err, "failed to download helm chart %q, version %q", name, version)
 }
 
 func getChartVersion(v *repo.ChartVersion) (*ChartVersion, error) {
@@ -399,7 +398,7 @@ func createEnvSettings(helmRepoHome string) helmEnv.EnvSettings {
 func (s *FileRepositoryStore) init() error {
 	// check local helm
 	if _, err := os.Stat(s.Env.Home.String()); os.IsNotExist(err) {
-		log.Infof("Helm directories [%s] not exists", s.Env.Home.String())
+		log.Infof("helm directories [%s] not exists", s.Env.Home.String())
 		err := s.installLocalHelm()
 		if err != nil {
 			return err
@@ -414,7 +413,7 @@ func (s *FileRepositoryStore) installLocalHelm() error {
 	if err := s.installHelmClient(); err != nil {
 		return err
 	}
-	log.Info("Helm client install succeeded")
+	log.Info("helm client install succeeded")
 
 	if err := s.ensureDefaultRepos(); err != nil {
 		return errors.Wrap(err, "Setting up default repos failed!")
@@ -427,7 +426,7 @@ func (s *FileRepositoryStore) ensureDefaultRepos() error {
 	stableRepositoryURL := viper.GetString("helm.stableRepositoryURL")
 	banzaiRepositoryURL := viper.GetString("helm.banzaiRepositoryURL")
 
-	log.Infof("Setting up default helm repos.")
+	log.Infof("setting up default helm chart repos.")
 
 	_, err := s.ReposAdd(
 		&repo.Entry{
@@ -453,10 +452,10 @@ func (s *FileRepositoryStore) ensureDefaultRepos() error {
 // installHelmClient Installs helm client on a given path
 func (s *FileRepositoryStore) installHelmClient() error {
 	if err := s.ensureDirectories(); err != nil {
-		return errors.Wrap(err, "Initializing helm directories failed!")
+		return errors.Wrap(err, "initializing helm directories failed!")
 	}
 
-	log.Info("Initializing helm client succeeded, happy helming!")
+	log.Info("initializing helm client succeeded, happy helming!")
 	return nil
 }
 
@@ -473,13 +472,13 @@ func (s *FileRepositoryStore) ensureDirectories() error {
 		home.Archive(),
 	}
 
-	log.Info("Setting up helm directories.")
+	log.Info("setting up helm directories.")
 
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {
-			log.Infof("Creating '%s'", p)
+			log.Infof("creating '%s'", p)
 			if err := os.MkdirAll(p, 0755); err != nil {
-				return errors.Wrapf(err, "Could not create '%s'", p)
+				return errors.Wrapf(err, "could not create '%s'", p)
 			}
 		} else if !fi.IsDir() {
 			return errors.Errorf("'%s' must be a directory", p)

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -49,13 +48,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/helm/pkg/chartutil"
-	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm"
-	helm_env "k8s.io/helm/pkg/helm/environment"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
-	"k8s.io/helm/pkg/repo"
 )
 
 // DefaultNamespace default namespace
@@ -308,7 +304,12 @@ func DeploymentHasTag(deployment *pkgHelm.GetDeploymentResponse, tagFilter strin
 	return false
 }
 
-func GetRequestedChart(releaseName, chartName, chartVersion string, chartPackage []byte, env helm_env.EnvSettings) (requestedChart *chart.Chart, err error) {
+func GetRequestedChart(orgName, releaseName, chartName, chartVersion string, chartPackage []byte) (requestedChart *chart.Chart, err error) {
+
+	repoStore, err := GetDefaultRepoStore(orgName)
+	if err != nil {
+		return nil, err
+	}
 
 	// If the request has a chart package sent by the user we install that
 	if chartPackage != nil && len(chartPackage) != 0 {
@@ -316,7 +317,7 @@ func GetRequestedChart(releaseName, chartName, chartVersion string, chartPackage
 	} else {
 		log.Infof("Deploying chart=%q, version=%q release name=%q", chartName, chartVersion, releaseName)
 		var downloadedChartPath string
-		downloadedChartPath, err = DownloadChartFromRepo(chartName, chartVersion, env)
+		downloadedChartPath, err = repoStore.DownloadChartFromRepo(chartName, chartVersion)
 		if err != nil {
 			return nil, errors.Wrap(err, "error downloading chart")
 		}
@@ -340,9 +341,9 @@ func GetRequestedChart(releaseName, chartName, chartVersion string, chartPackage
 }
 
 //UpgradeDeployment upgrades a Helm deployment
-func UpgradeDeployment(releaseName, chartName, chartVersion string, chartPackage []byte, values []byte, reuseValues bool, kubeConfig []byte, env helm_env.EnvSettings) (*rls.UpdateReleaseResponse, error) {
+func UpgradeDeployment(orgName, releaseName, chartName, chartVersion string, chartPackage []byte, values []byte, reuseValues bool, kubeConfig []byte) (*rls.UpdateReleaseResponse, error) {
 
-	chartRequested, err := GetRequestedChart(releaseName, chartName, chartVersion, chartPackage, env)
+	chartRequested, err := GetRequestedChart(orgName, releaseName, chartName, chartVersion, chartPackage)
 	if err != nil {
 		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
@@ -370,9 +371,9 @@ func UpgradeDeployment(releaseName, chartName, chartVersion string, chartPackage
 }
 
 //CreateDeployment creates a Helm deployment in chosen namespace
-func CreateDeployment(chartName, chartVersion string, chartPackage []byte, namespace string, releaseName string, dryRun bool, odPcts map[string]int, kubeConfig []byte, env helm_env.EnvSettings, overrideOpts ...helm.InstallOption) (*rls.InstallReleaseResponse, error) {
+func CreateDeployment(orgName, chartName, chartVersion string, chartPackage []byte, namespace string, releaseName string, dryRun bool, odPcts map[string]int, kubeConfig []byte, overrideOpts ...helm.InstallOption) (*rls.InstallReleaseResponse, error) {
 
-	chartRequested, err := GetRequestedChart(releaseName, chartName, chartVersion, chartPackage, env)
+	chartRequested, err := GetRequestedChart(orgName, releaseName, chartName, chartVersion, chartPackage)
 	if err != nil {
 		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
@@ -711,341 +712,6 @@ func MergeValues(dest map[string]interface{}, src map[string]interface{}) map[st
 		dest[k] = MergeValues(destMap, nextMap)
 	}
 	return dest
-}
-
-// ReposGet returns repo
-func ReposGet(env helm_env.EnvSettings) ([]*repo.Entry, error) {
-
-	repoPath := env.Home.RepositoryFile()
-	log.Debugf("Helm repo path: %s", repoPath)
-
-	f, err := repo.LoadRepositoriesFile(repoPath)
-	if err != nil {
-		return nil, err
-	}
-	if len(f.Repositories) == 0 {
-		return make([]*repo.Entry, 0), nil
-	}
-
-	return f.Repositories, nil
-}
-
-// ReposAdd adds repo(s)
-func ReposAdd(env helm_env.EnvSettings, Hrepo *repo.Entry) (bool, error) {
-	repoFile := env.Home.RepositoryFile()
-	var f *repo.RepoFile
-	if _, err := os.Stat(repoFile); err != nil {
-		log.Infof("Creating %s", repoFile)
-		f = repo.NewRepoFile()
-	} else {
-		f, err = repo.LoadRepositoriesFile(repoFile)
-		if err != nil {
-			return false, errors.Wrap(err, "Cannot create a new ChartRepo")
-		}
-		log.Debugf("Profile file %q loaded.", repoFile)
-	}
-
-	for _, n := range f.Repositories {
-		log.Debugf("repo: %s", n.Name)
-		if n.Name == Hrepo.Name {
-			return false, nil
-		}
-	}
-
-	c := repo.Entry{
-		Name:  Hrepo.Name,
-		URL:   Hrepo.URL,
-		Cache: env.Home.CacheIndex(Hrepo.Name),
-	}
-	r, err := repo.NewChartRepository(&c, getter.All(env))
-	if err != nil {
-		return false, errors.Wrap(err, "Cannot create a new ChartRepo")
-	}
-	log.Debugf("New repo added: %s", Hrepo.Name)
-
-	errIdx := r.DownloadIndexFile("")
-	if errIdx != nil {
-		return false, errors.Wrap(errIdx, "Repo index download failed")
-	}
-	f.Add(&c)
-	if errW := f.WriteFile(repoFile, 0644); errW != nil {
-		return false, errors.Wrap(errW, "Cannot write helm repo profile file")
-	}
-	return true, nil
-}
-
-// ReposDelete deletes repo(s)
-func ReposDelete(env helm_env.EnvSettings, repoName string) error {
-	repoFile := env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
-
-	r, err := repo.LoadRepositoriesFile(repoFile)
-	if err != nil {
-		return err
-	}
-
-	if !r.Remove(repoName) {
-		return ErrRepoNotFound
-	}
-	if err := r.WriteFile(repoFile, 0644); err != nil {
-		return err
-	}
-
-	if _, err := os.Stat(env.Home.CacheIndex(repoName)); err == nil {
-		err = os.Remove(env.Home.CacheIndex(repoName))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-
-}
-
-// ReposModify modifies repo(s)
-func ReposModify(env helm_env.EnvSettings, repoName string, newRepo *repo.Entry) error {
-
-	log.Debug("ReposModify")
-	repoFile := env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
-	log.Debugf("New repo content: %#v", newRepo)
-
-	f, err := repo.LoadRepositoriesFile(repoFile)
-	if err != nil {
-		return err
-	}
-
-	if !f.Has(repoName) {
-		return ErrRepoNotFound
-	}
-
-	var formerRepo *repo.Entry
-	repos := f.Repositories
-	for _, r := range repos {
-		if r.Name == repoName {
-			formerRepo = r
-		}
-	}
-
-	if formerRepo != nil {
-		if len(newRepo.Name) == 0 {
-			newRepo.Name = formerRepo.Name
-			log.Infof("new repo name field is empty, replaced with: %s", formerRepo.Name)
-		}
-
-		if len(newRepo.URL) == 0 {
-			newRepo.URL = formerRepo.URL
-			log.Infof("new repo url field is empty, replaced with: %s", formerRepo.URL)
-		}
-
-		if len(newRepo.Cache) == 0 {
-			newRepo.Cache = formerRepo.Cache
-			log.Infof("new repo cache field is empty, replaced with: %s", formerRepo.Cache)
-		}
-	}
-
-	f.Update(newRepo)
-
-	if errW := f.WriteFile(repoFile, 0644); errW != nil {
-		return errors.Wrap(errW, "Cannot write helm repo profile file")
-	}
-	return nil
-}
-
-// ReposUpdate updates a repo(s)
-func ReposUpdate(env helm_env.EnvSettings, repoName string) error {
-
-	repoFile := env.Home.RepositoryFile()
-	log.Debugf("Repo File: %s", repoFile)
-
-	f, err := repo.LoadRepositoriesFile(repoFile)
-
-	if err != nil {
-		return errors.Wrap(err, "Load ChartRepo")
-	}
-
-	for _, cfg := range f.Repositories {
-		if cfg.Name == repoName {
-			c, err := repo.NewChartRepository(cfg, getter.All(env))
-			if err != nil {
-				return errors.Wrap(err, "Cannot get ChartRepo")
-			}
-			errIdx := c.DownloadIndexFile("")
-			if errIdx != nil {
-				return errors.Wrap(errIdx, "Repo index download failed")
-			}
-			return nil
-
-		}
-	}
-
-	return ErrRepoNotFound
-}
-
-// ChartList describe a chart list
-type ChartList struct {
-	Name   string               `json:"name"`
-	Charts []repo.ChartVersions `json:"charts"`
-}
-
-// ChartsGet returns chart list
-func ChartsGet(env helm_env.EnvSettings, queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error) {
-	log.Debugf("Helm repo path %s", env.Home.RepositoryFile())
-	f, err := repo.LoadRepositoriesFile(env.Home.RepositoryFile())
-	if err != nil {
-		return nil, err
-	}
-	if len(f.Repositories) == 0 {
-		return nil, nil
-	}
-	cl := make([]ChartList, 0)
-
-	for _, r := range f.Repositories {
-
-		log.Debugf("Repository: %s", r.Name)
-		i, errIndx := repo.LoadIndexFile(r.Cache)
-		if errIndx != nil {
-			return nil, errIndx
-		}
-		repoMatched, _ := regexp.MatchString(queryRepo, strings.ToLower(r.Name))
-		if repoMatched || queryRepo == "" {
-			log.Debugf("Repository: %s Matched", r.Name)
-			c := ChartList{
-				Name:   r.Name,
-				Charts: make([]repo.ChartVersions, 0),
-			}
-			for n := range i.Entries {
-				log.Debugf("Chart: %s", n)
-				chartMatched, _ := regexp.MatchString("^"+queryName+"$", strings.ToLower(n))
-
-				kwString := strings.ToLower(strings.Join(i.Entries[n][0].Keywords, " "))
-				log.Debugf("kwString: %s", kwString)
-
-				kwMatched, _ := regexp.MatchString(queryKeyword, kwString)
-				if (chartMatched || queryName == "") && (kwMatched || queryKeyword == "") {
-					log.Debugf("Chart: %s Matched", n)
-					if queryVersion == "latest" {
-						c.Charts = append(c.Charts, repo.ChartVersions{i.Entries[n][0]})
-					} else {
-						c.Charts = append(c.Charts, i.Entries[n])
-					}
-				}
-
-			}
-			cl = append(cl, c)
-
-		}
-	}
-	return cl, nil
-}
-
-// ChartDetails describes a chart details
-type ChartDetails struct {
-	Name     string          `json:"name"`
-	Repo     string          `json:"repo"`
-	Versions []*ChartVersion `json:"versions"`
-}
-
-// ChartVersion describes a chart verion
-type ChartVersion struct {
-	Chart  *repo.ChartVersion `json:"chart"`
-	Values string             `json:"values"`
-	Readme string             `json:"readme"`
-}
-
-// ChartGet returns chart details
-func ChartGet(env helm_env.EnvSettings, chartRepo, chartName, chartVersion string) (details *ChartDetails, err error) {
-
-	repoPath := env.Home.RepositoryFile()
-	log.Debugf("Helm repo path: %s", repoPath)
-	var f *repo.RepoFile
-	f, err = repo.LoadRepositoriesFile(repoPath)
-	if err != nil {
-		return
-	}
-
-	if len(f.Repositories) == 0 {
-		return
-	}
-
-	for _, repository := range f.Repositories {
-
-		log.Debugf("Repository: %s", repository.Name)
-
-		var i *repo.IndexFile
-		i, err = repo.LoadIndexFile(repository.Cache)
-		if err != nil {
-			return
-		}
-
-		details = &ChartDetails{
-			Name: chartName,
-			Repo: chartRepo,
-		}
-
-		if repository.Name == chartRepo {
-
-			for name, chartVersions := range i.Entries {
-				log.Debugf("Chart: %s", name)
-				if chartName == name {
-					for _, v := range chartVersions {
-
-						if v.Version == chartVersion || chartVersion == "" {
-
-							var ver *ChartVersion
-							ver, err = getChartVersion(v)
-							if err != nil {
-								return
-							}
-							details.Versions = []*ChartVersion{ver}
-
-							return
-						} else if chartVersion == versionAll {
-							var ver *ChartVersion
-							ver, err = getChartVersion(v)
-							if err != nil {
-								log.Warnf("error during getting chart[%s - %s]: %s", v.Name, v.Version, err.Error())
-							} else {
-								details.Versions = append(details.Versions, ver)
-							}
-
-						}
-
-					}
-					return
-				}
-
-			}
-
-		}
-	}
-	return
-}
-
-func getChartVersion(v *repo.ChartVersion) (*ChartVersion, error) {
-	log.Infof("get chart[%s - %s]", v.Name, v.Version)
-
-	chartSource := v.URLs[0]
-	log.Debugf("chartSource: %s", chartSource)
-	reader, err := DownloadFile(chartSource)
-	if err != nil {
-		return nil, err
-	}
-	valuesStr, err := GetChartFile(reader, "values.yaml")
-	if err != nil {
-		return nil, err
-	}
-	log.Debugf("values hash: %s", valuesStr)
-
-	readmeStr, err := GetChartFile(reader, "README.md")
-	if err != nil {
-		return nil, err
-	}
-
-	return &ChartVersion{
-		Chart:  v,
-		Values: valuesStr,
-		Readme: readmeStr,
-	}, nil
 }
 
 // GetVersionedChartName returns chart name enriched with version number

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -309,7 +309,7 @@ func DeploymentHasTag(deployment *pkgHelm.GetDeploymentResponse, tagFilter strin
 
 func GetRequestedChart(orgName, releaseName, chartName, chartVersion string, chartPackage []byte, log logur.Logger) (requestedChart *chart.Chart, err error) {
 
-	repoStore, err := GetDefaultRepoStore(orgName, log)
+	repoStore, err := CreateDefaultRepoStore(orgName, log)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func GetRequestedChart(orgName, releaseName, chartName, chartVersion string, cha
 	} else {
 		log.Info("downloading chart")
 		var downloadedChartPath string
-		downloadedChartPath, err = repoStore.DownloadChartFromRepo(chartName, chartVersion)
+		downloadedChartPath, err = repoStore.DownloadChart(chartName, chartVersion)
 		if err != nil {
 			return nil, errors.Wrap(err, "error downloading chart")
 		}

--- a/helm/install.go
+++ b/helm/install.go
@@ -16,12 +16,9 @@ package helm
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/internal/backoff"
 	phelm "github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
@@ -35,11 +32,6 @@ import (
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/helm/cmd/helm/installer"
-	"k8s.io/helm/pkg/downloader"
-	"k8s.io/helm/pkg/getter"
-	helmEnv "k8s.io/helm/pkg/helm/environment"
-	"k8s.io/helm/pkg/helm/helmpath"
-	"k8s.io/helm/pkg/repo"
 )
 
 //PreInstall create's serviceAccount and AccountRoleBinding
@@ -175,133 +167,6 @@ func RetryHelmInstall(log logrus.FieldLogger, helmInstall *phelm.Install, kubeco
 		return nil
 	}
 	return fmt.Errorf("timeout during helm install")
-}
-
-// CreateEnvSettings Create env settings on a given path
-func CreateEnvSettings(helmRepoHome string) helmEnv.EnvSettings {
-	var settings helmEnv.EnvSettings
-	settings.Home = helmpath.Home(helmRepoHome)
-	return settings
-}
-
-// GenerateHelmRepoEnv Generate helm path based on orgName
-func GenerateHelmRepoEnv(orgName string) (env helmEnv.EnvSettings) {
-	var helmPath = config.GetHelmPath(orgName)
-	env = CreateEnvSettings(fmt.Sprintf("%s/%s", helmPath, phelm.HelmPostFix))
-
-	// check local helm
-	if _, err := os.Stat(helmPath); os.IsNotExist(err) {
-		log.Infof("Helm directories [%s] not exists", helmPath)
-		InstallLocalHelm(env)
-	}
-
-	return
-}
-
-// DownloadChartFromRepo download a given chart
-func DownloadChartFromRepo(name, version string, env helmEnv.EnvSettings) (string, error) {
-	dl := downloader.ChartDownloader{
-		HelmHome: env.Home,
-		Getters:  getter.All(env),
-	}
-	if _, err := os.Stat(env.Home.Archive()); os.IsNotExist(err) {
-		log.Infof("Creating '%s' directory.", env.Home.Archive())
-		os.MkdirAll(env.Home.Archive(), 0744)
-	}
-
-	log.Infof("Downloading helm chart %q, version %q to %q", name, version, env.Home.Archive())
-	filename, _, err := dl.DownloadTo(name, version, env.Home.Archive())
-	if err == nil {
-		lname, err := filepath.Abs(filename)
-		if err != nil {
-			return filename, errors.Wrapf(err, "Could not create absolute path from %s", filename)
-		}
-		log.Debugf("Fetched helm chart %q, version %q to %q", name, version, filename)
-		return lname, nil
-	}
-
-	return filename, errors.Wrapf(err, "Failed to download chart %q, version %q", name, version)
-}
-
-// InstallHelmClient Installs helm client on a given path
-func InstallHelmClient(env helmEnv.EnvSettings) error {
-	if err := EnsureDirectories(env); err != nil {
-		return errors.Wrap(err, "Initializing helm directories failed!")
-	}
-
-	log.Info("Initializing helm client succeeded, happy helming!")
-	return nil
-}
-
-// EnsureDirectories for helm repo local install
-func EnsureDirectories(env helmEnv.EnvSettings) error {
-	home := env.Home
-	configDirectories := []string{
-		home.String(),
-		home.Repository(),
-		home.Cache(),
-		home.LocalRepository(),
-		home.Plugins(),
-		home.Starters(),
-		home.Archive(),
-	}
-
-	log.Info("Setting up helm directories.")
-
-	for _, p := range configDirectories {
-		if fi, err := os.Stat(p); err != nil {
-			log.Infof("Creating '%s'", p)
-			if err := os.MkdirAll(p, 0755); err != nil {
-				return errors.Wrapf(err, "Could not create '%s'", p)
-			}
-		} else if !fi.IsDir() {
-			return errors.Errorf("'%s' must be a directory", p)
-		}
-	}
-	return nil
-}
-
-func ensureDefaultRepos(env helmEnv.EnvSettings) error {
-
-	stableRepositoryURL := viper.GetString("helm.stableRepositoryURL")
-	banzaiRepositoryURL := viper.GetString("helm.banzaiRepositoryURL")
-
-	log.Infof("Setting up default helm repos.")
-
-	_, err := ReposAdd(
-		env,
-		&repo.Entry{
-			Name:  phelm.StableRepository,
-			URL:   stableRepositoryURL,
-			Cache: env.Home.CacheIndex(phelm.StableRepository),
-		})
-	if err != nil {
-		return errors.Wrapf(err, "cannot init repo: %s", phelm.StableRepository)
-	}
-	_, err = ReposAdd(
-		env,
-		&repo.Entry{
-			Name:  phelm.BanzaiRepository,
-			URL:   banzaiRepositoryURL,
-			Cache: env.Home.CacheIndex(phelm.BanzaiRepository),
-		})
-	if err != nil {
-		return errors.Wrapf(err, "cannot init repo: %s", phelm.BanzaiRepository)
-	}
-	return nil
-}
-
-// InstallLocalHelm install helm into the given path
-func InstallLocalHelm(env helmEnv.EnvSettings) error {
-	if err := InstallHelmClient(env); err != nil {
-		return err
-	}
-	log.Info("Helm client install succeeded")
-
-	if err := ensureDefaultRepos(env); err != nil {
-		return errors.Wrap(err, "Setting up default repos failed!")
-	}
-	return nil
 }
 
 // Install uses Kubernetes client to install Tiller.

--- a/helm/repo_store.go
+++ b/helm/repo_store.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"k8s.io/helm/pkg/repo"
+)
+
+// ChartDetails describes a chart details
+type ChartDetails struct {
+	Name     string          `json:"name"`
+	Repo     string          `json:"repo"`
+	Versions []*ChartVersion `json:"versions"`
+}
+
+// ChartVersion describes a chart verion
+type ChartVersion struct {
+	Chart  *repo.ChartVersion `json:"chart"`
+	Values string             `json:"values"`
+	Readme string             `json:"readme"`
+}
+
+// ChartList describe a chart list
+type ChartList struct {
+	Name   string               `json:"name"`
+	Charts []repo.ChartVersions `json:"charts"`
+}
+
+// RepositoryStore
+type RepositoryStore interface {
+	ReposAdd(Hrepo *repo.Entry) (bool, error)
+	ReposDelete(repoName string) error
+	ReposModify(repoName string, newRepo *repo.Entry) error
+	ReposUpdate(repoName string) error
+	ReposGet() ([]*repo.Entry, error)
+	ChartsGet(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error)
+	ChartGet(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error)
+	DownloadChartFromRepo(name, version string) (string, error)
+}
+
+func GetDefaultRepoStore(orgName string) (RepositoryStore, error) {
+	return NewFileRepositoryStore(orgName)
+}

--- a/helm/repo_store.go
+++ b/helm/repo_store.go
@@ -41,16 +41,16 @@ type ChartList struct {
 
 // RepositoryStore
 type RepositoryStore interface {
-	ReposAdd(helmChartRepo *repo.Entry) (bool, error)
-	ReposDelete(repoName string) error
-	ReposModify(repoName string, newRepo *repo.Entry) error
-	ReposUpdate(repoName string) error
-	ReposGet() ([]*repo.Entry, error)
-	ChartsGet(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error)
-	ChartGet(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error)
-	DownloadChartFromRepo(name, version string) (string, error)
+	AddRepo(helmChartRepo *repo.Entry) (bool, error)
+	DeleteRepo(repoName string) error
+	ModifyRepo(repoName string, newRepo *repo.Entry) error
+	UpdateRepo(repoName string) error
+	GetRepos() ([]*repo.Entry, error)
+	GetCharts(queryName, queryRepo, queryVersion, queryKeyword string) ([]ChartList, error)
+	GetChart(chartRepo, chartName, chartVersion string) (details *ChartDetails, err error)
+	DownloadChart(name, version string) (string, error)
 }
 
-func GetDefaultRepoStore(orgName string, log logur.Logger) (RepositoryStore, error) {
-	return NewFileRepositoryStore(orgName, log)
+func CreateDefaultRepoStore(orgName string, log logur.Logger) (RepositoryStore, error) {
+	return newFileRepositoryStore(orgName, log)
 }

--- a/helm/repo_store.go
+++ b/helm/repo_store.go
@@ -15,6 +15,7 @@
 package helm
 
 import (
+	"github.com/goph/logur"
 	"k8s.io/helm/pkg/repo"
 )
 
@@ -40,7 +41,7 @@ type ChartList struct {
 
 // RepositoryStore
 type RepositoryStore interface {
-	ReposAdd(Hrepo *repo.Entry) (bool, error)
+	ReposAdd(helmChartRepo *repo.Entry) (bool, error)
 	ReposDelete(repoName string) error
 	ReposModify(repoName string, newRepo *repo.Entry) error
 	ReposUpdate(repoName string) error
@@ -50,6 +51,6 @@ type RepositoryStore interface {
 	DownloadChartFromRepo(name, version string) (string, error)
 }
 
-func GetDefaultRepoStore(orgName string) (RepositoryStore, error) {
-	return NewFileRepositoryStore(orgName)
+func GetDefaultRepoStore(orgName string, log logur.Logger) (RepositoryStore, error) {
+	return NewFileRepositoryStore(orgName, log)
 }

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -295,6 +295,7 @@ func (s *DeploymentsService) installDeployment(
 	}
 
 	_, err = helm.CreateDeployment(
+		s.org.Name,
 		deploymentName,
 		chartVersion,
 		nil,
@@ -303,7 +304,6 @@ func (s *DeploymentsService) installDeployment(
 		false,
 		nil,
 		kubeConfig,
-		helm.GenerateHelmRepoEnv(s.org.Name),
 		options...,
 	)
 	if err != nil {

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -304,6 +305,7 @@ func (s *DeploymentsService) installDeployment(
 		false,
 		nil,
 		kubeConfig,
+		logrusadapter.NewFromEntry(s.logger.WithFields(logrus.Fields{})),
 		options...,
 	)
 	if err != nil {

--- a/internal/clusterfeature/clusterfeatureadapter/featuremanager.go
+++ b/internal/clusterfeature/clusterfeatureadapter/featuremanager.go
@@ -154,6 +154,7 @@ func (fhi *featureHelmInstaller) installDeployment(
 		k8sHelm.ValueOverrides(values),
 	}
 	_, err = helm.CreateDeployment(
+		cluster.GetOrganizationName(),
 		deploymentName,
 		chartVersion,
 		nil,
@@ -162,7 +163,6 @@ func (fhi *featureHelmInstaller) installDeployment(
 		false,
 		nil,
 		kubeConfig,
-		helm.GenerateHelmRepoEnv(cluster.GetOrganizationName()),
 		options...,
 	)
 	if err != nil {

--- a/internal/clusterfeature/clusterfeatureadapter/featuremanager.go
+++ b/internal/clusterfeature/clusterfeatureadapter/featuremanager.go
@@ -163,6 +163,7 @@ func (fhi *featureHelmInstaller) installDeployment(
 		false,
 		nil,
 		kubeConfig,
+		fhi.logger,
 		options...,
 	)
 	if err != nil {

--- a/internal/clustergroup/deployment/manager.go
+++ b/internal/clustergroup/deployment/manager.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/log"
@@ -124,7 +125,7 @@ func (m CGDeploymentManager) installDeploymentOnCluster(log *logrus.Entry, apiCl
 		return err
 	}
 
-	hClient, err := pkgHelm.NewClient(k8sConfig, m.logger)
+	hClient, err := pkgHelm.NewClient(k8sConfig, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return err
 	}
@@ -164,7 +165,7 @@ func (m CGDeploymentManager) upgradeDeploymentOnCluster(log *logrus.Entry, apiCl
 		return err
 	}
 
-	hClient, err := pkgHelm.NewClient(k8sConfig, m.logger)
+	hClient, err := pkgHelm.NewClient(k8sConfig, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func (m CGDeploymentManager) findRelease(apiCluster api.Cluster, name string) (*
 		return nil, err
 	}
 
-	hClient, err := pkgHelm.NewClient(k8sConfig, m.logger)
+	hClient, err := pkgHelm.NewClient(k8sConfig, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 
 		return nil, err
@@ -598,7 +599,7 @@ func (m CGDeploymentManager) SyncDeployment(clusterGroup *api.ClusterGroup, orgN
 	// get deployment status for each cluster group member
 	response := make([]TargetClusterStatus, 0)
 
-	requestedChart, err := helm.GetRequestedChart(orgName, depInfo.ReleaseName, depInfo.Chart, depInfo.ChartVersion, deploymentModel.DeploymentPackage)
+	requestedChart, err := helm.GetRequestedChart(orgName, depInfo.ReleaseName, depInfo.Chart, depInfo.ChartVersion, deploymentModel.DeploymentPackage, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
@@ -728,7 +729,7 @@ func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, or
 		}
 	}
 
-	requestedChart, err := helm.GetRequestedChart(orgName, cgDeployment.ReleaseName, cgDeployment.Name, cgDeployment.Version, cgDeployment.Package)
+	requestedChart, err := helm.GetRequestedChart(orgName, cgDeployment.ReleaseName, cgDeployment.Name, cgDeployment.Version, cgDeployment.Package, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return nil, fmt.Errorf("error loading chart: %v", err)
 	}
@@ -766,8 +767,7 @@ func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, or
 // UpdateDeployment upgrades deployment using provided values or using already provided values if ReUseValues = true.
 // The deployment is installed on a member cluster in case it's was not installed previously.
 func (m CGDeploymentManager) UpdateDeployment(clusterGroup *api.ClusterGroup, orgName string, cgDeployment *ClusterGroupDeployment) ([]TargetClusterStatus, error) {
-
-	requestedChart, err := helm.GetRequestedChart(orgName, cgDeployment.ReleaseName, cgDeployment.Name, cgDeployment.Version, cgDeployment.Package)
+	requestedChart, err := helm.GetRequestedChart(orgName, cgDeployment.ReleaseName, cgDeployment.Name, cgDeployment.Version, cgDeployment.Package, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return nil, fmt.Errorf("error loading chart: %v", err)
 	}

--- a/internal/federation/deployment.go
+++ b/internal/federation/deployment.go
@@ -85,7 +85,7 @@ func InstallOrUpgradeDeployment(
 			if !upgrade {
 				return nil
 			}
-			_, err = helm.UpgradeDeployment(releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+			_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig)
 			if err != nil {
 				return emperror.WrapWith(err, "could not upgrade deployment", "deploymentName", deploymentName)
 			}
@@ -104,6 +104,7 @@ func InstallOrUpgradeDeployment(
 	}
 
 	_, err = helm.CreateDeployment(
+		org.Name,
 		deploymentName,
 		chartVersion,
 		nil,
@@ -112,7 +113,6 @@ func InstallOrUpgradeDeployment(
 		false,
 		nil,
 		kubeConfig,
-		helm.GenerateHelmRepoEnv(org.Name),
 		options...,
 	)
 	if err != nil {

--- a/internal/federation/deployment.go
+++ b/internal/federation/deployment.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
+	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/helm"
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/pkg/errors"
 	k8sHelm "k8s.io/helm/pkg/helm"
 	pkgHelmRelease "k8s.io/helm/pkg/proto/hapi/release"
@@ -54,6 +56,9 @@ func InstallOrUpgradeDeployment(
 	wait bool,
 	upgrade bool,
 ) error {
+
+	log := config.Logger()
+
 	kubeConfig, err := c.GetK8sConfig()
 	if err != nil {
 		return emperror.Wrap(err, "could not get k8s config")
@@ -85,7 +90,7 @@ func InstallOrUpgradeDeployment(
 			if !upgrade {
 				return nil
 			}
-			_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig)
+			_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig, logrusadapter.New(log))
 			if err != nil {
 				return emperror.WrapWith(err, "could not upgrade deployment", "deploymentName", deploymentName)
 			}
@@ -113,6 +118,7 @@ func InstallOrUpgradeDeployment(
 		false,
 		nil,
 		kubeConfig,
+		logrusadapter.New(log),
 		options...,
 	)
 	if err != nil {

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/pipeline/helm"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -301,7 +302,7 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 		return emperror.Wrap(err, "could not get organization")
 	}
 
-	rs, err := helm.GetDefaultRepoStore(org.Name)
+	rs, err := helm.GetDefaultRepoStore(org.Name, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return emperror.WrapWith(err, "failed to get repo store")
 	}

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -302,12 +302,12 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 		return emperror.Wrap(err, "could not get organization")
 	}
 
-	rs, err := helm.GetDefaultRepoStore(org.Name, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
+	rs, err := helm.CreateDefaultRepoStore(org.Name, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return emperror.WrapWith(err, "failed to get repo store")
 	}
 
-	_, err = rs.ReposAdd(&repo.Entry{
+	_, err = rs.AddRepo(&repo.Entry{
 		Name: "kubefed-charts",
 		URL:  "https://raw.githubusercontent.com/banzaicloud/kubefed/master/charts",
 	})

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -301,8 +301,12 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 		return emperror.Wrap(err, "could not get organization")
 	}
 
-	env := helm.GenerateHelmRepoEnv(org.Name)
-	_, err = helm.ReposAdd(env, &repo.Entry{
+	rs, err := helm.GetDefaultRepoStore(org.Name)
+	if err != nil {
+		return emperror.WrapWith(err, "failed to get repo store")
+	}
+
+	_, err = rs.ReposAdd(&repo.Entry{
 		Name: "kubefed-charts",
 		URL:  "https://raw.githubusercontent.com/banzaicloud/kubefed/master/charts",
 	})

--- a/internal/federation/reconcile_ext_dns.go
+++ b/internal/federation/reconcile_ext_dns.go
@@ -124,7 +124,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 		return emperror.Wrap(err, "could not marshal chart value overrides")
 	}
 
-	_, err = helm.UpgradeDeployment(releaseName, deploymentName, resp.Release.Chart.Metadata.Version, nil, valuesOverride, true, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+	_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, resp.Release.Chart.Metadata.Version, nil, valuesOverride, true, kubeConfig)
 	if err != nil {
 		return emperror.WrapWith(err, "could not upgrade deployment", "deploymentName", deploymentName)
 	}

--- a/internal/federation/reconcile_ext_dns.go
+++ b/internal/federation/reconcile_ext_dns.go
@@ -25,6 +25,8 @@ import (
 	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
+	"github.com/goph/logur/adapters/logrusadapter"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -60,7 +62,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 		return emperror.Wrap(err, "could not get organization")
 	}
 
-	hClient, err := pkgHelm.NewClient(kubeConfig, m.logger)
+	hClient, err := pkgHelm.NewClient(kubeConfig, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 
 		return err
@@ -124,7 +126,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 		return emperror.Wrap(err, "could not marshal chart value overrides")
 	}
 
-	_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, resp.Release.Chart.Metadata.Version, nil, valuesOverride, true, kubeConfig)
+	_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, resp.Release.Chart.Metadata.Version, nil, valuesOverride, true, kubeConfig, logrusadapter.NewFromEntry(m.logger.WithFields(logrus.Fields{})))
 	if err != nil {
 		return emperror.WrapWith(err, "could not upgrade deployment", "deploymentName", deploymentName)
 	}

--- a/internal/istio/istiofeature/helm.go
+++ b/internal/istio/istiofeature/helm.go
@@ -86,7 +86,7 @@ func installOrUpgradeDeployment(
 			if !upgrade {
 				return nil
 			}
-			_, err = helm.UpgradeDeployment(releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig, helm.GenerateHelmRepoEnv(org.Name))
+			_, err = helm.UpgradeDeployment(org.Name, releaseName, deploymentName, chartVersion, nil, values, false, kubeConfig)
 			if err != nil {
 				return emperror.WrapWith(err, "could not upgrade deployment", "deploymentName", deploymentName)
 			}
@@ -105,6 +105,7 @@ func installOrUpgradeDeployment(
 	}
 
 	_, err = helm.CreateDeployment(
+		org.Name,
 		deploymentName,
 		chartVersion,
 		nil,
@@ -113,7 +114,6 @@ func installOrUpgradeDeployment(
 		false,
 		nil,
 		kubeConfig,
-		helm.GenerateHelmRepoEnv(org.Name),
 		options...,
 	)
 	if err != nil {

--- a/internal/istio/istiofeature/reconcile_istio_operator.go
+++ b/internal/istio/istiofeature/reconcile_istio_operator.go
@@ -97,6 +97,7 @@ func (m *MeshReconciler) installIstioOperator(c cluster.CommonCluster, logger lo
 		viper.GetString(pConfig.IstioOperatorChartVersion),
 		true,
 		true,
+		m.logger,
 	)
 	if err != nil {
 		return emperror.Wrap(err, "could not install Istio operator")

--- a/internal/istio/istiofeature/reconcile_uistio.go
+++ b/internal/istio/istiofeature/reconcile_uistio.go
@@ -174,6 +174,7 @@ func (m *MeshReconciler) installUistio(c cluster.CommonCluster, monitoring monit
 		viper.GetString(pConfig.UistioChartVersion),
 		true,
 		true,
+		m.logger,
 	)
 	if err != nil {
 		return emperror.Wrap(err, "could not install Uistio")

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/goph/emperror"
+	"github.com/goph/logur"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/helm/portforwarder"
 	"k8s.io/helm/pkg/kube"
@@ -32,7 +32,7 @@ type Client struct {
 	*helm.Client
 }
 
-func NewClient(kubeConfig []byte, logger logrus.FieldLogger) (*Client, error) {
+func NewClient(kubeConfig []byte, logger logur.Logger) (*Client, error) {
 	config, err := k8sclient.NewClientConfig(kubeConfig)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create kubernetes client config for helm client")
@@ -50,7 +50,7 @@ func NewClient(kubeConfig []byte, logger logrus.FieldLogger) (*Client, error) {
 	}
 
 	tillerTunnelAddress := fmt.Sprintf("localhost:%d", tillerTunnel.Local)
-	logger.WithField("address", tillerTunnelAddress).Debug("created kubernetes tunnel on address")
+	logur.WithFields(logger, logur.Fields{"address": tillerTunnelAddress}).Debug("created kubernetes tunnel on address")
 
 	hClient := helm.NewClient(helm.Host(tillerTunnelAddress))
 


### PR DESCRIPTION
…sitoryStore

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no
| Related tickets | fixes partially #2125 
| License         | Apache 2.0


### What's in this PR?

- gather helm repo related functions behind a new interface helm.RepositoryStore
- move current file base functions into helm.FileRepositoryStore

### Why?
The goal is to be able to persist repos to db creating db backed implementation of helm.RepositoryStore

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
