### PR TITLE
Security scan feature - handle include-all scenario

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -403,6 +403,7 @@ func main() {
 					commonSecretStore,
 					featureAnchoreService,
 					featureWhitelistService,
+					emperror.MakeContextAware(errorHandler),
 					logger,
 				),
 				featureVault.MakeFeatureOperator(clusterGetter,

--- a/internal/clusterfeature/features/securityscan/resource_service.go
+++ b/internal/clusterfeature/features/securityscan/resource_service.go
@@ -200,6 +200,7 @@ func (nss *namespaceService) LabelNamespaces(ctx context.Context, clusterID uint
 	return combinedErr
 }
 
+// mergeLabels processes the labels the given namespace should have (required not to lose any namespace on update)
 func (nss *namespaceService) mergeLabels(currentLabels map[string]string, newLabels map[string]string) map[string]string {
 	mergedLabels := currentLabels
 	if mergedLabels == nil {

--- a/internal/clusterfeature/features/securityscan/resource_service.go
+++ b/internal/clusterfeature/features/securityscan/resource_service.go
@@ -270,7 +270,7 @@ func (nss *namespaceService) CleanupLabels(ctx context.Context, clusterID uint, 
 		namespaces[i] = nsEntry.Name
 	}
 
-	if err := nss.RemoveLabels(ctx, clusterID, namespaces, []string{"scan"}); err != nil {
+	if err := nss.RemoveLabels(ctx, clusterID, namespaces, labelsIn); err != nil {
 		return errors.WrapIf(err, "failed to remove security scan labels from namespaces ")
 	}
 

--- a/internal/clusterfeature/features/securityscan/resource_service.go
+++ b/internal/clusterfeature/features/securityscan/resource_service.go
@@ -16,6 +16,7 @@ package securityscan
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -151,6 +152,9 @@ type NamespaceService interface {
 
 	// RemoveLabels removes the labels from the slice of namespaces
 	RemoveLabels(ctx context.Context, clusterID uint, namespaces []string, labels []string) error
+
+	// removes all the passed in labels from all the namespaces in the cluster
+	CleanupLabels(ctx context.Context, clusterID uint, labels []string) error
 }
 
 type namespaceService struct {
@@ -247,6 +251,30 @@ func (nss *namespaceService) RemoveLabels(ctx context.Context, clusterID uint, n
 	}
 	nss.logger.Info("removed labels from namespaces", map[string]interface{}{"namespaces": namespaces, "labels": labels})
 	return combinedErr
+}
+
+func (nss *namespaceService) CleanupLabels(ctx context.Context, clusterID uint, labelsIn []string) error {
+	namespacesCli, err := nss.getNamespacesCli(ctx, clusterID)
+	if err != nil {
+		return errors.WrapIf(err, "failed to get namespaces client")
+	}
+
+	// selects all namespaces labeled with the passed in labels (label Exists)
+	nsListPtr, err := namespacesCli.List(metav1.ListOptions{LabelSelector: strings.Join(labelsIn, ",")})
+	if err != nil {
+		return errors.WrapIf(err, "failed to retrieve labeled namespaces")
+	}
+
+	namespaces := make([]string, len(nsListPtr.Items))
+	for i, nsEntry := range nsListPtr.Items {
+		namespaces[i] = nsEntry.Name
+	}
+
+	if err := nss.RemoveLabels(ctx, clusterID, namespaces, []string{"scan"}); err != nil {
+		return errors.WrapIf(err, "failed to remove security scan labels from namespaces ")
+	}
+
+	return nil
 }
 
 func (nss *namespaceService) getNamespacesCli(ctx context.Context, clusterID uint) (v1.NamespaceInterface, error) {

--- a/internal/clusterfeature/features/securityscan/spec.go
+++ b/internal/clusterfeature/features/securityscan/spec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/banzaicloud/pipeline/internal/clusterfeature"
+	"github.com/banzaicloud/pipeline/internal/global"
 )
 
 //featureSpec security scan cluster feature specific specification
@@ -102,6 +103,13 @@ func (w webHookConfigSpec) Validate() error {
 	if w.Enabled {
 		if w.Selector == "" || len(w.Namespaces) == 0 {
 			return errors.NewPlain("selector and namespaces must be filled")
+		}
+
+		for _, ns := range w.Namespaces {
+			if ns == global.Config.Cluster.Namespace || ns == "kube-system" {
+				return errors.Errorf("the following namespaces may not be modified: %v",
+					[]string{global.Config.Cluster.Namespace, "kube-system"})
+			}
 		}
 	}
 


### PR DESCRIPTION
- The PR covers the include-all (include + *) scenario for the security scan webhook configuration
- It also adds error handler for the feature operator used for cases when the activation of the feature encounters  (minor) errors (eg.: inexistent ns is passed through the api) 

fixes #2435