### PR TITLE
Config remove attempts

### DIFF
--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -71,6 +71,7 @@ const mapUsersTemplate = `- userarn: %s
 `
 
 const asgWaitLoopSleepSeconds = 5
+const asgFulfillmentTimeout = 10 * time.Minute
 
 // CreateEKSClusterFromRequest creates ClusterModel struct from the request
 func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId uint, userId uint) (*EKSCluster, error) {
@@ -331,7 +332,7 @@ func (c *EKSCluster) CreateCluster() error {
 	}
 
 	creationContext.ScaleEnabled = c.GetScaleOptions() != nil && c.GetScaleOptions().Enabled
-	ASGWaitLoopCount := int(viper.GetDuration(config.EksASGFulfillmentTimeout).Seconds() / asgWaitLoopSleepSeconds)
+	ASGWaitLoopCount := int(asgFulfillmentTimeout.Seconds() / asgWaitLoopSleepSeconds)
 	headNodePoolName := viper.GetString(config.PipelineHeadNodePoolName)
 
 	actions := []utils.Action{
@@ -882,7 +883,7 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 		}
 	}
 
-	ASGWaitLoopCount := int(viper.GetDuration(config.EksASGFulfillmentTimeout).Seconds() / asgWaitLoopSleepSeconds)
+	ASGWaitLoopCount := int(asgFulfillmentTimeout.Seconds() / asgWaitLoopSleepSeconds)
 	headNodePoolName := viper.GetString(config.PipelineHeadNodePoolName)
 
 	deleteNodePoolAction := action.NewDeleteStacksAction(c.log, deleteContext, nodePoolsToDelete...)
@@ -926,7 +927,7 @@ func (c *EKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest,
 	defer close(waitChan)
 
 	var caughtErrors []error
-	ASGWaitLoopCount := int(viper.GetDuration(config.EksASGFulfillmentTimeout).Seconds() / asgWaitLoopSleepSeconds)
+	ASGWaitLoopCount := int(asgFulfillmentTimeout.Seconds() / asgWaitLoopSleepSeconds)
 
 	for poolName, nodePool := range request.NodePools {
 

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -105,8 +105,6 @@ signingKey = "Th1s!sMyR4Nd0MStri4gPleaseChangeIt"
 # audience = "https://pipeline.banzaicloud.com"
 
 [helm]
-retryAttempt = 30
-retrySleepSeconds = 15
 tillerVersion = "v2.14.2"
 path = "./var/cache"
 

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -191,10 +191,6 @@ forbiddenLabelDomains=[
 [eks]
 ASGFulfillmentTimeout="10m"
 
-[gke]
-resourceDeleteWaitAttempt = 12
-resourceDeleteSleepSeconds = 5
-
 [oke]
 waitAttemptsForNodepoolActive = 60
 sleepSecondsForNodepoolActive = 30

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -191,10 +191,6 @@ forbiddenLabelDomains=[
 [eks]
 ASGFulfillmentTimeout="10m"
 
-[oke]
-waitAttemptsForNodepoolActive = 60
-sleepSecondsForNodepoolActive = 30
-
 [ark]
 name = "ark"
 namespace = "pipeline-system"

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -188,9 +188,6 @@ forbiddenLabelDomains=[
 		"google.com"
 ]
 
-[eks]
-ASGFulfillmentTimeout="10m"
-
 [ark]
 name = "ark"
 namespace = "pipeline-system"

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -179,9 +179,6 @@ namespace = "pipeline-system"
 # the node-affinity and toleration as described in docs/infra-node-pool.md
 #headNodePoolName="head"
 
-headNodeTaintRetryAttempt=30
-headNodeTaintRetrySleepSeconds=5
-
 forbiddenLabelDomains=[
 		"k8s.io",
 		"kubernetes.io",

--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -62,10 +62,6 @@ loglevel = "debug"
 enabled = false
 projectId = ""
 
-[cloud]
-configRetryCount = 30
-configRetrySleep = 15
-
 [cors]
 AllowAllOrigins = false
 AllowOrigins = ["http://localhost:4200"]

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -86,10 +86,6 @@ const (
 	// AwsCredentialPath is the path in Vault to get AWS credentials from for Pipeline
 	AwsCredentialPath = "aws.credentials.path"
 
-	// Config keys to GKE resource delete
-	GKEResourceDeleteWaitAttempt  = "gke.resourceDeleteWaitAttempt"
-	GKEResourceDeleteSleepSeconds = "gke.resourceDeleteSleepSeconds"
-
 	// Config keys to OKE nodepool wait
 	OKEWaitAttemptsForNodepoolActive = "oke.waitAttemptsForNodepoolActive"
 	OKESleepSecondsForNodepoolActive = "oke.sleepSecondsForNodepoolActive"
@@ -282,9 +278,6 @@ func init() {
 	viper.SetDefault(DNSExternalDnsImageVersion, "0.5.15")
 	viper.SetDefault(DNSGcLogLevel, "debug")
 	viper.SetDefault(Route53MaintenanceWndMinute, 15)
-
-	viper.SetDefault(GKEResourceDeleteWaitAttempt, 12)
-	viper.SetDefault(GKEResourceDeleteSleepSeconds, 5)
 
 	viper.SetDefault(OKEWaitAttemptsForNodepoolActive, 60)
 	viper.SetDefault(OKESleepSecondsForNodepoolActive, 30)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -80,8 +80,6 @@ const (
 	// EksTemplateLocation is the configuration key the location to get EKS Cloud Formation templates from
 	// the location to get EKS Cloud Formation templates from
 	EksTemplateLocation = "eks.templateLocation"
-	// EksASGFulfillmentTimeout configuration key for the timeout of EKS ASG instance fulfillments
-	EksASGFulfillmentTimeout = "eks.ASGFulfillmentTimeout"
 
 	// AwsCredentialPath is the path in Vault to get AWS credentials from for Pipeline
 	AwsCredentialPath = "aws.credentials.path"
@@ -311,7 +309,6 @@ func init() {
 
 	viper.SetDefault(PipelineSystemNamespace, "pipeline-system")
 	viper.SetDefault(EksTemplateLocation, filepath.Join(pwd, "templates", "eks"))
-	viper.SetDefault(EksASGFulfillmentTimeout, "10m")
 
 	viper.SetDefault(SpotguideAllowPrereleases, false)
 	viper.SetDefault(SpotguideAllowPrivateRepos, false)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/spf13/viper"
-
-	"github.com/banzaicloud/pipeline/pkg/helm"
 )
 
 const (
@@ -213,8 +211,6 @@ func init() {
 	viper.SetDefault("cicd.url", "http://localhost:8000")
 	viper.SetDefault("cicd.insecure", false)
 	viper.SetDefault("cicd.scm", "github")
-	viper.SetDefault(helm.HELM_RETRY_ATTEMPT_CONFIG, 30)
-	viper.SetDefault(helm.HELM_RETRY_SLEEP_SECONDS, 15)
 	viper.SetDefault("helm.tillerVersion", "v2.14.2")
 	viper.SetDefault("helm.stableRepositoryURL", "https://kubernetes-charts.storage.googleapis.com")
 	viper.SetDefault("helm.banzaiRepositoryURL", "https://kubernetes-charts.banzaicloud.com")

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -219,8 +219,6 @@ func init() {
 	viper.SetDefault("helm.stableRepositoryURL", "https://kubernetes-charts.storage.googleapis.com")
 	viper.SetDefault("helm.banzaiRepositoryURL", "https://kubernetes-charts.banzaicloud.com")
 	viper.SetDefault(helmPath, "./orgs")
-	viper.SetDefault("cloud.configRetryCount", 30)
-	viper.SetDefault("cloud.configRetrySleep", 15)
 	viper.SetDefault(AwsCredentialPath, "secret/data/banzaicloud/aws")
 
 	pwd, err := os.Getwd()

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -61,9 +61,6 @@ const (
 	// PipelineHeadNodePoolName name of our Head node pool for Pipeline Infra deployments
 	PipelineHeadNodePoolName = "infra.headNodePoolName"
 
-	HeadNodeTaintRetryAttempt      = "infra.headNodeTaintRetryAttempt"
-	HeadNodeTaintRetrySleepSeconds = "infra.headNodeTaintRetrySleepSeconds"
-
 	// PipelineLabelDomain reserved node pool label domains
 	PipelineLabelDomain = "infra.pipelineLabelDomain"
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -86,10 +86,6 @@ const (
 	// AwsCredentialPath is the path in Vault to get AWS credentials from for Pipeline
 	AwsCredentialPath = "aws.credentials.path"
 
-	// Config keys to OKE nodepool wait
-	OKEWaitAttemptsForNodepoolActive = "oke.waitAttemptsForNodepoolActive"
-	OKESleepSecondsForNodepoolActive = "oke.sleepSecondsForNodepoolActive"
-
 	// ARK
 	ARKName                = "ark.name"
 	ARKNamespace           = "ark.namespace"
@@ -278,9 +274,6 @@ func init() {
 	viper.SetDefault(DNSExternalDnsImageVersion, "0.5.15")
 	viper.SetDefault(DNSGcLogLevel, "debug")
 	viper.SetDefault(Route53MaintenanceWndMinute, 15)
-
-	viper.SetDefault(OKEWaitAttemptsForNodepoolActive, 60)
-	viper.SetDefault(OKESleepSecondsForNodepoolActive, 30)
 
 	viper.SetDefault(ARKName, "ark")
 	viper.SetDefault(ARKNamespace, "pipeline-system")

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -21,12 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ### [ Constants to helm]
-const (
-	HELM_RETRY_ATTEMPT_CONFIG = "helm.retryAttempt"
-	HELM_RETRY_SLEEP_SECONDS  = "helm.retrySleepSeconds"
-)
-
 // Stable repository constants
 const (
 	StableRepository = "stable"

--- a/pkg/providers/oracle/oci/ce_cluster.go
+++ b/pkg/providers/oracle/oci/ce_cluster.go
@@ -23,9 +23,6 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/containerengine"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-
-	pipConfig "github.com/banzaicloud/pipeline/config"
 )
 
 // CreateCluster creates an OKE cluster specified in the request
@@ -185,18 +182,18 @@ func (ce *ContainerEngine) GetClusters() (clusters []containerengine.ClusterSumm
 	return clusters, err
 }
 
+const okeWaitAttemptsForNodepoolActive = 60
+const okeSleepForNodepoolActive = 30 * time.Second
+
 // WaitingForClusterNodePoolActiveState waits until every node in the existing pools is in ACTIVE state
 // only checks node pools specified in nodepoolNamesToCheck if any
 func (ce *ContainerEngine) WaitingForClusterNodePoolActiveState(clusterID *string, nodepoolNamesToCheck map[string]bool) error {
 
 	ce.oci.logger.Info("Waiting for all nodepools state to be ACTIVE on all nodes")
 
-	maxAttempts := viper.GetInt(pipConfig.OKEWaitAttemptsForNodepoolActive)
-	sleepSeconds := viper.GetInt(pipConfig.OKESleepSecondsForNodepoolActive)
+	for i := 0; i <= okeWaitAttemptsForNodepoolActive; i++ {
 
-	for i := 0; i <= maxAttempts; i++ {
-
-		time.Sleep(time.Duration(sleepSeconds) * time.Second)
+		time.Sleep(okeSleepForNodepoolActive)
 
 		nodePools, err := ce.GetNodePools(clusterID)
 		if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Removes configurable retry configuration options and replaces them with constants.


### Why?

As far as we can tell, we don't need to be able to configure these. Most of the options became obsolete anyway. They can be added back later if necessary.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
