### PR TITLE
fedv2: use latest patched version of rc5 image

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -184,6 +184,8 @@ const (
 
 	FederationChartVersion = "federation.chartVersion"
 	FederationChartName    = "federation.chartName"
+	FederationImageTag     = "federation.imageTag"
+	FederationImageRepo    = "federation.imageRepo"
 
 	DomainHookEnabled = "hooks.domainHookEnabled"
 )
@@ -360,8 +362,10 @@ func init() {
 	viper.SetDefault(PrometheusServiceContext, "prometheus")
 	viper.SetDefault(PrometheusLocalPort, 9090)
 
-	viper.SetDefault(FederationChartVersion, "0.1.0-rc3")
+	viper.SetDefault(FederationChartVersion, "0.1.0-rc5")
 	viper.SetDefault(FederationChartName, "kubefed-charts/kubefed")
+	viper.SetDefault(FederationImageTag, "banzaicloud")
+	viper.SetDefault(FederationImageRepo, "v0.1.0-rc5-bzc.1")
 
 	viper.SetDefault(DNSExternalDnsReleaseName, "dns")
 	viper.SetDefault(DNSExternalDnsChartName, "stable/external-dns")

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/kisielk/errcheck v1.2.0 // indirect
 	github.com/kisielk/gotool v1.0.0 // indirect
-	github.com/kubernetes-sigs/kubefed v0.1.0-rc2
+	github.com/kubernetes-sigs/kubefed v0.1.0-rc5
 	github.com/lestrrat-go/backoff v0.0.0-20190107202757-0bc2a4274cd0
 	github.com/microcosm-cc/bluemonday v0.0.0-20180327211928-995366fdf961
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
@@ -155,12 +155,12 @@ require (
 	k8s.io/kubectl v0.0.0-20190523211420-5b63b0fd89bb // indirect
 	k8s.io/kubernetes v1.13.5
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da // indirect
-	sigs.k8s.io/kubefed v0.1.0-rc2
+	sigs.k8s.io/kubefed v0.1.0-rc5
 	vbom.ml/util v0.0.0-20170409195630-256737ac55c4 // indirect
 )
 
 replace (
-	github.com/kubernetes-sigs/kubefed => github.com/kubernetes-sigs/kubefed v0.1.0-rc2
+	github.com/kubernetes-sigs/kubefed => github.com/kubernetes-sigs/kubefed v0.1.0-rc5
 	github.com/qor/auth v0.0.0-20190103025640-46aae9fa92fa => github.com/banzaicloud/auth v0.1.3
 	gopkg.in/yaml.v2 => github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182
 
@@ -172,5 +172,5 @@ replace (
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20190325194458-f2b4781c3ae1
 	k8s.io/client-go => k8s.io/client-go v10.0.0+incompatible
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4
-	sigs.k8s.io/kubefed => sigs.k8s.io/kubefed v0.1.0-rc2
+	sigs.k8s.io/kubefed => sigs.k8s.io/kubefed v0.1.0-rc5
 )

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-sigs/kubefed v0.1.0-rc2 h1:F+Mc4VHKrrgyuf+LxUVj3b5g+v2rfcscFCqztlQ4tF8=
 github.com/kubernetes-sigs/kubefed v0.1.0-rc2/go.mod h1:nPkYUhlYxO0WBozg6wMjCLNzmhVFQ3tprNXczC5qc8E=
+github.com/kubernetes-sigs/kubefed v0.1.0-rc5 h1:h2RNPoajNkmZSDRNFmOO9z7i3vH9H9sC7mc1zQPRvZ4=
+github.com/kubernetes-sigs/kubefed v0.1.0-rc5/go.mod h1:nPkYUhlYxO0WBozg6wMjCLNzmhVFQ3tprNXczC5qc8E=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lestrrat-go/backoff v0.0.0-20190107202757-0bc2a4274cd0 h1:42NOlmEjGA3qZ1qSWc/QVFo0DuVXG1zewVXFMZj+ZLs=
 github.com/lestrrat-go/backoff v0.0.0-20190107202757-0bc2a4274cd0/go.mod h1:CNQaGVRTtvkLlWshyDozYy79pBflEOWskqCMSxLTfQ0=
@@ -1042,6 +1044,8 @@ sigs.k8s.io/controller-runtime v0.1.10 h1:amLOmcekVdnsD1uIpmgRqfTbQWJ2qxvQkcdeFh
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/kubefed v0.1.0-rc2 h1:7rX/BH5OFZq6nP42SEHs2i8uQKPfN09FWMkOyr3nf0g=
 sigs.k8s.io/kubefed v0.1.0-rc2/go.mod h1:V1YuAhi6d/zPg61MydwJWsV2z04K749Mvm3g2tx1M7E=
+sigs.k8s.io/kubefed v0.1.0-rc5 h1:RKT/wiOC3hPUXb82jHJJwqeNF9pWKdW9uVEcwVqMvs4=
+sigs.k8s.io/kubefed v0.1.0-rc5/go.mod h1:V1YuAhi6d/zPg61MydwJWsV2z04K749Mvm3g2tx1M7E=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -72,7 +72,7 @@ type DesiredState string
 
 const (
 	federationReleaseName = "federationv2"
-	federationCRDSuffix   = "kubefed.k8s.io"
+	federationCRDSuffix   = "kubefed.io"
 
 	DesiredStatePresent DesiredState = "present"
 	DesiredStateAbsent  DesiredState = "absent"
@@ -83,7 +83,7 @@ const (
 	clusterLabelLocation     = "location"
 	clusterLabelGroupName    = "groupName"
 
-	multiClusterGroup        = "multiclusterdns.kubefed.k8s.io"
+	multiClusterGroup        = "multiclusterdns.kubefed.io"
 	multiClusterGroupVersion = "v1alpha1"
 )
 

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -278,11 +278,15 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 		federatedIngress = "Disabled"
 	}
 
+	fedImageTag := viper.GetString(pConfig.FederationImageTag)
+	fedImageRepo := viper.GetString(pConfig.FederationImageRepo)
 	values := map[string]interface{}{
 		"global": map[string]interface{}{
 			"scope": scope,
 		},
 		"controllermanager": map[string]interface{}{
+			"repository": fedImageTag,
+			"tag":        fedImageRepo,
 			"featureGates": map[string]interface{}{
 				"SchedulerPreferences":         schedulerPreferences,
 				"CrossClusterServiceDiscovery": crossClusterServiceDiscovery,

--- a/internal/federation/reconcile_dns_cluster_role.go
+++ b/internal/federation/reconcile_dns_cluster_role.go
@@ -23,8 +23,6 @@ import (
 	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
-const kubefedDnsAPIGroup = "multiclusterdns.kubefed.k8s.io"
-
 func (m *FederationReconciler) ReconcileClusterRoleForExtDNS(desiredState DesiredState) error {
 	if desiredState == DesiredStatePresent {
 		err := m.createClusterRoleForExternalDNS()
@@ -72,7 +70,7 @@ func (m *FederationReconciler) createClusterRoleForExternalDNS() error {
 		},
 		Rules: []v1.PolicyRule{
 			{
-				APIGroups: []string{kubefedDnsAPIGroup},
+				APIGroups: []string{multiClusterGroup},
 				Resources: []string{v1.ResourceAll},
 				Verbs:     []string{"get", "watch", "list", "create", "update"},
 			},

--- a/internal/federation/reconcile_ext_dns.go
+++ b/internal/federation/reconcile_ext_dns.go
@@ -15,6 +15,7 @@
 package federation
 
 import (
+	"fmt"
 	"strings"
 
 	"emperror.dev/emperror"
@@ -105,7 +106,7 @@ func (m *FederationReconciler) ensureCRDSourceForExtDNS(
 			"crd",
 		},
 		ExtraArgs: map[string]string{
-			"crd-source-apiversion": "multiclusterdns.kubefed.k8s.io/v1alpha1",
+			"crd-source-apiversion": fmt.Sprintf("%s/%s", multiClusterGroup, multiClusterGroupVersion),
 			"crd-source-kind":       "DNSEndpoint",
 		},
 		TxtPrefix: "cname",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| License         | Apache 2.0


### What's in this PR?
Use latest patched kubefed image: v0.1.0-rc5-bzc.1 from banzai repo. Change group names of federated objects (from: kubefed.k8s.io --> kubefed.io) to align with latest changes.


### Why?
ReplicaSchedulingPreference is not working correctly in v0.1.0-rc5.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)


