### PR TITLE
vault-feature: close client after work

### DIFF
--- a/internal/clusterfeature/features/vault/client.go
+++ b/internal/clusterfeature/features/vault/client.go
@@ -132,6 +132,10 @@ func (m vaultManager) deletePolicy() error {
 	return m.vaultClient.RawClient().Sys().DeletePolicy(getPolicyName(m.orgID, m.clusterID))
 }
 
+func (m vaultManager) close() {
+	m.vaultClient.Close()
+}
+
 func getRoleName(isCustomVault bool) string {
 	if isCustomVault {
 		return customRoleName

--- a/internal/clusterfeature/features/vault/common.go
+++ b/internal/clusterfeature/features/vault/common.go
@@ -23,7 +23,7 @@ const (
 	customRoleName          = "pipeline-webhook"
 	pipelineRoleName        = "pipeline"
 	authMethodType          = "kubernetes"
-	authMethodPathPrefix    = "kubernetes"
+	authMethodPathPrefix    = "kubernetes-cluster"
 	policyNamePrefix        = "allow_cluster_secrets"
 	vaultTokenReviewer      = "vault-token-reviewer"
 	vaultTokenKey           = "token"

--- a/internal/clusterfeature/features/vault/manager.go
+++ b/internal/clusterfeature/features/vault/manager.go
@@ -82,6 +82,8 @@ func (m FeatureManager) GetOutput(ctx context.Context, clusterID uint, spec clus
 		return nil, errors.WrapIf(err, "failed to create Vault manager")
 	}
 
+	defer vaultManager.close()
+
 	chartVersion := getChartVersion()
 
 	vaultOutput, err := getVaultOutput(*vaultManager, orgID, clusterID)

--- a/internal/clusterfeature/features/vault/operator.go
+++ b/internal/clusterfeature/features/vault/operator.go
@@ -72,7 +72,6 @@ func (op FeatureOperator) Name() string {
 func (op FeatureOperator) Apply(ctx context.Context, clusterID uint, spec clusterfeature.FeatureSpec) error {
 	ctx, err := op.ensureOrgIDInContext(ctx, clusterID)
 	if err != nil {
-
 		return err
 	}
 
@@ -206,6 +205,8 @@ func (op FeatureOperator) configureVault(
 		if err != nil {
 			return errors.WrapIf(err, "failed to create Vault manager")
 		}
+
+		defer vaultManager.close()
 
 		// create policy
 		var policy string
@@ -353,6 +354,8 @@ func (op FeatureOperator) Deactivate(ctx context.Context, clusterID uint, spec c
 		if err != nil {
 			return errors.WrapIf(err, "failed to create Vault manager")
 		}
+
+		defer vaultManager.close()
 
 		// delete role
 		if _, err := vaultManager.deleteRole(); err != nil {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Closing the Vault client (stop token renewal) after feature work is done.

Also the mount path should be changed since `kubernetes/` is already taken.

### Why?
To prevent resource leaks.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)