### PR TITLE
Fix: delete PKE on AWS cluster failes due to nil pointer dereference

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -63,7 +63,9 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 		errs := make([]error, len(futures))
 		for i, future := range futures {
-			errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't terminate node pool %q", nodePools[i].Name)
+			if future != nil {
+				errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't terminate node pool %q", nodePools[i].Name)
+			}
 		}
 
 		if err := errors.Combine(errs...); err != nil {
@@ -97,7 +99,9 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 		errs := make([]error, len(futures))
 		for i, future := range futures {
-			errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't terminate node pool %q", nodePools[i].Name)
+			if future != nil {
+				errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't terminate node pool %q", nodePools[i].Name)
+			}
 		}
 
 		if err := errors.Combine(errs...); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
