### PR TITLE
Fix: type parameter is missing from default storage class on ACK

### DIFF
--- a/cluster/ack.go
+++ b/cluster/ack.go
@@ -468,9 +468,7 @@ func (c *ACKCluster) CreateCluster() error {
 	}
 
 	// create default storage class
-	// TODO change this storagev1.VolumeBindingImmediate to storagev1.VolumeBindingWaitForFirstConsumer
-	// when Alibaba supports this feature
-	err = createDefaultStorageClass(kubeClient, "alicloud/disk", storagev1.VolumeBindingImmediate)
+	err = createDefaultStorageClass(kubeClient, "alicloud/disk", storagev1.VolumeBindingWaitForFirstConsumer, map[string]string{"type": "cloud_efficiency"})
 	if err != nil {
 		return emperror.With(err, "cluster", c.modelCluster.Name)
 	}

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -321,7 +321,7 @@ func (c *EKSCluster) CreateCluster() error {
 
 	if storageClassConstraint.Check(kubeVersion) {
 		// create default storage class
-		err = createDefaultStorageClass(kubeClient, "kubernetes.io/aws-ebs", volumeBindingMode)
+		err = createDefaultStorageClass(kubeClient, "kubernetes.io/aws-ebs", volumeBindingMode, nil)
 		if err != nil {
 			return emperror.WrapWith(err, "failed to create default storage class",
 				"provisioner", "kubernetes.io/aws-ebs",

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -109,7 +109,7 @@ func (c *KubeCluster) Persist() error {
 
 // createDefaultStorageClass creates a default storage class as some clusters are not created with
 // any storage classes or with default one
-func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provisioner string, volumeBindingMode storagev1.VolumeBindingMode) error {
+func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provisioner string, volumeBindingMode storagev1.VolumeBindingMode, parameters map[string]string) error {
 	defaultStorageClass := storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
@@ -119,6 +119,7 @@ func createDefaultStorageClass(kubernetesClient *kubernetes.Clientset, provision
 		},
 		VolumeBindingMode: &volumeBindingMode,
 		Provisioner:       provisioner,
+		Parameters:        parameters,
 	}
 
 	_, err := kubernetesClient.StorageV1().StorageClasses().Create(&defaultStorageClass)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
