### PR TITLE
cadence: createNonexistentDomain should default to true

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -68,7 +68,7 @@ cadence:
     host: "127.0.0.1"
 #    port: 7933
 #    domain: "pipeline"
-#    createNonexistentDomain: true
+    createNonexistentDomain: true
 #    workflowExecutionRetentionPeriodInDays: 3
 
 cors:


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
cadence: createNonexistentDomain should default to true


