### PR TITLE
Use banzaicloud.io when there is no base domain

### DIFF
--- a/cluster/hooks_ingress.go
+++ b/cluster/hooks_ingress.go
@@ -68,28 +68,33 @@ func InstallIngressControllerPostHook(cluster CommonCluster) error {
 			return emperror.WrapWith(err, "failed to get organization", "organizationId", orgID)
 		}
 
-		baseDomain, err := dns.GetBaseDomain()
-		if err != nil {
-			return emperror.Wrap(err, "failed to get base domain")
-		}
-
-		orgDomainName := strings.ToLower(fmt.Sprintf("%s.%s", organization.Name, baseDomain))
-		err = dns.ValidateSubdomain(orgDomainName)
-		if err != nil {
-			return emperror.Wrap(err, "invalid domain for TLS cert")
-		}
-
-		wildcardOrgDomainName := fmt.Sprintf("*.%s", orgDomainName)
-		err = dns.ValidateWildcardSubdomain(wildcardOrgDomainName)
-		if err != nil {
-			return emperror.Wrap(err, "invalid wildcard domain for TLS cert")
-		}
+		baseDomain := strings.ToLower(global.Config.Cluster.DNS.BaseDomain)
 
 		certRequest := tls.ServerCertificateRequest{
 			Subject: pkix.Name{
-				CommonName: wildcardOrgDomainName,
+				CommonName: "banzaicloud.io",
 			},
-			DNSNames: []string{orgDomainName, wildcardOrgDomainName},
+		}
+
+		if baseDomain != "" {
+			orgDomainName := strings.ToLower(fmt.Sprintf("%s.%s", organization.Name, baseDomain))
+			err = dns.ValidateSubdomain(orgDomainName)
+			if err != nil {
+				return emperror.Wrap(err, "invalid domain for TLS cert")
+			}
+
+			wildcardOrgDomainName := fmt.Sprintf("*.%s", orgDomainName)
+			err = dns.ValidateWildcardSubdomain(wildcardOrgDomainName)
+			if err != nil {
+				return emperror.Wrap(err, "invalid wildcard domain for TLS cert")
+			}
+
+			certRequest = tls.ServerCertificateRequest{
+				Subject: pkix.Name{
+					CommonName: wildcardOrgDomainName,
+				},
+				DNSNames: []string{orgDomainName, wildcardOrgDomainName},
+			}
 		}
 
 		rootCA, cert, key, err := certGenerator.GenerateServerCertificate(certRequest)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Use `banzaicloud.io` as a cert domain when there is no base domain configured.


### Why?
Ingress posthook requires a default CA.
When it's missing the posthook generates one on it's own.
In order to do that, it needs a DNS name which is usually the base domain.
There is no base domain though when the platform DNS is disabled.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
