### PR TITLE
[Monitoring] Add regex check to retention field

### DIFF
--- a/internal/clusterfeature/features/monitoring/spec.go
+++ b/internal/clusterfeature/features/monitoring/spec.go
@@ -16,7 +16,7 @@ package monitoring
 
 import (
 	"fmt"
-	"time"
+	"regexp"
 
 	"emperror.dev/errors"
 	"github.com/mitchellh/mapstructure"
@@ -184,8 +184,13 @@ func (s storageSpec) Validate() error {
 		return requiredFieldError{fieldName: "retention"}
 	}
 
-	if _, err := time.ParseDuration(s.Retention); err != nil {
-		return errors.WrapIf(err, "failed to parse retention")
+	match, err := regexp.MatchString("[0-9]+(ms|s|m|h|d|w|y)", s.Retention)
+	if err != nil {
+		return errors.WrapIf(err, "failed to check retention")
+	}
+
+	if !match {
+		return errors.WrapIf(err, "invalid retention")
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Replace parseDuration with regex match in case of retention field

### Why?
In case of `time.ParseDuration` valid time units are `"ns", "us" (or "µs"), "ms", "s", "m", "h"` but we need `"ms", "s", "m", "h", "d", "w", "y'`


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

