### PR TITLE
Validate KubeConf secret when added and when used at cluster import

### DIFF
--- a/secret/verify/common.go
+++ b/secret/verify/common.go
@@ -38,6 +38,8 @@ func NewVerifier(cloudType string, values map[string]string) Verifier {
 		return CreateGCPSecretVerifier(values)
 	case pkgCluster.Oracle:
 		return oracle.CreateOCISecret(values)
+	case pkgCluster.Kubernetes:
+		return CreateKubeConfigSecretVerifier(values)
 	default:
 		return nil
 	}

--- a/secret/verify/kubernetes.go
+++ b/secret/verify/kubernetes.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"encoding/base64"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	"github.com/banzaicloud/pipeline/pkg/secret"
+)
+
+type kubernetesConfigVerifier struct {
+	kubeConfigStr string
+}
+
+func (v *kubernetesConfigVerifier) VerifySecret() error {
+	if v.kubeConfigStr == "" {
+		return errors.New("no Kubernetes config provided")
+	}
+
+	kubeConfig, err := base64.StdEncoding.DecodeString(v.kubeConfigStr)
+	if err != nil {
+		return errors.WrapIf(err, "can't decode Kubernetes config")
+	}
+
+	clientSet, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
+	if err != nil {
+		return errors.WrapIf(err, "couldn't get Kubernetes client")
+	}
+
+	_, err = clientSet.ServerVersion()
+
+	return errors.WrapIf(err, "couldn't validate Kubernetes config")
+}
+
+// CreateKubeConfigSecretVerifier creates a verifier that checks if the provided KubeConfig
+// is valid by trying to execute simple operation (get api server version) using it
+func CreateKubeConfigSecretVerifier(values map[string]string) *kubernetesConfigVerifier {
+	return &kubernetesConfigVerifier{
+		kubeConfigStr: values[secret.K8SConfig],
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Validate Kubernetes config secret by trying to query API server version using it.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Kubernetes config passed to Pipeline might be syntactically correct while unusable in Pipeline's context for various reasons (e.g. it uses an external auth provider that is not available to Pipeline). The passed Kubernetes config must be verified that Pipeline can use it to interact with Kubernetes cluster references in the config.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

