### PR TITLE
Replace consecutive json.Marshal+Unmarshal calls

### DIFF
--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -15,12 +15,12 @@
 package cluster
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"emperror.dev/emperror"
 	"github.com/ghodss/yaml"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -46,17 +46,8 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 )
 
-func castToPostHookParam(data *pkgCluster.PostHookParam, output interface{}) (err error) {
-
-	var bytes []byte
-	bytes, err = json.Marshal(data)
-	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(bytes, &output)
-
-	return
+func castToPostHookParam(data pkgCluster.PostHookParam, output interface{}) error {
+	return mapstructure.Decode(data, output)
 }
 
 func installDeployment(cluster CommonCluster, namespace string, deploymentName string, releaseName string, values []byte, chartVersion string, wait bool) error {
@@ -483,7 +474,7 @@ func addLabelsToNode(client *kubernetes.Clientset, nodeName string, labels map[s
 func RestoreFromBackup(cluster CommonCluster, param pkgCluster.PostHookParam) error {
 
 	var params arkAPI.RestoreFromBackupParams
-	err := castToPostHookParam(&param, &params)
+	err := castToPostHookParam(param, &params)
 	if err != nil {
 		return err
 	}

--- a/cluster/hooks_nodelabels.go
+++ b/cluster/hooks_nodelabels.go
@@ -81,7 +81,7 @@ type NodePoolLabelParam struct {
 // SetupNodePoolLabelsSet deploys NodePoolLabelSet resources for each nodepool.
 func SetupNodePoolLabelsSet(cluster CommonCluster, param pkgCluster.PostHookParam) error {
 	var nodePoolParam NodePoolLabelParam
-	err := castToPostHookParam(&param, &nodePoolParam)
+	err := castToPostHookParam(param, &nodePoolParam)
 	if err != nil {
 		return emperror.Wrap(err, "posthook param failed")
 	}

--- a/internal/clusterfeature/features/logging/operator.go
+++ b/internal/clusterfeature/features/logging/operator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/common"
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/internal/util"
+	"github.com/banzaicloud/pipeline/pkg/jsonstructure"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -683,14 +684,9 @@ func (op FeatureOperator) generateFlowResource(outputDefinition outputDefinition
 }
 
 func mergeValuesWithConfig(chartValues interface{}, configValues interface{}) ([]byte, error) {
-	valuesBytes, err := json.Marshal(chartValues)
+	out, err := jsonstructure.Encode(chartValues)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to decode chartValues")
-	}
-
-	var out map[string]interface{}
-	if err := json.Unmarshal(valuesBytes, &out); err != nil {
-		return nil, errors.WrapIf(err, "failed to unmarshal values")
+		return nil, errors.WrapIf(err, "failed to encode chart values")
 	}
 
 	result, err := util.Merge(configValues, out)

--- a/internal/clusterfeature/features/monitoring/operator.go
+++ b/internal/clusterfeature/features/monitoring/operator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/common"
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/internal/util"
+	"github.com/banzaicloud/pipeline/pkg/jsonstructure"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -354,14 +355,9 @@ func (op FeatureOperator) installPrometheusOperator(
 }
 
 func mergeOperatorValuesWithConfig(chartValues interface{}, configValues interface{}) ([]byte, error) {
-	valuesBytes, err := json.Marshal(chartValues)
+	out, err := jsonstructure.Encode(chartValues)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to decode chartValues")
-	}
-
-	var out map[string]interface{}
-	if err := json.Unmarshal(valuesBytes, &out); err != nil {
-		return nil, errors.WrapIf(err, "failed to unmarshal operator values")
+		return nil, errors.WrapIf(err, "failed to encode chart values")
 	}
 
 	result, err := util.Merge(configValues, out)

--- a/pkg/jsonstructure/encode.go
+++ b/pkg/jsonstructure/encode.go
@@ -1,0 +1,222 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonstructure
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/banzaicloud/pipeline/pkg/mirror"
+)
+
+// Encode returns a transformation of v that is equivalent with JSON encoding and decoding v.
+func Encode(v interface{}) (interface{}, error) {
+	return encode(reflect.ValueOf(v))
+}
+
+func encode(v reflect.Value) (interface{}, error) {
+	numberType := reflect.TypeOf(float64(0))
+
+	switch v.Kind() {
+	// null
+	case reflect.Invalid:
+		return nil, nil
+
+	// boolean, string
+	case reflect.Bool:
+		return v.Bool(), nil
+	case reflect.String:
+		return v.String(), nil
+
+	// number
+	case reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Convert(numberType).Interface(), nil
+
+	// array
+	case reflect.Slice:
+		if v.IsNil() {
+			return nil, nil
+		}
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return base64.StdEncoding.EncodeToString(v.Bytes()), nil
+		}
+		fallthrough
+	case reflect.Array:
+		arr := make([]interface{}, v.Len())
+		for i := range arr {
+			val, err := encode(v.Index(i))
+			if err != nil {
+				return nil, err
+			}
+			arr[i] = val
+		}
+		return arr, nil
+
+	// indirection
+	case reflect.Interface, reflect.Ptr:
+		return encode(deref(v))
+
+	case reflect.Map:
+		if v.Type().Key().Kind() == reflect.String {
+			if v.IsNil() {
+				return nil, nil
+			}
+
+			obj := make(map[string]interface{}, v.Len())
+			for it := v.MapRange(); it.Next(); {
+				key := it.Key().String()
+				val, err := encode(it.Value())
+				if err != nil {
+					return nil, err
+				}
+				obj[key] = val
+			}
+			return obj, nil
+		}
+
+	case reflect.Struct:
+		obj := make(map[string]interface{}, v.NumField())
+		if err := encodeStruct(obj, v); err != nil {
+			return nil, err
+		}
+		return obj, nil
+
+	default:
+	}
+	return nil, encodeError{v}
+}
+
+func encodeStruct(obj map[string]interface{}, value reflect.Value) error {
+	for it := mirror.NewStructIter(value); it.Next(); {
+		if err := encodeField(obj, it.Field(), it.Value()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeField(obj map[string]interface{}, field reflect.StructField, value reflect.Value) error {
+	jsonTag := field.Tag.Get("json")
+	if jsonTag == "-" {
+		// omit field
+		return nil
+	}
+
+	jsonTags := strings.Split(jsonTag, ",")
+
+	var (
+		omitempty bool
+	)
+
+	if len(jsonTags) > 1 {
+		for _, t := range jsonTags[1:] {
+			switch t {
+			case "omitempty":
+				omitempty = true
+			}
+		}
+	}
+
+	if omitempty && isEmpty(value) {
+		// omit empty field
+		return nil
+	}
+
+	var key string
+	if name := jsonTags[0]; name != "" {
+		key = name
+	}
+
+	if field.Anonymous && key == "" {
+		switch value := derefPtr(value); value.Kind() {
+		case reflect.Invalid:
+			// omit nil pointer
+			return nil
+		case reflect.Struct:
+			if err := encodeStruct(obj, value); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	val, err := encode(value)
+	if err != nil {
+		return err
+	}
+
+	if key == "" {
+		key = field.Name
+	}
+
+	obj[key] = val
+
+	return nil
+}
+
+func isEmpty(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Bool:
+		return value.Bool() == false
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return math.Float64bits(value.Float()) == 0
+	case reflect.Interface, reflect.Ptr:
+		return value.IsNil()
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return value.Len() == 0
+	default:
+		return false
+	}
+}
+
+func indirect(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		return true
+	default:
+		return false
+	}
+}
+
+func deref(value reflect.Value) reflect.Value {
+	if indirect(value) {
+		return deref(value.Elem())
+	}
+	return value
+}
+
+func derefPtr(value reflect.Value) reflect.Value {
+	if value.Kind() == reflect.Ptr {
+		return value.Elem()
+	}
+	return value
+}
+
+type encodeError struct {
+	value reflect.Value
+}
+
+func (e encodeError) Error() string {
+	return fmt.Sprintf("cannot encode value: %#v", e.value)
+}

--- a/pkg/jsonstructure/encode_test.go
+++ b/pkg/jsonstructure/encode_test.go
@@ -1,0 +1,945 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonstructure
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncode(t *testing.T) {
+	type (
+		NamedBool bool
+
+		NamedInterface interface {
+			Method()
+		}
+
+		NamedStruct struct {
+			Field bool
+		}
+	)
+
+	var (
+		aBool      bool
+		aNamedBool NamedBool
+	)
+
+	testCases := map[string]struct {
+		Input  interface{}
+		Result interface{}
+		Error  interface{}
+	}{
+		"nil": {
+			Input:  nil,
+			Result: nil,
+		},
+
+		// simple types
+
+		"false": {
+			Input:  false,
+			Result: false,
+		},
+		"true": {
+			Input:  true,
+			Result: true,
+		},
+		"float32": {
+			Input:  float32(42),
+			Result: float64(42),
+		},
+		"float64": {
+			Input:  float64(42),
+			Result: float64(42),
+		},
+		"int": {
+			Input:  int(42),
+			Result: float64(42),
+		},
+		"int8": {
+			Input:  int8(42),
+			Result: float64(42),
+		},
+		"int16": {
+			Input:  int16(42),
+			Result: float64(42),
+		},
+		"int32": {
+			Input:  int32(42),
+			Result: float64(42),
+		},
+		"int64": {
+			Input:  int64(42),
+			Result: float64(42),
+		},
+		"uint": {
+			Input:  uint(42),
+			Result: float64(42),
+		},
+		"uint8": {
+			Input:  uint8(42),
+			Result: float64(42),
+		},
+		"uint16": {
+			Input:  uint16(42),
+			Result: float64(42),
+		},
+		"uint32": {
+			Input:  uint32(42),
+			Result: float64(42),
+		},
+		"uint64": {
+			Input:  uint64(42),
+			Result: float64(42),
+		},
+		"uint64 max": {
+			Input:  ^uint64(0),
+			Result: float64(^uint64(0)),
+		},
+		"uintptr": {
+			Input:  uintptr(42),
+			Result: float64(42),
+		},
+		"unsafe.Pointer": {
+			Input: unsafe.Pointer(nil),
+			Error: true,
+		},
+		"complex64": {
+			Input: complex64(0 + 0i),
+			Error: true,
+		},
+		"complex128": {
+			Input: complex128(0 + 0i),
+			Error: true,
+		},
+		"string": {
+			Input:  "42",
+			Result: "42",
+		},
+		"byte": {
+			Input:  byte(42),
+			Result: float64(42),
+		},
+		"rune": {
+			Input:  rune(42),
+			Result: float64(42),
+		},
+
+		// composite types
+
+		// pointers
+		"nil bool pointer": {
+			Input:  (*bool)(nil),
+			Result: nil,
+		},
+		"non-nil bool pointer": {
+			Input:  &aBool,
+			Result: aBool,
+		},
+		"nil named bool pointer": {
+			Input:  (*NamedBool)(nil),
+			Result: nil,
+		},
+		"non-nil named bool pointer": {
+			Input:  &aNamedBool,
+			Result: bool(aNamedBool),
+		},
+
+		// arrays
+		"empty bool array": {
+			Input:  [...]bool{},
+			Result: []interface{}{},
+		},
+		"non-empty bool array": {
+			Input:  [...]bool{false, true},
+			Result: []interface{}{false, true},
+		},
+		"empty float32 array": {
+			Input:  [...]float32{},
+			Result: []interface{}{},
+		},
+		"non-empty float32 array": {
+			Input:  [...]float32{42},
+			Result: []interface{}{float64(42)},
+		},
+		"empty float64 array": {
+			Input:  [...]float64{},
+			Result: []interface{}{},
+		},
+		"non-empty float64 array": {
+			Input:  [...]float64{42},
+			Result: []interface{}{float64(42)},
+		},
+		"empty byte array": {
+			Input:  [...]byte{},
+			Result: []interface{}{},
+		},
+		"non-empty byte array": {
+			Input:  [...]byte{42},
+			Result: []interface{}{float64(42)},
+		},
+		"empty interface{} array": {
+			Input:  [...]interface{}{},
+			Result: []interface{}{},
+		},
+		"non-empy interface{} array": {
+			Input: [...]interface{}{
+				nil,
+				false, true,
+				float32(42), float64(42), int(42), uint(42),
+				[...]bool{false, true},
+				[]bool{false, true},
+				[...]interface{}{},
+				[]interface{}{},
+				map[string]bool{
+					"false": false,
+					"true":  true,
+				},
+				map[string]interface{}{},
+			},
+			Result: []interface{}{
+				nil,
+				false, true,
+				float64(42), float64(42), float64(42), float64(42),
+				[]interface{}{false, true},
+				[]interface{}{false, true},
+				[]interface{}{},
+				[]interface{}{},
+				map[string]interface{}{
+					"false": false,
+					"true":  true,
+				},
+				map[string]interface{}{},
+			},
+		},
+
+		// slices
+		"nil bool slice": {
+			Input:  []bool(nil),
+			Result: nil,
+		},
+		"empty bool slice": {
+			Input:  []bool{},
+			Result: []interface{}{},
+		},
+		"non-empty bool slice": {
+			Input:  []bool{false, true},
+			Result: []interface{}{false, true},
+		},
+		"nil byte slice": {
+			Input:  []byte(nil),
+			Result: nil,
+		},
+		"empty byte slice": {
+			Input:  []byte{},
+			Result: "",
+		},
+		"non-empty byte slice": {
+			Input:  []byte{1, 2, 3},
+			Result: "AQID",
+		},
+		"nil interface{} slice": {
+			Input:  []interface{}(nil),
+			Result: nil,
+		},
+		"empty interface{} slice": {
+			Input:  []interface{}{},
+			Result: []interface{}{},
+		},
+
+		// channels
+		"nil chan": {
+			Input: (chan bool)(nil),
+			Error: true,
+		},
+		"non-nil chan": {
+			Input: make(chan bool),
+			Error: true,
+		},
+
+		// functions
+		"nil func": {
+			Input: (func())(nil),
+			Error: true,
+		},
+		"non-nil func": {
+			Input: func() {},
+			Error: true,
+		},
+
+		// maps
+		"nil map[bool]bool": {
+			Input: (map[bool]bool)(nil),
+			Error: true,
+		},
+		"empty map[bool]bool": {
+			Input: map[bool]bool{},
+			Error: true,
+		},
+		"non-empty map[bool]bool": {
+			Input: map[bool]bool{false: true, true: false},
+			Error: true,
+		},
+		"nil map[string]bool": {
+			Input:  map[string]bool(nil),
+			Result: nil,
+		},
+		"empty map[string]bool": {
+			Input:  map[string]bool{},
+			Result: map[string]interface{}{},
+		},
+		"non-empty map[string]bool": {
+			Input: map[string]bool{
+				"false": false,
+				"true":  true,
+			},
+			Result: map[string]interface{}{
+				"false": false,
+				"true":  true,
+			},
+		},
+		"map[string]interface{}": {
+			Input: map[string]interface{}{
+				"nil":     nil,
+				"false":   false,
+				"true":    true,
+				"float32": float32(42),
+				"float64": float64(42),
+				"int":     int(42),
+				"uint":    uint(42),
+				"array":   [...]interface{}{},
+				"slice":   []interface{}{},
+			},
+			Result: map[string]interface{}{
+				"nil":     nil,
+				"false":   false,
+				"true":    true,
+				"float32": float64(42),
+				"float64": float64(42),
+				"int":     float64(42),
+				"uint":    float64(42),
+				"array":   []interface{}{},
+				"slice":   []interface{}{},
+			},
+		},
+
+		// structs
+		"empty struct": {
+			Input:  struct{}{},
+			Result: map[string]interface{}{},
+		},
+		"struct with false bool field, no tag": {
+			Input: struct {
+				Field bool
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with true bool field, no tag": {
+			Input: struct {
+				Field bool
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{
+				"Field": true,
+			},
+		},
+		"struct with false bool field, omit tag": {
+			Input: struct {
+				Field bool `json:"-"`
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with true bool field, omit tag": {
+			Input: struct {
+				Field bool `json:"-"`
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with false bool field, empty tag": {
+			Input: struct {
+				Field bool `json:""`
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with true bool field, empty tag": {
+			Input: struct {
+				Field bool `json:""`
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{
+				"Field": true,
+			},
+		},
+		"struct with false bool field, rename tag": {
+			Input: struct {
+				Field bool `json:"field"`
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{
+				"field": false,
+			},
+		},
+		"struct with true bool field, rename tag": {
+			Input: struct {
+				Field bool `json:"field"`
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{
+				"field": true,
+			},
+		},
+		"struct with false bool field, omitempty tag": {
+			Input: struct {
+				Field bool `json:",omitempty"`
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with true bool field, omitempty tag": {
+			Input: struct {
+				Field bool `json:",omitempty"`
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{
+				"Field": true,
+			},
+		},
+		"struct with false bool field, rename and omitempty tag": {
+			Input: struct {
+				Field bool `json:"field,omitempty"`
+			}{
+				Field: false,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with true bool field, rename and omitempty tag": {
+			Input: struct {
+				Field bool `json:"field,omitempty"`
+			}{
+				Field: true,
+			},
+			Result: map[string]interface{}{
+				"field": true,
+			},
+		},
+		"struct with zero int field, no tag": {
+			Input: struct {
+				Field int
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{
+				"Field": float64(0),
+			},
+		},
+		"struct with non-zero int field, no tag": {
+			Input: struct {
+				Field int
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{
+				"Field": float64(42),
+			},
+		},
+		"struct with zero int field, omit tag": {
+			Input: struct {
+				Field int `json:"-"`
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-zero int field, omit tag": {
+			Input: struct {
+				Field int `json:"-"`
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with zero int field, empty tag": {
+			Input: struct {
+				Field int `json:""`
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{
+				"Field": float64(0),
+			},
+		},
+		"struct with non-zero int field, empty tag": {
+			Input: struct {
+				Field int `json:""`
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{
+				"Field": float64(42),
+			},
+		},
+		"struct with zero int field, rename tag": {
+			Input: struct {
+				Field int `json:"field"`
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{
+				"field": float64(0),
+			},
+		},
+		"struct with non-zero int field, rename tag": {
+			Input: struct {
+				Field int `json:"field"`
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{
+				"field": float64(42),
+			},
+		},
+		"struct with zero int field, omitempty tag": {
+			Input: struct {
+				Field int `json:",omitempty"`
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-zero int field, omitempty tag": {
+			Input: struct {
+				Field int `json:",omitempty"`
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{
+				"Field": float64(42),
+			},
+		},
+		"struct with zero int field, rename and omitempty tag": {
+			Input: struct {
+				Field int `json:"field,omitempty"`
+			}{
+				Field: 0,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-zero int field, rename and omitempty tag": {
+			Input: struct {
+				Field int `json:"field,omitempty"`
+			}{
+				Field: 42,
+			},
+			Result: map[string]interface{}{
+				"field": float64(42),
+			},
+		},
+		"struct with nil embedded interface field, no tag": {
+			Input: struct {
+				NamedInterface
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": nil,
+			},
+		},
+		"struct with nil embedded interface field, omit tag": {
+			Input: struct {
+				NamedInterface `json:"-"`
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with nil embedded interface field, empty tag": {
+			Input: struct {
+				NamedInterface `json:""`
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": nil,
+			},
+		},
+		"struct with nil embedded interface field, rename tag": {
+			Input: struct {
+				NamedInterface `json:"interface"`
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{
+				"interface": nil,
+			},
+		},
+		"struct with nil embedded interface field, omitempty tag": {
+			Input: struct {
+				NamedInterface `json:",omitempty"`
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with nil embedded interface field, rename and omitempty tag": {
+			Input: struct {
+				NamedInterface `json:"interface,omitempty"`
+			}{
+				NamedInterface: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with false named-bool-implemented embedded interface field, no tag": {
+			Input: struct {
+				NamedInterface
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": false,
+			},
+		},
+		"struct with false named-bool-implemented embedded interface field, omit tag": {
+			Input: struct {
+				NamedInterface `json:"-"`
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with false named-bool-implemented embedded interface field, empty tag": {
+			Input: struct {
+				NamedInterface `json:""`
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": false,
+			},
+		},
+		"struct with false named-bool-implemented embedded interface field, rename tag": {
+			Input: struct {
+				NamedInterface `json:"interface"`
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{
+				"interface": false,
+			},
+		},
+		"struct with false named-bool-implemented embedded interface field, omitempty tag": {
+			Input: struct {
+				NamedInterface `json:",omitempty"`
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": false,
+			},
+		},
+		"struct with false named-bool-implemented embedded interface field, rename and omitempty tag": {
+			Input: struct {
+				NamedInterface `json:"interface,omitempty"`
+			}{
+				NamedInterface: simpleInterfaceImplementer(false),
+			},
+			Result: map[string]interface{}{
+				"interface": false,
+			},
+		},
+		"struct with struct-implemented embedded interface field, no tag": {
+			Input: struct {
+				NamedInterface
+			}{
+				NamedInterface: structInterfaceImplementer{},
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+		"struct with nil pointer-implemented embedded interface field, no tag": {
+			Input: struct {
+				NamedInterface
+			}{
+				NamedInterface: (*pointerInterfaceImplementer)(nil),
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": nil,
+			},
+		},
+		"struct with non-nil pointer-implemented embedded interface field, no tag": {
+			Input: struct {
+				NamedInterface
+			}{
+				NamedInterface: &pointerInterfaceImplementer{},
+			},
+			Result: map[string]interface{}{
+				"NamedInterface": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+		"struct with embedded struct, no tag": {
+			Input: struct {
+				NamedStruct
+			}{
+				NamedStruct: NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with embedded struct, omit tag": {
+			Input: struct {
+				NamedStruct `json:"-"`
+			}{
+				NamedStruct: NamedStruct{},
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with embedded struct, rename tag": {
+			Input: struct {
+				NamedStruct `json:"struct"`
+			}{
+				NamedStruct: NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"struct": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+		"struct with embedded struct, omitempty tag": {
+			Input: struct {
+				NamedStruct `json:",omitempty"`
+			}{
+				NamedStruct: NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with embedded struct, rename and omitempty tag": {
+			Input: struct {
+				NamedStruct `json:"struct,omitempty"`
+			}{
+				NamedStruct: NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"struct": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+		"struct with nil embedded pointer to struct, no tag": {
+			Input: struct {
+				*NamedStruct
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-nil embedded pointer to struct, no tag": {
+			Input: struct {
+				*NamedStruct
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with nil embedded pointer to struct, omit tag": {
+			Input: struct {
+				*NamedStruct `json:"-"`
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-nil embedded pointer to struct, omit tag": {
+			Input: struct {
+				*NamedStruct `json:"-"`
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with nil embedded pointer to struct, empty tag": {
+			Input: struct {
+				*NamedStruct `json:""`
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-nil embedded pointer to struct, empty tag": {
+			Input: struct {
+				*NamedStruct `json:""`
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with nil embedded pointer to struct, rename tag": {
+			Input: struct {
+				*NamedStruct `json:"struct"`
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{
+				"struct": nil,
+			},
+		},
+		"struct with non-nil embedded pointer to struct, rename tag": {
+			Input: struct {
+				*NamedStruct `json:"struct"`
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"struct": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+		"struct with nil embedded pointer to struct, omitempty tag": {
+			Input: struct {
+				*NamedStruct `json:",omitempty"`
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-nil embedded pointer to struct, omitempty tag": {
+			Input: struct {
+				*NamedStruct `json:",omitempty"`
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"Field": false,
+			},
+		},
+		"struct with nil embedded pointer to struct, rename and omitempty tag": {
+			Input: struct {
+				*NamedStruct `json:"struct,omitempty"`
+			}{
+				NamedStruct: nil,
+			},
+			Result: map[string]interface{}{},
+		},
+		"struct with non-nil embedded pointer to struct, rename and omitempty tag": {
+			Input: struct {
+				*NamedStruct `json:"struct,omitempty"`
+			}{
+				NamedStruct: &NamedStruct{},
+			},
+			Result: map[string]interface{}{
+				"struct": map[string]interface{}{
+					"Field": false,
+				},
+			},
+		},
+
+		// user-defined types
+		"named bool": {
+			Input:  aNamedBool,
+			Result: bool(aNamedBool),
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			jsonRes, jsonErr := jsonMarshalUnmarshal(t, testCase.Input)
+
+			// verify the test case
+			switch testCase.Error {
+			case nil, false:
+				require.NoError(t, jsonErr, "bad test case: JSON returned with error but no error is expected")
+				require.Equal(t, jsonRes, testCase.Result, "bad test case: expected and JSON result differ")
+			default:
+				require.Error(t, jsonErr, "bad test case: JSON returned with success but an error is expected")
+			}
+
+			res, err := Encode(testCase.Input)
+
+			switch testCase.Error {
+			case nil, false:
+				require.NoError(t, err, "Encode expected to succeed but did not")
+				assert.Equal(t, testCase.Result, res)
+			case true:
+				require.Error(t, err, "Encode expected to fail")
+			default:
+				require.Equal(t, testCase.Error, err, "Encode expected to fail with specific error")
+			}
+		})
+	}
+}
+
+type structInterfaceImplementer struct {
+	Field bool
+}
+
+func (structInterfaceImplementer) Method() {}
+
+type pointerInterfaceImplementer struct {
+	Field bool
+}
+
+func (*pointerInterfaceImplementer) Method() {}
+
+type simpleInterfaceImplementer bool
+
+func (simpleInterfaceImplementer) Method() {}
+
+func jsonMarshalUnmarshal(t *testing.T, v interface{}) (res interface{}, err error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	t.Logf("json: %q", string(raw))
+
+	err = json.Unmarshal(raw, &res)
+	t.Logf("unmarshalled: %#v (%T)", res, res)
+	return
+}

--- a/pkg/mirror/struct_iter.go
+++ b/pkg/mirror/struct_iter.go
@@ -1,0 +1,102 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"reflect"
+)
+
+// StructRange returns a range iterator for a struct value.
+// It returns nil if v's Kind is not Struct.
+//
+// Call Next to advance the iterator, and Field/Value to access each entry.
+// Next returns false when the iterator is exhausted.
+// StructRange follows the same iteration semantics as a range statement.
+//
+// Example:
+//
+//  s := struct{
+//  	...
+//  }{
+//  	...
+//  }
+//	iter := unstructured.StructRange(s)
+// 	for iter.Next() {
+//		f := iter.Field()
+//		v := iter.Value()
+//		...
+//	}
+//
+func StructRange(v interface{}) *StructIter {
+	return NewStructIter(reflect.ValueOf(v))
+}
+
+// NewStructIter returns a new instance of StructIter for the specified value.
+// It returns nil if v's Kind is not Struct.
+func NewStructIter(val reflect.Value) *StructIter {
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
+
+	return &StructIter{
+		val: val,
+		typ: val.Type(),
+		n:   val.NumField(),
+		i:   -1,
+	}
+}
+
+// StructIter is an iterator for ranging over a struct's fields with their values
+type StructIter struct {
+	val reflect.Value
+	typ reflect.Type
+	n   int
+	i   int
+}
+
+// Next advances the iterator and reports whether there is another entry.
+// It returns false when the iterator is exhausted; subsequent calls will panic.
+func (it *StructIter) Next() bool {
+	if it == nil {
+		panic("nil iterator")
+	}
+	if it.i >= it.n {
+		panic("StructIter.Next called on exhausted iterator")
+	}
+	it.i++
+	return it.i < it.n
+}
+
+// Field returns the struct field of the iterator's current entry.
+func (it StructIter) Field() reflect.StructField {
+	if it.i < 0 {
+		panic("StructIter.Field called before Next")
+	}
+	if it.i >= it.n {
+		panic("StructIter.Field called on exhausted iterator")
+	}
+	return it.typ.Field(it.i)
+}
+
+// Value returns the value of the iterator's current entry.
+func (it StructIter) Value() reflect.Value {
+	if it.i < 0 {
+		panic("StructIter.Value called before Next")
+	}
+	if it.i >= it.n {
+		panic("StructIter.Value called on exhausted iterator")
+	}
+	return it.val.Field(it.i)
+}

--- a/spotguide/spotguide.go
+++ b/spotguide/spotguide.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -42,6 +41,7 @@ import (
 	"github.com/banzaicloud/pipeline/auth"
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/internal/util"
+	"github.com/banzaicloud/pipeline/pkg/jsonstructure"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/spotguide/scm"
 )
@@ -625,7 +625,7 @@ func createCICDRepoConfig(pipelineYAML []byte, request *LaunchRequest, platformD
 
 func cicdRepoConfigCluster(request *LaunchRequest, repoConfig *cicdRepoConfig) error {
 
-	clusterJSON, err := json.Marshal(request.Cluster)
+	clusterJSON, err := jsonstructure.Encode(request.Cluster)
 	if err != nil {
 		return err
 	}
@@ -642,7 +642,7 @@ func cicdRepoConfigCluster(request *LaunchRequest, repoConfig *cicdRepoConfig) e
 			}
 
 			// Merge the cluster from the request into the existing cluster value
-			err = json.Unmarshal(clusterJSON, &clusterStep.Cluster)
+			err = mapstructure.Decode(clusterJSON, &clusterStep.Cluster)
 			if err != nil {
 				return err
 			}
@@ -661,7 +661,7 @@ func cicdRepoConfigCluster(request *LaunchRequest, repoConfig *cicdRepoConfig) e
 	log.Debug("merge cluster info to cluster block")
 
 	// Merge the cluster from the request into the cluster block
-	if err := json.Unmarshal(clusterJSON, &repoConfig.Cluster); err != nil {
+	if err := mapstructure.Decode(clusterJSON, &repoConfig.Cluster); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
A function to replace json.Marshal+json.Unmarshal combos.

### Why?
It looks better. (And its probably faster.)

### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)

### To Do
- [x] Replace Marshal+Unmarshal combos with calls to Encode
