### PR TITLE
Fix UUID resource label

### DIFF
--- a/internal/global/uuid.go
+++ b/internal/global/uuid.go
@@ -21,7 +21,7 @@ import (
 
 type AwsTag string
 
-const ManagedByPipelineTag = "banzaicloud.io/pipeline/uuid"
+const ManagedByPipelineTag = "banzaicloud-pipeline-uuid"
 
 // PipelineUUID returns an UUID that identifies the specific installation (deployment) of the platform.
 // If UUID is not available, empty string is returned instead of generating a random one, because no UUID is better than one that always changes.

--- a/internal/providers/azure/pke/workflow/create_lb_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_lb_activity_test.go
@@ -161,7 +161,7 @@ func TestGetCreateOrUpdateLoadBalancerParams(t *testing.T) {
 			},
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 		}
 

--- a/internal/providers/azure/pke/workflow/create_nsg_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_nsg_activity_test.go
@@ -96,7 +96,7 @@ func TestGetCreateOrUpdateSecurityGroupParams(t *testing.T) {
 			},
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 		}
 		result := input.getCreateOrUpdateSecurityGroupParams()

--- a/internal/providers/azure/pke/workflow/create_public_ip_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_public_ip_activity_test.go
@@ -46,7 +46,7 @@ func TestGetCreateOrUpdatePublicIPAddressParams(t *testing.T) {
 			},
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 		}
 		result := input.getCreateOrUpdatePublicIPAddressParams()

--- a/internal/providers/azure/pke/workflow/create_route_table_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_route_table_activity_test.go
@@ -38,7 +38,7 @@ func TestGetCreateOrUpdateRouteTableParams(t *testing.T) {
 			Location: to.StringPtr("test-location"),
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 		}
 		result := input.getCreateOrUpdateRouteTableParams()

--- a/internal/providers/azure/pke/workflow/create_vmss_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_vmss_activity_test.go
@@ -68,7 +68,7 @@ func TestGetCreateOrUpdateVirtualMachineScaleSetParams(t *testing.T) {
 			},
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				Overprovision: to.BoolPtr(false),

--- a/internal/providers/azure/pke/workflow/create_vnet_activity_test.go
+++ b/internal/providers/azure/pke/workflow/create_vnet_activity_test.go
@@ -49,7 +49,7 @@ func TestGetCreateOrUpdateVirtualNetworkParams(t *testing.T) {
 			Location: to.StringPtr("test-location"),
 			Tags: map[string]*string{
 				"kubernetesCluster-test-cluster": to.StringPtr("owned"),
-				"io.banzaicloud.pipeline.uuid":   to.StringPtr(""),
+				"banzaicloud-pipeline-uuid":      to.StringPtr(""),
 			},
 			VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 				AddressSpace: &network.AddressSpace{

--- a/internal/providers/azure/uuid.go
+++ b/internal/providers/azure/uuid.go
@@ -18,11 +18,9 @@ import (
 	"github.com/banzaicloud/pipeline/internal/global"
 )
 
-const managedByPipelineTag = "io.banzaicloud.pipeline.uuid"
-
 // PipelineTags returns resource tags for Azure based on the pipeline uuid if available
 func PipelineTags() map[string]*string {
 	value := global.PipelineUUID()
 
-	return map[string]*string{managedByPipelineTag: &value}
+	return map[string]*string{global.ManagedByPipelineTag: &value}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2193
| License         | Apache 2.0


### What's in this PR?

Fixes and unifies Pipeline UUID resource label name.


### Why?

Cloud providers support resource labeling with different restrictions.
