### PR TITLE
use emperror.dev/errors instead of other error packages when possible…

### DIFF
--- a/internal/providers/azure/pke/adapter/gorm_store.go
+++ b/internal/providers/azure/pke/adapter/gorm_store.go
@@ -16,11 +16,11 @@ package adapter
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
 	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 
@@ -125,7 +125,7 @@ func fillClusterFromClusterModel(cl *pke.PKEOnAzureCluster, model cluster.Cluste
 
 func marshalStringSlice(s []string) string {
 	data, err := json.Marshal(s)
-	emperror.Panic(emperror.Wrap(err, "failed to marshal string slice"))
+	emperror.Panic(errors.WrapIf(err, "failed to marshal string slice"))
 	return string(data)
 }
 
@@ -134,7 +134,7 @@ func unmarshalStringSlice(s string) (result []string) {
 		// empty list in legacy format
 		return nil
 	}
-	err := emperror.Wrap(json.Unmarshal([]byte(s), &result), "failed to unmarshal string slice")
+	err := errors.WrapIf(json.Unmarshal([]byte(s), &result), "failed to unmarshal string slice")
 	if err != nil {
 		// try to parse legacy format
 		result = strings.Split(s, ",")
@@ -261,7 +261,7 @@ func (s gormAzurePKEClusterStore) Create(params pke.CreateParams) (c pke.PKEOnAz
 
 func (s gormAzurePKEClusterStore) DeleteNodePool(clusterID uint, nodePoolName string) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 	if nodePoolName == "" {
 		return errors.New("empty node pool name")
@@ -280,7 +280,7 @@ func (s gormAzurePKEClusterStore) DeleteNodePool(clusterID uint, nodePoolName st
 
 func (s gormAzurePKEClusterStore) Delete(clusterID uint) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -295,7 +295,7 @@ func (s gormAzurePKEClusterStore) Delete(clusterID uint) error {
 
 func (s gormAzurePKEClusterStore) GetByID(clusterID uint) (cluster pke.PKEOnAzureCluster, err error) {
 	if err := validateClusterID(clusterID); err != nil {
-		return cluster, emperror.Wrap(err, "invalid cluster ID")
+		return cluster, errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := gormAzurePKEClusterModel{
@@ -310,7 +310,7 @@ func (s gormAzurePKEClusterStore) GetByID(clusterID uint) (cluster pke.PKEOnAzur
 
 func (s gormAzurePKEClusterStore) SetStatus(clusterID uint, status, message string) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -347,7 +347,7 @@ func (s gormAzurePKEClusterStore) SetStatus(clusterID uint, status, message stri
 
 func (s gormAzurePKEClusterStore) SetActiveWorkflowID(clusterID uint, workflowID string) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := gormAzurePKEClusterModel{
@@ -359,7 +359,7 @@ func (s gormAzurePKEClusterStore) SetActiveWorkflowID(clusterID uint, workflowID
 
 func (s gormAzurePKEClusterStore) SetConfigSecretID(clusterID uint, secretID string) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -375,7 +375,7 @@ func (s gormAzurePKEClusterStore) SetConfigSecretID(clusterID uint, secretID str
 
 func (s gormAzurePKEClusterStore) SetSSHSecretID(clusterID uint, secretID string) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -391,7 +391,7 @@ func (s gormAzurePKEClusterStore) SetSSHSecretID(clusterID uint, secretID string
 
 func (s gormAzurePKEClusterStore) GetConfigSecretID(clusterID uint) (string, error) {
 	if err := validateClusterID(clusterID); err != nil {
-		return "", emperror.Wrap(err, "invalid cluster ID")
+		return "", errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -405,7 +405,7 @@ func (s gormAzurePKEClusterStore) GetConfigSecretID(clusterID uint) (string, err
 
 func (s gormAzurePKEClusterStore) SetFeature(clusterID uint, feature string, state bool) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := cluster.ClusterModel{
@@ -432,7 +432,7 @@ func (s gormAzurePKEClusterStore) SetFeature(clusterID uint, feature string, sta
 
 func (s gormAzurePKEClusterStore) SetNodePoolSizes(clusterID uint, nodePoolName string, min, max, desiredCount uint, autoscaling bool) error {
 	if err := validateClusterID(clusterID); err != nil {
-		return emperror.Wrap(err, "invalid cluster ID")
+		return errors.WrapIf(err, "invalid cluster ID")
 	}
 
 	model := gormAzurePKENodePoolModel{
@@ -483,9 +483,9 @@ func getError(db *gorm.DB, message string, args ...interface{}) error {
 		err = recordNotFoundError{}
 	}
 	if len(args) == 0 {
-		err = emperror.Wrap(err, message)
+		err = errors.WrapIf(err, message)
 	} else {
-		err = emperror.Wrapf(err, message, args...)
+		err = errors.WrapIff(err, message, args...)
 	}
 	return err
 }

--- a/internal/providers/azure/pke/driver/common.go
+++ b/internal/providers/azure/pke/driver/common.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -188,7 +188,7 @@ func getSubnetCIDR(ctx context.Context, client pkgAzure.SubnetsClient, resourceG
 	if subnet.StatusCode == http.StatusNotFound {
 		return "", notExistsYetError{}
 	} else if err != nil {
-		return "", emperror.Wrap(err, "failed to get subnet")
+		return "", errors.WrapIf(err, "failed to get subnet")
 	}
 	return to.String(subnet.AddressPrefix), nil
 }

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -22,8 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"emperror.dev/emperror"
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
@@ -190,7 +189,7 @@ func (a *AzurePkeCluster) DownloadK8sConfig() ([]byte, error) {
 func (a *AzurePkeCluster) GetAPIEndpoint() (string, error) {
 	config, err := a.GetK8sConfig()
 	if err != nil {
-		return "", emperror.Wrap(err, "failed to get cluster's Kubeconfig")
+		return "", errors.WrapIf(err, "failed to get cluster's Kubeconfig")
 	}
 
 	return pkgCluster.GetAPIEndpointFromKubeconfig(config)
@@ -362,7 +361,7 @@ func (a *AzurePkeCluster) GetCAHash() (string, error) {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return "", emperror.Wrapf(err, "failed to parse certificate")
+		return "", errors.WrapIff(err, "failed to parse certificate")
 	}
 	h := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	return fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:])), nil

--- a/internal/providers/azure/pke/driver/ssh.go
+++ b/internal/providers/azure/pke/driver/ssh.go
@@ -15,7 +15,7 @@
 package driver
 
 import (
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
 	intSecret "github.com/banzaicloud/pipeline/internal/secret"
@@ -27,11 +27,11 @@ func GetOrCreateSSHKeyPair(cluster pke.PKEOnAzureCluster, secrets secretStore, s
 
 	keyPair, secretID, err := intSecret.GetOrCreateSSHKeyPair(secrets, getOrCreateSSHKeyPairClusterAdapter(cluster))
 	if err != nil {
-		return nil, emperror.Wrap(err, "failed to get or create SSH key pair")
+		return nil, errors.WrapIf(err, "failed to get or create SSH key pair")
 	}
 	if secretID != cluster.SSHSecretID {
 		if err := store.SetSSHSecretID(cluster.ID, secretID); err != nil {
-			return nil, emperror.Wrap(err, "failed to set cluster SSH secret ID")
+			return nil, errors.WrapIf(err, "failed to set cluster SSH secret ID")
 		}
 	}
 	return keyPair, nil

--- a/internal/providers/azure/pke/workflow/azure.go
+++ b/internal/providers/azure/pke/workflow/azure.go
@@ -17,7 +17,7 @@ package workflow
 import (
 	"fmt"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	internalAzure "github.com/banzaicloud/pipeline/internal/providers/azure"
@@ -36,7 +36,7 @@ func NewAzureClientFactory(secretStore pkeworkflow.SecretStore) *AzureClientFact
 func (f *AzureClientFactory) New(organizationID uint, secretID string) (*pkgAzure.CloudConnection, error) {
 	s, err := f.secretStore.GetSecret(organizationID, secretID)
 	if err != nil {
-		return nil, emperror.Wrap(err, "failed to get secret")
+		return nil, errors.WrapIf(err, "failed to get secret")
 	}
 
 	err = s.ValidateSecretType(pkgAzure.Provider)
@@ -46,7 +46,7 @@ func (f *AzureClientFactory) New(organizationID uint, secretID string) (*pkgAzur
 
 	cc, err := pkgAzure.NewCloudConnection(&azure.PublicCloud, pkgAzure.NewCredentials(s.GetValues()))
 	if err != nil {
-		return nil, emperror.Wrap(err, "failed to create cloud connection")
+		return nil, errors.WrapIf(err, "failed to create cloud connection")
 	}
 
 	return cc, nil

--- a/internal/providers/azure/pke/workflow/create_public_ip_activity.go
+++ b/internal/providers/azure/pke/workflow/create_public_ip_activity.go
@@ -17,7 +17,7 @@ package workflow
 import (
 	"context"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-10-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"go.uber.org/cadence/activity"
@@ -70,7 +70,7 @@ func (a CreatePublicIPActivity) Execute(ctx context.Context, input CreatePublicI
 	}
 
 	cc, err := a.azureClientFactory.New(input.OrganizationID, input.SecretID)
-	if err = emperror.Wrap(err, "failed to create cloud connection"); err != nil {
+	if err = errors.WrapIf(err, "failed to create cloud connection"); err != nil {
 		return
 	}
 
@@ -79,19 +79,19 @@ func (a CreatePublicIPActivity) Execute(ctx context.Context, input CreatePublicI
 	client := cc.GetPublicIPAddressesClient()
 
 	future, err := client.CreateOrUpdate(ctx, input.ResourceGroupName, input.PublicIPAddress.Name, params)
-	if err = emperror.WrapWith(err, "sending request to create or update public ip failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "sending request to create or update public ip failed", keyvals...); err != nil {
 		return
 	}
 
 	logger.Debug("waiting for the completion of create or update load public ip operation")
 
 	err = future.WaitForCompletionRef(ctx, client.Client)
-	if err = emperror.WrapWith(err, "waiting for the completion of create or update load public ip operation failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "waiting for the completion of create or update load public ip operation failed", keyvals...); err != nil {
 		return
 	}
 
 	publicIP, err := future.Result(client.PublicIPAddressesClient)
-	if err = emperror.WrapWith(err, "getting load balancer create or update result failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "getting load balancer create or update result failed", keyvals...); err != nil {
 		return
 	}
 

--- a/internal/providers/azure/pke/workflow/create_vmss_activity.go
+++ b/internal/providers/azure/pke/workflow/create_vmss_activity.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"text/template"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"go.uber.org/cadence/activity"
@@ -116,12 +116,12 @@ func (a CreateVMSSActivity) Execute(ctx context.Context, input CreateVMSSActivit
 
 	var userDataScript strings.Builder
 	err = userDataScriptTemplate.Execute(&userDataScript, input.ScaleSet.UserDataScriptParams)
-	if err = emperror.Wrap(err, "failed to execute user data script template"); err != nil {
+	if err = errors.WrapIf(err, "failed to execute user data script template"); err != nil {
 		return
 	}
 
 	cc, err := a.azureClientFactory.New(input.OrganizationID, input.SecretID)
-	if err = emperror.Wrap(err, "failed to create cloud connection"); err != nil {
+	if err = errors.WrapIf(err, "failed to create cloud connection"); err != nil {
 		return
 	}
 
@@ -132,19 +132,19 @@ func (a CreateVMSSActivity) Execute(ctx context.Context, input CreateVMSSActivit
 	logger.Debug("sending request to create or update virtual machine scale set")
 
 	future, err := client.CreateOrUpdate(ctx, input.ResourceGroupName, input.ScaleSet.Name, params)
-	if err = emperror.WrapWith(err, "sending request to create or update virtual machine scale set failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "sending request to create or update virtual machine scale set failed", keyvals...); err != nil {
 		return
 	}
 
 	logger.Debug("waiting for the completion of create or update virtual machine scale set operation")
 
 	err = future.WaitForCompletionRef(ctx, client.Client)
-	if err = emperror.WrapWith(err, "waiting for the completion of create or update virtual machine scale set operation failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "waiting for the completion of create or update virtual machine scale set operation failed", keyvals...); err != nil {
 		return
 	}
 
 	vmss, err := future.Result(client.VirtualMachineScaleSetsClient)
-	if err = emperror.WrapWith(err, "getting virtual machine scale set create or update result failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "getting virtual machine scale set create or update result failed", keyvals...); err != nil {
 		return
 	}
 

--- a/internal/providers/azure/pke/workflow/delete_nodepool_from_store_activity.go
+++ b/internal/providers/azure/pke/workflow/delete_nodepool_from_store_activity.go
@@ -17,7 +17,7 @@ package workflow
 import (
 	"context"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
 )
@@ -43,7 +43,7 @@ func (a DeleteNodePoolFromStoreActivity) Execute(ctx context.Context, input Dele
 	for _, name := range input.NodePoolNames {
 		err := a.store.DeleteNodePool(input.ClusterID, name)
 		if err != nil {
-			return emperror.WrapWith(err, "failed to delete nodepool from store", "nodepool", name, "cluster", input.ClusterID)
+			return errors.WrapIfWithDetails(err, "failed to delete nodepool from store", "nodepool", name, "cluster", input.ClusterID)
 		}
 	}
 	return nil

--- a/internal/providers/azure/pke/workflow/delete_vmss_activity.go
+++ b/internal/providers/azure/pke/workflow/delete_vmss_activity.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"net/http"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/Azure/go-autorest/autorest/to"
 	"go.uber.org/cadence/activity"
 )
@@ -62,7 +62,7 @@ func (a DeleteVMSSActivity) Execute(ctx context.Context, input DeleteVMSSActivit
 
 	logger.Info("delete virtual machine scale set")
 	cc, err := a.azureClientFactory.New(input.OrganizationID, input.SecretID)
-	if err = emperror.Wrap(err, "failed to create cloud connection"); err != nil {
+	if err = errors.WrapIf(err, "failed to create cloud connection"); err != nil {
 		return
 	}
 
@@ -78,7 +78,7 @@ func (a DeleteVMSSActivity) Execute(ctx context.Context, input DeleteVMSSActivit
 			return nil
 		}
 
-		return emperror.WrapWith(err, "failed to get virtual machine scale set details", keyvals...)
+		return errors.WrapIfWithDetails(err, "failed to get virtual machine scale set details", keyvals...)
 	}
 
 	if !HasOwnedTag(input.ClusterName, to.StringMap(vmss.Tags)) {
@@ -87,7 +87,7 @@ func (a DeleteVMSSActivity) Execute(ctx context.Context, input DeleteVMSSActivit
 	}
 
 	future, err := client.Delete(ctx, input.ResourceGroupName, input.VMSSName)
-	if err = emperror.WrapWith(err, "sending request to delete virtual machine scale set failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "sending request to delete virtual machine scale set failed", keyvals...); err != nil {
 		if resp := future.Response(); resp != nil && resp.StatusCode == http.StatusNotFound {
 			logger.Warn("virtual machine scale set not found")
 			return nil
@@ -98,7 +98,7 @@ func (a DeleteVMSSActivity) Execute(ctx context.Context, input DeleteVMSSActivit
 	logger.Debug("waiting for the completion of delete virtual machine scale set operation")
 
 	err = future.WaitForCompletionRef(ctx, client.Client)
-	if err = emperror.WrapWith(err, "waiting for the completion of delete virtual machine scale set operation failed", keyvals...); err != nil {
+	if err = errors.WrapIfWithDetails(err, "waiting for the completion of delete virtual machine scale set operation failed", keyvals...); err != nil {
 		if resp := future.Response(); resp != nil && resp.StatusCode == http.StatusNotFound {
 			logger.Warn("virtual machine scale set not found")
 			return nil


### PR DESCRIPTION
… under internal/providers/azure/pke

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Switch from `errors`, `emperror.dev/emperror` and `github.com/pkg/errors` to `emperror.dev/errors` when possible.


### Why?
`emperror.dev/errors` can provide all required functions and more.


### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
