### PR TITLE
Support both 'release' and 'app.kubernetes.io/instance' labels to link objects to Helm releases

### DIFF
--- a/api/custom.go
+++ b/api/custom.go
@@ -261,7 +261,7 @@ func getIngressReleaseName(backend v1beta1.IngressBackend, serviceList *v1.Servi
 	serviceName := backend.ServiceName
 	for _, service := range serviceList.Items {
 		if service.Name == serviceName {
-			return service.Labels["release"]
+			return pkgHelm.GetHelmReleaseName(service.Labels)
 		}
 	}
 	return "No release name for this ingress."

--- a/api/custom_test.go
+++ b/api/custom_test.go
@@ -141,7 +141,7 @@ var (
 		Items: []v1.Service{{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name:   "serviceForIngress",
-				Labels: map[string]string{"release": dummyReleaseName},
+				Labels: map[string]string{pkgHelm.HelmReleaseNameLabel: dummyReleaseName},
 			},
 		},
 		},

--- a/api/security.go
+++ b/api/security.go
@@ -20,16 +20,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
-
-	"regexp"
 
 	"github.com/banzaicloud/anchore-image-validator/pkg/apis/security/v1alpha1"
 	clientV1alpha1 "github.com/banzaicloud/anchore-image-validator/pkg/clientset/v1alpha1"
 	"github.com/banzaicloud/pipeline/helm"
 	anchore "github.com/banzaicloud/pipeline/internal/security"
 	"github.com/banzaicloud/pipeline/pkg/common"
+	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/security"
 	"github.com/gin-gonic/gin"
@@ -538,12 +538,12 @@ func GetImageDeployments(c *gin.Context) {
 	for _, p := range pods {
 		for _, status := range p.Status.ContainerStatuses {
 			if getImageDigest(status.ImageID) == imageDigest {
-				releaseMap[p.Labels["release"]] = true
+				releaseMap[pkgHelm.GetHelmReleaseName(p.Labels)] = true
 			}
 		}
 		for _, status := range p.Status.InitContainerStatuses {
 			if getImageDigest(status.ImageID) == imageDigest {
-				releaseMap[p.Labels["release"]] = true
+				releaseMap[pkgHelm.GetHelmReleaseName(p.Labels)] = true
 			}
 		}
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -36,6 +36,26 @@ const (
 
 const releaseNameMaxLen = 53
 
+// the label Helm places on Kubernetes objects for differentiating between
+// different instances: https://helm.sh/docs/chart_best_practices/#standard-labels
+const HelmReleaseNameLabelLegacy = "release"
+const HelmReleaseNameLabel = "app.kubernetes.io/instance"
+
+// GetHelmReleaseName returns the helm release name placed by helm deployment Kubernetes objects
+// it checks for label with key `HelmReleaseNameLabel`, if no such label is present than falls back
+// the legacy label key
+func GetHelmReleaseName(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+
+	if labels[HelmReleaseNameLabel] != "" {
+		return labels[HelmReleaseNameLabel]
+	}
+
+	return labels[HelmReleaseNameLabelLegacy]
+}
+
 // Install describes an Helm install request
 type Install struct {
 	// Name of the kubeconfig context to use


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Consider beside label 'release' also 'app.kubernetes.io/instance' when trying to determine which helm release a Kubernetes resource belongs to.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Most of the helm charts use 'release' label to stamp a Kubernetes resource with the Helm release name. According to  https://helm.sh/docs/chart_best_practices/#standard-labels, the new recommendation is to use 'app.kubernetes.io/instance' thus Pipeline should handle both.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
