### PR TITLE
Use the latest Backyards release for the service mesh cluster group feature

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -328,7 +328,7 @@ dex:
 #
 #            canaryOperator:
 #                chart: "banzaicloud-stable/canary-operator"
-#                version: "0.1.5"
+#                version: "0.1.6"
 #
 #                values: {}
 #

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -309,26 +309,26 @@ dex:
 #            # See https://raw.githubusercontent.com/banzaicloud/banzai-charts/master/istio/deps/grafana/dashboards
 #            grafanaDashboardLocation: ./etc/dashboards/istio
 #
-#            pilotImage: "banzaicloud/istio-pilot:1.1.8-bzc.1"
-#            mixerImage: "banzaicloud/istio-mixer:1.1.8-bzc.1"
+#            pilotImage: "banzaicloud/istio-pilot:1.3.4-bzc"
+#            mixerImage: "banzaicloud/istio-mixer:1.3.4-bzc"
 #
 #        charts:
 #            istioOperator:
 #                chart: "banzaicloud-stable/istio-operator"
-#                version: "0.0.14"
+#                version: "0.0.24"
 #
 #                # See https://github.com/banzaicloud/istio-operator/tree/release-1.3/deploy/charts/istio-operator for details
 #                values: {}
 #
 #            backyards:
 #                chart: "banzaicloud-stable/backyards"
-#                version: "0.1.4"
+#                version: "1.0.3"
 #
 #                values: {}
 #
 #            canaryOperator:
 #                chart: "banzaicloud-stable/canary-operator"
-#                version: "0.1.2"
+#                version: "0.1.5"
 #
 #                values: {}
 #

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/banzaicloud/cicd-go v0.0.0-20190214150755-832df3e92677
 	github.com/banzaicloud/gin-utilz v0.1.0
 	github.com/banzaicloud/go-gin-prometheus v0.0.0-20181204122313-8145dbf52419
-	github.com/banzaicloud/istio-operator v0.0.0-20190430142744-7f4bf475ff8f
+	github.com/banzaicloud/istio-operator v0.0.0-20191104140059-90d1290d7342
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f
 	github.com/banzaicloud/nodepool-labels-operator v0.0.0-20190823114332-76c873e3a8cb
 	github.com/banzaicloud/prometheus-config v0.0.0-20181214142820-fc6ae4756a29

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/banzaicloud/go-gin-prometheus v0.0.0-20181204122313-8145dbf52419 h1:s
 github.com/banzaicloud/go-gin-prometheus v0.0.0-20181204122313-8145dbf52419/go.mod h1:1eXhK1Ld1vRFbNpqi8Eu1ktCCk5LARA1Tbdl8EsAfgE=
 github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182 h1:U3i2pc5I/dwlXqcTgPSHBP1k9ISjnyMlXh6Opi94pf8=
 github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182/go.mod h1:OeOXKxwBf3IGkKdrjisjo3pb+RlQNRMXpaGgiDdyRfA=
-github.com/banzaicloud/istio-operator v0.0.0-20190430142744-7f4bf475ff8f h1:51U6NGVl3M6Da4BhC+dzK1diR4FkqMoGhtb/E4xS3oA=
-github.com/banzaicloud/istio-operator v0.0.0-20190430142744-7f4bf475ff8f/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
+github.com/banzaicloud/istio-operator v0.0.0-20191104140059-90d1290d7342 h1:1thVJJgjxerPRgtHftg/fIX9pvZw9cfH+8zUG/voj6I=
+github.com/banzaicloud/istio-operator v0.0.0-20191104140059-90d1290d7342/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
 github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f h1:WeGZeO6I+lI1IG2vm1iXTeMrHLcMUjfoYm+rubBM5c4=
 github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f/go.mod h1:2GxaTh0YYmhQEMQ4wJ8Izr7sBecWZtnXlDzybR1hSO8=
 github.com/banzaicloud/nodepool-labels-operator v0.0.0-20190823114332-76c873e3a8cb h1:eq2A3Yrgzy4dGKpAeX5DXKRo1z3GOJvGsQ+WsPMik8Y=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -496,13 +496,28 @@ func Configure(v *viper.Viper, _ *pflag.FlagSet) {
 	v.SetDefault("cluster::backyards::istio::mixerImage", "banzaicloud/istio-mixer:1.3.4-bzc")
 	v.SetDefault("cluster::backyards::charts::istioOperator::chart", "banzaicloud-stable/istio-operator")
 	v.SetDefault("cluster::backyards::charts::istioOperator::version", "0.0.24")
-	v.SetDefault("cluster::backyards::charts::istioOperator::values", map[string]interface{}{})
+	v.SetDefault("cluster::backyards::charts::istioOperator::values", map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": "banzaicloud/istio-operator",
+			"tag":        "0.3.5",
+		},
+	})
 	v.SetDefault("cluster::backyards::charts::backyards::chart", "banzaicloud-stable/backyards")
 	v.SetDefault("cluster::backyards::charts::backyards::version", "1.0.3")
-	v.SetDefault("cluster::backyards::charts::backyards::values", map[string]interface{}{})
+	v.SetDefault("cluster::backyards::charts::backyards::values", map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": "banzaicloud/backyards",
+			"tag":        "1.0.3",
+		},
+	})
 	v.SetDefault("cluster::backyards::charts::canaryOperator::chart", "banzaicloud-stable/canary-operator")
-	v.SetDefault("cluster::backyards::charts::canaryOperator::version", "0.1.5")
-	v.SetDefault("cluster::backyards::charts::canaryOperator::values", map[string]interface{}{})
+	v.SetDefault("cluster::backyards::charts::canaryOperator::version", "0.1.6")
+	v.SetDefault("cluster::backyards::charts::canaryOperator::values", map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": "banzaicloud/istio-operator",
+			"tag":        "0.1.4",
+		},
+	})
 
 	v.SetDefault("cluster::federation::charts::kubefed::chart", "kubefed-charts/kubefed")
 	v.SetDefault("cluster::federation::charts::kubefed::version", "0.1.0-rc5")

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -492,44 +492,17 @@ func Configure(v *viper.Viper, _ *pflag.FlagSet) {
 
 	v.SetDefault("cluster::backyards::enabled", true)
 	v.SetDefault("cluster::backyards::istio::grafanaDashboardLocation", "./etc/dashboards/istio")
-	v.SetDefault("cluster::backyards::istio::pilotImage", "banzaicloud/istio-pilot:1.1.8-bzc.1")
-	v.SetDefault("cluster::backyards::istio::mixerImage", "banzaicloud/istio-mixer:1.1.8-bzc.1")
+	v.SetDefault("cluster::backyards::istio::pilotImage", "banzaicloud/istio-pilot:1.3.4-bzc")
+	v.SetDefault("cluster::backyards::istio::mixerImage", "banzaicloud/istio-mixer:1.3.4-bzc")
 	v.SetDefault("cluster::backyards::charts::istioOperator::chart", "banzaicloud-stable/istio-operator")
-	v.SetDefault("cluster::backyards::charts::istioOperator::version", "0.0.14")
-	v.SetDefault("cluster::backyards::charts::istioOperator::values", map[string]interface{}{
-		"operator": map[string]interface{}{
-			"image": map[string]interface{}{
-				"repository": "",
-				"tag":        "",
-			},
-		},
-	})
+	v.SetDefault("cluster::backyards::charts::istioOperator::version", "0.0.24")
+	v.SetDefault("cluster::backyards::charts::istioOperator::values", map[string]interface{}{})
 	v.SetDefault("cluster::backyards::charts::backyards::chart", "banzaicloud-stable/backyards")
-	v.SetDefault("cluster::backyards::charts::backyards::version", "0.1.4")
-	v.SetDefault("cluster::backyards::charts::backyards::values", map[string]interface{}{
-		"application": map[string]interface{}{
-			"image": map[string]interface{}{
-				"repository": "banzaicloud/backyards",
-				"tag":        "0.1.3",
-			},
-		},
-		"web": map[string]interface{}{
-			"image": map[string]interface{}{
-				"repository": "banzaicloud/backyards",
-				"tag":        "web-0.1.3",
-			},
-		},
-	})
+	v.SetDefault("cluster::backyards::charts::backyards::version", "1.0.3")
+	v.SetDefault("cluster::backyards::charts::backyards::values", map[string]interface{}{})
 	v.SetDefault("cluster::backyards::charts::canaryOperator::chart", "banzaicloud-stable/canary-operator")
-	v.SetDefault("cluster::backyards::charts::canaryOperator::version", "0.1.2")
-	v.SetDefault("cluster::backyards::charts::canaryOperator::values", map[string]interface{}{
-		"operator": map[string]interface{}{
-			"image": map[string]interface{}{
-				"repository": "banzaicloud/canary-operator",
-				"tag":        "0.1.0",
-			},
-		},
-	})
+	v.SetDefault("cluster::backyards::charts::canaryOperator::version", "0.1.5")
+	v.SetDefault("cluster::backyards::charts::canaryOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::federation::charts::kubefed::chart", "kubefed-charts/kubefed")
 	v.SetDefault("cluster::federation::charts::kubefed::version", "0.1.0-rc5")

--- a/internal/istio/istiofeature/api.go
+++ b/internal/istio/istiofeature/api.go
@@ -26,7 +26,7 @@ const (
 	FeatureName = "servicemesh"
 
 	istioOperatorReleaseName  = "istio-operator"
-	istioVersion              = "1.1"
+	istioVersion              = "1.3"
 	backyardsReleaseName      = "backyards"
 	canaryOperatorReleaseName = "canary"
 	prometheusHostname        = "monitor-prometheus-server.pipeline-system.svc.cluster.local"
@@ -39,6 +39,7 @@ const (
 	backyardsNamespace        = "backyards-system"
 	canaryOperatorNamespace   = "backyards-canary"
 	istioOperatorNamespace    = "istio-system"
+	zipkinAddress             = "backyards-zipkin.backyards-system:9411"
 
 	backoffDelaySeconds = 10
 	backoffMaxretries   = 10

--- a/internal/istio/istiofeature/reconcile.go
+++ b/internal/istio/istiofeature/reconcile.go
@@ -26,11 +26,9 @@ func (m *MeshReconciler) Reconcile() error {
 
 	switch desiredState {
 	case DesiredStatePresent:
+		// TODO - integrate with monitoring feature
 		reconcilers = []Reconciler{
 			m.ReconcileIstioOperatorNamespace,
-			m.ReconcileMonitoring,
-			m.ReconcilePrometheusScrapeConfig,
-			m.ReconcileGrafanaDashboards,
 			m.ReconcileIstioOperator,
 			m.ReconcileIstio,
 			m.ReconcileRemoteIstios,

--- a/internal/istio/istiofeature/reconcile.go
+++ b/internal/istio/istiofeature/reconcile.go
@@ -24,9 +24,10 @@ func (m *MeshReconciler) Reconcile() error {
 
 	var reconcilers []Reconciler
 
+	// TODO - integrate with monitoring feature
+
 	switch desiredState {
 	case DesiredStatePresent:
-		// TODO - integrate with monitoring feature
 		reconcilers = []Reconciler{
 			m.ReconcileIstioOperatorNamespace,
 			m.ReconcileIstioOperator,
@@ -39,8 +40,6 @@ func (m *MeshReconciler) Reconcile() error {
 		}
 	case DesiredStateAbsent:
 		reconcilers = []Reconciler{
-			m.ReconcilePrometheusScrapeConfig,
-			m.ReconcileGrafanaDashboards,
 			m.ReconcileRemoteIstios,
 			m.ReconcileIstio,
 			m.ReconcileIstioOperator,

--- a/internal/istio/istiofeature/reconcile_istio_cr.go
+++ b/internal/istio/istiofeature/reconcile_istio_cr.go
@@ -108,6 +108,8 @@ func (m *MeshReconciler) waitForIstioCRToBeDeleted(client *istiooperatorclientse
 
 // configureIstioCR configures istio-operator specific CR based on the given params
 func (m *MeshReconciler) configureIstioCR(istio *v1beta1.Istio, config Config) *v1beta1.Istio {
+	enabled := true
+
 	labels := istio.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string, 0)
@@ -132,9 +134,10 @@ func (m *MeshReconciler) configureIstioCR(istio *v1beta1.Istio, config Config) *
 		MaxReplicas: 1,
 	}
 	istio.Spec.SidecarInjector.RewriteAppHTTPProbe = true
+	istio.Spec.Tracing.Enabled = &enabled
+	istio.Spec.Tracing.Zipkin.Address = zipkinAddress
 
 	if len(m.Remotes) > 0 {
-		enabled := true
 		istio.Spec.UseMCP = enabled
 		istio.Spec.MTLS = enabled
 		istio.Spec.MeshExpansion = &enabled

--- a/internal/istio/istiofeature/reconcile_istio_cr.go
+++ b/internal/istio/istiofeature/reconcile_istio_cr.go
@@ -109,6 +109,7 @@ func (m *MeshReconciler) waitForIstioCRToBeDeleted(client *istiooperatorclientse
 // configureIstioCR configures istio-operator specific CR based on the given params
 func (m *MeshReconciler) configureIstioCR(istio *v1beta1.Istio, config Config) *v1beta1.Istio {
 	enabled := true
+	maxReplicas := int32(1)
 
 	labels := istio.GetLabels()
 	if labels == nil {
@@ -127,18 +128,21 @@ func (m *MeshReconciler) configureIstioCR(istio *v1beta1.Istio, config Config) *
 	istio.Spec.Gateways.EgressConfig.MaxReplicas = 1
 	istio.Spec.Pilot = v1beta1.PilotConfiguration{
 		Image:       m.Configuration.internalConfig.istioOperator.pilotImage,
-		MaxReplicas: 1,
+		MaxReplicas: maxReplicas,
 	}
 	istio.Spec.Mixer = v1beta1.MixerConfiguration{
-		Image:       m.Configuration.internalConfig.istioOperator.mixerImage,
-		MaxReplicas: 1,
+		K8sResourceConfiguration: v1beta1.K8sResourceConfiguration{
+			Image:       &m.Configuration.internalConfig.istioOperator.mixerImage,
+			MaxReplicas: &maxReplicas,
+		},
 	}
 	istio.Spec.SidecarInjector.RewriteAppHTTPProbe = true
 	istio.Spec.Tracing.Enabled = &enabled
 	istio.Spec.Tracing.Zipkin.Address = zipkinAddress
+	istio.Spec.Mixer.MultiClusterSupport = &enabled
 
 	if len(m.Remotes) > 0 {
-		istio.Spec.UseMCP = enabled
+		istio.Spec.UseMCP = &enabled
 		istio.Spec.MTLS = enabled
 		istio.Spec.MeshExpansion = &enabled
 		istio.Spec.ControlPlaneSecurityEnabled = enabled


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add support for the latest Backyards release.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Backyards is configured to use its own prometheus and grafana deployment, the integration with Pipeline monitoring feature will be added in the near future.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
