### PR TITLE
Use monitoring feature in HPA

### DIFF
--- a/api/hpa.go
+++ b/api/hpa.go
@@ -52,9 +52,16 @@ func (e *scaleTargetNotFoundError) Error() string {
 	return fmt.Sprintf("scaleTarget: %v not found!", e.scaleTargetRef)
 }
 
-// PutHpaResource create/updates a Hpa resource annotations on scaleTarget - a K8s deployment/statefulset
-func PutHpaResource(c *gin.Context) {
+type HPAAPI struct {
+}
 
+// NewHPAAPI returns a new HPAAPI.
+func NewHPAAPI() HPAAPI {
+	return HPAAPI{}
+}
+
+// PutHpaResource create/updates a Hpa resource annotations on scaleTarget - a K8s deployment/statefulset
+func (a HPAAPI) PutHpaResource(c *gin.Context) {
 	kubeConfig, ok := GetK8sConfig(c)
 	if !ok {
 		return
@@ -213,7 +220,7 @@ func runPrometheusQuery(config *rest.Config, client *kubernetes.Clientset, query
 }
 
 // DeleteHpaResource deletes a Hpa resource annotations from scaleTarget - K8s deployment/statefulset
-func DeleteHpaResource(c *gin.Context) {
+func (a HPAAPI) DeleteHpaResource(c *gin.Context) {
 
 	scaleTarget, ok := ginutils.RequiredQueryOrAbort(c, "scaleTarget")
 	if !ok {
@@ -248,7 +255,7 @@ func DeleteHpaResource(c *gin.Context) {
 }
 
 // GetHpaResource returns a Hpa resource bound to a K8s deployment/statefulset
-func GetHpaResource(c *gin.Context) {
+func (a HPAAPI) GetHpaResource(c *gin.Context) {
 	scaleTarget, ok := ginutils.RequiredQueryOrAbort(c, "scaleTarget")
 	if !ok {
 		return

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -667,8 +667,6 @@ func main() {
 
 				cRouter.Use(cluster.NewClusterCheckMiddleware(clusterManager, errorHandler))
 
-				hpaApi := api.NewHPAAPI()
-
 				cRouter.GET("", clusterAPI.GetCluster)
 				cRouter.GET("/pods", api.GetPodDetails)
 				cRouter.GET("/bootstrap", clusterAPI.GetBootstrapInfo)
@@ -690,9 +688,6 @@ func main() {
 				cRouter.POST("/deployments", api.CreateDeployment)
 				cRouter.GET("/deployments/:name", api.GetDeployment)
 				cRouter.GET("/deployments/:name/resources", api.GetDeploymentResources)
-				cRouter.GET("/hpa", hpaApi.GetHpaResource)
-				cRouter.PUT("/hpa", hpaApi.PutHpaResource)
-				cRouter.DELETE("/hpa", hpaApi.DeleteHpaResource)
 				cRouter.HEAD("/deployments", api.GetTillerStatus)
 				cRouter.DELETE("/deployments/:name", api.DeleteDeployment)
 				cRouter.PUT("/deployments/:name", api.UpgradeDeployment)
@@ -709,6 +704,7 @@ func main() {
 			)
 
 			// Cluster Feature API
+			var featureService clusterfeature.Service
 			{
 				logger := commonadapter.NewLogger(logger) // TODO: make this a context aware logger
 				featureRepository := clusterfeatureadapter.NewGormFeatureRepository(db, logger)
@@ -803,9 +799,9 @@ func main() {
 
 				featureManagerRegistry := clusterfeature.MakeFeatureManagerRegistry(featureManagers)
 				featureOperationDispatcher := clusterfeatureadapter.MakeCadenceFeatureOperationDispatcher(workflowClient, logger)
-				service := clusterfeature.MakeFeatureService(featureOperationDispatcher, featureManagerRegistry, featureRepository, logger)
+				featureService = clusterfeature.MakeFeatureService(featureOperationDispatcher, featureManagerRegistry, featureRepository, logger)
 				endpoints := clusterfeaturedriver.MakeEndpoints(
-					service,
+					featureService,
 					kitxendpoint.Chain(endpointMiddleware...),
 					appkit.EndpointLogger(commonLogger),
 				)
@@ -821,6 +817,11 @@ func main() {
 				cRouter.Any("/features", gin.WrapH(router))
 				cRouter.Any("/features/:featureName", gin.WrapH(router))
 			}
+
+			hpaApi := api.NewHPAAPI(featureService)
+			cRouter.GET("/hpa", hpaApi.GetHpaResource)
+			cRouter.PUT("/hpa", hpaApi.PutHpaResource)
+			cRouter.DELETE("/hpa", hpaApi.DeleteHpaResource)
 
 			// ClusterGroupAPI
 			cgroupsAPI := cgroupAPI.NewAPI(clusterGroupManager, deploymentManager, logrusLogger, errorHandler)

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -667,6 +667,8 @@ func main() {
 
 				cRouter.Use(cluster.NewClusterCheckMiddleware(clusterManager, errorHandler))
 
+				hpaApi := api.NewHPAAPI()
+
 				cRouter.GET("", clusterAPI.GetCluster)
 				cRouter.GET("/pods", api.GetPodDetails)
 				cRouter.GET("/bootstrap", clusterAPI.GetBootstrapInfo)
@@ -688,9 +690,9 @@ func main() {
 				cRouter.POST("/deployments", api.CreateDeployment)
 				cRouter.GET("/deployments/:name", api.GetDeployment)
 				cRouter.GET("/deployments/:name/resources", api.GetDeploymentResources)
-				cRouter.GET("/hpa", api.GetHpaResource)
-				cRouter.PUT("/hpa", api.PutHpaResource)
-				cRouter.DELETE("/hpa", api.DeleteHpaResource)
+				cRouter.GET("/hpa", hpaApi.GetHpaResource)
+				cRouter.PUT("/hpa", hpaApi.PutHpaResource)
+				cRouter.DELETE("/hpa", hpaApi.DeleteHpaResource)
 				cRouter.HEAD("/deployments", api.GetTillerStatus)
 				cRouter.DELETE("/deployments/:name", api.DeleteDeployment)
 				cRouter.PUT("/deployments/:name", api.UpgradeDeployment)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
Use monitoring feature in HPA instead of the old `Get[FEATURE]` api.


### Why?
We would like to get rid of feature setters/getters. This is the last dependency on them.

