### PR TITLE
authn: cleaner error handling during login/register

### DIFF
--- a/auth/util.go
+++ b/auth/util.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/banzaicloud/pipeline/config"
+	"github.com/banzaicloud/pipeline/pkg/common"
+	"github.com/gin-gonic/gin/render"
 	"github.com/jinzhu/gorm"
 	"github.com/spf13/viper"
 )
@@ -69,4 +71,11 @@ func GormErrorToStatusCode(err error) int {
 		return http.StatusNotFound
 	}
 	return http.StatusInternalServerError
+}
+
+func httpJSONError(w http.ResponseWriter, err error, code int) {
+	render := render.JSON{Data: common.ErrorResponse{Error: err.Error()}}
+	render.WriteContentType(w)
+	w.WriteHeader(code)
+	render.Render(w)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Error messages are cleanly returned as JSON now.
```json
{
  "error": "failed to query github login name: GET https://api.github.com/user/23779: 401 Bad credentials []"
}
```

Also, deregister call got added back (this was broken since the Dex migration).

### Why?
These messages were propagated through flash messages but sometimes they got lost or got scrambled in a bad HTML page, and the user didn't know why the login failed. This response is much cleaner and straightforward.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
