### PR TITLE
Move k8s config download to a separate workflow

### DIFF
--- a/cluster/common.go
+++ b/cluster/common.go
@@ -79,7 +79,6 @@ type CommonCluster interface {
 	SetTTL(time.Duration)
 
 	// Kubernetes
-	DownloadK8sConfig() ([]byte, error)
 	GetAPIEndpoint() (string, error)
 	GetK8sIpv4Cidrs() (*pkgCluster.Ipv4Cidrs, error)
 	GetK8sConfig() ([]byte, error)

--- a/cluster/create_workflow.go
+++ b/cluster/create_workflow.go
@@ -1,0 +1,123 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
+)
+
+const CreateClusterWorkflowName = "create-cluster-legacy"
+
+type CreateClusterWorkflowInput struct {
+	ClusterID uint
+}
+
+func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInput) error {
+	// Download k8s config (where applicable)
+	{
+		ao := workflow.ActivityOptions{
+			ScheduleToStartTimeout: 10 * time.Minute,
+			StartToCloseTimeout:    20 * time.Minute,
+			WaitForCancellation:    true,
+			RetryPolicy: &cadence.RetryPolicy{
+				InitialInterval:    15 * time.Second,
+				BackoffCoefficient: 1.0,
+				MaximumAttempts:    30,
+			},
+		}
+		ctx := workflow.WithActivityOptions(ctx, ao)
+
+		activityInput := DownloadK8sConfigActivityInput{
+			ClusterID: input.ClusterID,
+		}
+
+		err := workflow.ExecuteActivity(ctx, DownloadK8sConfigActivityName, activityInput).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const DownloadK8sConfigActivityName = "download-k8s-config-legacy"
+
+type DownloadK8sConfigActivityInput struct {
+	ClusterID uint
+}
+
+type DownloadK8sConfigActivity struct {
+	manager *Manager
+}
+
+func NewDownloadK8sConfigActivity(manager *Manager) DownloadK8sConfigActivity {
+	return DownloadK8sConfigActivity{
+		manager: manager,
+	}
+}
+
+// K8sConfigDownloader can download a cluster config.
+type K8sConfigDownloader interface {
+	DownloadK8sConfig() ([]byte, error)
+}
+
+func (a DownloadK8sConfigActivity) Execute(ctx context.Context, input DownloadK8sConfigActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With("clusterId", input.ClusterID)
+
+	cluster, err := a.manager.GetClusterByIDOnly(ctx, input.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	if cluster.GetConfigSecretId() != "" {
+		logger.Info("config is already present in Vault")
+
+		return nil
+	}
+
+	activityInfo := activity.GetInfo(ctx)
+
+	// On the first attempt try to get an existing config
+	if activityInfo.Attempt == 0 {
+		logger.Info("trying to get config for the first time")
+
+		config, err := cluster.GetK8sConfig()
+		if err == nil && len(config) > 0 {
+			logger.Info("saving existing config")
+
+			return StoreKubernetesConfig(cluster, config)
+		}
+	}
+
+	if downloader, ok := cluster.(K8sConfigDownloader); ok {
+		logger.Info("attempting to download config")
+
+		config, err := downloader.DownloadK8sConfig()
+		if err != nil {
+			return err
+		}
+
+		logger.Info("saving config")
+
+		return StoreKubernetesConfig(cluster, config)
+	}
+
+	return nil
+}

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -45,7 +45,6 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
 	"github.com/banzaicloud/pipeline/pkg/common"
-	pkgError "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
 	pkgSecret "github.com/banzaicloud/pipeline/pkg/secret"
 	"github.com/banzaicloud/pipeline/secret"
@@ -663,10 +662,6 @@ func (c *EC2ClusterPKE) DeletePKECluster(ctx context.Context, workflowClient cli
 	}
 
 	return nil
-}
-
-func (c *EC2ClusterPKE) DownloadK8sConfig() ([]byte, error) {
-	return nil, pkgError.ErrorFunctionShouldNotBeCalled
 }
 
 func (c *EC2ClusterPKE) GetAPIEndpoint() (string, error) {

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -25,10 +25,6 @@ import (
 // HookMap for api hook endpoints
 // nolint: gochecknoglobals
 var HookMap = map[string]PostFunctioner{
-	pkgCluster.StoreKubeConfig: &BasePostFunction{
-		f:            StoreKubeConfig,
-		ErrorHandler: ErrorHandler{},
-	},
 	pkgCluster.SetupPrivileges: &BasePostFunction{
 		f:            SetupPrivileges,
 		ErrorHandler: ErrorHandler{},

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -120,7 +120,6 @@ var HookMap = map[string]PostFunctioner{
 // BasePostHookFunctions default posthook functions after cluster create
 // nolint: gochecknoglobals
 var BasePostHookFunctions = []string{
-	pkgCluster.StoreKubeConfig,
 	pkgCluster.SetupPrivileges,
 	pkgCluster.LabelNodesWithNodePoolName,
 	pkgCluster.TaintHeadNodes,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -243,6 +243,11 @@ func main() {
 		setMasterTaintActivity := pkeworkflow.NewSetMasterTaintActivity(clusters)
 		activity.RegisterWithOptions(setMasterTaintActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.SetMasterTaintActivityName})
 
+		workflow.RegisterWithOptions(cluster.CreateClusterWorkflow, workflow.RegisterOptions{Name: cluster.CreateClusterWorkflowName})
+
+		downloadK8sConfigActivity := cluster.NewDownloadK8sConfigActivity(clusterManager)
+		activity.RegisterWithOptions(downloadK8sConfigActivity.Execute, activity.RegisterOptions{Name: cluster.DownloadK8sConfigActivityName})
+
 		workflow.RegisterWithOptions(cluster.RunPostHooksWorkflow, workflow.RegisterOptions{Name: cluster.RunPostHooksWorkflowName})
 
 		runPostHookActivity := cluster.NewRunPostHookActivity(clusterManager)

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -182,10 +182,6 @@ func (a *AzurePkeCluster) SetTTL(t time.Duration) {
 	// TODO: persist
 }
 
-func (a *AzurePkeCluster) DownloadK8sConfig() ([]byte, error) {
-	return nil, errors.New("AzurePkeCluster.DownloadK8sConfig is not implemented")
-}
-
 func (a *AzurePkeCluster) GetAPIEndpoint() (string, error) {
 	config, err := a.GetK8sConfig()
 	if err != nil {

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -72,7 +72,6 @@ const (
 
 // constants for posthooks
 const (
-	StoreKubeConfig                        = "StoreKubeConfig"
 	SetupPrivileges                        = "SetupPrivileges"
 	CreatePipelineNamespacePostHook        = "CreatePipelineNamespacePostHook"
 	InstallHelmPostHook                    = "InstallHelmPostHook"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Remove k8s config download from posthooks.


### Why?

Config download is highly distribution/cloud dependent and can hardly be implemented in a generic way. The legacy cluster create flow is basically the only flow still using it.

With the new cluster init manifest we are moving towards a cluster bootstrap/setup workflow which installs every generic component/manifest required by pipeline. K8s config download was basically the last step of the posthook/legacy cluster setup flow not running inside the cluster. Once it's gone, we can start building the generic cluster setup flow from existing posthooks.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
~~- [-] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)~~
~~- [-] Logging code meets the guideline (TODO)~~
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
