### PR TITLE
docker-compose: down should remove named volumes declared in the `volumes` like ldap-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ up: config/dex.yml config/ui/feature-set.json start config/config.toml ## Set up
 
 .PHONY: down
 down: clean ## Destroy the development environment
-	docker-compose down
+	docker-compose down -v
 	@ if [[ "$$OSTYPE" == "linux-gnu" ]]; then sudo rm -rf .docker/; else rm -rf .docker/; fi
 
 .PHONY: reset


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
In case of LDAP upstream IdP enabled in Docker Compose, there is a custom volume `ldap-config`, down leaves there so it should be destroyed as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
