### PR TITLE
Fix Backyards helm chart names

### DIFF
--- a/internal/istio/istiofeature/reconcile_backyards.go
+++ b/internal/istio/istiofeature/reconcile_backyards.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/pkg/backoff"
-	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 )
 
 type monitoringConfig struct {
@@ -220,7 +219,7 @@ func (m *MeshReconciler) installBackyards(c cluster.CommonCluster, monitoring mo
 	err = installOrUpgradeDeployment(
 		c,
 		backyardsNamespace,
-		pkgHelm.BanzaiRepository+"/"+m.Configuration.internalConfig.backyards.chartName,
+		m.Configuration.internalConfig.backyards.chartName,
 		backyardsReleaseName,
 		valuesOverride,
 		m.Configuration.internalConfig.backyards.chartVersion,

--- a/internal/istio/istiofeature/reconcile_canary_operator.go
+++ b/internal/istio/istiofeature/reconcile_canary_operator.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/banzaicloud/pipeline/cluster"
-	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 )
 
 func (m *MeshReconciler) ReconcileCanaryOperator(desiredState DesiredState) error {
@@ -104,7 +103,7 @@ func (m *MeshReconciler) installCanaryOperator(c cluster.CommonCluster, promethe
 	err = installOrUpgradeDeployment(
 		c,
 		canaryOperatorNamespace,
-		pkgHelm.BanzaiRepository+"/"+m.Configuration.internalConfig.canary.chartName,
+		m.Configuration.internalConfig.canary.chartName,
 		canaryOperatorReleaseName,
 		valuesOverride,
 		m.Configuration.internalConfig.canary.chartVersion,

--- a/internal/istio/istiofeature/reconcile_istio_operator.go
+++ b/internal/istio/istiofeature/reconcile_istio_operator.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/banzaicloud/pipeline/cluster"
-	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 )
 
 func (m *MeshReconciler) ReconcileIstioOperator(desiredState DesiredState) error {
@@ -91,7 +90,7 @@ func (m *MeshReconciler) installIstioOperator(c cluster.CommonCluster) error {
 	err = installOrUpgradeDeployment(
 		c,
 		istioOperatorNamespace,
-		pkgHelm.BanzaiRepository+"/"+m.Configuration.internalConfig.istioOperator.chartName,
+		m.Configuration.internalConfig.istioOperator.chartName,
 		istioOperatorReleaseName,
 		valuesOverride,
 		m.Configuration.internalConfig.istioOperator.chartVersion,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix Backyards helm chart names


### Why?
The config contains fully qualified chart names. Previous code manually prefixed chart names with repository.
