### PR TITLE
Fix worker database config

### DIFF
--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -140,6 +140,7 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("database.dialect", "mysql")
 	_ = v.BindEnv("database.host")
 	v.SetDefault("database.port", 3306)
+	v.SetDefault("database.tls", "")
 	_ = v.BindEnv("database.user")
 	_ = v.BindEnv("database.password")
 	v.RegisterAlias("database.pass", "database.password") // TODO: deprecate password


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add missing database TLS config default to worker config.


### Why?
AutomaticEnv only works for keys defined.
