### PR TITLE
dex: use the same db locally as other services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docker-compose.override.yml: ## Create docker compose override file
 .PHONY: start
 start: docker-compose.override.yml ## Start docker development environment
 	@ if [ docker-compose.override.yml -ot docker-compose.override.yml.dist ]; then diff -u docker-compose.override.yml* || (echo "!!! The distributed docker-compose.override.yml example changed. Please update your file accordingly (or at least touch it). !!!" && false); fi
-	mkdir -p .docker/volumes/{mysql,vault/file,vault/keys,dex}
+	mkdir -p .docker/volumes/{mysql,vault/file,vault/keys}
 	docker-compose up -d
 
 .PHONY: stop

--- a/config/dex.yml.dist
+++ b/config/dex.yml.dist
@@ -8,9 +8,24 @@ issuer: http://127.0.0.1:5556/dex
 #
 # See the storage document at Documentation/storage.md for further information.
 storage:
-  type: sqlite3
+  type: mysql
   config:
-    file: /dex/dex.db
+    host: mysql
+    port: 3306
+    database: dex
+    user: sparky
+    password: sparky123
+    ssl:
+      mode: "false"
+#  type: postgres
+#  config:
+#    host: postgres
+#    port: 5432
+#    database: dex
+#    user: sparky
+#    password: sparky123
+#    ssl:
+#      mode: disable
 
 # Configuration for the HTTP endpoints.
 web:

--- a/database/docker-init-mysql.sql
+++ b/database/docker-init-mysql.sql
@@ -6,3 +6,6 @@ GRANT ALL PRIVILEGES ON cadence.* TO 'sparky'@'%';
 
 CREATE DATABASE IF NOT EXISTS cadence_visibility;
 GRANT ALL PRIVILEGES ON cadence_visibility.* TO 'sparky'@'%';
+
+CREATE DATABASE IF NOT EXISTS dex;
+GRANT ALL PRIVILEGES ON dex.* TO 'sparky'@'%';

--- a/database/docker-init-postgres.sql
+++ b/database/docker-init-postgres.sql
@@ -6,3 +6,6 @@ GRANT ALL PRIVILEGES ON DATABASE cadence TO sparky;
 
 CREATE DATABASE cadence_visibility;
 GRANT ALL PRIVILEGES ON DATABASE cadence_visibility TO sparky;
+
+CREATE DATABASE dex;
+GRANT ALL PRIVILEGES ON DATABASE dex TO sparky;

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -89,8 +89,6 @@ services:
             - 127.0.0.1:5556:5556
             - 127.0.0.1:5557:5557
             - 127.0.0.1:5558:5558
-        volumes:
-            - ./.docker/volumes/dex:/dex
 
     cadence:
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
             RECOMMENDER_URL: https://beta.banzaicloud.io/recommender
 
     dex:
-        image: banzaicloud/dex-shim:0.3.10
+        image: banzaicloud/dex-shim:0.3.11
         command: serve /dex.yml
         restart: on-failure
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
             RECOMMENDER_URL: https://beta.banzaicloud.io/recommender
 
     dex:
-        image: banzaicloud/dex-shim:0.3.9
+        image: banzaicloud/dex-shim:0.3.10
         command: serve /dex.yml
         volumes:
             - ./config/dex.yml:/dex.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     dex:
         image: banzaicloud/dex-shim:0.3.10
         command: serve /dex.yml
+        restart: on-failure
         volumes:
             - ./config/dex.yml:/dex.yml
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | `$PIPELINE_DIR/.docker/volumes/dex`
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Use MySQL by default from local Dex, and added Postgres example.

### Why?
To use and browse the same DB as for other services.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
You are most probably using the SQLite backend currently. If you want to use the MySQL or Postgres backend right now, you have to create the `dex` database manually (if you don't want to loose your date), or

```bash
make down
rm config/dex.yml
make up
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested locally