### PR TITLE
Add missing resourceSummary field to dashboard cluster API response

### DIFF
--- a/internal/dashboard/api.go
+++ b/internal/dashboard/api.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"emperror.dev/emperror"
-	"github.com/banzaicloud/pipeline/api"
 	"github.com/banzaicloud/pipeline/internal/cluster/resourcesummary"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -442,7 +441,7 @@ func addResourceSummary(client *kubernetes.Clientset, response ClusterInfo) bool
 			continue
 		}
 
-		nodePool.ResourceSummary = make(map[string]api.NodeResourceSummary, len(nodes.Items))
+		nodePool.ResourceSummary = make(map[string]NodeResourceSummary, len(nodes.Items))
 
 		for _, node := range nodes.Items {
 			nodeSummary, err := resourcesummary.GetNodeSummary(client, node)
@@ -451,10 +450,10 @@ func addResourceSummary(client *kubernetes.Clientset, response ClusterInfo) bool
 				continue
 			}
 
-			cpuResource := api.Resource(nodeSummary.CPU)
-			memoryResource := api.Resource(nodeSummary.Memory)
-			nodePool.ResourceSummary[node.Name] = api.NodeResourceSummary{
-				ResourceSummary: api.ResourceSummary{
+			cpuResource := Resource(nodeSummary.CPU)
+			memoryResource := Resource(nodeSummary.Memory)
+			nodePool.ResourceSummary[node.Name] = NodeResourceSummary{
+				ResourceSummary: ResourceSummary{
 					CPU:    &cpuResource,
 					Memory: &memoryResource,
 				},

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -16,8 +16,6 @@ package dashboard
 
 import (
 	"time"
-
-	"github.com/banzaicloud/pipeline/api"
 )
 
 type Allocatable struct {
@@ -60,20 +58,20 @@ type Status struct {
 
 // NodePool describes a cluster's node pool.
 type NodePool struct {
-	Autoscaling     bool                               `json:"autoscaling"`
-	Count           int                                `json:"count,omitempty"`
-	InstanceType    string                             `json:"instanceType,omitempty"`
-	SpotPrice       string                             `json:"spotPrice,omitempty"`
-	Preemptible     bool                               `json:"preemptible,omitempty"`
-	MinCount        int                                `json:"minCount,omitempty"`
-	MaxCount        int                                `json:"maxCount,omitempty"`
-	Image           string                             `json:"image,omitempty"`
-	Version         string                             `json:"version,omitempty"`
-	Labels          map[string]string                  `json:"labels,omitempty"`
-	ResourceSummary map[string]api.NodeResourceSummary `json:"resourceSummary,omitempty"`
-	CreatedAt       time.Time                          `json:"createdAt,omitempty"`
-	CreatorName     string                             `json:"creatorName,omitempty"`
-	CreatorID       uint                               `json:"creatorId,omitempty"`
+	Autoscaling     bool                           `json:"autoscaling"`
+	Count           int                            `json:"count,omitempty"`
+	InstanceType    string                         `json:"instanceType,omitempty"`
+	SpotPrice       string                         `json:"spotPrice,omitempty"`
+	Preemptible     bool                           `json:"preemptible,omitempty"`
+	MinCount        int                            `json:"minCount,omitempty"`
+	MaxCount        int                            `json:"maxCount,omitempty"`
+	Image           string                         `json:"image,omitempty"`
+	Version         string                         `json:"version,omitempty"`
+	Labels          map[string]string              `json:"labels,omitempty"`
+	ResourceSummary map[string]NodeResourceSummary `json:"resourceSummary,omitempty"`
+	CreatedAt       time.Time                      `json:"createdAt,omitempty"`
+	CreatorName     string                         `json:"creatorName,omitempty"`
+	CreatorID       uint                           `json:"creatorId,omitempty"`
 }
 
 type ClusterInfo struct {
@@ -116,4 +114,24 @@ type GetDashboardResponse struct {
 type GetDashboardPathParams struct {
 	// in:path
 	OrgId string `json:"orgid"`
+}
+
+// ResourceSummary describes a node's resource summary with CPU and Memory capacity/request/limit/allocatable
+type ResourceSummary struct {
+	CPU    *Resource `json:"cpu,omitempty"`
+	Memory *Resource `json:"memory,omitempty"`
+}
+
+type NodeResourceSummary struct {
+	ResourceSummary
+
+	Status string `json:"status,omitempty"`
+}
+
+// Resource describes a resource summary with capacity/request/limit/allocatable
+type Resource struct {
+	Capacity    string `json:"capacity,omitempty"`
+	Allocatable string `json:"allocatable,omitempty"`
+	Limit       string `json:"limit,omitempty"`
+	Request     string `json:"request,omitempty"`
 }

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -16,6 +16,8 @@ package dashboard
 
 import (
 	"time"
+
+	"github.com/banzaicloud/pipeline/api"
 )
 
 type Allocatable struct {
@@ -58,19 +60,20 @@ type Status struct {
 
 // NodePool describes a cluster's node pool.
 type NodePool struct {
-	Autoscaling  bool              `json:"autoscaling"`
-	Count        int               `json:"count,omitempty"`
-	InstanceType string            `json:"instanceType,omitempty"`
-	SpotPrice    string            `json:"spotPrice,omitempty"`
-	Preemptible  bool              `json:"preemptible,omitempty"`
-	MinCount     int               `json:"minCount,omitempty"`
-	MaxCount     int               `json:"maxCount,omitempty"`
-	Image        string            `json:"image,omitempty"`
-	Version      string            `json:"version,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	CreatedAt    time.Time         `json:"createdAt,omitempty"`
-	CreatorName  string            `json:"creatorName,omitempty"`
-	CreatorID    uint              `json:"creatorId,omitempty"`
+	Autoscaling     bool                               `json:"autoscaling"`
+	Count           int                                `json:"count,omitempty"`
+	InstanceType    string                             `json:"instanceType,omitempty"`
+	SpotPrice       string                             `json:"spotPrice,omitempty"`
+	Preemptible     bool                               `json:"preemptible,omitempty"`
+	MinCount        int                                `json:"minCount,omitempty"`
+	MaxCount        int                                `json:"maxCount,omitempty"`
+	Image           string                             `json:"image,omitempty"`
+	Version         string                             `json:"version,omitempty"`
+	Labels          map[string]string                  `json:"labels,omitempty"`
+	ResourceSummary map[string]api.NodeResourceSummary `json:"resourceSummary,omitempty"`
+	CreatedAt       time.Time                          `json:"createdAt,omitempty"`
+	CreatorName     string                             `json:"creatorName,omitempty"`
+	CreatorID       uint                               `json:"creatorId,omitempty"`
 }
 
 type ClusterInfo struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add missing `resourceSummary` field to dashboard cluster API response

### Why?
UI can't show nodes under nodepools because of this missing field. After this change the the node appears on cluster details page

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
