### PR TITLE
Set valid DNS provider in case of Route53

### DIFF
--- a/internal/clusterfeature/features/dns/spec.go
+++ b/internal/clusterfeature/features/dns/spec.go
@@ -184,7 +184,7 @@ func (m *dnsFeatureManager) processCustomDNSFeatureValues(ctx context.Context, c
 	}
 
 	values.DomainFilters = customDns.DomainFilters
-	values.Provider = customDns.Provider.Name
+	values.Provider = getProviderNameForChart(customDns.Provider.Name)
 
 	return values, nil
 }
@@ -398,4 +398,13 @@ func (m *dnsFeatureManager) createCustomDnsChartValuesGoogle(
 	values.TxtPrefix = "txt-"
 
 	return nil
+}
+
+func getProviderNameForChart(p string) string {
+	switch p {
+	case dnsRoute53:
+		return "aws"
+	default:
+		return p
+	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Set dns provider to `aws` in case of route53

### Why?
This is the valid `provider` value to external dns chart

### Checklist

- [x] Implementation tested (with at least one cloud provider)
