### PR TITLE
DNS feature: region, batch change size taken from the spec

### DIFF
--- a/internal/clusterfeature/features/dns/operator.go
+++ b/internal/clusterfeature/features/dns/operator.go
@@ -234,7 +234,7 @@ func (op FeatureOperator) processCustomDNSFeatureValues(ctx context.Context, clu
 
 	switch provider := customDNS.Provider.Name; provider {
 	case dnsRoute53:
-		if err := op.createCustomDNSChartValuesAmazon(secretValues, values); err != nil {
+		if err := op.createCustomDNSChartValuesAmazon(secretValues, customDNS.Provider.Options, values); err != nil {
 			return nil, errors.Wrap(err, "failed to create Amazon custom DNS chart values")
 		}
 
@@ -318,7 +318,7 @@ type awsCredentials struct {
 	Region          string `mapstructure:"AWS_REGION"`
 }
 
-func (op FeatureOperator) createCustomDNSChartValuesAmazon(secretValues map[string]string, values *ExternalDnsChartValues) error {
+func (op FeatureOperator) createCustomDNSChartValuesAmazon(secretValues map[string]string, options *providerOptions, values *ExternalDnsChartValues) error {
 	var creds awsCredentials
 	if err := mapstructure.Decode(secretValues, &creds); err != nil {
 		return errors.WrapIf(err, "failed to bind feature spec credentials")
@@ -326,7 +326,8 @@ func (op FeatureOperator) createCustomDNSChartValuesAmazon(secretValues map[stri
 
 	// set secret values
 	providerSettings := &ExternalDnsAwsSettings{
-		Region: creds.Region,
+		Region:          options.Region,
+		BatchChangeSize: options.BatchChangeSize,
 		Credentials: &ExternalDnsAwsCredentials{
 			AccessKey: creds.AccessKeyID,
 			SecretKey: creds.SecretAccessKey,

--- a/internal/clusterfeature/features/dns/operator_test.go
+++ b/internal/clusterfeature/features/dns/operator_test.go
@@ -122,6 +122,10 @@ func TestFeatureOperator_Apply(t *testing.T) {
 					"provider": obj{
 						"name":     "route53",
 						"secretId": providerSecretID,
+						"options": obj{
+							"region":    "test-reg",
+							"batchSize": 10,
+						},
 					},
 				},
 			},
@@ -145,6 +149,10 @@ func TestFeatureOperator_Apply(t *testing.T) {
 							ResourceType:   brn.SecretResourceType,
 							ResourceID:     providerSecretID,
 						}.String(),
+						"options": obj{
+							"region":    "test-reg",
+							"batchSize": 10,
+						},
 					},
 				},
 			},

--- a/internal/clusterfeature/features/dns/spec.go
+++ b/internal/clusterfeature/features/dns/spec.go
@@ -91,6 +91,8 @@ type providerOptions struct {
 	DNSMasked          bool   `json:"dnsMasked" mapstructure:"dnsMasked"`
 	AzureResourceGroup string `json:"resourceGroup,omitempty" mapstructure:"resourceGroup"`
 	GoogleProject      string `json:"project,omitempty" mapstructure:"project"`
+	Region             string `json:"region,omitempty" mapstructure:"region"`
+	BatchChangeSize    uint   `json:"batchSize,omitempty" mapstructure:"batchSize"`
 }
 
 func (o *providerOptions) Validate(provider string) error {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Region and batch change size configuration for the external dns configuration are processed from the posted feature specification


### Why?
the above entries from the spec were ignored


### To Do
testing