### PR TITLE
Allow any traffic from cluster control plane to nodes

### DIFF
--- a/auth/migrate.go
+++ b/auth/migrate.go
@@ -29,7 +29,7 @@ func Migrate(db *gorm.DB, logger logrus.FieldLogger) error {
 		&AuthIdentity{},
 		&User{},
 		&UserOrganization{},
-		&OrganizationMigrationModel{}, // TODO change back to Organization once a new version is released
+		&Organization{},
 	}
 
 	var tableNames string

--- a/database/migrations/mysql/1568644399_drop_github_id_column_from_organizations_table.down.sql
+++ b/database/migrations/mysql/1568644399_drop_github_id_column_from_organizations_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD COLUMN `github_id` bigint(20) DEFAULT NULL;

--- a/database/migrations/mysql/1568644399_drop_github_id_column_from_organizations_table.up.sql
+++ b/database/migrations/mysql/1568644399_drop_github_id_column_from_organizations_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` DROP COLUMN `github_id`;

--- a/database/migrations/postgres/1568644399_drop_github_id_column_from_organizations_table.down.sql
+++ b/database/migrations/postgres/1568644399_drop_github_id_column_from_organizations_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ADD COLUMN "github_id" bigint UNIQUE;

--- a/database/migrations/postgres/1568644399_drop_github_id_column_from_organizations_table.up.sql
+++ b/database/migrations/postgres/1568644399_drop_github_id_column_from_organizations_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" DROP COLUMN "github_id";

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -222,8 +222,8 @@ Resources:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
       GroupId: !Ref NodeSecurityGroup
       SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: tcp
-      FromPort: 1025
+      IpProtocol: '-1'
+      FromPort: 0
       ToPort: 65535
 
   ControlPlaneEgressToNodeSecurityGroup:
@@ -232,29 +232,9 @@ Resources:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       GroupId: !Ref ClusterControlPlaneSecurityGroup
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: tcp
-      FromPort: 1025
+      IpProtocol: '-1'
+      FromPort: 0
       ToPort: 65535
-
-  NodeSecurityGroupFromControlPlaneOn443Ingress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
-      GroupId: !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: tcp
-      FromPort: 443
-      ToPort: 443
-
-  ControlPlaneEgressToNodeSecurityGroupOn443:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
-      GroupId: !Ref ClusterControlPlaneSecurityGroup
-      DestinationSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: tcp
-      FromPort: 443
-      ToPort: 443
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Pods running on EKS clusters worker nodes get IPs from the same subnet as the nodes, we should allow any traffic from the cluster control plane towards the nodes.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
