### PR TITLE
Add nsswitch.conf to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ FROM alpine:3.9
 
 RUN apk add --update --no-cache ca-certificates tzdata bash curl
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 SHELL ["/bin/bash", "-c"]
 
 COPY --from=builder /go/bin/aws-iam-authenticator /usr/bin/

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -16,6 +16,10 @@ FROM alpine:3.9
 
 RUN apk add --update --no-cache ca-certificates tzdata bash curl libc6-compat
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 SHELL ["/bin/bash", "-c"]
 
 COPY --from=builder /go/bin/aws-iam-authenticator /usr/bin/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -14,6 +14,10 @@ FROM alpine:3.9
 
 RUN apk add --update --no-cache ca-certificates tzdata bash curl
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 SHELL ["/bin/bash", "-c"]
 
 COPY --from=builder /go/bin/aws-iam-authenticator /usr/bin/


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Fixes Go's netgo implementation when running on Alpine.


### Why?

There is no default `nsswitch.conf` on Alpine.


### Additional context

https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
