### PR TITLE
Fix pending cluster feature activation

### DIFF
--- a/cluster/manager_get.go
+++ b/cluster/manager_get.go
@@ -17,8 +17,7 @@ package cluster
 import (
 	"context"
 
-	"emperror.dev/emperror"
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/banzaicloud/pipeline/model"
@@ -76,12 +75,12 @@ func (m *Manager) GetClusterByID(ctx context.Context, organizationID uint, clust
 
 	clusterModel, err := m.clusters.FindOneByID(organizationID, clusterID)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get cluster from database")
+		return nil, errors.WrapIf(err, "could not get cluster from database")
 	}
 
 	cluster, err := GetCommonClusterFromModel(clusterModel)
 	if err != nil {
-		return nil, emperror.Wrap(err, "could not get cluster from model")
+		return nil, errors.WrapIf(err, "could not get cluster from model")
 	}
 
 	return cluster, nil
@@ -97,12 +96,12 @@ func (m *Manager) GetClusterByIDOnly(ctx context.Context, clusterID uint) (Commo
 
 	clusterModel, err := m.clusters.FindOneByID(0, clusterID)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get cluster from database")
+		return nil, errors.WrapIf(err, "could not get cluster from database")
 	}
 
 	cluster, err := GetCommonClusterFromModel(clusterModel)
 	if err != nil {
-		return nil, emperror.Wrap(err, "could not get cluster from model")
+		return nil, errors.WrapIf(err, "could not get cluster from model")
 	}
 
 	return cluster, nil
@@ -119,12 +118,12 @@ func (m *Manager) GetClusterByName(ctx context.Context, organizationID uint, clu
 
 	clusterModel, err := m.clusters.FindOneByName(organizationID, clusterName)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get cluster from database")
+		return nil, errors.WrapIf(err, "could not get cluster from database")
 	}
 
 	cluster, err := GetCommonClusterFromModel(clusterModel)
 	if err != nil {
-		return nil, emperror.Wrap(err, "could not get cluster from model")
+		return nil, errors.WrapIf(err, "could not get cluster from model")
 	}
 
 	return cluster, nil
@@ -141,7 +140,7 @@ func (m *Manager) GetClustersBySecretID(ctx context.Context, organizationID uint
 
 	clusterModels, err := m.clusters.FindBySecret(organizationID, secretID)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get cluster from database")
+		return nil, errors.WrapIf(err, "could not get cluster from database")
 	}
 
 	return m.getClustersFromModels(clusterModels, logger), nil
@@ -168,4 +167,13 @@ func (m *Manager) getClustersFromModels(clusterModels []*model.ClusterModel, log
 	}
 
 	return clusters
+}
+
+// GetClusterStatus returns the status of the cluster with the specified ID
+func (m *Manager) GetClusterStatus(ctx context.Context, clusterID uint) (string, error) {
+	cm, err := m.clusters.FindOneByID(0, clusterID)
+	if err != nil {
+		return "", errors.WrapIf(err, "failed to get cluster model by ID")
+	}
+	return cm.Status, nil
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -334,7 +334,7 @@ func main() {
 			kubernetesService := kubernetes.NewKubernetesService(helmadapter.NewClusterService(clusterManager), logger)
 
 			clusterGetter := clusterfeatureadapter.MakeClusterGetter(clusterManager)
-			clusterService := clusterfeatureadapter.NewClusterService(clusterGetter)
+			clusterService := clusterfeatureadapter.NewClusterService(clusterManager)
 			orgDomainService := featureDns.NewOrgDomainService(clusterGetter, dnsSvc, logger)
 
 			customAnchoreConfigProvider := securityscan.NewCustomAnchoreConfigProvider(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
             - mysql
 
     cadence-web:
-        image: ubercadence/web:3.3.2
+        image: ubercadence/web:3.4.1
         environment:
             CADENCE_TCHANNEL_PEERS: cadence:7933
         depends_on:

--- a/internal/clusterfeature/clusterfeatureadapter/cadence_feature_operation_dispatcher.go
+++ b/internal/clusterfeature/clusterfeatureadapter/cadence_feature_operation_dispatcher.go
@@ -65,7 +65,7 @@ func (d CadenceFeatureOperationDispatcher) dispatchOperation(ctx context.Context
 	}
 	options := client.StartWorkflowOptions{
 		TaskList:                     "pipeline",
-		ExecutionStartToCloseTimeout: 40 * time.Minute,
+		ExecutionStartToCloseTimeout: 3 * time.Hour,
 		WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
 	}
 	workflowInput := workflow.ClusterFeatureJobWorkflowInput{

--- a/internal/clusterfeature/clusterfeatureadapter/cluster_getter.go
+++ b/internal/clusterfeature/clusterfeatureadapter/cluster_getter.go
@@ -1,0 +1,61 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterfeatureadapter
+
+import (
+	"context"
+
+	"github.com/banzaicloud/pipeline/cluster"
+)
+
+//go:generate mockery -name ClusterGetter -inpkg
+// ClusterGetter restricts the external dependencies for the repository
+type ClusterGetter interface {
+	GetClusterByIDOnly(ctx context.Context, clusterID uint) (Cluster, error)
+}
+
+// Cluster defines operations that can be performed on a k8s cluster
+type Cluster interface {
+	GetK8sConfig() ([]byte, error)
+	GetName() string
+	GetOrganizationId() uint
+	GetUID() string
+	GetID() uint
+	IsReady() (bool, error)
+	NodePoolExists(nodePoolName string) bool
+	RbacEnabled() bool
+}
+
+// CommonClusterGetter defines cluster getter methods that return a CommonCluster
+type CommonClusterGetter interface {
+	GetClusterByIDOnly(ctx context.Context, clusterID uint) (cluster.CommonCluster, error)
+}
+
+// MakeClusterGetter adapts a "CommonCluster" cluster getter to a clusterfeature cluster getter
+func MakeClusterGetter(clusterGetter CommonClusterGetter) ClusterGetterAdapter {
+	return ClusterGetterAdapter{
+		clusterGetter: clusterGetter,
+	}
+}
+
+// ClusterGetterAdapter adapts a "CommonCluster" cluster getter to a clusterfeature cluster getter
+type ClusterGetterAdapter struct {
+	clusterGetter CommonClusterGetter
+}
+
+// GetClusterByIDOnly returns the cluster with the specified ID
+func (a ClusterGetterAdapter) GetClusterByIDOnly(ctx context.Context, clusterID uint) (Cluster, error) {
+	return a.clusterGetter.GetClusterByIDOnly(ctx, clusterID)
+}

--- a/internal/clusterfeature/clusterfeatureadapter/cluster_getter.go
+++ b/internal/clusterfeature/clusterfeatureadapter/cluster_getter.go
@@ -33,7 +33,6 @@ type Cluster interface {
 	GetOrganizationId() uint
 	GetUID() string
 	GetID() uint
-	IsReady() (bool, error)
 	NodePoolExists(nodePoolName string) bool
 	RbacEnabled() bool
 }

--- a/internal/clusterfeature/clusterfeatureadapter/cluster_service.go
+++ b/internal/clusterfeature/clusterfeatureadapter/cluster_service.go
@@ -19,48 +19,9 @@ import (
 
 	"emperror.dev/errors"
 
-	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
-
-//go:generate mockery -name ClusterGetter -inpkg
-// ClusterGetter restricts the external dependencies for the repository
-type ClusterGetter interface {
-	GetClusterByIDOnly(ctx context.Context, clusterID uint) (Cluster, error)
-}
-
-// Cluster defines operations that can be performed on a k8s cluster
-type Cluster interface {
-	GetK8sConfig() ([]byte, error)
-	GetName() string
-	GetOrganizationId() uint
-	GetUID() string
-	GetID() uint
-	IsReady() (bool, error)
-	NodePoolExists(nodePoolName string) bool
-	RbacEnabled() bool
-}
-
-// MakeClusterGetter creates a ClusterGetter using a common cluster getter
-func MakeClusterGetter(clusterGetter CommonClusterGetter) ClusterGetter {
-	return clusterGetterAdapter{
-		ccGetter: clusterGetter,
-	}
-}
-
-// CommonClusterGetter defines cluster getter methods that return a CommonCluster
-type CommonClusterGetter interface {
-	GetClusterByIDOnly(ctx context.Context, clusterID uint) (cluster.CommonCluster, error)
-}
-
-type clusterGetterAdapter struct {
-	ccGetter CommonClusterGetter
-}
-
-func (a clusterGetterAdapter) GetClusterByIDOnly(ctx context.Context, clusterID uint) (Cluster, error) {
-	return a.ccGetter.GetClusterByIDOnly(ctx, clusterID)
-}
 
 // ClusterService is an adapter providing access to the core cluster layer.
 type ClusterService struct {

--- a/internal/clusterfeature/clusterfeatureadapter/cluster_service.go
+++ b/internal/clusterfeature/clusterfeatureadapter/cluster_service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 //go:generate mockery -name ClusterGetter -inpkg
@@ -63,31 +64,29 @@ func (a clusterGetterAdapter) GetClusterByIDOnly(ctx context.Context, clusterID 
 
 // ClusterService is an adapter providing access to the core cluster layer.
 type ClusterService struct {
-	clusterGetter ClusterGetter
+	clusterStatuser ClusterStatuser
+}
+
+// ClusterStatuser supports getting a cluster's status
+type ClusterStatuser interface {
+	GetClusterStatus(ctx context.Context, clusterID uint) (string, error)
 }
 
 // NewClusterService returns a new ClusterService instance.
-func NewClusterService(getter ClusterGetter) ClusterService {
+func NewClusterService(clusterStatuser ClusterStatuser) ClusterService {
 	return ClusterService{
-		clusterGetter: getter,
+		clusterStatuser: clusterStatuser,
 	}
 }
 
-// CheckClusterReady returns true is the cluster is ready to be accessed
+// CheckClusterReady returns true if the cluster is ready to be accessed
 func (s ClusterService) CheckClusterReady(ctx context.Context, clusterID uint) error {
-	c, err := s.clusterGetter.GetClusterByIDOnly(ctx, clusterID)
+	status, err := s.clusterStatuser.GetClusterStatus(ctx, clusterID)
 	if err != nil {
-
-		return errors.WrapIfWithDetails(err, "failed to retrieve cluster", "clusterId", clusterID)
+		return errors.WrapIfWithDetails(err, "failed to get cluster status", "clusterId", clusterID)
 	}
 
-	isReady, err := c.IsReady()
-	if err != nil {
-
-		return errors.WrapIfWithDetails(err, "failed to check cluster", "clusterId", clusterID)
-	}
-
-	if !isReady {
+	if status != pkgCluster.Running {
 		return clusterfeature.ClusterIsNotReadyError{
 			ClusterID: clusterID,
 		}

--- a/internal/clusterfeature/clusterfeatureadapter/workflow/common.go
+++ b/internal/clusterfeature/clusterfeatureadapter/workflow/common.go
@@ -22,10 +22,6 @@ import (
 	"go.uber.org/cadence/activity"
 )
 
-const (
-	shouldRetryReason = "should retry activity"
-)
-
 func shouldRetry(err error) bool {
 	var sh interface {
 		ShouldRetry() bool

--- a/internal/clusterfeature/features/dns/manager_test.go
+++ b/internal/clusterfeature/features/dns/manager_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
-	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 )
 
 func TestFeatureManager_Name(t *testing.T) {
@@ -37,8 +36,8 @@ func TestFeatureManager_GetOutput(t *testing.T) {
 	clusterName := "the-cluster"
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
 				Name: clusterName,
 			},
 		},

--- a/internal/clusterfeature/features/dns/operator_test.go
+++ b/internal/clusterfeature/features/dns/operator_test.go
@@ -70,7 +70,7 @@ func TestFeatureOperator_Apply(t *testing.T) {
 		},
 	}
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{},
+		Clusters: map[uint]dummyCluster{},
 	}
 	clusterService := clusterfeatureadapter.NewClusterService(clusterGetter)
 	helmService := dummyHelmService{}
@@ -84,7 +84,7 @@ func TestFeatureOperator_Apply(t *testing.T) {
 
 	cases := map[string]struct {
 		Spec    clusterfeature.FeatureSpec
-		Cluster clusterfeatureadapter.Cluster
+		Cluster dummyCluster
 		Error   interface{}
 	}{
 		"auto DNS, cluster ready": {
@@ -94,8 +94,8 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: true,
+				OrgID:  orgID,
+				Status: pkgCluster.Running,
 			},
 		},
 		"auto DNS, cluster not ready": {
@@ -105,8 +105,8 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: false,
+				OrgID:  orgID,
+				Status: pkgCluster.Creating,
 			},
 			Error: clusterfeature.ClusterIsNotReadyError{
 				ClusterID: clusterID,
@@ -130,8 +130,8 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: true,
+				OrgID:  orgID,
+				Status: pkgCluster.Running,
 			},
 		},
 		"custom DNS, cluster ready, with BRN": {
@@ -157,8 +157,8 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: true,
+				OrgID:  orgID,
+				Status: pkgCluster.Running,
 			},
 		},
 	}
@@ -185,9 +185,9 @@ func TestFeatureOperator_Deactivate(t *testing.T) {
 	clusterID := uint(42)
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
-				Ready: true,
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
+				Status: pkgCluster.Running,
 			},
 		},
 	}

--- a/internal/clusterfeature/features/monitoring/common_test.go
+++ b/internal/clusterfeature/features/monitoring/common_test.go
@@ -17,6 +17,8 @@ package monitoring
 import (
 	"context"
 
+	"emperror.dev/errors"
+
 	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/pkg/helm"
 	"github.com/banzaicloud/pipeline/secret"
@@ -34,11 +36,18 @@ const (
 )
 
 type dummyClusterGetter struct {
-	Clusters map[uint]clusterfeatureadapter.Cluster
+	Clusters map[uint]dummyCluster
 }
 
 func (d dummyClusterGetter) GetClusterByIDOnly(ctx context.Context, clusterID uint) (clusterfeatureadapter.Cluster, error) {
 	return d.Clusters[clusterID], nil
+}
+
+func (d dummyClusterGetter) GetClusterStatus(ctx context.Context, clusterID uint) (string, error) {
+	if c, ok := d.Clusters[clusterID]; ok {
+		return c.Status, nil
+	}
+	return "", errors.New("cluster not found")
 }
 
 type dummyCluster struct {
@@ -47,9 +56,9 @@ type dummyCluster struct {
 	OrgID     uint
 	ID        uint
 	UID       string
-	Ready     bool
 	NodePools map[string]bool
 	Rbac      bool
+	Status    string
 }
 
 func (d dummyCluster) GetK8sConfig() ([]byte, error) {
@@ -70,10 +79,6 @@ func (d dummyCluster) GetUID() string {
 
 func (d dummyCluster) GetID() uint {
 	return d.ID
-}
-
-func (d dummyCluster) IsReady() (bool, error) {
-	return d.Ready, nil
 }
 
 func (d dummyCluster) NodePoolExists(nodePoolName string) bool {

--- a/internal/clusterfeature/features/monitoring/manager_test.go
+++ b/internal/clusterfeature/features/monitoring/manager_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
-	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/secret"
@@ -41,8 +40,8 @@ func TestFeatureManager_GetOutput(t *testing.T) {
 	clusterName := "the-cluster"
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
 				Name:  clusterName,
 				OrgID: orgID,
 				ID:    clusterID,

--- a/internal/clusterfeature/features/monitoring/operator_test.go
+++ b/internal/clusterfeature/features/monitoring/operator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -39,7 +40,7 @@ func TestFeatureOperator_Apply(t *testing.T) {
 	orgID := uint(13)
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{},
+		Clusters: map[uint]dummyCluster{},
 	}
 	clusterService := clusterfeatureadapter.NewClusterService(clusterGetter)
 	helmService := dummyHelmService{}
@@ -73,15 +74,15 @@ func TestFeatureOperator_Apply(t *testing.T) {
 
 	cases := map[string]struct {
 		Spec    clusterfeature.FeatureSpec
-		Cluster clusterfeatureadapter.Cluster
+		Cluster dummyCluster
 		Error   interface{}
 	}{
 		"cluster not ready": {
 			Spec: clusterfeature.FeatureSpec{},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: false,
-				ID:    clusterID,
+				OrgID:  orgID,
+				Status: pkgCluster.Creating,
+				ID:     clusterID,
 			},
 			Error: clusterfeature.ClusterIsNotReadyError{
 				ClusterID: clusterID,
@@ -106,9 +107,9 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: true,
-				ID:    clusterID,
+				OrgID:  orgID,
+				Status: pkgCluster.Running,
+				ID:     clusterID,
 			},
 			Error: false,
 		},
@@ -137,10 +138,10 @@ func TestFeatureOperator_Deactivate(t *testing.T) {
 	orgID := uint(13)
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
-				Ready: true,
-				ID:    clusterID,
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
+				Status: pkgCluster.Running,
+				ID:     clusterID,
 			},
 		},
 	}

--- a/internal/clusterfeature/features/vault/common_test.go
+++ b/internal/clusterfeature/features/vault/common_test.go
@@ -17,6 +17,7 @@ package vault
 import (
 	"context"
 
+	"emperror.dev/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srest "k8s.io/client-go/rest"
@@ -31,11 +32,18 @@ type obj = map[string]interface{}
 const tokenSecretID = "vaulttokensecretid"
 
 type dummyClusterGetter struct {
-	Clusters map[uint]clusterfeatureadapter.Cluster
+	Clusters map[uint]dummyCluster
 }
 
 func (d dummyClusterGetter) GetClusterByIDOnly(ctx context.Context, clusterID uint) (clusterfeatureadapter.Cluster, error) {
 	return d.Clusters[clusterID], nil
+}
+
+func (d dummyClusterGetter) GetClusterStatus(ctx context.Context, clusterID uint) (string, error) {
+	if c, ok := d.Clusters[clusterID]; ok {
+		return c.Status, nil
+	}
+	return "", errors.New("cluster not found")
 }
 
 type dummyCluster struct {
@@ -44,9 +52,9 @@ type dummyCluster struct {
 	OrgID     uint
 	ID        uint
 	UID       string
-	Ready     bool
 	NodePools map[string]bool
 	Rbac      bool
+	Status    string
 }
 
 func (d dummyCluster) GetK8sConfig() ([]byte, error) {
@@ -67,10 +75,6 @@ func (d dummyCluster) GetUID() string {
 
 func (d dummyCluster) GetID() uint {
 	return d.ID
-}
-
-func (d dummyCluster) IsReady() (bool, error) {
-	return d.Ready, nil
 }
 
 func (d dummyCluster) NodePoolExists(nodePoolName string) bool {

--- a/internal/clusterfeature/features/vault/manager_test.go
+++ b/internal/clusterfeature/features/vault/manager_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/config"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
-	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/secret"
@@ -44,8 +43,8 @@ func TestFeatureManager_GetOutput(t *testing.T) {
 	clusterName := "the-cluster"
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
 				Name:  clusterName,
 				OrgID: orgID,
 				ID:    clusterID,

--- a/internal/clusterfeature/features/vault/operator_test.go
+++ b/internal/clusterfeature/features/vault/operator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
 	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -38,7 +39,7 @@ func TestFeatureOperator_Apply(t *testing.T) {
 	orgID := uint(13)
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{},
+		Clusters: map[uint]dummyCluster{},
 	}
 	clusterService := clusterfeatureadapter.NewClusterService(clusterGetter)
 	helmService := dummyHelmService{}
@@ -56,15 +57,15 @@ func TestFeatureOperator_Apply(t *testing.T) {
 
 	cases := map[string]struct {
 		Spec    clusterfeature.FeatureSpec
-		Cluster clusterfeatureadapter.Cluster
+		Cluster dummyCluster
 		Error   interface{}
 	}{
 		"cluster not ready": {
 			Spec: clusterfeature.FeatureSpec{},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: false,
-				ID:    clusterID,
+				OrgID:  orgID,
+				Status: pkgCluster.Creating,
+				ID:     clusterID,
 			},
 			Error: clusterfeature.ClusterIsNotReadyError{
 				ClusterID: clusterID,
@@ -81,9 +82,9 @@ func TestFeatureOperator_Apply(t *testing.T) {
 				},
 			},
 			Cluster: dummyCluster{
-				OrgID: orgID,
-				Ready: true,
-				ID:    clusterID,
+				OrgID:  orgID,
+				Status: pkgCluster.Running,
+				ID:     clusterID,
 			},
 			Error: false,
 		},
@@ -111,10 +112,10 @@ func TestFeatureOperator_Deactivate(t *testing.T) {
 	clusterID := uint(42)
 
 	clusterGetter := dummyClusterGetter{
-		Clusters: map[uint]clusterfeatureadapter.Cluster{
-			clusterID: dummyCluster{
-				Ready: true,
-				ID:    clusterID,
+		Clusters: map[uint]dummyCluster{
+			clusterID: {
+				Status: pkgCluster.Running,
+				ID:     clusterID,
 			},
 		},
 	}

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -75,7 +75,7 @@ func (s *HelmService) InstallDeployment(
 		return err
 	}
 
-	foundRelease, err := s.findRelease(releaseName, cluster)
+	foundRelease, err := findRelease(releaseName, cluster.KubeConfig)
 	if err != nil {
 		return errors.WithDetails(err, "chart", chartName)
 	}
@@ -146,7 +146,7 @@ func (s *HelmService) UpdateDeployment(
 		return err
 	}
 
-	foundRelease, err := s.findRelease(releaseName, cluster)
+	foundRelease, err := findRelease(releaseName, cluster.KubeConfig)
 	if err != nil {
 		return errors.WithDetails(err, "chart", chartName)
 	}
@@ -196,7 +196,7 @@ func (s *HelmService) ApplyDeployment(
 		return err
 	}
 
-	foundRelease, err := s.findRelease(releaseName, cluster)
+	foundRelease, err := findRelease(releaseName, cluster.KubeConfig)
 	if err != nil {
 		return errors.WithDetails(err, "chart", chartName)
 	}
@@ -296,7 +296,7 @@ func (s *HelmService) DeleteDeployment(ctx context.Context, clusterID uint, rele
 		return err
 	}
 
-	foundRelease, err := s.findRelease(releaseName, cluster)
+	foundRelease, err := findRelease(releaseName, cluster.KubeConfig)
 	if err != nil {
 		return err
 	}
@@ -329,8 +329,8 @@ func (s *HelmService) GetDeployment(ctx context.Context, clusterID uint, release
 	return helm.GetDeployment(releaseName, cluster.KubeConfig)
 }
 
-func (s *HelmService) findRelease(releaseName string, cluster *Cluster) (*release.Release, error) {
-	deployments, err := helm.ListDeployments(&releaseName, "", cluster.KubeConfig)
+func findRelease(releaseName string, k8sConfig []byte) (*release.Release, error) {
+	deployments, err := helm.ListDeployments(&releaseName, "", k8sConfig)
 	if err != nil {
 		return nil, errors.WrapIfWithDetails(err, "failed to fetch deployments", "release", releaseName)
 	}

--- a/internal/providers/azure/pke/workflow/delete_infra.go
+++ b/internal/providers/azure/pke/workflow/delete_infra.go
@@ -40,8 +40,7 @@ type DeleteAzureInfrastructureWorkflowInput struct {
 func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteAzureInfrastructureWorkflowInput) error {
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Minute,
-		StartToCloseTimeout:    10 * time.Minute,
-		ScheduleToCloseTimeout: 15 * time.Minute,
+		StartToCloseTimeout:    20 * time.Minute,
 		WaitForCancellation:    true,
 	}
 

--- a/internal/security/resource_service.go
+++ b/internal/security/resource_service.go
@@ -243,11 +243,5 @@ func (s securityResourceService) assembleWhiteListItem(whitelistItem security.Re
 // Cluster defines operations that can be performed on a k8s cluster
 type Cluster interface {
 	GetK8sConfig() ([]byte, error)
-	GetName() string
-	GetOrganizationId() uint
-	GetUID() string
 	GetID() uint
-	IsReady() (bool, error)
-	NodePoolExists(nodePoolName string) bool
-	RbacEnabled() bool
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2404 
| License         | Apache 2.0


### What's in this PR?
Cluster readiness is checked by polling the cluster status and waiting until the cluster is "RUNNING".


### Why?
Cluster feature activation failed when the feature was activated during cluster creation because the readiness condition was wrong


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
