### PR TITLE
enable RBAC for hpa-operator dependency: metrics-server (PR#2361)

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -407,6 +407,7 @@ func InstallHorizontalPodAutoscalerPostHook(cluster CommonCluster) error {
 				"enabled": true,
 			}
 			values["metrics-server"] = map[string]interface{}{
+				"rbac":        map[string]interface{}{"create": true},
 				"affinity":    GetHeadNodeAffinity(cluster),
 				"tolerations": GetHeadNodeTolerations(),
 			}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?

Metrics Server - required if not already deployed by managed K8S, like GKE etc. - fails with RBAC problems:
```
ERROR: logging before flag.Parse: E1008 09:26:20.601059       1 memcache.go:153] couldn't get resource list for metrics.k8s.io/v1beta1: an error on the server ("Internal Server Error: \"/apis/metrics.k8s.io/v1beta1\": subjectaccessreviews.authorization.k8s.io is forbidden: User \"system:serviceaccount:pipeline-system:hpa-operator-metrics-server\" cannot create resource \"subjectaccessreviews\" in API group \"authorization.k8s.io\" at the cluster scope") has prevented the request from succeeding
```

The cause is that rbac is not enabled by default on [metrics-sever Helm chart](https://github.com/banzaicloud/banzai-charts/tree/master/metrics-server)

The fix sets rbac.create=true value for metrcis-sever.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
