### PR TITLE
Fix Activity retry process in case of features

### DIFF
--- a/internal/clusterfeature/clusterfeatureadapter/workflow/cluster_feature_apply_activity.go
+++ b/internal/clusterfeature/clusterfeatureadapter/workflow/cluster_feature_apply_activity.go
@@ -17,6 +17,8 @@ package workflow
 import (
 	"context"
 
+	"go.uber.org/cadence"
+
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
 )
 
@@ -43,5 +45,11 @@ func (a ClusterFeatureApplyActivity) Execute(ctx context.Context, input ClusterF
 	if err != nil {
 		return err
 	}
-	return f.Apply(ctx, input.ClusterID, input.FeatureSpec)
+
+	err = f.Apply(ctx, input.ClusterID, input.FeatureSpec)
+	if ok := shouldRetry(err); ok {
+		return cadence.NewCustomError(shouldRetryReason)
+	}
+
+	return err
 }

--- a/internal/clusterfeature/clusterfeatureadapter/workflow/cluster_feature_deactivate_activity.go
+++ b/internal/clusterfeature/clusterfeatureadapter/workflow/cluster_feature_deactivate_activity.go
@@ -17,6 +17,8 @@ package workflow
 import (
 	"context"
 
+	"go.uber.org/cadence"
+
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
 )
 
@@ -43,5 +45,11 @@ func (a ClusterFeatureDeactivateActivity) Execute(ctx context.Context, input Clu
 	if err != nil {
 		return err
 	}
-	return f.Deactivate(ctx, input.ClusterID, input.FeatureSpec)
+
+	err = f.Deactivate(ctx, input.ClusterID, input.FeatureSpec)
+	if ok := shouldRetry(err); ok {
+		return cadence.NewCustomError(shouldRetryReason)
+	}
+
+	return err
 }

--- a/internal/clusterfeature/clusterfeatureadapter/workflow/common.go
+++ b/internal/clusterfeature/clusterfeatureadapter/workflow/common.go
@@ -1,0 +1,31 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "errors"
+
+const (
+	shouldRetryReason = "should retry activity"
+)
+
+func shouldRetry(err error) bool {
+	var sh interface {
+		ShouldRetry() bool
+	}
+	if errors.As(err, &sh) {
+		return sh.ShouldRetry()
+	}
+	return false
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Check retry errors after `apply` and `deactivate` and return with a `customError` (and reason) of Candence. After this we can easily check this type of error in the workflow

### Why?
Currently we cannot activate/deactivate the features properly while the cluster is not in ready state. Because of this the feature actions will be failed

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
