### PR TITLE
Add Loki to deafult Helm repositories

### DIFF
--- a/config/config.toml.dist
+++ b/config/config.toml.dist
@@ -116,6 +116,7 @@ path = "./var/cache"
 #helm repo URLs
 stableRepositoryURL = "https://kubernetes-charts.storage.googleapis.com"
 banzaiRepositoryURL = "https://kubernetes-charts.banzaicloud.com"
+lokiRepositoryURL = "https://grafana.github.io/loki/charts"
 
 [monitor]
 enabled = false

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -189,6 +189,10 @@ const (
 	PrometheusOperatorVersionKey    = "prometheusOperator.chartVersion"
 	PrometheusPushgatewayChartKey   = "prometheusPushgateway.chart"
 	PrometheusPushgatewayVersionKey = "prometheusPushgateway.chartVersion"
+
+	HelmStableRepositoryKey = "helm.stableRepositoryURL"
+	HelmBanzaiRepositoryKey = "helm.banzaiRepositoryURL"
+	HelmLokiRepositoryKey   = "helm.lokiRepositoryURL"
 )
 
 // Init initializes the configurations
@@ -212,8 +216,9 @@ func init() {
 	viper.SetDefault("cicd.insecure", false)
 	viper.SetDefault("cicd.scm", "github")
 	viper.SetDefault("helm.tillerVersion", "v2.14.2")
-	viper.SetDefault("helm.stableRepositoryURL", "https://kubernetes-charts.storage.googleapis.com")
-	viper.SetDefault("helm.banzaiRepositoryURL", "https://kubernetes-charts.banzaicloud.com")
+	viper.SetDefault(HelmStableRepositoryKey, "https://kubernetes-charts.storage.googleapis.com")
+	viper.SetDefault(HelmBanzaiRepositoryKey, "https://kubernetes-charts.banzaicloud.com")
+	viper.SetDefault(HelmLokiRepositoryKey, "https://grafana.github.io/loki/charts")
 	viper.SetDefault(helmPath, "./orgs")
 	viper.SetDefault(AwsCredentialPath, "secret/data/banzaicloud/aws")
 

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -1009,7 +1009,7 @@ func ChartGet(env helm_env.EnvSettings, chartRepo, chartName, chartVersion strin
 						if v.Version == chartVersion || chartVersion == "" {
 
 							var ver *ChartVersion
-							ver, err = getChartVersion(v)
+							ver, err = getChartVersion(v, repository.URL)
 							if err != nil {
 								return
 							}
@@ -1018,7 +1018,7 @@ func ChartGet(env helm_env.EnvSettings, chartRepo, chartName, chartVersion strin
 							return
 						} else if chartVersion == versionAll {
 							var ver *ChartVersion
-							ver, err = getChartVersion(v)
+							ver, err = getChartVersion(v, repository.URL)
 							if err != nil {
 								log.Warnf("error during getting chart[%s - %s]: %s", v.Name, v.Version, err.Error())
 							} else {
@@ -1038,10 +1038,15 @@ func ChartGet(env helm_env.EnvSettings, chartRepo, chartName, chartVersion strin
 	return
 }
 
-func getChartVersion(v *repo.ChartVersion) (*ChartVersion, error) {
+func getChartVersion(v *repo.ChartVersion, repoUrl string) (*ChartVersion, error) {
 	log.Infof("get chart[%s - %s]", v.Name, v.Version)
 
 	chartSource := v.URLs[0]
+	if !strings.HasPrefix(chartSource, "http") {
+		// append with repo url to avoid unsupported protocol scheme errors
+		chartSource = fmt.Sprintf("%s/%s", repoUrl, chartSource)
+	}
+
 	log.Debugf("chartSource: %s", chartSource)
 	reader, err := DownloadFile(chartSource)
 	if err != nil {

--- a/helm/install.go
+++ b/helm/install.go
@@ -266,32 +266,39 @@ func EnsureDirectories(env helmEnv.EnvSettings) error {
 }
 
 func ensureDefaultRepos(env helmEnv.EnvSettings) error {
-
-	stableRepositoryURL := viper.GetString("helm.stableRepositoryURL")
-	banzaiRepositoryURL := viper.GetString("helm.banzaiRepositoryURL")
+	var repos = []struct {
+		name string
+		url  string
+	}{
+		{
+			name: phelm.StableRepository,
+			url:  viper.GetString(config.HelmStableRepositoryKey),
+		},
+		{
+			name: phelm.BanzaiRepository,
+			url:  viper.GetString(config.HelmBanzaiRepositoryKey),
+		},
+		{
+			name: phelm.LokiRepository,
+			url:  viper.GetString(config.HelmLokiRepositoryKey),
+		},
+	}
 
 	log.Infof("Setting up default helm repos.")
 
-	_, err := ReposAdd(
-		env,
-		&repo.Entry{
-			Name:  phelm.StableRepository,
-			URL:   stableRepositoryURL,
-			Cache: env.Home.CacheIndex(phelm.StableRepository),
-		})
-	if err != nil {
-		return errors.Wrapf(err, "cannot init repo: %s", phelm.StableRepository)
+	for _, r := range repos {
+		_, err := ReposAdd(
+			env,
+			&repo.Entry{
+				Name:  r.name,
+				URL:   r.url,
+				Cache: env.Home.CacheIndex(r.name),
+			})
+		if err != nil {
+			return errors.Wrapf(err, "cannot init repo: %s", r.name)
+		}
 	}
-	_, err = ReposAdd(
-		env,
-		&repo.Entry{
-			Name:  phelm.BanzaiRepository,
-			URL:   banzaiRepositoryURL,
-			Cache: env.Home.CacheIndex(phelm.BanzaiRepository),
-		})
-	if err != nil {
-		return errors.Wrapf(err, "cannot init repo: %s", phelm.BanzaiRepository)
-	}
+
 	return nil
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -25,6 +25,7 @@ import (
 const (
 	StableRepository = "stable"
 	BanzaiRepository = "banzaicloud-stable"
+	LokiRepository   = "loki"
 	HelmPostFix      = "helm"
 )
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add a new deafult Helm repository with name `loki` from `https://grafana.github.io/loki/charts` url 

### Why?
`Loki` component of the `Logging` feature will be apply from this new repository



### Checklist

- [x] Implementation tested (with at least one cloud provider)

