### PR TITLE
auth: support org creation on all providers

### DIFF
--- a/auth/user.go
+++ b/auth/user.go
@@ -305,11 +305,7 @@ func (bus BanzaiUserStorer) Save(schema *auth.Schema, authCtx *auth.Context) (us
 	bus.events.OrganizationRegistered(currentUser.Organizations[0].ID, currentUser.ID)
 
 	// Import organizations in case of DEX
-	if schema.Provider == ProviderDexGithub {
-		err = bus.orgImporter.ImportOrganizationsFromDex(currentUser, organizations, ProviderGithub)
-	} else if schema.Provider == ProviderDexGitlab {
-		err = bus.orgImporter.ImportOrganizationsFromDex(currentUser, organizations, ProviderGitlab)
-	}
+	err = bus.orgImporter.ImportOrganizationsFromDex(currentUser, organizations, getBackendProvider(schema.Provider))
 
 	return currentUser, fmt.Sprint(db.NewScope(currentUser).PrimaryKeyValue()), err
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0

### What's in this PR?
Adds support for org creation for all IdP.

### Why?
GitHub and Gitlab orgs were sourced only until now, we need to support LDAP and others as well.


### Additional context
N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
