### PR TITLE
[Monitoring] Add deafult Alertmanager values

### DIFF
--- a/internal/clusterfeature/features/monitoring/operator.go
+++ b/internal/clusterfeature/features/monitoring/operator.go
@@ -599,7 +599,11 @@ func (m chartValuesManager) generateAlertmanagerChartValues(ctx context.Context,
 		}, nil
 	}
 
-	return nil, nil
+	return &alertmanagerValues{
+		baseValues: baseValues{
+			Enabled: false,
+		},
+	}, nil
 }
 
 func (m chartValuesManager) generatePrometheusChartValues(ctx context.Context, spec prometheusSpec, secretName string) *prometheusValues {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add Alertmanager to the values in case of disabled state too

### Why?
To avoid deploy errors

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

