### PR TITLE
Use goproxy in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,17 +34,8 @@ jobs:
                         - build-deps-v1-{{ .Branch }}-{{ checksum "Makefile" }}
 
             -
-                restore_cache:
-                    name: Restore Go module cache
-                    keys:
-                        - gomod-v1-{{ .Branch }}-{{ checksum "go.sum" }}
-                        - gomod-v1-{{ .Branch }}
-                        - gomod-v1-master
-                        - gomod-v1
-
-            -
                 run:
-                    name: Download Go module cache
+                    name: Download Go modules
                     command: go mod download
 
             -
@@ -53,13 +44,6 @@ jobs:
                     command: |
                       sudo apt-get update
                       sudo apt-get install -y mysql-client mysql-utilities postgresql-client
-
-            -
-                save_cache:
-                    name: Save Go module cache
-                    key: gomod-v1-{{ .Branch }}-{{ checksum "go.sum" }}
-                    paths:
-                        - /go/pkg/mod
 
             -
                 restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
                 environment:
                     GOFLAG: -mod=readonly
                     GOCACHE: "/tmp/go/cache"
+                    GOPROXY: https://proxy.golang.org
             -
                 image: mysql:5.7
                 command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Try to use a GOPROXY in the circle build and possibly replace the go module cache.


### Why?

To speed up the build.
