### PR TITLE
Fix non-deterministic map iterations in Cadence workflows

### DIFF
--- a/internal/providers/pke/pkeworkflow/update_cluster.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster.go
@@ -102,7 +102,9 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 
 		errs := make([]error, len(futures))
 		for i, future := range futures {
-			errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't delete node pool %q", input.NodePoolsToDelete[i].Name)
+			if future != nil {
+				errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't delete node pool %q", input.NodePoolsToDelete[i].Name)
+			}
 		}
 
 		if err := errors.Combine(errs...); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2155
| License         | Apache 2.0


### What's in this PR?
Future map structures are converted to slices to ensure iterations are deterministic.


### Additional context

In some cases the implementation itself was affected. Please take that into account when reviewing.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

~~- [-] Implementation tested (with at least one cloud provider)~~
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
