### PR TITLE
Fix in-cluster Kubernetes client

### DIFF
--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -52,10 +52,15 @@ func NewClientFromKubeConfig(kubeConfig []byte) (*kubernetes.Clientset, error) {
 func NewInClusterClient() (*kubernetes.Clientset, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, emperror.Wrap(err, "failed to fetch in-cluster configuration")
+		return nil, errors.Wrap(err, "failed to fetch in-cluster configuration")
 	}
 
-	return NewClientFromConfig(config)
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client for config")
+	}
+
+	return client, nil
 }
 
 // globallyRoutable decides if an address is a globally routable IPv4 address


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR fixes in-cluster k8s clients.


### Why?

The new k8s client helper methods introduced IP filtering to limit
where the client can connect.

In case of in-cluster clients however this is not necessary.
