### PR TITLE
[Monitoring] Remove readonly tag from generated secrets

### DIFF
--- a/internal/clusterfeature/features/monitoring/operator.go
+++ b/internal/clusterfeature/features/monitoring/operator.go
@@ -351,7 +351,6 @@ func (op FeatureOperator) generateGrafanaSecret(
 		Tags: []string{
 			clusterNameSecretTag,
 			clusterUIDSecretTag,
-			secret.TagBanzaiReadonly,
 			releaseSecretTag,
 			grafanaSecretTag,
 		},

--- a/internal/clusterfeature/features/monitoring/operator_secret.go
+++ b/internal/clusterfeature/features/monitoring/operator_secret.go
@@ -48,7 +48,6 @@ func (m secretManager) generateHTPasswordSecret(ctx context.Context) error {
 		clusterNameSecretTag,
 		clusterUIDSecretTag,
 		releaseSecretTag,
-		secret.TagBanzaiReadonly,
 		featureSecretTag,
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Remove readonly tag from generated secrets in case of Monitoring feature

### Why?
We can't delete these secrets with readonly tag


### Checklist
- [x] Implementation tested (with at least one cloud provider)

