### PR TITLE
[Logging] Create only one ClusterFlow resource

### DIFF
--- a/internal/clusterfeature/features/logging/common.go
+++ b/internal/clusterfeature/features/logging/common.go
@@ -25,6 +25,7 @@ const (
 	providerGoogleGCS  = "gcs"
 	providerAlibabaOSS = "oss"
 	providerAzure      = "azure"
+	providerLoki       = "loki"
 
 	tlsSecretName                     = "logging-tls-secret"
 	loggingOperatorReleaseName        = "logging-operator"
@@ -48,7 +49,7 @@ const (
 	fluentdSecretName   = "logging-operator-fluentd-secret"
 
 	lokiOutputDefinitionName = "loki-output"
-	lokiFlowResourceName     = "loki-flow"
+	flowResourceName         = "banzai-logging-flow"
 )
 
 func getLokiSecretName(clusterID uint) string {

--- a/internal/clusterfeature/features/logging/operator.go
+++ b/internal/clusterfeature/features/logging/operator.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 
 	"emperror.dev/errors"
+	"github.com/mitchellh/copystructure"
+
 	"github.com/banzaicloud/pipeline/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/endpoints"
@@ -29,7 +31,6 @@ import (
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/internal/util"
 	"github.com/banzaicloud/pipeline/secret"
-	"github.com/mitchellh/copystructure"
 )
 
 // FeatureOperator implements the Logging feature operator

--- a/internal/clusterfeature/features/logging/operator.go
+++ b/internal/clusterfeature/features/logging/operator.go
@@ -19,11 +19,6 @@ import (
 	"encoding/json"
 
 	"emperror.dev/errors"
-	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
-	"github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
-	"github.com/mitchellh/copystructure"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/banzaicloud/pipeline/auth"
 	pkgCluster "github.com/banzaicloud/pipeline/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/endpoints"
@@ -34,6 +29,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/internal/util"
 	"github.com/banzaicloud/pipeline/secret"
+	"github.com/mitchellh/copystructure"
 )
 
 // FeatureOperator implements the Logging feature operator
@@ -112,12 +108,17 @@ func (op FeatureOperator) Apply(ctx context.Context, clusterID uint, spec cluste
 		return errors.WrapIf(err, "failed to install logging-operator-logging")
 	}
 
-	if err := op.processClusterOutput(ctx, boundSpec.ClusterOutput, cl); err != nil {
-		return errors.WrapIf(err, "failed to create output definition and flow resource")
-	}
-
 	if err := op.processLoki(ctx, boundSpec.Loki, cl); err != nil {
 		return errors.WrapIf(err, "failed to install Loki")
+	}
+
+	outputManagers, err := op.createClusterOutputDefinitions(ctx, boundSpec, cl)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create cluster output definitions")
+	}
+
+	if err := op.createClusterFlowResource(ctx, outputManagers, cl.GetID()); err != nil {
+		return errors.WrapIf(err, "failed to create cluster flow resource")
 	}
 
 	return nil
@@ -385,87 +386,9 @@ func (op FeatureOperator) processLoki(ctx context.Context, spec lokiSpec, cl clu
 		); err != nil {
 			return errors.WrapIf(err, "failed to apply Loki deployment")
 		}
-
-		if err := op.createLokiOutputDefinition(ctx, cl); err != nil {
-			return errors.WrapIf(err, "failed to create output definition for Loki")
-		}
-
-		if err := op.createLokiFlowResource(ctx, cl.GetID()); err != nil {
-			return errors.WrapIf(err, "failed to create flow resource for Loki")
-		}
 	}
 
 	return nil
-}
-
-func (op FeatureOperator) createLokiOutputDefinition(ctx context.Context, cl clusterfeatureadapter.Cluster) error {
-	k8sConfig, err := cl.GetK8sConfig()
-	if err != nil {
-		return errors.WrapIfWithDetails(err, "failed to get kubeconfig", "cluster", cl.GetID())
-	}
-
-	serviceURL, err := op.endpointsService.GetServiceURL(k8sConfig, lokiServiceName, op.config.Namespace)
-	if err != nil {
-		return errors.WrapIf(err, "failed to get Loki service url")
-	}
-
-	// delete former Loki outputs
-	var formerOutputs v1beta1.ClusterOutputList
-	if err := op.kubernetesService.List(ctx, cl.GetID(), nil, &formerOutputs); err != nil {
-		return errors.WrapIf(err, "failed to list cluster outputs")
-	}
-	for _, item := range formerOutputs.Items {
-		if item.Name == lokiOutputDefinitionName {
-			if err := op.kubernetesService.DeleteObject(ctx, cl.GetID(), &item); err != nil {
-				return errors.WrapIf(err, "failed to delete Loki cluster outputs")
-			}
-		}
-	}
-
-	var outputDef = &v1beta1.ClusterOutput{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      lokiOutputDefinitionName,
-			Namespace: op.config.Namespace,
-		},
-		Spec: v1beta1.ClusterOutputSpec{
-			OutputSpec: v1beta1.OutputSpec{
-				LokiOutput: &output.LokiOutput{
-					Url:                       serviceURL,
-					ConfigureKubernetesLabels: true,
-				},
-			},
-		},
-	}
-
-	return op.kubernetesService.EnsureObject(ctx, cl.GetID(), outputDef)
-}
-
-func (op FeatureOperator) createLokiFlowResource(ctx context.Context, clusterID uint) error {
-	var flowRes = &v1beta1.ClusterFlow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      lokiFlowResourceName,
-			Namespace: op.config.Namespace,
-		},
-		Spec: v1beta1.FlowSpec{
-			Selectors:  map[string]string{},
-			OutputRefs: []string{lokiOutputDefinitionName},
-		},
-	}
-
-	// delete former Loki cluster flows
-	var formerFlowRes v1beta1.ClusterFlowList
-	if err := op.kubernetesService.List(ctx, clusterID, nil, &formerFlowRes); err != nil {
-		return errors.WrapIf(err, "failed to list cluster flows")
-	}
-	for _, item := range formerFlowRes.Items {
-		if item.Name == lokiFlowResourceName {
-			if err := op.kubernetesService.DeleteObject(ctx, clusterID, &item); err != nil {
-				return errors.WrapIf(err, "failed to delete Loki cluster flow")
-			}
-		}
-	}
-
-	return op.kubernetesService.EnsureObject(ctx, clusterID, flowRes)
 }
 
 func (op FeatureOperator) installLokiSecret(ctx context.Context, secretName string, cl clusterfeatureadapter.Cluster) error {
@@ -561,125 +484,6 @@ func (op FeatureOperator) installLoggingOperator(ctx context.Context, clusterID 
 		valuesBytes,
 		op.config.Charts.Operator.Version,
 	)
-}
-
-func (op FeatureOperator) createOutputDefinition(ctx context.Context, spec clusterOutputSpec, cl clusterfeatureadapter.Cluster) (outputDefinitionManager, error) {
-	// install secrets to cluster
-	sourceSecretName, err := op.secretStore.GetNameByID(ctx, spec.Provider.SecretID)
-	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get secret name", "secretID", spec.Provider.SecretID)
-	}
-
-	if err := op.installSecretForOutput(ctx, spec, sourceSecretName, cl); err != nil {
-		return nil, errors.WrapIf(err, "failed to install secret to cluster for cluster output")
-	}
-
-	// create output definition manager
-	manager, err := newOutputDefinitionManager(spec.Provider.Name, sourceSecretName)
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to create output definition manager")
-	}
-
-	// generate output definition
-	outputDefinition, err := generateOutputDefinition(ctx, manager, op.secretStore, spec, op.config.Namespace, cl.GetOrganizationId())
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to generate output definition")
-	}
-
-	// remove old output definitions
-	var outputList v1beta1.ClusterOutputList
-	if err := op.kubernetesService.List(ctx, cl.GetID(), nil, &outputList); err != nil {
-		return nil, errors.WrapIf(err, "failed to list output definitions")
-	}
-
-	for _, item := range outputList.Items {
-		if item.Name != lokiOutputDefinitionName {
-			if err := op.kubernetesService.DeleteObject(ctx, cl.GetID(), &item); err != nil {
-				return nil, errors.WrapIfWithDetails(err, "failed to delete output definition", "name", item.Name)
-			}
-		}
-	}
-
-	// create new output definition
-	if err := op.kubernetesService.EnsureObject(ctx, cl.GetID(), outputDefinition); err != nil {
-		return nil, errors.WrapIf(err, "failed to create output definition")
-	}
-
-	return manager, nil
-}
-
-func (op FeatureOperator) installSecretForOutput(ctx context.Context, spec clusterOutputSpec, sourceSecretName string, cl clusterfeatureadapter.Cluster) error {
-	secretManager, err := newOutputSecretInstallManager(spec.Provider.Name, sourceSecretName, op.config.Namespace)
-	if err != nil {
-		return errors.WrapIf(err, "failed to create output secret installer")
-	}
-
-	secretValues, err := op.secretStore.GetSecretValues(ctx, spec.Provider.SecretID)
-	if err != nil {
-		return errors.WrapIfWithDetails(err, "failed to get secret values", "secretID", spec.Provider.SecretID)
-	}
-
-	installSecretRequest, err := secretManager.generateSecretRequest(secretValues, spec.Provider.Bucket)
-	if err != nil {
-		return errors.WrapIf(err, "failed to generate install secret request")
-	}
-
-	if _, err := op.installSecret(ctx, cl, sourceSecretName, *installSecretRequest); err != nil {
-		return errors.WrapIf(err, "failed to install secret to cluster")
-	}
-
-	return nil
-}
-
-func (op FeatureOperator) processClusterOutput(ctx context.Context, spec clusterOutputSpec, cl clusterfeatureadapter.Cluster) error {
-	if spec.Enabled {
-		// create output definitions
-		outputDefinition, err := op.createOutputDefinition(ctx, spec, cl)
-		if err != nil {
-			return errors.WrapIf(err, "failed to create output definition")
-		}
-
-		// create flow resource
-		if err := op.createFlowResource(ctx, outputDefinition, cl.GetID()); err != nil {
-			return errors.WrapIf(err, "failed to create flow resource")
-		}
-	}
-
-	return nil
-}
-
-func (op FeatureOperator) createFlowResource(ctx context.Context, outputDefinition outputDefinitionManager, clusterID uint) error {
-	var flowResource = op.generateFlowResource(outputDefinition)
-
-	// remove old flow resources
-	var flowList v1beta1.ClusterFlowList
-	if err := op.kubernetesService.List(ctx, clusterID, nil, &flowList); err != nil {
-		return errors.WrapIf(err, "failed to list flow resources")
-	}
-
-	for _, item := range flowList.Items {
-		if item.Name != lokiFlowResourceName {
-			if err := op.kubernetesService.DeleteObject(ctx, clusterID, &item); err != nil {
-				return errors.WrapIfWithDetails(err, "failed to delete flow resource", "name", item.Name)
-			}
-		}
-	}
-
-	// create new flow resource
-	return op.kubernetesService.EnsureObject(ctx, clusterID, flowResource)
-}
-
-func (op FeatureOperator) generateFlowResource(outputDefinition outputDefinitionManager) *v1beta1.ClusterFlow {
-	return &v1beta1.ClusterFlow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      outputDefinition.getFlowName(),
-			Namespace: op.config.Namespace,
-		},
-		Spec: v1beta1.FlowSpec{
-			Selectors:  map[string]string{},
-			OutputRefs: []string{outputDefinition.getOutputName()},
-		},
-	}
 }
 
 func mergeValuesWithConfig(chartValues interface{}, configValues interface{}) ([]byte, error) {

--- a/internal/clusterfeature/features/logging/operator_flow_resource.go
+++ b/internal/clusterfeature/features/logging/operator_flow_resource.go
@@ -1,0 +1,57 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (op FeatureOperator) createClusterFlowResource(ctx context.Context, managers []outputDefinitionManager, clusterID uint) error {
+	// delete old ClusterFlow resource
+	if err := op.kubernetesService.DeleteObject(ctx, clusterID, &v1beta1.ClusterFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      flowResourceName,
+			Namespace: op.config.Namespace,
+		},
+	}); err != nil {
+		return errors.WrapIfWithDetails(err, "failed to delete flow resource")
+	}
+
+	// create new flow resource
+	var flowResource = op.generateFlowResource(managers)
+	return op.kubernetesService.EnsureObject(ctx, clusterID, flowResource)
+}
+
+func (op FeatureOperator) generateFlowResource(definitions []outputDefinitionManager) *v1beta1.ClusterFlow {
+	var outputRefs []string
+	for _, d := range definitions {
+		outputRefs = append(outputRefs, d.getName())
+	}
+
+	return &v1beta1.ClusterFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      flowResourceName,
+			Namespace: op.config.Namespace,
+		},
+		Spec: v1beta1.FlowSpec{
+			Selectors:  map[string]string{},
+			OutputRefs: outputRefs,
+		},
+	}
+}

--- a/internal/clusterfeature/features/logging/operator_output_definition.go
+++ b/internal/clusterfeature/features/logging/operator_output_definition.go
@@ -1,0 +1,121 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
+
+	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
+)
+
+func (op FeatureOperator) createClusterOutputDefinitions(ctx context.Context, spec featureSpec, cl clusterfeatureadapter.Cluster) ([]outputDefinitionManager, error) {
+	var creators []outputManagerCreator
+	if spec.ClusterOutput.Enabled {
+
+		// install secrets to cluster
+		sourceSecretName, err := op.secretStore.GetNameByID(ctx, spec.ClusterOutput.Provider.SecretID)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "failed to get secret name", "secretID", spec.ClusterOutput.Provider.SecretID)
+		}
+
+		if err := op.installSecretForOutput(ctx, spec.ClusterOutput, sourceSecretName, cl); err != nil {
+			return nil, errors.WrapIf(err, "failed to install secret to cluster for cluster output")
+		}
+
+		creators = append(creators, outputManagerCreator{
+			name:             spec.ClusterOutput.Provider.Name,
+			sourceSecretName: sourceSecretName,
+			providerSpec:     spec.ClusterOutput.Provider,
+		})
+	}
+
+	if spec.Loki.Enabled {
+		serviceURL, err := op.getLokiServiceURL(cl)
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to get Loki service url")
+		}
+
+		creators = append(creators, outputManagerCreator{
+			name:       providerLoki,
+			serviceURL: serviceURL,
+		})
+	}
+
+	// remove old output definitions
+	var outputList v1beta1.ClusterOutputList
+	if err := op.kubernetesService.List(ctx, cl.GetID(), nil, &outputList); err != nil {
+		return nil, errors.WrapIf(err, "failed to list output definitions")
+	}
+
+	for _, item := range outputList.Items {
+		if err := op.kubernetesService.DeleteObject(ctx, cl.GetID(), &item); err != nil {
+			return nil, errors.WrapIfWithDetails(err, "failed to delete output definition", "name", item.Name)
+		}
+	}
+
+	// create output definition managers
+	var managers = newOutputDefinitionManager(creators)
+	for _, m := range managers {
+
+		// generate output definition
+		outputDefinition, err := generateOutputDefinition(ctx, m, op.secretStore, op.config.Namespace, cl.GetOrganizationId())
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to generate output definition")
+		}
+
+		// create new output definition
+		if err := op.kubernetesService.EnsureObject(ctx, cl.GetID(), outputDefinition); err != nil {
+			return nil, errors.WrapIf(err, "failed to create output definition")
+		}
+
+	}
+
+	return managers, nil
+}
+
+func (op FeatureOperator) getLokiServiceURL(cl clusterfeatureadapter.Cluster) (string, error) {
+	k8sConfig, err := cl.GetK8sConfig()
+	if err != nil {
+		return "", errors.WrapIfWithDetails(err, "failed to get kubeconfig", "cluster", cl.GetID())
+	}
+
+	return op.endpointsService.GetServiceURL(k8sConfig, lokiServiceName, op.config.Namespace)
+}
+
+func (op FeatureOperator) installSecretForOutput(ctx context.Context, spec clusterOutputSpec, sourceSecretName string, cl clusterfeatureadapter.Cluster) error {
+	secretManager, err := newOutputSecretInstallManager(spec.Provider.Name, sourceSecretName, op.config.Namespace)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create output secret installer")
+	}
+
+	secretValues, err := op.secretStore.GetSecretValues(ctx, spec.Provider.SecretID)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to get secret values", "secretID", spec.Provider.SecretID)
+	}
+
+	installSecretRequest, err := secretManager.generateSecretRequest(secretValues, spec.Provider.Bucket)
+	if err != nil {
+		return errors.WrapIf(err, "failed to generate install secret request")
+	}
+
+	if _, err := op.installSecret(ctx, cl, sourceSecretName, *installSecretRequest); err != nil {
+		return errors.WrapIf(err, "failed to install secret to cluster")
+	}
+
+	return nil
+}

--- a/internal/clusterfeature/features/logging/output_definition.go
+++ b/internal/clusterfeature/features/logging/output_definition.go
@@ -19,142 +19,73 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
-	"github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/banzaicloud/pipeline/internal/common"
-	"github.com/banzaicloud/pipeline/internal/providers"
-	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
-	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
-	"github.com/banzaicloud/pipeline/secret"
 )
 
-type baseOutputManager struct {
+type outputManagerCreator struct {
+	name             string
 	sourceSecretName string
+	serviceURL       string
+	providerSpec     providerSpec
 }
 
 type outputDefinitionManager interface {
-	getOutputSpec(clusterOutputSpec, bucketOptions) v1beta1.ClusterOutputSpec
-	getOutputName() string
-	getFlowName() string
+	getOutputSpec(bucketSpec, bucketOptions) v1beta1.ClusterOutputSpec
+	getProviderSpec() providerSpec
+	getName() string
 }
 
-func newOutputDefinitionManager(providerName, sourceSecretName string) (outputDefinitionManager, error) {
-	switch providerName {
-	case providerAmazonS3:
-		return outputDefinitionManagerS3{baseOutputManager{sourceSecretName: sourceSecretName}}, nil
-	case providerGoogleGCS:
-		return outputDefinitionManagerGCS{baseOutputManager{sourceSecretName: sourceSecretName}}, nil
-	case providerAzure:
-		return outputDefinitionManagerAzure{baseOutputManager{sourceSecretName: sourceSecretName}}, nil
-	case providerAlibabaOSS:
-		return outputDefinitionManagerOSS{baseOutputManager{sourceSecretName: sourceSecretName}}, nil
-	default:
-		return nil, errors.NewWithDetails("unsupported provider", "provider", providerName)
+func newOutputDefinitionManager(creators []outputManagerCreator) (managers []outputDefinitionManager) {
+	for _, creator := range creators {
+		var baseManager = baseOutputManager{
+			sourceSecretName: creator.sourceSecretName,
+			providerSpec:     creator.providerSpec,
+		}
+		switch creator.name {
+		case providerAmazonS3:
+			managers = append(managers, outputDefinitionManagerS3{baseOutputManager: baseManager})
+		case providerGoogleGCS:
+			managers = append(managers, outputDefinitionManagerGCS{baseOutputManager: baseManager})
+		case providerAzure:
+			managers = append(managers, outputDefinitionManagerAzure{baseOutputManager: baseManager})
+		case providerAlibabaOSS:
+			managers = append(managers, outputDefinitionManagerOSS{baseOutputManager: baseManager})
+		case providerLoki:
+			managers = append(managers, outputDefinitionManagerLoki{serviceURL: creator.serviceURL})
+		}
 	}
-}
 
-type bucketOptions struct {
-	s3 *struct {
-		region string
-	}
-	oss *struct {
-		region string
-	}
-	gcs *struct {
-		project string
-	}
-}
-
-func (baseOutputManager) getBufferSpec() *output.Buffer {
-	return &output.Buffer{
-		Timekey:       "1m",
-		TimekeyWait:   "10s",
-		TimekeyUseUtc: true,
-	}
-}
-
-func (baseOutputManager) getPathSpec() string {
-	return "logs/${tag}/%Y/%m/%d/"
+	return
 }
 
 func generateOutputDefinition(
 	ctx context.Context,
 	m outputDefinitionManager,
 	secretStore common.SecretStore,
-	spec clusterOutputSpec,
 	namespace string,
 	orgID uint,
 ) (*v1beta1.ClusterOutput, error) {
-	secretValues, err := secretStore.GetSecretValues(ctx, spec.Provider.SecretID)
-	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get secret", "secretID", spec.Provider.SecretID)
-	}
+	var spec = m.getProviderSpec()
+	var bucketOptions = &bucketOptions{}
+	if spec.SecretID != "" {
+		secretValues, err := secretStore.GetSecretValues(ctx, spec.SecretID)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "failed to get secret", "secretID", spec.SecretID)
+		}
 
-	bucketOptions, err := generateBucketOptions(spec.Provider, secretValues, orgID)
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to generate bucket options")
+		bucketOptions, err = generateBucketOptions(spec, secretValues, orgID)
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to generate bucket options")
+		}
 	}
 
 	return &v1beta1.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.getOutputName(),
+			Name:      m.getName(),
 			Namespace: namespace,
 		},
-		Spec: m.getOutputSpec(spec, *bucketOptions),
+		Spec: m.getOutputSpec(spec.Bucket, *bucketOptions),
 	}, nil
-}
-
-func generateBucketOptions(spec providerSpec, secretValues map[string]string, orgID uint) (*bucketOptions, error) {
-	var secretItems = &secret.SecretItemResponse{
-		Values: secretValues,
-	}
-	switch spec.Name {
-	case providerAmazonS3:
-		return generateS3BucketOptions(spec, secretItems, orgID)
-	case providerGoogleGCS:
-		return generateGCSBucketOptions(secretValues), nil
-	case providerAlibabaOSS:
-		return generateOSSBucketOptions(spec, secretItems, orgID)
-	default:
-		return &bucketOptions{}, nil
-	}
-}
-
-func generateS3BucketOptions(spec providerSpec, secretItems *secret.SecretItemResponse, orgID uint) (*bucketOptions, error) {
-	region, err := providers.GetBucketLocation(pkgCluster.Amazon, secretItems, spec.Bucket.Name, orgID, nil)
-	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get S3 bucket region", "bucket", spec.Bucket)
-	}
-	return &bucketOptions{
-		s3: &struct {
-			region string
-		}{
-			region: region,
-		},
-	}, nil
-}
-
-func generateOSSBucketOptions(spec providerSpec, secretItems *secret.SecretItemResponse, orgID uint) (*bucketOptions, error) {
-	region, err := providers.GetBucketLocation(pkgCluster.Alibaba, secretItems, spec.Bucket.Name, orgID, nil)
-	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get OSS bucket region", "bucket", spec.Bucket.Name)
-	}
-	return &bucketOptions{
-		oss: &struct {
-			region string
-		}{
-			region: region,
-		},
-	}, nil
-}
-
-func generateGCSBucketOptions(secretValues map[string]string) *bucketOptions {
-	return &bucketOptions{
-		gcs: &struct {
-			project string
-		}{
-			project: secretValues[secrettype.ProjectId],
-		},
-	}
 }

--- a/internal/clusterfeature/features/logging/output_definition_azure.go
+++ b/internal/clusterfeature/features/logging/output_definition_azure.go
@@ -24,15 +24,11 @@ type outputDefinitionManagerAzure struct {
 	baseOutputManager
 }
 
-func (outputDefinitionManagerAzure) getOutputName() string {
+func (outputDefinitionManagerAzure) getName() string {
 	return "azure-output"
 }
 
-func (outputDefinitionManagerAzure) getFlowName() string {
-	return "azure-flow"
-}
-
-func (m outputDefinitionManagerAzure) getOutputSpec(spec clusterOutputSpec, _ bucketOptions) v1beta1.ClusterOutputSpec {
+func (m outputDefinitionManagerAzure) getOutputSpec(spec bucketSpec, _ bucketOptions) v1beta1.ClusterOutputSpec {
 	return v1beta1.ClusterOutputSpec{
 		OutputSpec: v1beta1.OutputSpec{
 			AzureStorage: &output.AzureStorage{
@@ -53,7 +49,7 @@ func (m outputDefinitionManagerAzure) getOutputSpec(spec clusterOutputSpec, _ bu
 						},
 					},
 				},
-				AzureContainer: spec.Provider.Bucket.Name,
+				AzureContainer: spec.Name,
 				Buffer:         m.getBufferSpec(),
 			},
 		},

--- a/internal/clusterfeature/features/logging/output_definition_base.go
+++ b/internal/clusterfeature/features/logging/output_definition_base.go
@@ -1,0 +1,38 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import "github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
+
+type baseOutputManager struct {
+	sourceSecretName string
+	providerSpec     providerSpec
+}
+
+func (baseOutputManager) getBufferSpec() *output.Buffer {
+	return &output.Buffer{
+		Timekey:       "1m",
+		TimekeyWait:   "10s",
+		TimekeyUseUtc: true,
+	}
+}
+
+func (baseOutputManager) getPathSpec() string {
+	return "logs/${tag}/%Y/%m/%d/"
+}
+
+func (b baseOutputManager) getProviderSpec() providerSpec {
+	return b.providerSpec
+}

--- a/internal/clusterfeature/features/logging/output_definition_bucket.go
+++ b/internal/clusterfeature/features/logging/output_definition_bucket.go
@@ -1,0 +1,90 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"emperror.dev/errors"
+
+	"github.com/banzaicloud/pipeline/internal/providers"
+	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	"github.com/banzaicloud/pipeline/secret"
+)
+
+type bucketOptions struct {
+	s3 *struct {
+		region string
+	}
+	oss *struct {
+		region string
+	}
+	gcs *struct {
+		project string
+	}
+}
+
+func generateBucketOptions(spec providerSpec, secretValues map[string]string, orgID uint) (*bucketOptions, error) {
+	var secretItems = &secret.SecretItemResponse{
+		Values: secretValues,
+	}
+	switch spec.Name {
+	case providerAmazonS3:
+		return generateS3BucketOptions(spec, secretItems, orgID)
+	case providerGoogleGCS:
+		return generateGCSBucketOptions(secretValues), nil
+	case providerAlibabaOSS:
+		return generateOSSBucketOptions(spec, secretItems, orgID)
+	default:
+		return &bucketOptions{}, nil
+	}
+}
+
+func generateS3BucketOptions(spec providerSpec, secretItems *secret.SecretItemResponse, orgID uint) (*bucketOptions, error) {
+	region, err := providers.GetBucketLocation(pkgCluster.Amazon, secretItems, spec.Bucket.Name, orgID, nil)
+	if err != nil {
+		return nil, errors.WrapIfWithDetails(err, "failed to get S3 bucket region", "bucket", spec.Bucket)
+	}
+	return &bucketOptions{
+		s3: &struct {
+			region string
+		}{
+			region: region,
+		},
+	}, nil
+}
+
+func generateOSSBucketOptions(spec providerSpec, secretItems *secret.SecretItemResponse, orgID uint) (*bucketOptions, error) {
+	region, err := providers.GetBucketLocation(pkgCluster.Alibaba, secretItems, spec.Bucket.Name, orgID, nil)
+	if err != nil {
+		return nil, errors.WrapIfWithDetails(err, "failed to get OSS bucket region", "bucket", spec.Bucket.Name)
+	}
+	return &bucketOptions{
+		oss: &struct {
+			region string
+		}{
+			region: region,
+		},
+	}, nil
+}
+
+func generateGCSBucketOptions(secretValues map[string]string) *bucketOptions {
+	return &bucketOptions{
+		gcs: &struct {
+			project string
+		}{
+			project: secretValues[secrettype.ProjectId],
+		},
+	}
+}

--- a/internal/clusterfeature/features/logging/output_definition_loki.go
+++ b/internal/clusterfeature/features/logging/output_definition_loki.go
@@ -17,35 +17,27 @@ package logging
 import (
 	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
 	"github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
-	loggingSecret "github.com/banzaicloud/logging-operator/pkg/sdk/model/secret"
 )
 
-type outputDefinitionManagerGCS struct {
-	baseOutputManager
+type outputDefinitionManagerLoki struct {
+	serviceURL string
 }
 
-func (outputDefinitionManagerGCS) getName() string {
-	return "gcs-output"
-}
-
-func (m outputDefinitionManagerGCS) getOutputSpec(spec bucketSpec, op bucketOptions) v1beta1.ClusterOutputSpec {
+func (o outputDefinitionManagerLoki) getOutputSpec(_ bucketSpec, _ bucketOptions) v1beta1.ClusterOutputSpec {
 	return v1beta1.ClusterOutputSpec{
 		OutputSpec: v1beta1.OutputSpec{
-			GCSOutput: &output.GCSOutput{
-				Project: op.gcs.project,
-				Keyfile: "",
-				CredentialsJson: &loggingSecret.Secret{
-					ValueFrom: &loggingSecret.ValueFrom{
-						SecretKeyRef: &loggingSecret.KubernetesSecret{
-							Name: m.sourceSecretName,
-							Key:  outputDefinitionSecretKeyGCS,
-						},
-					},
-				},
-				Bucket: spec.Name,
-				Path:   m.getPathSpec(),
-				Buffer: m.getBufferSpec(),
+			LokiOutput: &output.LokiOutput{
+				Url:                       o.serviceURL,
+				ConfigureKubernetesLabels: true,
 			},
 		},
 	}
+}
+
+func (outputDefinitionManagerLoki) getName() string {
+	return lokiOutputDefinitionName
+}
+
+func (outputDefinitionManagerLoki) getProviderSpec() providerSpec {
+	return providerSpec{}
 }

--- a/internal/clusterfeature/features/logging/output_definition_oss.go
+++ b/internal/clusterfeature/features/logging/output_definition_oss.go
@@ -24,20 +24,16 @@ type outputDefinitionManagerOSS struct {
 	baseOutputManager
 }
 
-func (outputDefinitionManagerOSS) getOutputName() string {
+func (outputDefinitionManagerOSS) getName() string {
 	return "oss-output"
 }
 
-func (outputDefinitionManagerOSS) getFlowName() string {
-	return "oss-flow"
-}
-
-func (m outputDefinitionManagerOSS) getOutputSpec(spec clusterOutputSpec, op bucketOptions) v1beta1.ClusterOutputSpec {
+func (m outputDefinitionManagerOSS) getOutputSpec(spec bucketSpec, op bucketOptions) v1beta1.ClusterOutputSpec {
 	return v1beta1.ClusterOutputSpec{
 		OutputSpec: v1beta1.OutputSpec{
 			OSSOutput: &output.OSSOutput{
 				Endpoint: "",
-				Bucket:   spec.Provider.Bucket.Name,
+				Bucket:   spec.Name,
 				AccessKeyId: &loggingSecret.Secret{
 					ValueFrom: &loggingSecret.ValueFrom{
 						SecretKeyRef: &loggingSecret.KubernetesSecret{

--- a/internal/clusterfeature/features/logging/output_definition_s3.go
+++ b/internal/clusterfeature/features/logging/output_definition_s3.go
@@ -24,15 +24,11 @@ type outputDefinitionManagerS3 struct {
 	baseOutputManager
 }
 
-func (outputDefinitionManagerS3) getOutputName() string {
+func (outputDefinitionManagerS3) getName() string {
 	return "s3-output"
 }
 
-func (outputDefinitionManagerS3) getFlowName() string {
-	return "s3-flow"
-}
-
-func (m outputDefinitionManagerS3) getOutputSpec(spec clusterOutputSpec, op bucketOptions) v1beta1.ClusterOutputSpec {
+func (m outputDefinitionManagerS3) getOutputSpec(spec bucketSpec, op bucketOptions) v1beta1.ClusterOutputSpec {
 	return v1beta1.ClusterOutputSpec{
 		OutputSpec: v1beta1.OutputSpec{
 			S3OutputConfig: &output.S3OutputConfig{
@@ -54,7 +50,7 @@ func (m outputDefinitionManagerS3) getOutputSpec(spec clusterOutputSpec, op buck
 				},
 				Path:     m.getPathSpec(),
 				S3Region: op.s3.region,
-				S3Bucket: spec.Provider.Bucket.Name,
+				S3Bucket: spec.Name,
 				Buffer:   m.getBufferSpec(),
 				Format: &output.Format{
 					Type: "json",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
In case of enabled `Loki` and `cluster output` we currently create 2 `ClusterFlow`. After these changes we only create just one with name `banzai-logging-flow`

### Why?


### Additional context

```yaml
apiVersion: v1
items:
- apiVersion: logging.banzaicloud.io/v1beta1
  kind: ClusterFlow
  metadata:
    creationTimestamp: 2019-11-20T10:08:27Z
    generation: 1
    name: banzai-logging-flow
    namespace: pipeline-system
    resourceVersion: "510377"
    selfLink: /apis/logging.banzaicloud.io/v1beta1/namespaces/pipeline-system/clusterflows/banzai-logging-flow
    uid: aaaaaa-bbbb-cccc-dddd-eeefffrree
  spec:
    outputRefs:
    - s3-output
    - loki-output
    selectors: {}
  status: {}
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
