### PR TITLE
Add missing resourceSummary field to dashboard cluster API response

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -16,6 +16,8 @@ package dashboard
 
 import (
 	"time"
+
+	"github.com/banzaicloud/pipeline/api"
 )
 
 type Allocatable struct {
@@ -58,19 +60,20 @@ type Status struct {
 
 // NodePool describes a cluster's node pool.
 type NodePool struct {
-	Autoscaling  bool              `json:"autoscaling"`
-	Count        int               `json:"count,omitempty"`
-	InstanceType string            `json:"instanceType,omitempty"`
-	SpotPrice    string            `json:"spotPrice,omitempty"`
-	Preemptible  bool              `json:"preemptible,omitempty"`
-	MinCount     int               `json:"minCount,omitempty"`
-	MaxCount     int               `json:"maxCount,omitempty"`
-	Image        string            `json:"image,omitempty"`
-	Version      string            `json:"version,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	CreatedAt    time.Time         `json:"createdAt,omitempty"`
-	CreatorName  string            `json:"creatorName,omitempty"`
-	CreatorID    uint              `json:"creatorId,omitempty"`
+	Autoscaling     bool                               `json:"autoscaling"`
+	Count           int                                `json:"count,omitempty"`
+	InstanceType    string                             `json:"instanceType,omitempty"`
+	SpotPrice       string                             `json:"spotPrice,omitempty"`
+	Preemptible     bool                               `json:"preemptible,omitempty"`
+	MinCount        int                                `json:"minCount,omitempty"`
+	MaxCount        int                                `json:"maxCount,omitempty"`
+	Image           string                             `json:"image,omitempty"`
+	Version         string                             `json:"version,omitempty"`
+	Labels          map[string]string                  `json:"labels,omitempty"`
+	ResourceSummary map[string]api.NodeResourceSummary `json:"resourceSummary,omitempty"`
+	CreatedAt       time.Time                          `json:"createdAt,omitempty"`
+	CreatorName     string                             `json:"creatorName,omitempty"`
+	CreatorID       uint                               `json:"creatorId,omitempty"`
 }
 
 type ClusterInfo struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add missing `resourceSummary` field to dashboard cluster API response

### Why?
UI can't show nodes under nodepools because of this missing field. After this change the the node appears on cluster details page

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
