### PR TITLE
EKS: delete unused ENIs that were not released by EKS CNI plugin during cluster delete operation

### DIFF
--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -504,9 +504,33 @@ func (c *EKSCluster) DeleteCluster() error {
 		return err
 	}
 
+	clusterStackName := c.generateStackNameForCluster()
+	cloudformationSrv := cloudformation.New(awsSession)
+	describeStacksOutput, err := cloudformationSrv.DescribeStacks(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(clusterStackName),
+	})
+	if err != nil {
+		return err
+	}
+
+	var vpcId string
+	var securityGroupIds []string
+	for _, output := range describeStacksOutput.Stacks[0].Outputs {
+		switch aws.StringValue(output.OutputKey) {
+		case "SecurityGroups":
+			securityGroupIds = append(securityGroupIds, aws.StringValue(output.OutputValue))
+		case "NodeSecurityGroup":
+			securityGroupIds = append(securityGroupIds, aws.StringValue(output.OutputValue))
+		case "VpcId":
+			vpcId = aws.StringValue(output.OutputValue)
+		}
+	}
+
 	deleteContext := action.NewEksClusterDeleteContext(
 		awsSession,
 		c.modelCluster.Name,
+		vpcId,
+		securityGroupIds,
 	)
 	var actions []utils.Action
 	actions = append(actions, action.NewWaitResourceDeletionAction(c.log, deleteContext)) // wait for ELBs to be deleted
@@ -520,12 +544,12 @@ func (c *EKSCluster) DeleteCluster() error {
 		action.NewDeleteSSHKeyAction(c.log, deleteContext, c.generateSSHKeyNameForCluster()),
 		action.NewDeleteClusterUserAccessKeyAction(c.log, deleteContext),
 		action.NewDeleteClusterUserAccessKeySecretAction(c.log, deleteContext, c.GetOrganizationId()),
+		action.NewDeleteOrphanNICsAction(NewLogurLogger(c.log), deleteContext),
 		action.NewDeleteStacksAction(c.log, deleteContext, c.getSubnetStackNamesToDelete(awsSession)...),
 		action.NewDeleteStacksAction(c.log, deleteContext, c.generateStackNameForCluster()),
 	)
 	_, err = utils.NewActionExecutor(c.log).ExecuteActions(actions, nil, false)
 	if err != nil {
-		c.log.Errorln("EKS cluster delete error:", err.Error())
 		return err
 	}
 
@@ -699,7 +723,7 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 	autoscalingSrv := autoscaling.New(awsSession)
 	describeStacksOutput, err := cloudformationSrv.DescribeStacks(describeStacksInput)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var vpcId, securityGroupId, nodeSecurityGroupId, nodeInstanceRoleId, clusterUserArn, clusterUserAccessKeyId, clusterUserSecretAccessKey string
@@ -723,11 +747,14 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 		return err
 	}
 
-	if len(securityGroupId) == 0 {
-		return errors.New("securityGroupId output not found on stack: " + clusterStackName)
+	if securityGroupId == "" {
+		return errors.Errorf("SecurityGroups output not found on stack: %s", clusterStackName)
 	}
-	if len(vpcId) == 0 {
-		return errors.New("vpcId output not found on stack: " + clusterStackName)
+	if nodeSecurityGroupId == "" {
+		return errors.Errorf("NodeSecurityGroup output not found on stack: %s", clusterStackName)
+	}
+	if vpcId == "" {
+		return errors.Errorf("VpcId output not found on stack: %s", clusterStackName)
 	}
 
 	nodePoolTemplate, err := pkgEks.GetNodePoolTemplate()
@@ -768,6 +795,8 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 	deleteContext := action.NewEksClusterDeleteContext(
 		awsSession,
 		c.modelCluster.Name,
+		vpcId,
+		[]string{securityGroupId, nodeSecurityGroupId},
 	)
 
 	subnetMapping := make(map[string][]*action.EksSubnet)

--- a/pkg/cluster/eks/action/network.go
+++ b/pkg/cluster/eks/action/network.go
@@ -394,7 +394,7 @@ func (a *DeleteOrphanNICsAction) ExecuteAction(input interface{}) (interface{}, 
 	// collect orphan ENIs
 	// CNI plugin applies the following tags to ENIs https://aws.amazon.com/blogs/opensource/vpc-cni-plugin-v1-1-available/
 	tagsFilter := map[string][]string{
-		"node.k8s.amazonaws.com/instance_id": {""},
+		"node.k8s.amazonaws.com/instance_id": nil,
 	}
 	nics, err := netSvc.GetUnusedNetworkInterfaces(a.context.VpcID, a.context.SecurityGroupIDs, tagsFilter)
 	if err != nil {

--- a/pkg/providers/amazon/ec2/network.go
+++ b/pkg/providers/amazon/ec2/network.go
@@ -225,10 +225,6 @@ func (svc *NetworkSvc) GetUnusedNetworkInterfaces(vpcId string, securityGroupIds
 			Name:   aws.String("vpc-id"),
 			Values: []*string{aws.String(vpcId)},
 		},
-		/*{
-			Name:   aws.String("attachment.status"),
-			Values: []*string{aws.String("detaching"), aws.String("detached")},
-		},*/
 		{
 			Name:   aws.String("status"),
 			Values: []*string{aws.String("available")},

--- a/pkg/providers/amazon/ec2/network.go
+++ b/pkg/providers/amazon/ec2/network.go
@@ -244,16 +244,22 @@ func (svc *NetworkSvc) GetUnusedNetworkInterfaces(vpcId string, securityGroupIds
 	}
 
 	for k, v := range tagsFilter {
-		values := make([]*string, len(v))
+		if v == nil {
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("tag-key"),
+				Values: []*string{aws.String(k)},
+			})
+		} else {
+			values := make([]*string, len(v))
+			for i := range v {
+				values[i] = aws.String(v[i])
+			}
 
-		for i := range v {
-			values[i] = aws.String(v[i])
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String(fmt.Sprintf("tag:%s", k)),
+				Values: values,
+			})
 		}
-
-		filters = append(filters, &ec2.Filter{
-			Name:   aws.String(fmt.Sprintf("tag:%s", k)),
-			Values: values,
-		})
 	}
 
 	var nicIds []string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview of the implementation, which decisions were made and why. -->
Search for network interfaces that were created by EKS CNI plugin and are no longer "in-use" and delete them prior starting to delete subnets and vpc at cluster deletion.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
EKS CNI plugin allocates native AWS VPC IPs addresses for PODs. Behind the scenes what happens is that multiple network interfaces (ENIs) are created and attached to the nodes with multiple pre-allocated IPs. Pods running on the node will get an IP from these.
When pods and nodes are deleted the ENIs of which IPs are not used any more are deleted. However, it may happen that some of these ENIs are left behind (detached state) holding a reference to the subnets they are in. This blocks cluster deletion as subnets can not be deleted until these ENIs are not cleaned up.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
