### PR TITLE
Fix dialect config

### DIFF
--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -133,9 +133,10 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.RegisterAlias("errorHandler.serviceVersion", "appVersion")
 
 	// Pipeline configuration
-	viper.SetDefault("pipeline.basePath", "")
+	v.SetDefault("pipeline.basePath", "")
 
 	// Database configuration
+	v.SetDefault("database.dialect", "mysql")
 	_ = v.BindEnv("database.host")
 	v.SetDefault("database.port", 3306)
 	_ = v.BindEnv("database.user")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Fix missing dialect in worker config.


### Why?

Worker uses it's own Viper instance. Every configuration parameter must be registered in it's instance as well.
