### PR TITLE
fedv2: use latest rc3 chart, create rolebinding in case globalScope=f…

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -293,7 +293,8 @@ func main() {
 
 	cgroupAdapter := cgroupAdapter.NewClusterGetter(clusterManager)
 	clusterGroupManager := clustergroup.NewManager(cgroupAdapter, clustergroup.NewClusterGroupRepository(db, log), log, errorHandler)
-	federationHandler := federation.NewFederationHandler(cgroupAdapter, log, errorHandler)
+	infraNamespace := viper.GetString(config.PipelineSystemNamespace)
+	federationHandler := federation.NewFederationHandler(cgroupAdapter, infraNamespace, log, errorHandler)
 	deploymentManager := deployment.NewCGDeploymentManager(db, cgroupAdapter, log, errorHandler)
 	serviceMeshFeatureHandler := cgFeatureIstio.NewServiceMeshFeatureHandler(cgroupAdapter, log, errorHandler)
 	clusterGroupManager.RegisterFeatureHandler(federation.FeatureName, federationHandler)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -357,7 +357,7 @@ func init() {
 	viper.SetDefault(PrometheusServiceContext, "prometheus")
 	viper.SetDefault(PrometheusLocalPort, 9090)
 
-	viper.SetDefault(FederationChartVersion, "0.1.0-rc2")
+	viper.SetDefault(FederationChartVersion, "0.1.0-rc3")
 	viper.SetDefault(FederationChartName, "kubefed-charts/kubefed")
 
 	viper.SetDefault(DNSExternalDnsReleaseName, "dns")

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -57,6 +57,7 @@ type FederationReconciler struct {
 	ClusterGroupName string
 	Host             cluster.CommonCluster
 	Members          []cluster.CommonCluster
+	InfraNamespace   string
 
 	clusterGetter            api.ClusterGetter
 	logger                   logrus.FieldLogger
@@ -87,11 +88,12 @@ const (
 )
 
 // NewFederationReconciler crates a new feature reconciler for Federation
-func NewFederationReconciler(clusterGroupName string, config Config, clusterGetter api.ClusterGetter, logger logrus.FieldLogger, errorHandler emperror.Handler) *FederationReconciler {
+func NewFederationReconciler(clusterGroupName string, config Config, clusterGetter api.ClusterGetter, infraNamespace string, logger logrus.FieldLogger, errorHandler emperror.Handler) *FederationReconciler {
 	reconciler := &FederationReconciler{
 		Configuration:    config,
 		ClusterGroupName: clusterGroupName,
 		clusterGetter:    clusterGetter,
+		InfraNamespace:   infraNamespace,
 		logger:           logger,
 		errorHandler:     errorHandler,
 	}

--- a/internal/federation/reconcile.go
+++ b/internal/federation/reconcile.go
@@ -32,7 +32,12 @@ func (m *FederationReconciler) Reconcile() error {
 		}
 		// configure ext dns only if FederatedIngress or CrossClusterServiceDiscovery is enabled
 		if m.Configuration.FederatedIngress || m.Configuration.CrossClusterServiceDiscovery {
-			reconcilers = append(reconcilers, m.ReconcileCRBForExtDNS, m.ReconcileExternalDNSController)
+			if m.Configuration.GlobalScope {
+				reconcilers = append(reconcilers, m.ReconcileClusterRoleBindingForExtDNS)
+			} else {
+				reconcilers = append(reconcilers, m.ReconcileRoleBindingForExtDNS)
+			}
+			reconcilers = append(reconcilers, m.ReconcileExternalDNSController)
 		}
 	case DesiredStateAbsent:
 		reconcilers = []Reconciler{
@@ -41,7 +46,11 @@ func (m *FederationReconciler) Reconcile() error {
 			m.ReconcileFederatedTypes,
 			m.ReconcileController,
 			m.ReconcileExternalDNSController,
-			m.ReconcileCRBForExtDNS,
+		}
+		if m.Configuration.GlobalScope {
+			reconcilers = append(reconcilers, m.ReconcileClusterRoleBindingForExtDNS)
+		} else {
+			reconcilers = append(reconcilers, m.ReconcileRoleBindingForExtDNS)
 		}
 	}
 

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -305,7 +305,7 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 	env := helm.GenerateHelmRepoEnv(org.Name)
 	_, err = helm.ReposAdd(env, &repo.Entry{
 		Name: "kubefed-charts",
-		URL:  "https://raw.githubusercontent.com/banzaicloud/kubefed/master/charts",
+		URL:  "https://raw.githubusercontent.com/banzaicloud/kubefed/helm_chart/charts",
 	})
 	if err != nil {
 		return emperror.WrapWith(err, "failed to add kube-chart repo")


### PR DESCRIPTION
…alse

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0

### What's in this PR?
- use latest rc3 chart, from a tag
- create rolebinding instead of clusterrolebindig for externalDns in case of namespace scoped fed control plane (globalScope=false)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)