### PR TITLE
HTTP proxy for Azure PKE

### DIFF
--- a/.gen/pipeline/README.md
+++ b/.gen/pipeline/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: latest
-- Build date: 2019-10-18T13:27:16.875Z[GMT]
+- Build date: 2019-10-18T14:19:45.010Z[GMT]
 
 
 ### Running the server

--- a/.gen/pipeline/SHA256SUMS
+++ b/.gen/pipeline/SHA256SUMS
@@ -1,1 +1,1 @@
-1f437a7b76def2fa044f874d47c6cc49089fcfe0b08be7342e6d39592111f04a  apis/pipeline/pipeline.yaml
+e52a3650467f23c3c3bdb55ba36804662a974f2f5161a191444d8e81db052b70  apis/pipeline/pipeline.yaml

--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -9409,6 +9409,38 @@ components:
       allOf:
       - $ref: '#/components/schemas/CreateClusterRequestBase'
       - $ref: '#/components/schemas/CreatePKEClusterRequestBase_allOf'
+    PKEClusterHTTPProxy:
+      properties:
+        http:
+          $ref: '#/components/schemas/PKEClusterHTTPProxyOptions'
+        https:
+          $ref: '#/components/schemas/PKEClusterHTTPProxyOptions'
+        exceptions:
+          description: list of URLs excluded from proxying
+          items:
+            example: .example.org
+            type: string
+          type: array
+      type: object
+    PKEClusterHTTPProxyOptions:
+      properties:
+        host:
+          description: host of the proxy
+          example: proxy.example.org
+          type: string
+        port:
+          description: port the proxy is available on
+          example: 12345
+          maximum: 65535
+          minimum: 0
+          type: integer
+        secretId:
+          description: ID of the secret containing the username and password for the
+            proxy
+          type: string
+      required:
+      - host
+      type: object
     CreatePKEOnAzureClusterRequest:
       allOf:
       - $ref: '#/components/schemas/CreatePKEClusterRequestBase'
@@ -14434,6 +14466,8 @@ components:
       properties:
         kubernetes:
           $ref: '#/components/schemas/CreatePKEClusterKubernetes'
+        proxy:
+          $ref: '#/components/schemas/PKEClusterHTTPProxy'
       required:
       - kubernetes
     CreatePKEOnAzureClusterRequest_allOf:

--- a/.gen/pipeline/pipeline/model_create_cluster_request_v2.go
+++ b/.gen/pipeline/pipeline/model_create_cluster_request_v2.go
@@ -28,6 +28,8 @@ type CreateClusterRequestV2 struct {
 
 	Kubernetes CreatePkeClusterKubernetes `json:"kubernetes"`
 
+	Proxy PkeClusterHttpProxy `json:"proxy,omitempty"`
+
 	// Non-existent resources will be created in this location. Existing resources that must have the same location as the cluster will be validated against this.
 	Location string `json:"location,omitempty"`
 

--- a/.gen/pipeline/pipeline/model_create_pke_on_azure_cluster_request.go
+++ b/.gen/pipeline/pipeline/model_create_pke_on_azure_cluster_request.go
@@ -28,6 +28,8 @@ type CreatePkeOnAzureClusterRequest struct {
 
 	Kubernetes CreatePkeClusterKubernetes `json:"kubernetes"`
 
+	Proxy PkeClusterHttpProxy `json:"proxy,omitempty"`
+
 	// Non-existent resources will be created in this location. Existing resources that must have the same location as the cluster will be validated against this.
 	Location string `json:"location,omitempty"`
 

--- a/.gen/pipeline/pipeline/model_pke_cluster_http_proxy.go
+++ b/.gen/pipeline/pipeline/model_pke_cluster_http_proxy.go
@@ -10,9 +10,12 @@
 
 package pipeline
 
-type CreatePkeClusterRequestBaseAllOf struct {
+type PkeClusterHttpProxy struct {
 
-	Kubernetes CreatePkeClusterKubernetes `json:"kubernetes"`
+	Http PkeClusterHttpProxyOptions `json:"http,omitempty"`
 
-	Proxy PkeClusterHttpProxy `json:"proxy,omitempty"`
+	Https PkeClusterHttpProxyOptions `json:"https,omitempty"`
+
+	// list of URLs excluded from proxying
+	Exceptions []string `json:"exceptions,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_pke_cluster_http_proxy_options.go
+++ b/.gen/pipeline/pipeline/model_pke_cluster_http_proxy_options.go
@@ -10,23 +10,14 @@
 
 package pipeline
 
-type CreatePkeClusterRequestBase struct {
+type PkeClusterHttpProxyOptions struct {
 
-	Name string `json:"name"`
+	// host of the proxy
+	Host string `json:"host"`
 
-	Features []Feature `json:"features,omitempty"`
+	// port the proxy is available on
+	Port int32 `json:"port,omitempty"`
 
+	// ID of the secret containing the username and password for the proxy
 	SecretId string `json:"secretId,omitempty"`
-
-	SecretName string `json:"secretName,omitempty"`
-
-	SshSecretId string `json:"sshSecretId,omitempty"`
-
-	ScaleOptions ScaleOptions `json:"scaleOptions,omitempty"`
-
-	Type string `json:"type"`
-
-	Kubernetes CreatePkeClusterKubernetes `json:"kubernetes"`
-
-	Proxy PkeClusterHttpProxy `json:"proxy,omitempty"`
 }

--- a/api/cluster/pke_azure.go
+++ b/api/cluster/pke_azure.go
@@ -76,6 +76,19 @@ func (req CreatePKEOnAzureClusterRequest) ToAzurePKEClusterCreationParams(organi
 		},
 		NodePools: requestToClusterNodepools(req.Nodepools, userID),
 		Features:  features,
+		HTTPProxy: intPKE.HTTPProxy{
+			HTTP:       clientPKEClusterHTTPProxyOptionsToPKEHTTPProxyOptions(req.Proxy.Http),
+			HTTPS:      clientPKEClusterHTTPProxyOptionsToPKEHTTPProxyOptions(req.Proxy.Https),
+			Exceptions: req.Proxy.Exceptions,
+		},
+	}
+}
+
+func clientPKEClusterHTTPProxyOptionsToPKEHTTPProxyOptions(o pipeline.PkeClusterHttpProxyOptions) intPKE.HTTPProxyOptions {
+	return intPKE.HTTPProxyOptions{
+		Host:     o.Host,
+		Port:     uint16(o.Port),
+		SecretID: o.SecretId,
 	}
 }
 

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -6745,13 +6745,50 @@ components:
                   properties:
                         kubernetes:
                             $ref: '#/components/schemas/CreatePKEClusterKubernetes'
+                        proxy:
+                            $ref: '#/components/schemas/PKEClusterHTTPProxy'
+
+        PKEClusterHTTPProxy:
+            type: object
+            properties:
+                http:
+                    description: "HTTP proxy options"
+                    $ref: '#/components/schemas/PKEClusterHTTPProxyOptions'
+                https:
+                    description: "HTTPS proxy options"
+                    $ref: '#/components/schemas/PKEClusterHTTPProxyOptions'
+                exceptions:
+                    description: "list of URLs excluded from proxying"
+                    type: array
+                    items:
+                        type: string
+                        example: ".example.org"
+
+        PKEClusterHTTPProxyOptions:
+            type: object
+            required:
+                - host
+            properties:
+                host:
+                    description: "host of the proxy"
+                    type: string
+                    example: "proxy.example.org"
+                port:
+                    description: "port the proxy is available on"
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    example: 12345
+                secretId:
+                    description: "ID of the secret containing the username and password for the proxy"
+                    type: string
 
         CreatePKEOnAzureClusterRequest:
             allOf:
                 - $ref: '#/components/schemas/CreatePKEClusterRequestBase'
                 - type: object
                   required:
-                    - resourceGroup
+                        - resourceGroup
                   properties:
                         location:
                             type: string
@@ -6766,8 +6803,7 @@ components:
                         nodepools:
                             type: array
                             items:
-                              $ref: '#/components/schemas/PKEOnAzureNodePool'
-
+                                $ref: '#/components/schemas/PKEOnAzureNodePool'
 
         PKEOnAzureClusterNetwork:
             type: object

--- a/cmd/worker/pke.go
+++ b/cmd/worker/pke.go
@@ -1,0 +1,28 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"go.uber.org/cadence/activity"
+
+	pkeworkflow "github.com/banzaicloud/pipeline/internal/pke/workflow"
+)
+
+func registerPKEWorkflows(passwordSecrets pkeworkflow.PasswordSecretStore) {
+	{
+		a := pkeworkflow.NewAssembleHTTPProxySettingsActivity(passwordSecrets)
+		activity.RegisterWithOptions(a.Execute, activity.RegisterOptions{Name: pkeworkflow.AssembleHTTPProxySettingsActivityName})
+	}
+}

--- a/database/migrations/mysql/1569937443_add_http_proxy_to_pke_azure.down.sql
+++ b/database/migrations/mysql/1569937443_add_http_proxy_to_pke_azure.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `azure_pke_clusters` DROP COLUMN `http_proxy`;

--- a/database/migrations/mysql/1569937443_add_http_proxy_to_pke_azure.up.sql
+++ b/database/migrations/mysql/1569937443_add_http_proxy_to_pke_azure.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `azure_pke_clusters` ADD COLUMN `http_proxy` json DEFAULT NULL;

--- a/database/migrations/postgres/1569937443_add_http_proxy_to_pke_azure.down.sql
+++ b/database/migrations/postgres/1569937443_add_http_proxy_to_pke_azure.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "azure_pke_clusters" DROP COLUMN "http_proxy";

--- a/database/migrations/postgres/1569937443_add_http_proxy_to_pke_azure.up.sql
+++ b/database/migrations/postgres/1569937443_add_http_proxy_to_pke_azure.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "azure_pke_clusters" ADD COLUMN "http_proxy" json;

--- a/internal/pke/http_proxy.go
+++ b/internal/pke/http_proxy.go
@@ -1,0 +1,29 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pke
+
+// HTTPProxy define the HTTP proxy settings to configure on a PKE cluster
+type HTTPProxy struct {
+	HTTP       HTTPProxyOptions
+	HTTPS      HTTPProxyOptions
+	Exceptions []string
+}
+
+// HTTPProxyOptions define the options of a HTTP(S) proxy
+type HTTPProxyOptions struct {
+	Host     string
+	Port     uint16
+	SecretID string
+}

--- a/internal/pke/workflow/adapter/secret_store.go
+++ b/internal/pke/workflow/adapter/secret_store.go
@@ -1,0 +1,91 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+
+	"emperror.dev/errors"
+
+	"github.com/banzaicloud/pipeline/internal/pke/workflow"
+	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
+	"github.com/banzaicloud/pipeline/pkg/brn"
+)
+
+type PasswordSecretStore struct {
+	store SecretStore
+}
+
+type SecretStore interface {
+	GetSecretValues(ctx context.Context, secretID string) (map[string]string, error)
+}
+
+func NewPasswordSecretStore(store SecretStore) PasswordSecretStore {
+	return PasswordSecretStore{
+		store: store,
+	}
+}
+
+func (s PasswordSecretStore) GetSecret(ctx context.Context, orgID uint, secretID string) (workflow.PasswordSecret, error) {
+	if !brn.IsBRN(secretID) {
+		secretID = brn.ResourceName{
+			Scheme:         brn.Scheme,
+			OrganizationID: orgID,
+			ResourceType:   brn.SecretResourceType,
+			ResourceID:     secretID,
+		}.String()
+	}
+
+	values, err := s.store.GetSecretValues(ctx, secretID)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to get secret values")
+	}
+	ps, err := toPasswordSecret(values)
+	return ps, errors.WrapIf(err, "failed to adapt password secret")
+}
+
+func toPasswordSecret(s map[string]string) (ps passwordSecret, err error) {
+	ps.username, err = getSecretValue(s, secrettype.Username)
+	if err != nil {
+		return
+	}
+	ps.password, err = getSecretValue(s, secrettype.Password)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func getSecretValue(s map[string]string, k string) (string, error) {
+	v, ok := s[k]
+	if !ok {
+		return "", errors.New(fmt.Sprintf("%q key missing from secret", k))
+	}
+	return v, nil
+}
+
+type passwordSecret struct {
+	username string
+	password string
+}
+
+func (s passwordSecret) Username() string {
+	return s.username
+}
+
+func (s passwordSecret) Password() string {
+	return s.password
+}

--- a/internal/pke/workflow/assemble_http_proxy_settings_activity.go
+++ b/internal/pke/workflow/assemble_http_proxy_settings_activity.go
@@ -1,0 +1,104 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"net/url"
+
+	"emperror.dev/errors"
+)
+
+const AssembleHTTPProxySettingsActivityName = "assemble-http-proxy-settings"
+
+type PasswordSecret interface {
+	Username() string
+	Password() string
+}
+
+type PasswordSecretStore interface {
+	GetSecret(ctx context.Context, organizationID uint, secretID string) (PasswordSecret, error)
+}
+
+type AssembleHTTPProxySettingsActivity struct {
+	secrets PasswordSecretStore
+}
+
+func NewAssembleHTTPProxySettingsActivity(secrets PasswordSecretStore) AssembleHTTPProxySettingsActivity {
+	return AssembleHTTPProxySettingsActivity{
+		secrets: secrets,
+	}
+}
+
+type AssembleHTTPProxySettingsActivityInput struct {
+	OrganizationID     uint
+	HTTPProxyHostPort  string
+	HTTPProxySecretID  string
+	HTTPSProxyHostPort string
+	HTTPSProxySecretID string
+}
+
+type AssembleHTTPProxySettingsActivityOutput struct {
+	Settings HTTPProxy
+}
+
+type HTTPProxy struct {
+	HTTPProxyURL  string
+	HTTPSProxyURL string
+}
+
+func (a AssembleHTTPProxySettingsActivity) Execute(
+	ctx context.Context,
+	input AssembleHTTPProxySettingsActivityInput,
+) (output AssembleHTTPProxySettingsActivityOutput, err error) {
+	output.Settings.HTTPProxyURL, err = a.assembleProxyURL(ctx, "http", input.HTTPProxyHostPort, input.OrganizationID, input.HTTPProxySecretID)
+	if err != nil {
+		return
+	}
+
+	output.Settings.HTTPSProxyURL, err = a.assembleProxyURL(ctx, "https", input.HTTPSProxyHostPort, input.OrganizationID, input.HTTPSProxySecretID)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (a AssembleHTTPProxySettingsActivity) assembleProxyURL(
+	ctx context.Context,
+	scheme string,
+	hostPort string,
+	organizationID uint,
+	secretID string,
+) (string, error) {
+	if hostPort == "" {
+		return "", nil
+	}
+
+	var user *url.Userinfo
+	if secretID != "" {
+		s, err := a.secrets.GetSecret(ctx, organizationID, secretID)
+		if err != nil {
+			return "", errors.WrapIf(err, "failed to get secret")
+		}
+		user = url.UserPassword(s.Username(), s.Password())
+	}
+
+	return (&url.URL{
+		Scheme: scheme,
+		User:   user,
+		Host:   hostPort,
+	}).String(), nil
+}

--- a/internal/pke/workflow/assemble_http_proxy_settings_activity_test.go
+++ b/internal/pke/workflow/assemble_http_proxy_settings_activity_test.go
@@ -1,0 +1,159 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"emperror.dev/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssembleHTTPProxySettings(t *testing.T) {
+	orgID := uint(13)
+	httpSecretID := "http-secret-id"
+	httpsSecretID := "https-secret-id"
+
+	a := NewAssembleHTTPProxySettingsActivity(dummyPasswordSecretStore{
+		entries: map[uint]map[string]dummyPasswordSecret{
+			orgID: {
+				httpSecretID: {
+					username: "http-username",
+					password: "http-password",
+				},
+				httpsSecretID: {
+					username: "https-username",
+					password: "https-password",
+				},
+			},
+		},
+	})
+
+	tc := map[string]struct {
+		Input  AssembleHTTPProxySettingsActivityInput
+		Output HTTPProxy
+		Error  interface{}
+	}{
+		"with everything": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:     orgID,
+				HTTPProxyHostPort:  "http-proxy.org:1234",
+				HTTPProxySecretID:  httpSecretID,
+				HTTPSProxyHostPort: "https-proxy.org:2345",
+				HTTPSProxySecretID: httpsSecretID,
+			},
+			Output: HTTPProxy{
+				HTTPProxyURL:  "http://http-username:http-password@http-proxy.org:1234",
+				HTTPSProxyURL: "https://https-username:https-password@https-proxy.org:2345",
+			},
+		},
+		"http only with secret": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:    orgID,
+				HTTPProxyHostPort: "http-proxy.org:1234",
+				HTTPProxySecretID: httpSecretID,
+			},
+			Output: HTTPProxy{
+				HTTPProxyURL: "http://http-username:http-password@http-proxy.org:1234",
+			},
+		},
+		"http only without secret": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:    orgID,
+				HTTPProxyHostPort: "http-proxy.org:1234",
+			},
+			Output: HTTPProxy{
+				HTTPProxyURL: "http://http-proxy.org:1234",
+			},
+		},
+		"https only with secret": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:     orgID,
+				HTTPSProxyHostPort: "https-proxy.org:2345",
+				HTTPSProxySecretID: httpsSecretID,
+			},
+			Output: HTTPProxy{
+				HTTPSProxyURL: "https://https-username:https-password@https-proxy.org:2345",
+			},
+		},
+		"https only without secret": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:     orgID,
+				HTTPSProxyHostPort: "https-proxy.org:2345",
+			},
+			Output: HTTPProxy{
+				HTTPSProxyURL: "https://https-proxy.org:2345",
+			},
+		},
+		"empty": {
+			Input:  AssembleHTTPProxySettingsActivityInput{},
+			Output: HTTPProxy{},
+		},
+		"missing secret": {
+			Input: AssembleHTTPProxySettingsActivityInput{
+				OrganizationID:     uint(24),
+				HTTPProxyHostPort:  "http-proxy.org:1234",
+				HTTPProxySecretID:  httpSecretID,
+				HTTPSProxyHostPort: "https-proxy.org:2345",
+				HTTPSProxySecretID: httpsSecretID,
+			},
+			Error: true,
+		},
+	}
+
+	for name, tv := range tc {
+		t.Run(name, func(t *testing.T) {
+			output, err := a.Execute(context.Background(), tv.Input)
+			switch tv.Error {
+			case true:
+				require.Error(t, err)
+			case false, nil:
+				require.NoError(t, err)
+				require.Equal(t, AssembleHTTPProxySettingsActivityOutput{
+					Settings: tv.Output,
+				}, output)
+			default:
+				require.Equal(t, tv.Error, err)
+			}
+		})
+	}
+}
+
+type dummyPasswordSecretStore struct {
+	entries map[uint]map[string]dummyPasswordSecret
+}
+
+func (s dummyPasswordSecretStore) GetSecret(ctx context.Context, orgID uint, secretID string) (PasswordSecret, error) {
+	if secrets, ok := s.entries[orgID]; ok {
+		if secret, ok := secrets[secretID]; ok {
+			return secret, nil
+		}
+	}
+	return nil, errors.New("secret not found")
+}
+
+type dummyPasswordSecret struct {
+	username string
+	password string
+}
+
+func (s dummyPasswordSecret) Username() string {
+	return s.username
+}
+
+func (s dummyPasswordSecret) Password() string {
+	return s.password
+}

--- a/internal/providers/azure/pke/adapter/gorm_store.go
+++ b/internal/providers/azure/pke/adapter/gorm_store.go
@@ -15,6 +15,7 @@
 package adapter
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
+	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
@@ -75,12 +77,65 @@ type gormAzurePKEClusterModel struct {
 	ActiveWorkflowID  string
 	KubernetesVersion string
 
+	HTTPProxy httpProxyModel `gorm:"type:json"`
+
 	Cluster   cluster.ClusterModel        `gorm:"foreignkey:ClusterID"`
 	NodePools []gormAzurePKENodePoolModel `gorm:"foreignkey:ClusterID;association_foreignkey:ClusterID"`
 }
 
 func (gormAzurePKEClusterModel) TableName() string {
 	return GORMAzurePKEClustersTableName
+}
+
+type httpProxyModel struct {
+	HTTP       httpProxyOptionsModel `json:"http,omitempty"`
+	HTTPS      httpProxyOptionsModel `json:"https,omitempty"`
+	Exceptions []string              `json:"exceptions,omitempty"`
+}
+
+func (m *httpProxyModel) Scan(v interface{}) error {
+	if s, ok := v.(string); ok {
+		v = []byte(s)
+	}
+	return json.Unmarshal(v.([]byte), m)
+}
+
+func (m httpProxyModel) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}
+
+func (m *httpProxyModel) fromEntity(e intPKE.HTTPProxy) {
+	m.HTTP.fromEntity(e.HTTP)
+	m.HTTPS.fromEntity(e.HTTPS)
+	m.Exceptions = e.Exceptions
+}
+
+func (m httpProxyModel) toEntity() intPKE.HTTPProxy {
+	return intPKE.HTTPProxy{
+		HTTP:       m.HTTP.toEntity(),
+		HTTPS:      m.HTTPS.toEntity(),
+		Exceptions: m.Exceptions,
+	}
+}
+
+type httpProxyOptionsModel struct {
+	Host     string `json:"host"`
+	Port     uint16 `json:"port,omitempty"`
+	SecretID string `json:"secretId,omitempty"`
+}
+
+func (m *httpProxyOptionsModel) fromEntity(e intPKE.HTTPProxyOptions) {
+	m.Host = e.Host
+	m.Port = e.Port
+	m.SecretID = e.SecretID
+}
+
+func (m httpProxyOptionsModel) toEntity() intPKE.HTTPProxyOptions {
+	return intPKE.HTTPProxyOptions{
+		Host:     m.Host,
+		Port:     m.Port,
+		SecretID: m.SecretID,
+	}
 }
 
 type recordNotFoundError struct{}
@@ -142,7 +197,7 @@ func unmarshalStringSlice(s string) (result []string) {
 	return
 }
 
-func fillClusterFromAzurePKEClusterModel(cluster *pke.PKEOnAzureCluster, model gormAzurePKEClusterModel) {
+func fillClusterFromAzurePKEClusterModel(cluster *pke.PKEOnAzureCluster, model gormAzurePKEClusterModel) error {
 	fillClusterFromClusterModel(cluster, model.Cluster)
 
 	cluster.ResourceGroup.Name = model.ResourceGroupName
@@ -158,6 +213,10 @@ func fillClusterFromAzurePKEClusterModel(cluster *pke.PKEOnAzureCluster, model g
 
 	cluster.Kubernetes.Version = model.KubernetesVersion
 	cluster.ActiveWorkflowID = model.ActiveWorkflowID
+
+	cluster.HTTPProxy = model.HTTPProxy.toEntity()
+
+	return nil
 }
 
 func fillNodePoolFromModel(nodePool *pke.NodePool, model gormAzurePKENodePoolModel) {
@@ -237,6 +296,9 @@ func (s gormAzurePKEClusterStore) Create(params pke.CreateParams) (c pke.PKEOnAz
 		VirtualNetworkName:     params.VirtualNetworkName,
 		NodePools:              nodePools,
 	}
+
+	model.HTTPProxy.fromEntity(params.HTTPProxy)
+
 	{
 		// Adapting to legacy format. TODO: Please remove this as soon as possible.
 		for _, f := range params.Features {
@@ -255,7 +317,9 @@ func (s gormAzurePKEClusterStore) Create(params pke.CreateParams) (c pke.PKEOnAz
 	if err = getError(s.db.Preload("Cluster").Preload("NodePools").Create(&model), "failed to create cluster model"); err != nil {
 		return
 	}
-	fillClusterFromAzurePKEClusterModel(&c, model)
+	if err := fillClusterFromAzurePKEClusterModel(&c, model); err != nil {
+		return c, errors.WrapIf(err, "failed to fill cluster from model")
+	}
 	return
 }
 
@@ -293,7 +357,7 @@ func (s gormAzurePKEClusterStore) Delete(clusterID uint) error {
 	return getError(s.db.Delete(model), "failed to soft-delete model from database")
 }
 
-func (s gormAzurePKEClusterStore) GetByID(clusterID uint) (cluster pke.PKEOnAzureCluster, err error) {
+func (s gormAzurePKEClusterStore) GetByID(clusterID uint) (cluster pke.PKEOnAzureCluster, _ error) {
 	if err := validateClusterID(clusterID); err != nil {
 		return cluster, errors.WrapIf(err, "invalid cluster ID")
 	}
@@ -301,10 +365,12 @@ func (s gormAzurePKEClusterStore) GetByID(clusterID uint) (cluster pke.PKEOnAzur
 	model := gormAzurePKEClusterModel{
 		ClusterID: clusterID,
 	}
-	if err = getError(s.db.Preload("Cluster").Preload("NodePools").Where(&model).First(&model), "failed to load model from database"); err != nil {
-		return
+	if err := getError(s.db.Preload("Cluster").Preload("NodePools").Where(&model).First(&model), "failed to load model from database"); err != nil {
+		return cluster, err
 	}
-	fillClusterFromAzurePKEClusterModel(&cluster, model)
+	if err := fillClusterFromAzurePKEClusterModel(&cluster, model); err != nil {
+		return cluster, errors.WrapIf(err, "failed to fill cluster from model")
+	}
 	return
 }
 

--- a/internal/providers/azure/pke/cluster.go
+++ b/internal/providers/azure/pke/cluster.go
@@ -57,6 +57,7 @@ type PKEOnAzureCluster struct {
 	VirtualNetwork   VirtualNetwork
 	Kubernetes       intPKE.Kubernetes
 	ActiveWorkflowID string
+	HTTPProxy        intPKE.HTTPProxy
 
 	Monitoring   bool
 	Logging      bool

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -514,6 +514,9 @@ export PRIVATE_IP=$(hostname -I | cut -d" " -f 1)
 until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
 chmod +x /usr/local/bin/pke
 export PATH=$PATH:/usr/local/bin/
+export HTTP_PROXY="{{ .HttpProxy }}"
+export HTTPS_PROXY="{{ .HttpsProxy }}"
+export NO_PROXY="{{ .NoProxy }}"
 
 pke install master --pipeline-url="{{ .PipelineURL }}" \
 --pipeline-insecure="{{ .PipelineURLInsecure }}" \
@@ -544,6 +547,9 @@ const workerUserDataScriptTemplate = `#!/bin/sh
 until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
 chmod +x /usr/local/bin/pke
 export PATH=$PATH:/usr/local/bin/
+export HTTP_PROXY="{{ .HttpProxy }}"
+export HTTPS_PROXY="{{ .HttpsProxy }}"
+export NO_PROXY="{{ .NoProxy }}"
 
 pke install worker --pipeline-url="{{ .PipelineURL }}" \
 --pipeline-insecure="{{ .PipelineURLInsecure }}" \

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -382,6 +382,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 		},
 		VirtualMachineScaleSetTemplates: vmssTemplates,
 		PostHooks:                       postHooks,
+		HTTPProxy:                       cl.HTTPProxy,
 	}
 	workflowOptions := client.StartWorkflowOptions{
 		TaskList:                     "pipeline",

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -150,6 +151,7 @@ type AzurePKEClusterCreationParams struct {
 	ScaleOptions   pkgCluster.ScaleOptions
 	SecretID       string
 	SSHSecretID    string
+	HTTPProxy      intPKE.HTTPProxy
 }
 
 // Create
@@ -218,6 +220,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 		NodePools:          nodePools,
 		VirtualNetworkName: params.Network.Name,
 		KubernetesVersion:  params.Kubernetes.Version,
+		HTTPProxy:          params.HTTPProxy,
 	}
 	cl, err = cc.store.Create(createParams)
 	if err != nil {
@@ -271,6 +274,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 		ClusterName:                 cl.Name,
 		KubernetesVersion:           cl.Kubernetes.Version,
 		Location:                    cl.Location,
+		NoProxy:                     strings.Join(cl.HTTPProxy.Exceptions, ","),
 		OrganizationID:              cl.OrganizationID,
 		PipelineExternalURL:         cc.config.PipelineExternalURL,
 		PipelineExternalURLInsecure: cc.config.PipelineExternalURLInsecure,

--- a/internal/providers/azure/pke/driver/common.go
+++ b/internal/providers/azure/pke/driver/common.go
@@ -49,6 +49,7 @@ type nodePoolTemplateFactory struct {
 	VirtualNetworkName          string
 	OIDCClientID                string
 	OIDCIssuerURL               string
+	NoProxy                     string
 }
 
 func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMachineScaleSetTemplate, workflow.SubnetTemplate, []workflow.RoleAssignmentTemplate) {
@@ -148,6 +149,9 @@ func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMach
 				"TenantID":              f.TenantID,
 				"VnetName":              f.VirtualNetworkName,
 				"VnetResourceGroupName": f.ResourceGroupName,
+				"HttpProxy":             "<not yet set>",
+				"HttpsProxy":            "<not yet set>",
+				"NoProxy":               f.NoProxy,
 			},
 			UserDataScriptTemplate: userDataScriptTemplate,
 			Zones:                  np.Zones,

--- a/internal/providers/azure/pke/store.go
+++ b/internal/providers/azure/pke/store.go
@@ -18,6 +18,7 @@ import (
 	"emperror.dev/errors"
 
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
+	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
@@ -36,6 +37,7 @@ type CreateParams struct {
 	VirtualNetworkName string
 	NodePools          []NodePool
 	Features           []intCluster.Feature
+	HTTPProxy          intPKE.HTTPProxy
 }
 
 // AzurePKEClusterStore defines behaviors of PKEOnAzureCluster persistent storage

--- a/internal/providers/azure/pke/store.go
+++ b/internal/providers/azure/pke/store.go
@@ -15,7 +15,7 @@
 package pke
 
 import (
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 
 	intCluster "github.com/banzaicloud/pipeline/internal/cluster"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
@@ -55,14 +55,9 @@ type AzurePKEClusterStore interface {
 
 // IsNotFound returns true if the error is about a resource not being found
 func IsNotFound(err error) bool {
-	// Check the root cause error.
-	err = errors.Cause(err)
-
-	if e, ok := err.(interface {
+	var notFoundErr interface {
 		NotFound() bool
-	}); ok {
-		return e.NotFound()
 	}
 
-	return false
+	return errors.As(err, &notFoundErr) && notFoundErr.NotFound()
 }

--- a/internal/providers/azure/pke/workflow/create_cluster.go
+++ b/internal/providers/azure/pke/workflow/create_cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/clustersetup"
+	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
@@ -47,6 +48,7 @@ type CreateClusterWorkflowInput struct {
 	SecurityGroups                  []SecurityGroup
 	VirtualMachineScaleSetTemplates []VirtualMachineScaleSetTemplate
 	PostHooks                       pkgCluster.PostHooks
+	HTTPProxy                       intPKE.HTTPProxy
 }
 
 func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInput) error {
@@ -97,6 +99,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		ScaleSets:         input.VirtualMachineScaleSetTemplates,
 		SecurityGroups:    input.SecurityGroups,
 		VirtualNetwork:    input.VirtualNetworkTemplate,
+		HTTPProxy:         input.HTTPProxy,
 	}
 	err := workflow.ExecuteChildWorkflow(ctx, CreateInfraWorkflowName, infraInput).Get(ctx, nil)
 	if err != nil {

--- a/internal/providers/azure/pke/workflow/create_vmss_activity.go
+++ b/internal/providers/azure/pke/workflow/create_vmss_activity.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"go.uber.org/cadence/activity"
 
+	intPKEWorkflow "github.com/banzaicloud/pipeline/internal/pke/workflow"
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow/pkeworkflowadapter"
 )
 
@@ -54,6 +55,7 @@ type CreateVMSSActivityInput struct {
 	ClusterName       string
 	ResourceGroupName string
 	ScaleSet          VirtualMachineScaleSet
+	HTTPProxy         intPKEWorkflow.HTTPProxy
 }
 
 // VirtualMachineScaleSet represents an Azure virtual machine scale set
@@ -113,6 +115,9 @@ func (a CreateVMSSActivity) Execute(ctx context.Context, input CreateVMSSActivit
 	}
 
 	input.ScaleSet.UserDataScriptParams["PipelineToken"] = token
+
+	input.ScaleSet.UserDataScriptParams["HttpProxy"] = input.HTTPProxy.HTTPProxyURL
+	input.ScaleSet.UserDataScriptParams["HttpsProxy"] = input.HTTPProxy.HTTPSProxyURL
 
 	var userDataScript strings.Builder
 	err = userDataScriptTemplate.Execute(&userDataScript, input.ScaleSet.UserDataScriptParams)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Add HTTP(S) proxy settings for Azure PKE clusters. The following are added:
* REST API extensions to receive proxy settings
* persist proxy settings with cluster data
* add environment variables to user data scripts defining the necessary proxy settings

The tasks in the user data script should be modified if necessary to make use of the settings.

### Why?
In closed network environments (or for other reasons) users should be able to set an HTTP(S) proxy to be used for PKE installation and other initialization tasks.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated (if needed)
