### PR TITLE
Upgrade external-dns to version 0.5.15

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -745,34 +745,15 @@ func RegisterDomainPostHook(commonCluster CommonCluster) error {
 
 	log.Info("route53 secret successfully installed into cluster.")
 
-	/*externalDnsValues := map[string]interface{}{
-		"rbac": map[string]bool{
-			"create": commonCluster.RbacEnabled() == true,
-		},
-		"image": map[string]string{
-			"tag": viper.GetString(pipConfig.DNSExternalDnsImageVersion),
-		},
-		"aws": map[string]string{
-			"secretKey": route53Secret.Values[pkgSecret.AwsSecretAccessKey],
-			"accessKey": route53Secret.Values[pkgSecret.AwsAccessKeyId],
-			"region":    route53Secret.Values[pkgSecret.AwsRegion],
-		},
-		"domainFilters": []string{domain},
-		"policy":        "sync",
-		"txtOwnerId":    commonCluster.GetUID(),
-		"affinity":      GetHeadNodeAffinity(commonCluster),
-		"tolerations":   GetHeadNodeTolerations(),
-	}*/
-
 	externalDnsValues := dns.ExternalDnsChartValues{
-		Rbac: dns.ExternalDnsRbac{
+		Rbac: dns.ExternalDnsRbacSettings{
 			Create: commonCluster.RbacEnabled() == true,
 		},
 		Sources: []string{"service", "ingress"},
-		Image: dns.ExternalDnsImage{
+		Image: dns.ExternalDnsImageSettings{
 			Tag: viper.GetString(pipConfig.DNSExternalDnsImageVersion),
 		},
-		Aws: dns.ExternalDnsAws{
+		Aws: dns.ExternalDnsAwsSettings{
 			Credentials: dns.ExternalDnsAwsCredentials{
 				SecretKey: route53Secret.Values[pkgSecret.AwsSecretAccessKey],
 				AccessKey: route53Secret.Values[pkgSecret.AwsAccessKeyId],

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/goph/emperror"
 	"github.com/goph/logur"
 	"github.com/goph/logur/integrations/zaplog"
@@ -109,6 +110,8 @@ func main() {
 	buildInfo := buildinfo.New(version, commitHash, buildDate)
 
 	logger.Info("starting application", buildInfo.Fields())
+
+	global.AutoDNSEnabled = viper.GetString(conf.DNSBaseDomain) != "" && viper.GetString(conf.DNSBaseDomain) != "example.com"
 
 	var group run.Group
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -40,7 +40,7 @@ const (
 	// DNSGcLogLevel configuration key for the DNS garbage collector logging level default value: "debug"
 	DNSGcLogLevel = "dns.gcLogLevel"
 
-	// DNSExternalDnsChartVersion set the external-dns chart version default value: "1.6.2"
+	// DNSExternalDnsChartVersion set the external-dns chart version default value: "2.2.3"
 	DNSExternalDnsChartVersion = "dns.externalDnsChartVersion"
 
 	// DNSExternalDnsImageVersion set the external-dns image version
@@ -247,8 +247,8 @@ func init() {
 	viper.SetDefault("tls.validity", "8760h") // 1 year
 	viper.SetDefault(DNSBaseDomain, "example.org")
 	viper.SetDefault(DNSGcIntervalMinute, 1)
-	viper.SetDefault(DNSExternalDnsChartVersion, "1.6.2")
-	viper.SetDefault(DNSExternalDnsImageVersion, "v0.5.11")
+	viper.SetDefault(DNSExternalDnsChartVersion, "2.2.3")
+	viper.SetDefault(DNSExternalDnsImageVersion, "0.5.15")
 	viper.SetDefault(DNSGcLogLevel, "debug")
 	viper.SetDefault(Route53MaintenanceWndMinute, 15)
 

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -27,33 +27,40 @@ import (
 
 // ExternalDnsChartValues describes external-dns helm chart values (https://hub.helm.sh/charts/stable/external-dns)
 type ExternalDnsChartValues struct {
-	Sources       []string          `json:"sources,omitempty" yaml:"sources,omitempty"`
-	Rbac          ExternalDnsRbac   `json:"rbac,omitempty" yaml:"rbac,omitempty"`
-	Image         ExternalDnsImage  `json:"image,omitempty" yaml:"image,omitempty"`
-	DomainFilters []string          `json:"domainFilters,omitempty" yaml:"domainFilters,omitempty"`
-	Policy        string            `json:"policy,omitempty" yaml:"policy,omitempty"`
-	TxtOwnerId    string            `json:"txtOwnerId,omitempty" yaml:"txtOwnerId,omitempty"`
-	Affinity      v1.Affinity       `json:"affinity,omitempty" yaml:"affinity,omitempty"`
-	Tolerations   []v1.Toleration   `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
-	ExtraArgs     map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
-	TxtPrefix     string            `json:"txtPrefix,omitempty" yaml:"txtPrefix,omitempty"`
-	Aws           ExternalDnsAws    `json:"aws,omitempty" yaml:"aws,omitempty"`
+	Sources       []string                     `json:"sources,omitempty" yaml:"sources,omitempty"`
+	Rbac          ExternalDnsRbacSettings      `json:"rbac,omitempty" yaml:"rbac,omitempty"`
+	Image         ExternalDnsImageSettings     `json:"image,omitempty" yaml:"image,omitempty"`
+	DomainFilters []string                     `json:"domainFilters,omitempty" yaml:"domainFilters,omitempty"`
+	Policy        string                       `json:"policy,omitempty" yaml:"policy,omitempty"`
+	TxtOwnerId    string                       `json:"txtOwnerId,omitempty" yaml:"txtOwnerId,omitempty"`
+	Affinity      v1.Affinity                  `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	Tolerations   []v1.Toleration              `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
+	ExtraArgs     map[string]string            `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	TxtPrefix     string                       `json:"txtPrefix,omitempty" yaml:"txtPrefix,omitempty"`
+	Crd           ExternalDnsCrdSourceSettings `json:"crd,omitempty" yaml:"crd,omitempty"`
+	Aws           ExternalDnsAwsSettings       `json:"aws,omitempty" yaml:"aws,omitempty"`
 }
 
-type ExternalDnsRbac struct {
+type ExternalDnsRbacSettings struct {
 	Create             bool   `json:"create,omitempty" yaml:"create,omitempty"`
 	ServiceAccountName string `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	ApiVersion         string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 	PspEnabled         bool   `json:"pspEnabled,omitempty" yaml:"pspEnabled,omitempty"`
 }
 
-type ExternalDnsImage struct {
+type ExternalDnsImageSettings struct {
 	Registry   string `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`
 	Tag        string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
-type ExternalDnsAws struct {
+type ExternalDnsCrdSourceSettings struct {
+	Create     bool   `json:"create,omitempty" yaml:"create,omitempty"`
+	Apiversion string `json:"apiversion,omitempty" yaml:"apiversion,omitempty"`
+	Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
+}
+
+type ExternalDnsAwsSettings struct {
 	Credentials     ExternalDnsAwsCredentials `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 	Region          string                    `json:"region,omitempty" yaml:"region,omitempty"`
 	ZoneType        string                    `json:"zoneType,omitempty" yaml:"zoneType,omitempty"`

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -21,8 +21,51 @@ import (
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/goph/emperror"
 	"github.com/spf13/viper"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+// ExternalDnsChartValues describes external-dns helm chart values (https://hub.helm.sh/charts/stable/external-dns)
+type ExternalDnsChartValues struct {
+	Sources       []string          `json:"sources,omitempty" yaml:"sources,omitempty"`
+	Rbac          ExternalDnsRbac   `json:"rbac,omitempty" yaml:"rbac,omitempty"`
+	Image         ExternalDnsImage  `json:"image,omitempty" yaml:"image,omitempty"`
+	DomainFilters []string          `json:"domainFilters,omitempty" yaml:"domainFilters,omitempty"`
+	Policy        string            `json:"policy,omitempty" yaml:"policy,omitempty"`
+	TxtOwnerId    string            `json:"txtOwnerId,omitempty" yaml:"txtOwnerId,omitempty"`
+	Affinity      v1.Affinity       `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	Tolerations   []v1.Toleration   `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
+	ExtraArgs     map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	TxtPrefix     string            `json:"txtPrefix,omitempty" yaml:"txtPrefix,omitempty"`
+	Aws           ExternalDnsAws    `json:"aws,omitempty" yaml:"aws,omitempty"`
+}
+
+type ExternalDnsRbac struct {
+	Create             bool   `json:"create,omitempty" yaml:"create,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
+	ApiVersion         string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	PspEnabled         bool   `json:"pspEnabled,omitempty" yaml:"pspEnabled,omitempty"`
+}
+
+type ExternalDnsImage struct {
+	Registry   string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Tag        string `json:"tag,omitempty" yaml:"tag,omitempty"`
+}
+
+type ExternalDnsAws struct {
+	Credentials     ExternalDnsAwsCredentials `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	Region          string                    `json:"region,omitempty" yaml:"region,omitempty"`
+	ZoneType        string                    `json:"zoneType,omitempty" yaml:"zoneType,omitempty"`
+	AssumeRoleArn   string                    `json:"assumeRoleArn,omitempty" yaml:"assumeRoleArn,omitempty"`
+	BatchChangeSize uint                      `json:"batchChangeSize,omitempty" yaml:"batchChangeSize,omitempty"`
+}
+
+type ExternalDnsAwsCredentials struct {
+	AccessKey string `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	SecretKey string `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
+}
 
 // GetBaseDomain returns the DNS base domain from [dns.domain] config. Changes the read domain to lowercase
 // to ensure it's DNS-1123 compliant

--- a/dns/route53/route53.go
+++ b/dns/route53/route53.go
@@ -482,8 +482,8 @@ func (dns *awsRoute53) unregisterDomain(orgId uint, domain string) error {
 	}
 
 	// delete route53 secret
-	secretItem, err := secret.Store.GetByName(orgId, IAMUserAccessKeySecretName)
-	if err != nil && err != secret.ErrSecretNotExists {
+	secretItem, err := dns.getRoute53Secret(orgId)
+	if err != nil {
 		dns.updateStateWithError(state, err)
 		return err
 	}

--- a/internal/federation/reconcile_ext_dns.go
+++ b/internal/federation/reconcile_ext_dns.go
@@ -20,6 +20,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/cluster"
 	pipConfig "github.com/banzaicloud/pipeline/config"
+	"github.com/banzaicloud/pipeline/dns"
 	"github.com/banzaicloud/pipeline/helm"
 	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/ghodss/yaml"
@@ -40,12 +41,6 @@ func (m *FederationReconciler) ReconcileExternalDNSController(desiredState Desir
 		return emperror.Wrap(err, "could not update ExternalDNS controller")
 	}
 	return nil
-}
-
-type ExtDNSParams struct {
-	Sources   []string          `json:"sources"`
-	ExtraArgs map[string]string `json:"extraArgs"`
-	TxtPrefix string            `json:"txtPrefix,omitempty"`
 }
 
 func (m *FederationReconciler) ensureCRDSourceForExtDNS(
@@ -83,7 +78,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 
 	crdPresent := false
 
-	currentValues := &ExtDNSParams{}
+	currentValues := &dns.ExternalDnsChartValues{}
 	err = yaml.Unmarshal([]byte(resp.Release.Config.Raw), &currentValues)
 	if err != nil {
 		return err
@@ -102,7 +97,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 		return nil
 	}
 
-	values := ExtDNSParams{
+	values := dns.ExternalDnsChartValues{
 		Sources: []string{
 			"service",
 			"ingress",
@@ -116,7 +111,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 	}
 
 	if desiredState == DesiredStateAbsent {
-		values = ExtDNSParams{
+		values = dns.ExternalDnsChartValues{
 			Sources: []string{
 				"service",
 				"ingress",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Upgrade external-dns to version 0.5.15.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The external-dns helm chart used by Pipeline was quite outdated which had no support for the latest version of external-dns components


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
