### PR TITLE
Fix Azure PKE prepare conditions

### DIFF
--- a/internal/providers/azure/pke/driver/preparers.go
+++ b/internal/providers/azure/pke/driver/preparers.go
@@ -267,7 +267,7 @@ func (p NodePoolPreparer) prepareExistingNodePool(ctx context.Context, nodePool 
 		}
 		nodePool.InstanceType = existing.InstanceType
 	}
-	if stringSliceSetEqual(nodePool.Roles, existing.Roles) {
+	if !stringSliceSetEqual(nodePool.Roles, existing.Roles) {
 		if nodePool.Roles != nil {
 			logMismatchOn(p, "Roles", existing.Roles, nodePool.Roles)
 		}
@@ -289,7 +289,7 @@ func (p NodePoolPreparer) prepareExistingNodePool(ctx context.Context, nodePool 
 		}
 		nodePool.Subnet.CIDR = existingSubnetCIDR
 	}
-	if stringSliceSetEqual(nodePool.Zones, existing.Zones) {
+	if !stringSliceSetEqual(nodePool.Zones, existing.Zones) {
 		if nodePool.Zones != nil {
 			logMismatchOn(p, "Zones", existing.Zones, nodePool.Zones)
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Fix conditions checking string set equality of roles and zones of existing node pools.

### Why?
The conditions were checking for equality instead of inequality, thus emitting warnings wrongly.
