### PR TITLE
vault-feature: simplify role output

### DIFF
--- a/internal/clusterfeature/features/vault/manager.go
+++ b/internal/clusterfeature/features/vault/manager.go
@@ -110,7 +110,7 @@ func getVaultOutput(m vaultManager, orgID, clusterID uint) (map[string]interface
 
 	out := map[string]interface{}{
 		"authMethodPath": getAuthMethodPath(orgID, clusterID),
-		"rolePath":       getRolePath(orgID, clusterID, getRoleName(m.customVault)),
+		"role":           getRoleName(m.customVault),
 		"version":        vaultVersion,
 	}
 	if !m.customVault {

--- a/internal/clusterfeature/features/vault/manager_test.go
+++ b/internal/clusterfeature/features/vault/manager_test.go
@@ -95,7 +95,7 @@ func TestFeatureManager_GetOutput(t *testing.T) {
 			output: clusterfeature.FeatureOutput{
 				"vault": map[string]interface{}{
 					"authMethodPath": "kubernetes-cluster/13/42",
-					"rolePath":       "auth/kubernetes-cluster/13/42/role/pipeline",
+					"role":           "pipeline",
 					"version":        vVersion,
 					"policy": fmt.Sprintf(`
 			path "secret/data/orgs/%d/*" {
@@ -122,7 +122,7 @@ func TestFeatureManager_GetOutput(t *testing.T) {
 			output: clusterfeature.FeatureOutput{
 				"vault": map[string]interface{}{
 					"authMethodPath": "kubernetes-cluster/13/42",
-					"rolePath":       "auth/kubernetes-cluster/13/42/role/pipeline-webhook",
+					"role":           "pipeline-webhook",
 					"version":        vVersion,
 				},
 				"webhook": map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/banzai-cli/pull/144
| License         | Apache 2.0


### What's in this PR?
Instead of rolePath, the role is enough for client consumption.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
