### PR TITLE
[Monitoring] Set serviceMonitorSelectorNilUsesHelmValues to true in Pr…

### DIFF
--- a/internal/clusterfeature/features/monitoring/operator.go
+++ b/internal/clusterfeature/features/monitoring/operator.go
@@ -733,6 +733,7 @@ func (m chartValuesManager) generatePrometheusChartValues(
 						},
 					},
 				},
+				ServiceMonitorSelectorNilUsesHelmValues: false,
 			},
 			Annotations: annotations,
 		}

--- a/internal/clusterfeature/features/monitoring/values.go
+++ b/internal/clusterfeature/features/monitoring/values.go
@@ -106,11 +106,12 @@ type pagerdutyConfigValues struct {
 }
 
 type SpecValues struct {
-	RoutePrefix   string                 `json:"routePrefix"`
-	RetentionSize string                 `json:"retentionSize"`
-	Retention     string                 `json:"retention"`
-	StorageSpec   map[string]interface{} `json:"storageSpec"`
-	Image         imageValues            `json:"image"`
+	RoutePrefix                             string                 `json:"routePrefix"`
+	RetentionSize                           string                 `json:"retentionSize"`
+	Retention                               string                 `json:"retention"`
+	StorageSpec                             map[string]interface{} `json:"storageSpec"`
+	ServiceMonitorSelectorNilUsesHelmValues bool                   `json:"serviceMonitorSelectorNilUsesHelmValues"`
+	Image                                   imageValues            `json:"image"`
 }
 
 type prometheusValues struct {


### PR DESCRIPTION
…ometheus values

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Set serviceMonitorSelectorNilUsesHelmValues to true in Prometheus values

### Why?
If `serviceMonitorSelectorNilUsesHelmValues` is true (this is chart default) will cause the prometheus resource to be created with selectors based on values in the helm deployment, which will also match the servicemonitors created


### Checklist

- [x] Implementation tested (with at least one cloud provider)
