### PR TITLE
Fix: imported cluster can not be deleted if it's kubeconf is invalid

### DIFF
--- a/cluster/manager_delete.go
+++ b/cluster/manager_delete.go
@@ -206,7 +206,15 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 				LabelSelector: labels.Set{"owner": "pipeline"}.AsSelector().String(),
 			})
 			if err != nil {
-				return emperror.Wrap(err, "can not list namespaces")
+				err = emperror.Wrap(err, "can not list namespaces")
+
+				if !force {
+					cluster.SetStatus(pkgCluster.Error, err.Error())
+
+					return err
+				}
+
+				logger.Error(err)
 			}
 		}
 

--- a/internal/cluster/kubernetes/user_namespace_deleter.go
+++ b/internal/cluster/kubernetes/user_namespace_deleter.go
@@ -48,7 +48,7 @@ func (d UserNamespaceDeleter) Delete(organizationID uint, clusterName string, na
 		if nsList == nil {
 			nsList, err = client.CoreV1().Namespaces().List(metav1.ListOptions{})
 			if err != nil {
-				return emperror.Wrap(err, "could not list nsList to delete")
+				return emperror.Wrap(err, "could not list namespaces")
 			}
 		}
 
@@ -93,8 +93,7 @@ func (d UserNamespaceDeleter) Delete(organizationID uint, clusterName string, na
 			case "default", "kube-system", "kube-public":
 				continue
 			}
-
-			if len(namespaces.Items) > 0 {
+			if namespaces != nil && len(namespaces.Items) > 0 {
 				match := false
 				for _, ns := range namespaces.Items {
 					if remainingNamespace.Name == ns.Name {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In case of force delete remove imported cluster regardless if its kubeconfig is invalid or the  kubeconfig  relies on an external authenticator that is not available to Pipeline.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Imported clusters with invalid kubeconfig or kubeconfig that relies on an external authenticator that is not available to Pipeline can't be removed from Pipeline.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
