### PR TITLE
set timeout for dashboard k8s client connections

### DIFF
--- a/internal/dashboard/api.go
+++ b/internal/dashboard/api.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"time"
 
 	"emperror.dev/emperror"
 	"github.com/gin-gonic/gin"
@@ -260,7 +261,7 @@ func (d *DashboardAPI) getClusterDashboardInfo(logger *logrus.Entry, commonClust
 		return
 	}
 
-	client, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
+	client, err := k8sclient.NewClientFromKubeConfigWithTimeout(kubeConfig, 5*time.Second)
 	if err != nil {
 		partialResponse = true
 		return

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -17,6 +17,7 @@ package k8sclient
 import (
 	"context"
 	"net"
+	"time"
 
 	"emperror.dev/emperror"
 	"github.com/pkg/errors"
@@ -44,7 +45,16 @@ func NewClientFromKubeConfig(kubeConfig []byte) (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create client config")
 	}
+	return NewClientFromConfig(config)
+}
 
+// NewClientFromKubeConfig creates a new Kubernetes client from raw kube config.
+func NewClientFromKubeConfigWithTimeout(kubeConfig []byte, timeout time.Duration) (*kubernetes.Clientset, error) {
+	config, err := NewClientConfig(kubeConfig)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to create client config")
+	}
+	config.Timeout = timeout
 	return NewClientFromConfig(config)
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Set 5 secs timeout for k8s client connection from dashboard to avoid waiting too much for clusters temporarily or not reachable anymore.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated, client regenerated (`make generate-client`) (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
