### PR TITLE
Fix object merge

### DIFF
--- a/spotguide/merge.go
+++ b/spotguide/merge.go
@@ -18,44 +18,12 @@ import (
 	"reflect"
 )
 
-func max(x, y int) int {
-	if x > y {
+func min(x, y int) int {
+	if x < y {
 		return x
 	}
 
 	return y
-}
-
-func elementOrNil(arr []interface{}, i int) interface{} {
-	if i < len(arr) {
-		return arr[i]
-	}
-
-	return nil
-}
-
-func getKeys(obj map[string]interface{}) []string {
-	keys := []string{}
-	for key := range obj {
-		keys = append(keys, key)
-	}
-
-	return keys
-}
-
-func mergeKeys(a, b []string) []string {
-	keys := append(a, b...)
-
-	seen := make(map[string]bool)
-	uniqKeys := []string{}
-	for _, entry := range keys {
-		if _, value := seen[entry]; !value {
-			seen[entry] = true
-			uniqKeys = append(uniqKeys, entry)
-		}
-	}
-
-	return uniqKeys
 }
 
 func merge(dst, src interface{}) (interface{}, error) {
@@ -100,7 +68,7 @@ func merge(dst, src interface{}) (interface{}, error) {
 
 		switch srcV := src.(type) {
 		case map[string]interface{}:
-			for _, key := range mergeKeys(getKeys(dstV), getKeys(srcV)) {
+			for key := range srcV {
 				val, err := merge(dstV[key], srcV[key])
 				if err != nil {
 					return dst, err
@@ -123,15 +91,19 @@ func merge(dst, src interface{}) (interface{}, error) {
 
 		switch srcV := src.(type) {
 		case []interface{}:
-			length := max(len(dstV), len(srcV))
+			// merge elements at common indices
+			length := min(len(dstV), len(srcV))
 			for i := 0; i < length; i++ {
-				val, err := merge(elementOrNil(dstV, i), elementOrNil(srcV, i))
+				val, err := merge(dstV[i], srcV[i])
 				if err != nil {
 					return dst, err
 				}
 
 				dstV[i] = val
 			}
+
+			// append surplus from src (if any)
+			dstV = append(dstV, srcV[length:]...)
 
 			return dstV, nil
 		default:

--- a/spotguide/merge_test.go
+++ b/spotguide/merge_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spotguide
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	testCases := map[string]struct {
+		Dst interface{}
+		Src interface{}
+		Res interface{}
+		Err interface{}
+	}{
+		"shorter dst array, longer src array": {
+			Dst: []interface{}{
+				1, 2, 3,
+			},
+			Src: []interface{}{
+				4, 5, 6, 7,
+			},
+			Res: []interface{}{
+				4, 5, 6, 7,
+			},
+		},
+		"longer dst array, shorter src array": {
+			Dst: []interface{}{
+				1, 2, 3, 4,
+			},
+			Src: []interface{}{
+				5, 6, 7,
+			},
+			Res: []interface{}{
+				5, 6, 7, 4,
+			},
+		},
+		"object dst, object src": {
+			Dst: map[string]interface{}{
+				"foo": 1,
+				"bar": 2,
+			},
+			Src: map[string]interface{}{
+				"bar": 3,
+				"buz": 4,
+			},
+			Res: map[string]interface{}{
+				"foo": 1,
+				"bar": 3,
+				"buz": 4,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			res, err := merge(testCase.Dst, testCase.Src)
+			switch testCase.Err {
+			case nil, false:
+				require.NoError(t, err)
+				assert.Equal(t, testCase.Res, res)
+			case true:
+				require.Error(t, err)
+			default:
+				require.Equal(t, testCase.Err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
* Fix a panic when `dst` and `src` are both slices, but `src` is longer than `dst`.
* Simplify existing code.
* Add tests covering modifications.
