### PR TITLE
Remove break to collect all tagged deployments

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -296,7 +296,6 @@ func ListDeployments(filter *string, tagFilter string, kubeConfig []byte) (*rls.
 			if DeploymentHasTag(deployment.Deployment, tagFilter) {
 				filteredResp.Releases = append(filteredResp.Releases, deployment.Release)
 				filteredResp.Count++
-				break
 			}
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Remove break to collect all tagged deployments

### Why?
Currently the deployment list (in case of tag filter) doesn't collect all tagged (and matched) deployment:
```json
[
  {
    "releaseName": "spotguide1",
    "supported": true,
    "whiteListed": false,
    "rejected": false
  }
]
```

After this change:
```
[
  {
    "releaseName": "spotguide1",
    ...
    "supported": true,
    "whiteListed": false,
    "rejected": false
  },
  {
    "releaseName": "spotguide2",
    ...
    "supported": true,
    "whiteListed": false,
    "rejected": false
  }
]
```

### Additional context
Because of this `break` wrong notes shown on summary page of Spotguide (if 1 cluster has more Spotguide)