### PR TITLE
Use serializable optional uint type

### DIFF
--- a/internal/providers/azure/pke/driver/cluster_updater.go
+++ b/internal/providers/azure/pke/driver/cluster_updater.go
@@ -23,7 +23,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/antihax/optional"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/cadence/client"
 
@@ -175,7 +174,7 @@ func (cu AzurePKEClusterUpdater) Update(ctx context.Context, params AzurePKEClus
 		var changes workflow.VirtualMachineScaleSetChanges
 
 		if !np.Autoscaling {
-			changes.InstanceCount = optional.NewUint(uint(np.Count))
+			changes.InstanceCount = workflow.NewUint(uint(np.Count))
 		}
 
 		if changes != (workflow.VirtualMachineScaleSetChanges{}) {

--- a/internal/providers/azure/pke/workflow/update_vmss_activity.go
+++ b/internal/providers/azure/pke/workflow/update_vmss_activity.go
@@ -21,7 +21,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/antihax/optional"
 	"go.uber.org/cadence/activity"
 )
 
@@ -44,7 +43,19 @@ type UpdateVMSSActivityInput struct {
 
 type VirtualMachineScaleSetChanges struct {
 	Name          string
-	InstanceCount optional.Uint
+	InstanceCount OptionalUint
+}
+
+type OptionalUint struct {
+	IsSet bool
+	Value uint
+}
+
+func NewUint(v uint) OptionalUint {
+	return OptionalUint{
+		IsSet: true,
+		Value: v,
+	}
 }
 
 // MakeUpdateVMSSActivity returns a new UpdateVMSSActivity
@@ -94,8 +105,8 @@ func (a UpdateVMSSActivity) Execute(ctx context.Context, input UpdateVMSSActivit
 	}
 
 	sku := compute.Sku{}
-	if input.Changes.InstanceCount.IsSet() {
-		sku.Capacity = to.Int64Ptr(int64(input.Changes.InstanceCount.Value()))
+	if input.Changes.InstanceCount.IsSet {
+		sku.Capacity = to.Int64Ptr(int64(input.Changes.InstanceCount.Value))
 	}
 
 	future, err := client.Update(ctx, input.ResourceGroupName, input.Changes.Name, compute.VirtualMachineScaleSetUpdate{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
A custom optional uint type that is properly serializable.

### Why?
The imported optional uint type was not properly serializable because it does not implement marshaler/unmarshaler and all its fields are private.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
