### PR TITLE
Allow HEAD requests for members

### DIFF
--- a/auth/authz.go
+++ b/auth/authz.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -109,7 +110,7 @@ func (e RbacEnforcer) Enforce(org *Organization, user *User, path, method string
 		return true, nil
 	case RoleMember:
 		// Members can only read organization resources
-		if ok, err := regexp.MatchString(`^/api/v1/orgs(?:/.*)?$`, path); err != nil || (ok && method != "GET") {
+		if ok, err := regexp.MatchString(`^/api/v1/orgs(?:/.*)?$`, path); err != nil || (ok && method != http.MethodGet && method != http.MethodHead) {
 			return false, nil
 		}
 

--- a/auth/authz_test.go
+++ b/auth/authz_test.go
@@ -209,6 +209,12 @@ func TestRbacEnforcer_Enforce(t *testing.T) {
 		},
 		{
 			role:     RoleMember,
+			path:     "/api/v1/orgs/1/buckets",
+			method:   "HEAD",
+			expected: true,
+		},
+		{
+			role:     RoleMember,
 			path:     "/api/v1/orgs/1/clusters",
 			method:   "POST",
 			expected: false,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Allow HEAD requests for organization members.


### Why?

Organization members should be able to read resources.