### PR TITLE
spotguide: scrape shared spotguides in cron workflow

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -433,7 +433,6 @@ func main() {
 		scmFactory,
 		sharedSpotguideOrg,
 		spotguidePlatformData,
-		workflowClient,
 	)
 
 	// subscribe to organization creations and sync spotguides into the newly created organizations
@@ -449,7 +448,7 @@ func main() {
 	})
 
 	// periodically sync shared spotguides
-	if err := spotguideManager.ScheduleScrapingSharedSpotguides(); err != nil {
+	if err := spotguide.ScheduleScrapingSharedSpotguides(workflowClient); err != nil {
 		errorHandler.Handle(errors.WrapIf(err, "failed to schedule syncing shared spotguides"))
 	}
 

--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -156,4 +156,13 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cadence.domain", "pipeline")
 	v.SetDefault("cadence.createNonexistentDomain", false)
 	v.SetDefault("cadence.workflowExecutionRetentionPeriodInDays", 3)
+
+	// Spotguide configuration
+	_ = v.BindEnv("github.token")
+	_ = v.BindEnv("gitlab.token")
+	v.SetDefault("cicd.scm", "github")
+	v.SetDefault("spotguide.syncInterval", 15*time.Minute)
+	v.SetDefault("spotguide.allowPrereleases", false)
+	v.SetDefault("spotguide.allowPrivateRepos", false)
+	v.SetDefault("spotguide.sharedLibraryGitHubOrganization", "spotguides")
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -209,8 +209,9 @@ func main() {
 		generateCertificatesActivity := pkeworkflow.NewGenerateCertificatesActivity(clusterSecretStore)
 		activity.RegisterWithOptions(generateCertificatesActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.GenerateCertificatesActivityName})
 
-		scrapeSharedSpotguidesWorkflow := spotguide.NewScrapeSharedSpotguidesWorkflow(spotguideManager)
-		workflow.RegisterWithOptions(scrapeSharedSpotguidesWorkflow.Execute, workflow.RegisterOptions{Name: spotguide.ScrapeSharedSpotguidesWorkflowName})
+		scrapeSharedSpotguidesActivity := spotguide.NewScrapeSharedSpotguidesActivity(spotguideManager)
+		workflow.RegisterWithOptions(spotguide.ScrapeSharedSpotguidesWorkflow, workflow.RegisterOptions{Name: spotguide.ScrapeSharedSpotguidesWorkflowName})
+		activity.RegisterWithOptions(scrapeSharedSpotguidesActivity.Execute, activity.RegisterOptions{Name: spotguide.ScrapeSharedSpotguidesActivityName})
 
 		createDexClientActivity := pkeworkflow.NewCreateDexClientActivity(clusters, clusterAuthService)
 		activity.RegisterWithOptions(createDexClientActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.CreateDexClientActivityName})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -196,7 +196,6 @@ func main() {
 			scmFactory,
 			nil,
 			spotguide.PlatformData{},
-			nil,
 		)
 
 		// Register amazon specific workflows and activities

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -311,7 +311,7 @@ func init() {
 
 	viper.SetDefault(SpotguideAllowPrereleases, false)
 	viper.SetDefault(SpotguideAllowPrivateRepos, false)
-	viper.SetDefault(SpotguideSyncInterval, 5*time.Minute)
+	viper.SetDefault(SpotguideSyncInterval, 15*time.Minute)
 	viper.SetDefault(SpotguideSharedLibraryGitHubOrganization, "spotguides")
 
 	viper.SetDefault("issue.type", "github")

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -137,7 +137,6 @@ type SpotguideManager struct {
 	scmFactory                scm.SCMFactory
 	sharedLibraryOrganization *auth.Organization
 	platformData              PlatformData
-	workflowClient            cadenceClient.Client
 }
 
 func EnsureSharedSpotguideOrganization(db *gorm.DB, scm string, sharedLibraryOrganization string) (*auth.Organization, error) {

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -17,9 +17,9 @@ package spotguide
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -36,6 +36,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
+	cadenceClient "go.uber.org/cadence/client"
 	"gopkg.in/yaml.v2"
 
 	"github.com/banzaicloud/pipeline/auth"
@@ -136,9 +137,10 @@ type SpotguideManager struct {
 	scmFactory                scm.SCMFactory
 	sharedLibraryOrganization *auth.Organization
 	platformData              PlatformData
+	workflowClient            cadenceClient.Client
 }
 
-func CreateSharedSpotguideOrganization(db *gorm.DB, scm string, sharedLibraryOrganization string) (*auth.Organization, error) {
+func EnsureSharedSpotguideOrganization(db *gorm.DB, scm string, sharedLibraryOrganization string) (*auth.Organization, error) {
 	// insert shared organization to DB if not exists
 	var sharedOrg *auth.Organization
 
@@ -161,6 +163,7 @@ func NewSpotguideManager(
 	scmFactory scm.SCMFactory,
 	sharedLibraryOrganization *auth.Organization,
 	platformData PlatformData,
+	workflowClient cadenceClient.Client,
 ) *SpotguideManager {
 	pipelineVersion, _ := semver.NewVersion(pipelineVersionString)
 
@@ -170,6 +173,7 @@ func NewSpotguideManager(
 		scmFactory:                scmFactory,
 		sharedLibraryOrganization: sharedLibraryOrganization,
 		platformData:              platformData,
+		workflowClient:            workflowClient,
 	}
 }
 
@@ -198,14 +202,29 @@ func (s *SpotguideManager) isSpotguideReleaseAllowed(release scm.RepositoryRelea
 	return supported && (!prerelease || viper.GetBool(config.SpotguideAllowPrereleases))
 }
 
-func (s *SpotguideManager) ScrapeSharedSpotguides() error {
-	if s.sharedLibraryOrganization == nil {
-		return fmt.Errorf("failed to scrape shared spotguides")
+func (s *SpotguideManager) ScheduleScrapingSharedSpotguides() error {
+	workflowOptions := cadenceClient.StartWorkflowOptions{
+		ID:                           ScrapeSharedSpotguidesWorkflowName,
+		WorkflowIDReusePolicy:        cadenceClient.WorkflowIDReusePolicyAllowDuplicate,
+		TaskList:                     "pipeline",
+		ExecutionStartToCloseTimeout: 15 * time.Minute,
+		CronSchedule:                 "@every " + viper.GetDuration(config.SpotguideSyncInterval).String(),
 	}
+	_, err := s.workflowClient.StartWorkflow(context.Background(), workflowOptions, ScrapeSharedSpotguidesWorkflowName)
+	return err
+}
 
+func (s *SpotguideManager) scrapeSharedSpotguides() error {
 	sharedSCM, err := s.scmFactory.CreateSharedSCM()
 	if err != nil {
 		return emperror.Wrap(err, "failed to create SCM client")
+	}
+
+	if s.sharedLibraryOrganization == nil {
+		s.sharedLibraryOrganization, err = EnsureSharedSpotguideOrganization(s.db, viper.GetString("cicd.scm"), viper.GetString(config.SpotguideSharedLibraryGitHubOrganization))
+		if err != nil {
+			return emperror.Wrap(err, "failed to query shared spotguide organization")
+		}
 	}
 
 	return s.scrapeSpotguides(s.sharedLibraryOrganization, sharedSCM)
@@ -324,20 +343,16 @@ func (s *SpotguideManager) scrapeSpotguides(org *auth.Organization, scm scm.SCM)
 }
 
 func (s *SpotguideManager) GetSpotguides(orgID uint) (spotguides []*SpotguideRepo, err error) {
-	query := s.db.Where(SpotguideRepo{OrganizationID: orgID})
-	if s.sharedLibraryOrganization != nil {
-		query = query.Or(SpotguideRepo{OrganizationID: s.sharedLibraryOrganization.ID})
-	}
+	query := s.db.Where(SpotguideRepo{OrganizationID: orgID}).
+		Or(SpotguideRepo{OrganizationID: s.sharedLibraryOrganization.ID})
 
 	err = query.Find(&spotguides).Error
 	return spotguides, err
 }
 
 func (s *SpotguideManager) GetSpotguide(orgID uint, name, version string) (*SpotguideRepo, error) {
-	query := s.db.Where(SpotguideRepo{OrganizationID: orgID, Name: name, Version: version})
-	if s.sharedLibraryOrganization != nil {
-		query = query.Or(SpotguideRepo{OrganizationID: s.sharedLibraryOrganization.ID, Name: name, Version: version})
-	}
+	query := s.db.Where(SpotguideRepo{OrganizationID: orgID, Name: name, Version: version}).
+		Or(SpotguideRepo{OrganizationID: s.sharedLibraryOrganization.ID, Name: name, Version: version})
 
 	spotguide := SpotguideRepo{}
 	err := query.First(&spotguide).Error

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -163,7 +163,6 @@ func NewSpotguideManager(
 	scmFactory scm.SCMFactory,
 	sharedLibraryOrganization *auth.Organization,
 	platformData PlatformData,
-	workflowClient cadenceClient.Client,
 ) *SpotguideManager {
 	pipelineVersion, _ := semver.NewVersion(pipelineVersionString)
 
@@ -173,7 +172,6 @@ func NewSpotguideManager(
 		scmFactory:                scmFactory,
 		sharedLibraryOrganization: sharedLibraryOrganization,
 		platformData:              platformData,
-		workflowClient:            workflowClient,
 	}
 }
 
@@ -202,7 +200,7 @@ func (s *SpotguideManager) isSpotguideReleaseAllowed(release scm.RepositoryRelea
 	return supported && (!prerelease || viper.GetBool(config.SpotguideAllowPrereleases))
 }
 
-func (s *SpotguideManager) ScheduleScrapingSharedSpotguides() error {
+func ScheduleScrapingSharedSpotguides(workflowClient cadenceClient.Client) error {
 	workflowOptions := cadenceClient.StartWorkflowOptions{
 		ID:                           ScrapeSharedSpotguidesWorkflowName,
 		WorkflowIDReusePolicy:        cadenceClient.WorkflowIDReusePolicyAllowDuplicate,
@@ -210,7 +208,7 @@ func (s *SpotguideManager) ScheduleScrapingSharedSpotguides() error {
 		ExecutionStartToCloseTimeout: 15 * time.Minute,
 		CronSchedule:                 "@every " + viper.GetDuration(config.SpotguideSyncInterval).String(),
 	}
-	_, err := s.workflowClient.StartWorkflow(context.Background(), workflowOptions, ScrapeSharedSpotguidesWorkflowName)
+	_, err := workflowClient.StartWorkflow(context.Background(), workflowOptions, ScrapeSharedSpotguidesWorkflowName)
 	return err
 }
 

--- a/spotguide/sync_spotguides_workflow.go
+++ b/spotguide/sync_spotguides_workflow.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spotguide
+
+import (
+	"emperror.dev/emperror"
+	"go.uber.org/cadence/workflow"
+)
+
+const ScrapeSharedSpotguidesWorkflowName = "scrape-shared-spotguides"
+
+type ScrapeSharedSpotguidesWorkflow struct {
+	manager *SpotguideManager
+}
+
+type ClusterDNSRecordsDeleter interface {
+	Delete(organizationID uint, clusterUID string) error
+}
+
+func NewScrapeSharedSpotguidesWorkflow(manager *SpotguideManager) ScrapeSharedSpotguidesWorkflow {
+	return ScrapeSharedSpotguidesWorkflow{
+		manager: manager,
+	}
+}
+
+func (a ScrapeSharedSpotguidesWorkflow) Execute(ctx workflow.Context) error {
+	return emperror.Wrap(a.manager.scrapeSharedSpotguides(), "failed to scrape shared spotguides")
+}

--- a/spotguide/sync_spotguides_workflow.go
+++ b/spotguide/sync_spotguides_workflow.go
@@ -44,7 +44,6 @@ func ScrapeSharedSpotguidesWorkflow(ctx workflow.Context) error {
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Minute,
 		StartToCloseTimeout:    10 * time.Minute,
-		ScheduleToCloseTimeout: 15 * time.Minute,
 		WaitForCancellation:    true,
 	}
 

--- a/spotguide/sync_spotguides_workflow.go
+++ b/spotguide/sync_spotguides_workflow.go
@@ -25,10 +25,6 @@ type ScrapeSharedSpotguidesWorkflow struct {
 	manager *SpotguideManager
 }
 
-type ClusterDNSRecordsDeleter interface {
-	Delete(organizationID uint, clusterUID string) error
-}
-
 func NewScrapeSharedSpotguidesWorkflow(manager *SpotguideManager) ScrapeSharedSpotguidesWorkflow {
 	return ScrapeSharedSpotguidesWorkflow{
 		manager: manager,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/pipeline/issues/2158
| License         | Apache 2.0


### What's in this PR?
Instead of a Go routine shared spotguides are scraped now in a Cadence Cron Workflow.

### Why?
More elegant, and when in running in HA mode - more correct. :)


### Additional context
Currently the first decision task fails in a CronWorkflow, but then it finishes properly.
There is a pending issue in Cadence: uber/cadence#2100


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
