### PR TITLE
[Monitoring] Make providers of Alertmanager optional

### DIFF
--- a/internal/clusterfeature/features/monitoring/common.go
+++ b/internal/clusterfeature/features/monitoring/common.go
@@ -29,6 +29,7 @@ const (
 	featureSecretTag                 = "feature:monitoring"
 	generatedSecretUsername          = "admin"
 	alertManagerProviderConfigName   = "default-receiver"
+	alertManagerNullReceiverName     = "null"
 
 	ingressTypeGrafana      = "Grafana"
 	ingressTypePrometheus   = "Prometheus"

--- a/internal/clusterfeature/features/monitoring/spec.go
+++ b/internal/clusterfeature/features/monitoring/spec.go
@@ -213,15 +213,11 @@ func (s alertmanagerSpec) Validate() error {
 			return err
 		}
 
-		var hasProvider bool
 		// validate Slack notification provider
 		if slackProv, ok := s.Provider[alertmanagerProviderSlack]; ok {
 			var slack slackSpec
 			if err := mapstructure.Decode(slackProv, &slack); err != nil {
 				return errors.WrapIf(err, "failed to bind Slack config")
-			}
-			if slack.Enabled {
-				hasProvider = true
 			}
 			if err := slack.Validate(); err != nil {
 				return errors.WrapIf(err, "error during validating Slack")
@@ -234,18 +230,10 @@ func (s alertmanagerSpec) Validate() error {
 			if err := mapstructure.Decode(pagerDutyProv, &pd); err != nil {
 				return errors.WrapIf(err, "failed to bind PagerDuty config")
 			}
-			if pd.Enabled {
-				hasProvider = true
-			}
 			if err := pd.Validate(); err != nil {
 				return errors.WrapIf(err, "error during validating PagerDuty")
 			}
 		}
-
-		if !hasProvider {
-			return errors.New("at least one notification provider required")
-		}
-
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Make providers of Alertmanager optional


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
