### PR TITLE
Rename opaque to any

### DIFF
--- a/docs/cluster-feature.md
+++ b/docs/cluster-feature.md
@@ -13,7 +13,7 @@ The two feature operations, `Apply` and `Deactivate` perform their tasks synchro
 They should return a `ClusterNotReadyError`—or an error implementing the `ShouldRetry() bool` behavior—when the cluster's not (yet) ready for the operation.
 The `Apply` method receives its specification run through `PrepareSpec`.
 
-We suggest using the `Transformation`s in `pkg/opaque` when implementing specification transformations in `PrepareSpec`. When frequently used generic patterns arise, please consider factoring them out into the `opaque` package for reuse (or the `internal/clusterfeature/features` package for more specific patterns).
+We suggest using the `Transformation`s in `pkg/any` when implementing specification transformations in `PrepareSpec`. When frequently used generic patterns arise, please consider factoring them out into the `any` package for reuse (or the `internal/clusterfeature/features` package for more specific patterns).
 
 If the original specification provided by the user is considered valid by `ValidateSpec` the prepared specification should be too.
 

--- a/pkg/any/value.go
+++ b/pkg/any/value.go
@@ -1,0 +1,18 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package any
+
+// Value can represent any value
+type Value = interface{}

--- a/pkg/any/xform.go
+++ b/pkg/any/xform.go
@@ -17,14 +17,14 @@ package any
 // Transformation can transform a value to another
 type Transformation interface {
 	// Transform performs the transformation
-	Transform(interface{}) (interface{}, error)
+	Transform(Value) (Value, error)
 }
 
 // TransformationFunc wraps a function that implements the transformation
-type TransformationFunc func(interface{}) (interface{}, error)
+type TransformationFunc func(Value) (Value, error)
 
 // Transform implements the transformation by delegating to the wrapped function
-func (f TransformationFunc) Transform(src interface{}) (interface{}, error) {
+func (f TransformationFunc) Transform(src Value) (Value, error) {
 	return f(src)
 }
 
@@ -34,13 +34,13 @@ const Identity identityTransformation = false
 // The underlying type must be one of the scalar types to allow for defining a const instance
 type identityTransformation bool
 
-func (identityTransformation) Transform(src interface{}) (interface{}, error) {
+func (identityTransformation) Transform(src Value) (Value, error) {
 	return src, nil
 }
 
 // Compose returns the composition of the specified transformations performed in order
 func Compose(transformations ...Transformation) Transformation {
-	return TransformationFunc(func(o interface{}) (interface{}, error) {
+	return TransformationFunc(func(o Value) (Value, error) {
 		var err error
 		for _, t := range transformations {
 			o, err = t.Transform(o)

--- a/pkg/any/xform.go
+++ b/pkg/any/xform.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package opaque
+package any
 
-// Transformation can transform an opaque value to another
+// Transformation can transform a value to another
 type Transformation interface {
 	// Transform performs the transformation
 	Transform(interface{}) (interface{}, error)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Rename `opaque` package to `any`.

### Why?
`any` is a better name for `interface{}` than `opaque`
