### PR TITLE
circleci: fix install dependencies step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     build:
         docker:
             -
-                image: circleci/golang:1.12
+                image: circleci/golang:1.12-stretch
                 environment:
                     GOFLAG: -mod=readonly
             -
@@ -47,7 +47,9 @@ jobs:
             -
                 run:
                     name: Install build dependencies
-                    command: sudo apt-get install -y mysql-client mysql-utilities postgresql-client
+                    command: |
+                      sudo apt-get update
+                      sudo apt-get install -y mysql-client mysql-utilities postgresql-client
 
             -
                 save_cache:


### PR DESCRIPTION
https://discuss.circleci.com/t/docker-convenience-images-updates-july-2019/31239

> The apt-get index cache is no longer present in images. If your image uses sudo apt-get install, after this update it will fail unless you first run sudo apt-get update. It’s often best to do is do this all in one command—for example, sudo apt-get update && sudo apt-get install <my-package>.

> Debian 10-based images. Debian 10 “Buster” was released on July 6th. For our images that offer variant distros, -buster will be an option.