### PR TITLE
Eks deleteflow cadence

### DIFF
--- a/api/cluster_update.go
+++ b/api/cluster_update.go
@@ -79,6 +79,11 @@ func (a *ClusterAPI) UpdateCluster(c *gin.Context) {
 
 		ctx := ginutils.Context(context.Background(), c)
 
+		switch c := commonCluster.(type) {
+		case *cluster.EKSCluster:
+			c.WorkflowClient = a.workflowClient
+		}
+
 		err = a.clusterManager.UpdateCluster(ctx, updateCtx, updater)
 	}
 	if err != nil {

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -368,6 +368,7 @@ func (c *EKSCluster) CreateCluster() error {
 	}
 
 	c.modelCluster.EKS.NodeInstanceRoleId = output.NodeInstanceRoleID
+	c.modelCluster.EKS.VpcId = aws.String(output.VpcID)
 
 	// persist the id of the newly created subnets
 	for _, subnet := range output.Subnets {

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -450,6 +450,7 @@ func (c *EKSCluster) DeleteEKSCluster(ctx context.Context, workflowClient client
 		ClusterName:    c.GetName(),
 		NodePoolNames:  nodePoolNames,
 		K8sSecretID:    c.GetConfigSecretId(),
+		DefaultUser:    c.modelCluster.EKS.DefaultUser,
 		Forced:         force,
 	}
 

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -40,18 +40,15 @@ import (
 	"go.uber.org/cadence/client"
 
 	"github.com/banzaicloud/pipeline/internal/cloudinfo"
-	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgEks "github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/eks/action"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
-	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
-	"github.com/banzaicloud/pipeline/utils"
 )
 
 const asgWaitLoopSleepSeconds = 5
@@ -375,9 +372,10 @@ func (c *EKSCluster) CreateCluster() error {
 		for _, subnetModel := range c.modelCluster.EKS.Subnets {
 			if (aws.StringValue(subnetModel.SubnetId) != "" && aws.StringValue(subnetModel.SubnetId) == subnet.SubnetID) ||
 				(aws.StringValue(subnetModel.SubnetId) == "" && aws.StringValue(subnetModel.Cidr) != "" && aws.StringValue(subnetModel.Cidr) == subnet.Cidr) {
-				subnetModel.SubnetId = &subnet.SubnetID
-				subnetModel.Cidr = &subnet.Cidr
-				subnetModel.AvailabilityZone = &subnet.AvailabilityZone
+				sub := subnet
+				subnetModel.SubnetId = &sub.SubnetID
+				subnetModel.Cidr = &sub.Cidr
+				subnetModel.AvailabilityZone = &sub.AvailabilityZone
 				break
 			}
 		}
@@ -430,139 +428,48 @@ func (c *EKSCluster) GetDistribution() string {
 	return c.modelCluster.Distribution
 }
 
-// DeleteCluster deletes cluster from EKS
 func (c *EKSCluster) DeleteCluster() error {
+	panic("not used")
+}
+
+// DeleteCluster deletes cluster from EKS
+func (c *EKSCluster) DeleteEKSCluster(ctx context.Context, workflowClient client.Client, force bool) error {
 	c.log.Info("Start delete EKS cluster")
 
-	awsCred, err := c.createAWSCredentialsFromSecret()
-	if err != nil {
-		return err
-	}
-
-	awsSession, err := session.NewSession(&aws.Config{
-		Region:      aws.String(c.modelCluster.Location),
-		Credentials: awsCred,
-	})
-	if err != nil {
-		return err
-	}
-
-	clusterStackName := c.generateStackNameForCluster()
-	cloudformationSrv := cloudformation.New(awsSession)
-	describeStacksOutput, err := cloudformationSrv.DescribeStacks(&cloudformation.DescribeStacksInput{
-		StackName: aws.String(clusterStackName),
-	})
-	if err != nil {
-		return err
-	}
-
-	var vpcId string
-	var securityGroupIds []string
-	for _, output := range describeStacksOutput.Stacks[0].Outputs {
-		switch aws.StringValue(output.OutputKey) {
-		case "SecurityGroups":
-			securityGroupIds = append(securityGroupIds, aws.StringValue(output.OutputValue))
-		case "NodeSecurityGroup":
-			securityGroupIds = append(securityGroupIds, aws.StringValue(output.OutputValue))
-		case "VpcId":
-			vpcId = aws.StringValue(output.OutputValue)
-		}
-	}
-
-	deleteContext := action.NewEksClusterDeleteContext(
-		awsSession,
-		c.modelCluster.Name,
-		vpcId,
-		securityGroupIds,
-	)
-	var actions []utils.Action
-	actions = append(actions, action.NewWaitResourceDeletionAction(c.log, deleteContext)) // wait for ELBs to be deleted
-
-	nodePoolStackNames := c.getNodepoolStackNamesToDelete(awsSession)
-	deleteNodePoolsAction := action.NewDeleteStacksAction(c.log, deleteContext, nodePoolStackNames...)
-
-	actions = append(actions,
-		deleteNodePoolsAction,
-		action.NewDeleteClusterAction(c.log, deleteContext),
-		action.NewDeleteSSHKeyAction(c.log, deleteContext, c.generateSSHKeyNameForCluster()),
-		action.NewDeleteClusterUserAccessKeySecretAction(c.log, deleteContext, c.GetOrganizationId()),
-		action.NewDeleteOrphanNICsAction(NewLogurLogger(c.log), deleteContext),
-		action.NewDeleteStacksAction(c.log, deleteContext, c.getSubnetStackNamesToDelete(awsSession)...),
-		action.NewDeleteStacksAction(c.log, deleteContext, clusterStackName),
-		action.NewDeleteStacksAction(c.log, deleteContext, c.generateStackNameForIAM()),
-	)
-
-	if !c.modelCluster.EKS.DefaultUser {
-		actions = append(actions, action.NewDeleteClusterUserAccessKeyAction(c.log, deleteContext))
-	}
-
-	_, err = utils.NewActionExecutor(c.log).ExecuteActions(actions, nil, false)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *EKSCluster) getNodepoolStackNamesToDelete(sess *session.Session) []string {
-	stackNames := make([]string, 0)
-	uniqueMap := make(map[string]bool, 0)
-
+	nodePoolNames := make([]string, 0)
 	for _, nodePool := range c.modelCluster.EKS.NodePools {
-		nodePoolStackName := c.generateNodePoolStackName(nodePool)
-		stackNames = append(stackNames, nodePoolStackName)
-		uniqueMap[nodePoolStackName] = true
+		nodePoolNames = append(nodePoolNames, nodePool.Name)
 	}
 
-	c.log.Debugf("stack names from DB: %+v", stackNames)
-
-	oldTags := map[string]string{
-		"pipeline-created":      "true",
-		"pipeline-cluster-name": c.GetName(),
-		"pipeline-stack-type":   "nodepool",
+	input := workflow.DeleteClusterWorkflowInput{
+		OrganizationID: c.GetOrganizationId(),
+		Region:         c.modelCluster.Location,
+		SecretID:       c.GetSecretId(),
+		ClusterID:      c.GetID(),
+		ClusterUID:     c.GetUID(),
+		ClusterName:    c.GetName(),
+		NodePoolNames:  nodePoolNames,
+		K8sSecretID:    c.GetConfigSecretId(),
+		Forced:         force,
 	}
-	tags := map[string]string{
-		global.ManagedByPipelineTag:         global.ManagedByPipelineValue,
-		"banzaicloud-pipeline-cluster-name": c.GetName(),
-		"banzaicloud-pipeline-stack-type":   "nodepool",
-	}
 
-	// for backward compatibility looks for node pool stacks tagged by earlier version of Pipeline
-	cfStackNamesByOldTags, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(sess), oldTags)
+	workflowOptions := client.StartWorkflowOptions{
+		TaskList:                     "pipeline",
+		ExecutionStartToCloseTimeout: 1 * 24 * time.Hour,
+	}
+	exec, err := workflowClient.ExecuteWorkflow(ctx, workflowOptions, eksworkflow.DeleteClusterWorkflowName, input)
 	if err != nil {
-		c.log.Error(err)
+		return err
 	}
 
-	cfStackNames, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(sess), tags)
+	err = c.SetCurrentWorkflowID(exec.GetID())
 	if err != nil {
-		c.log.Error(err)
-	}
-	cfStackNames = append(cfStackNames, cfStackNamesByOldTags...)
-
-	for _, stackName := range cfStackNames {
-		if !uniqueMap[stackName] {
-			stackNames = append(stackNames, stackName)
-		}
+		return err
 	}
 
-	c.log.Debugf("stack names from DB + CF: %+v", stackNames)
-
-	return stackNames
-}
-
-func (c *EKSCluster) getSubnetStackNamesToDelete(sess *session.Session) []string {
-
-	tags := map[string]string{
-		global.ManagedByPipelineTag:         global.ManagedByPipelineValue,
-		"banzaicloud-pipeline-cluster-name": c.GetName(),
-		"banzaicloud-pipeline-stack-type":   "subnet",
-	}
-
-	cfStackNames, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(sess), tags)
+	err = exec.Get(ctx, nil)
 	if err != nil {
-		c.log.Error(err)
-	} else {
-		return cfStackNames
+		return err
 	}
 
 	return nil
@@ -650,199 +557,103 @@ func (c *EKSCluster) createNodePoolsFromUpdateRequest(requestedNodePools map[str
 func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterRequest, updatedBy uint) error {
 	c.log.Info("start updating EKS cluster")
 
-	awsCred, err := c.createAWSCredentialsFromSecret()
-	if err != nil {
-		return err
-	}
-
-	awsSession, err := session.NewSession(&aws.Config{
-		Region:      aws.String(c.modelCluster.Location),
-		Credentials: awsCred,
-	})
-	if err != nil {
-		return err
-	}
-
-	var actions []utils.Action
-
-	clusterStackName := c.generateStackNameForCluster()
-	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(clusterStackName)}
-	cloudformationSrv := cloudformation.New(awsSession)
-	autoscalingSrv := autoscaling.New(awsSession)
-	describeStacksOutput, err := cloudformationSrv.DescribeStacks(describeStacksInput)
-	if err != nil {
-		return err
-	}
-
-	var vpcId, securityGroupId, nodeSecurityGroupId, nodeInstanceRoleId, clusterUserArn, clusterUserAccessKeyId, clusterUserSecretAccessKey string
-	for _, output := range describeStacksOutput.Stacks[0].Outputs {
-		switch aws.StringValue(output.OutputKey) {
-		case "SecurityGroups":
-			securityGroupId = aws.StringValue(output.OutputValue)
-		case "NodeSecurityGroup":
-			nodeSecurityGroupId = aws.StringValue(output.OutputValue)
-		case "VpcId":
-			vpcId = aws.StringValue(output.OutputValue)
-		case "ClusterUserArn":
-			clusterUserArn = aws.StringValue(output.OutputValue)
-		}
-	}
-
-	nodeInstanceRoleId = c.modelCluster.EKS.NodeInstanceRoleId
-
-	clusterUserAccessKeyId, clusterUserSecretAccessKey, err = action.GetClusterUserAccessKeyIdAndSecretVault(c.GetOrganizationId(), c.GetName())
-	if err != nil {
-		return err
-	}
-
-	if securityGroupId == "" {
-		return errors.Errorf("SecurityGroups output not found on stack: %s", clusterStackName)
-	}
-	if nodeSecurityGroupId == "" {
-		return errors.Errorf("NodeSecurityGroup output not found on stack: %s", clusterStackName)
-	}
-	if vpcId == "" {
-		return errors.Errorf("VpcId output not found on stack: %s", clusterStackName)
-	}
-
-	nodePoolTemplate, err := pkgEks.GetNodePoolTemplate()
-	if err != nil {
-		log.Errorln("getting CloudFormation template for node pools failed: ", err.Error())
-		return err
-	}
-
 	modelNodePools, err := c.createNodePoolsFromUpdateRequest(updateRequest.EKS.NodePools, updatedBy)
 	if err != nil {
 		return err
 	}
 
-	var subnets []*action.EksSubnet
+	subnets := make([]workflow.Subnet, 0)
 	for _, subnet := range c.modelCluster.EKS.Subnets {
-		subnets = append(subnets, &action.EksSubnet{
+		subnets = append(subnets, workflow.Subnet{
 			SubnetID:         aws.StringValue(subnet.SubnetId),
 			Cidr:             aws.StringValue(subnet.Cidr),
 			AvailabilityZone: aws.StringValue(subnet.AvailabilityZone),
 		})
 	}
 
-	createUpdateContext := action.NewEksClusterUpdateContext(
-		awsSession,
-		c.modelCluster.Name,
-		aws.String(securityGroupId),
-		aws.String(nodeSecurityGroupId),
-		subnets,
-		c.generateSSHKeyNameForCluster(),
-		aws.String(vpcId),
-		nodeInstanceRoleId,
-		clusterUserArn,
-		clusterUserAccessKeyId,
-		clusterUserSecretAccessKey,
-	)
-	createUpdateContext.ScaleEnabled = c.GetScaleOptions() != nil && c.GetScaleOptions().Enabled
-
-	deleteContext := action.NewEksClusterDeleteContext(
-		awsSession,
-		c.modelCluster.Name,
-		vpcId,
-		[]string{securityGroupId, nodeSecurityGroupId},
-	)
-
-	subnetMapping := make(map[string][]*action.EksSubnet)
-
-	var nodePoolsToCreate []*model.AmazonNodePoolsModel
-	var nodePoolsToUpdate []*model.AmazonNodePoolsModel
-	var nodePoolsToDelete []string
-
+	subnetMapping := make(map[string][]workflow.Subnet)
 	for _, nodePool := range modelNodePools {
 
-		log := c.log.WithField("nodePool", nodePool.Name)
-		stackName := c.generateNodePoolStackName(nodePool)
-		describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(stackName)}
-		describeStacksOutput, err := cloudformationSrv.DescribeStacks(describeStacksInput)
-
-		if err == nil {
-			// delete nodePool
-			if nodePool.Delete {
-				log.Info("node pool will be deleted")
-				nodePoolsToDelete = append(nodePoolsToDelete, c.generateNodePoolStackName(nodePool))
-				continue
-			}
-			// update nodePool
-			log.Info("node pool already exists will be updated")
-			// load params which are not updatable from nodeGroup Stack
-			for _, param := range describeStacksOutput.Stacks[0].Parameters {
-				switch *param.ParameterKey {
-				case "NodeImageId":
-					nodePool.NodeImage = aws.StringValue(param.ParameterValue)
-				case "NodeInstanceType":
-					nodePool.NodeInstanceType = aws.StringValue(param.ParameterValue)
-				case "NodeSpotPrice":
-					nodePool.NodeSpotPrice = aws.StringValue(param.ParameterValue)
-				}
-			}
-			// get current Desired count from ASG linked to nodeGroup stack if Autoscaling is enabled, as we don't to override
-			// in this case only min/max counts
-			asg, err := getAutoScalingGroup(cloudformationSrv, autoscalingSrv, stackName)
-			if err != nil {
-				return errors.WrapIff(err, "unable to find ASG for node pool %q", nodePool.Name)
-			}
-
-			// override nodePool.Count with current DesiredCapacity in case of autoscale, as we don't want allow direct
-			// setting of DesiredCapacity via API, however we have to limit it to be between new min, max values.
-			if nodePool.Autoscaling && asg != nil {
-				if asg.DesiredCapacity != nil {
-					nodePool.Count = int(*asg.DesiredCapacity)
-				}
-				if nodePool.Count < nodePool.NodeMinCount {
-					nodePool.Count = nodePool.NodeMinCount
-				}
-				if nodePool.Count > nodePool.NodeMaxCount {
-					nodePool.Count = nodePool.NodeMaxCount
-				}
-				log.Infof("DesiredCapacity for %v will be: %v", aws.StringValue(asg.AutoScalingGroupARN), nodePool.Count)
-			}
-
-			nodePoolsToUpdate = append(nodePoolsToUpdate, nodePool)
-		} else {
-			if nodePool.Delete {
-				log.Warnf("node pool to be deleted doesn't exists: %v", err)
-				continue
-			}
-			// create nodePool
-			log.Info("node pool doesn't exists will be created")
-			nodePoolsToCreate = append(nodePoolsToCreate, nodePool)
-
-			for reqNodePoolName, reqNodePool := range updateRequest.EKS.NodePools {
-				if reqNodePoolName == nodePool.Name {
-					if reqNodePool.Subnet == nil {
-						c.log.WithField("nodePool", nodePool.Name).Info("no subnet specified for node pool in the update request")
-						subnetMapping[nodePool.Name] = append(subnetMapping[nodePool.Name], subnets[0])
-					} else {
-						for _, subnet := range subnets {
-							if (reqNodePool.Subnet.SubnetId != "" && subnet.SubnetID == reqNodePool.Subnet.SubnetId) ||
-								(reqNodePool.Subnet.Cidr != "" && subnet.Cidr == reqNodePool.Subnet.Cidr) {
-								subnetMapping[nodePool.Name] = append(subnetMapping[nodePool.Name], subnet)
-							}
+		if nodePool.Delete {
+			continue
+		}
+		// set subnets for node pools to be created & updated, however at the moment we don't update subnets for
+		// already existing nodepools
+		for reqNodePoolName, reqNodePool := range updateRequest.EKS.NodePools {
+			if reqNodePoolName == nodePool.Name {
+				if reqNodePool.Subnet == nil {
+					c.log.WithField("nodePool", nodePool.Name).Info("no subnet specified for node pool in the update request")
+					subnetMapping[nodePool.Name] = append(subnetMapping[nodePool.Name], subnets[0])
+				} else {
+					for _, subnet := range subnets {
+						if (reqNodePool.Subnet.SubnetId != "" && subnet.SubnetID == reqNodePool.Subnet.SubnetId) ||
+							(reqNodePool.Subnet.Cidr != "" && subnet.Cidr == reqNodePool.Subnet.Cidr) {
+							subnetMapping[nodePool.Name] = append(subnetMapping[nodePool.Name], subnet)
 						}
 					}
 				}
 			}
 		}
+
 	}
 
-	ASGWaitLoopCount := int(asgFulfillmentTimeout.Seconds() / asgWaitLoopSleepSeconds)
+	input := workflow.UpdateClusterstructureWorkflowInput{
+		Region:             c.modelCluster.Location,
+		OrganizationID:     c.GetOrganizationId(),
+		SecretID:           c.GetSecretId(),
+		ClusterUID:         c.GetUID(),
+		ClusterName:        c.GetName(),
+		ScaleEnabled:       c.GetScaleOptions() != nil && c.GetScaleOptions().Enabled,
+		NodeInstanceRoleID: c.modelCluster.EKS.NodeInstanceRoleId,
+	}
 
-	deleteNodePoolAction := action.NewDeleteStacksAction(c.log, deleteContext, nodePoolsToDelete...)
-	createNodePoolAction := action.NewCreateUpdateNodePoolStackAction(c.log, true, createUpdateContext, ASGWaitLoopCount, asgWaitLoopSleepSeconds*time.Second, nodePoolTemplate, subnetMapping, nodePoolsToCreate...)
-	updateNodePoolAction := action.NewCreateUpdateNodePoolStackAction(c.log, false, createUpdateContext, ASGWaitLoopCount, asgWaitLoopSleepSeconds*time.Second, nodePoolTemplate, nil, nodePoolsToUpdate...)
+	input.Subnets = subnets
+	input.ASGSubnetMapping = subnetMapping
 
-	actions = append(actions, createNodePoolAction, updateNodePoolAction, deleteNodePoolAction)
+	asgList := make([]workflow.AutoscaleGroup, 0)
+	for _, np := range modelNodePools {
+		asg := workflow.AutoscaleGroup{
+			Name:             np.Name,
+			NodeSpotPrice:    np.NodeSpotPrice,
+			Autoscaling:      np.Autoscaling,
+			NodeMinCount:     np.NodeMinCount,
+			NodeMaxCount:     np.NodeMaxCount,
+			Count:            np.Count,
+			NodeImage:        np.NodeImage,
+			NodeInstanceType: np.NodeInstanceType,
+			Labels:           np.Labels,
+			Delete:           np.Delete,
+		}
+		if np.ID == 0 {
+			asg.Create = true
+		}
+		asgList = append(asgList, asg)
+	}
 
-	_, err = utils.NewActionExecutor(c.log).ExecuteActions(actions, nil, false)
+	input.AsgList = asgList
+
+	ctx := context.Background()
+	workflowOptions := client.StartWorkflowOptions{
+		TaskList:                     "pipeline",
+		ExecutionStartToCloseTimeout: 1 * 24 * time.Hour,
+	}
+	exec, err := c.WorkflowClient.ExecuteWorkflow(ctx, workflowOptions, eksworkflow.UpdateClusterWorkflowName, input)
 	if err != nil {
 		return err
 	}
 
+	err = c.SetCurrentWorkflowID(exec.GetID())
+	if err != nil {
+		return err
+	}
+
+	var out interface{}
+	err = exec.Get(ctx, out)
+	if err != nil {
+		return err
+	}
+
+	c.log.Info("EKS cluster updated.")
 	c.modelCluster.EKS.NodePools = modelNodePools
 
 	return nil
@@ -912,40 +723,6 @@ func (c *EKSCluster) UpdateNodePools(request *pkgCluster.UpdateNodePoolsRequest,
 	}
 
 	return errors.Combine(caughtErrors...)
-}
-
-func getAutoScalingGroup(cloudformationSrv *cloudformation.CloudFormation, autoscalingSrv *autoscaling.AutoScaling, stackName string) (*autoscaling.Group, error) {
-	describeStackResourceInput := &cloudformation.DescribeStackResourcesInput{
-		StackName: aws.String(stackName),
-	}
-	stackResources, err := cloudformationSrv.DescribeStackResources(describeStackResourceInput)
-	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get stack resources", "stack", stackName)
-	}
-
-	var asgId *string
-	for _, res := range stackResources.StackResources {
-		if aws.StringValue(res.LogicalResourceId) == "NodeGroup" {
-			asgId = res.PhysicalResourceId
-			break
-		}
-	}
-
-	if asgId == nil {
-		return nil, nil
-	}
-
-	describeAutoScalingGroupsInput := autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{
-			asgId,
-		},
-	}
-	describeAutoScalingGroupsOutput, err := autoscalingSrv.DescribeAutoScalingGroups(&describeAutoScalingGroupsInput)
-	if err != nil {
-		return nil, err
-	}
-
-	return describeAutoScalingGroupsOutput.AutoScalingGroups[0], nil
 }
 
 func (c *EKSCluster) getAutoScalingGroupName(cloudformationSrv *cloudformation.CloudFormation, autoscalingSrv *autoscaling.AutoScaling, nodePoolName string) (*string, error) {

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -574,12 +574,10 @@ func (c *EKSCluster) UpdateCluster(updateRequest *pkgCluster.UpdateClusterReques
 
 	subnetMapping := make(map[string][]workflow.Subnet)
 	for _, nodePool := range modelNodePools {
-
-		if nodePool.Delete {
+		// set subnets only for node pools to be updated
+		if nodePool.Delete || nodePool.ID != 0 {
 			continue
 		}
-		// set subnets for node pools to be created & updated, however at the moment we don't update subnets for
-		// already existing nodepools
 		for reqNodePoolName, reqNodePool := range updateRequest.EKS.NodePools {
 			if reqNodePoolName == nodePool.Name {
 				if reqNodePool.Subnet == nil {

--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -81,11 +81,17 @@ func registerEKSWorkflows(secretStore eksworkflow.SecretStore) error {
 	createAsgActivity := eksworkflow.NewCreateAsgActivity(awsSessionFactory, nodePoolTemplate, waitAttempts, waitInterval)
 	activity.RegisterWithOptions(createAsgActivity.Execute, activity.RegisterOptions{Name: eksworkflow.CreateAsgActivityName})
 
+	updateAsgActivity := eksworkflow.NewUpdateAsgActivity(awsSessionFactory, nodePoolTemplate, waitAttempts, waitInterval)
+	activity.RegisterWithOptions(updateAsgActivity.Execute, activity.RegisterOptions{Name: eksworkflow.UpdateAsgActivityName})
+
 	createUserAccessKeyActivity := eksworkflow.NewCreateClusterUserAccessKeyActivity(awsSessionFactory)
 	activity.RegisterWithOptions(createUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: eksworkflow.CreateClusterUserAccessKeyActivityName})
 
 	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory)
 	activity.RegisterWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: eksworkflow.BootstrapActivityName})
+
+	// update cluster workflow
+	workflow.RegisterWithOptions(eksworkflow.UpdateClusterWorkflow, workflow.RegisterOptions{Name: eksworkflow.UpdateClusterWorkflowName})
 
 	// delete cluster workflow
 	workflow.RegisterWithOptions(eksworkflow.DeleteClusterWorkflow, workflow.RegisterOptions{Name: eksworkflow.DeleteClusterWorkflowName})
@@ -96,6 +102,30 @@ func registerEKSWorkflows(secretStore eksworkflow.SecretStore) error {
 
 	waitELBsDeletionActivity := eksworkflow.NewWaitELBsDeletionActivity(awsSessionFactory)
 	activity.RegisterWithOptions(waitELBsDeletionActivity.Execute, activity.RegisterOptions{Name: eksworkflow.WaitELBsDeletionActivityName})
+
+	getNodepoolStacksActivity := eksworkflow.NewGetNodepoolStacksActivity(awsSessionFactory)
+	activity.RegisterWithOptions(getNodepoolStacksActivity.Execute, activity.RegisterOptions{Name: eksworkflow.GetNodepoolStacksActivityName})
+
+	deleteStackActivity := eksworkflow.NewDeleteStackActivity(awsSessionFactory, nodePoolTemplate)
+	activity.RegisterWithOptions(deleteStackActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteStackActivityName})
+
+	deleteControlPlaneActivity := eksworkflow.NewDeleteControlPlaneActivity(awsSessionFactory)
+	activity.RegisterWithOptions(deleteControlPlaneActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteControlPlaneActivityName})
+
+	deleteSshKeyActivity := eksworkflow.NewDeleteSshKeyActivity(awsSessionFactory)
+	activity.RegisterWithOptions(deleteSshKeyActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteSshKeyActivityName})
+
+	deleteClusterUserAccessKeyActivity := eksworkflow.NewDeleteClusterUserAccessKeyActivity(awsSessionFactory)
+	activity.RegisterWithOptions(deleteClusterUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteClusterUserAccessKeyActivityName})
+
+	getOrphanNicsActivity := eksworkflow.NewGetOrphanNICsActivity(awsSessionFactory)
+	activity.RegisterWithOptions(getOrphanNicsActivity.Execute, activity.RegisterOptions{Name: eksworkflow.GetOrphanNICsActivityName})
+
+	deleteOrphanNicActivity := eksworkflow.NewDeleteOrphanNICActivity(awsSessionFactory)
+	activity.RegisterWithOptions(deleteOrphanNicActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteOrphanNICActivityName})
+
+	getSubnetStacksActivity := eksworkflow.NewGetSubnetStacksActivity(awsSessionFactory)
+	activity.RegisterWithOptions(getSubnetStacksActivity.Execute, activity.RegisterOptions{Name: eksworkflow.GetSubnetStacksActivityName})
 
 	return nil
 }

--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -87,5 +87,15 @@ func registerEKSWorkflows(secretStore eksworkflow.SecretStore) error {
 	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory)
 	activity.RegisterWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: eksworkflow.BootstrapActivityName})
 
+	// delete cluster workflow
+	workflow.RegisterWithOptions(eksworkflow.DeleteClusterWorkflow, workflow.RegisterOptions{Name: eksworkflow.DeleteClusterWorkflowName})
+	workflow.RegisterWithOptions(eksworkflow.DeleteInfrastructureWorkflow, workflow.RegisterOptions{Name: eksworkflow.DeleteInfraWorkflowName})
+
+	getOwnedELBsActivity := eksworkflow.NewGetOwnedELBsActivity(awsSessionFactory)
+	activity.RegisterWithOptions(getOwnedELBsActivity.Execute, activity.RegisterOptions{Name: eksworkflow.GetOwnedELBsActivityName})
+
+	waitELBsDeletionActivity := eksworkflow.NewWaitELBsDeletionActivity(awsSessionFactory)
+	activity.RegisterWithOptions(waitELBsDeletionActivity.Execute, activity.RegisterOptions{Name: eksworkflow.WaitELBsDeletionActivityName})
+
 	return nil
 }

--- a/internal/providers/amazon/eks/workflow/amazon.go
+++ b/internal/providers/amazon/eks/workflow/amazon.go
@@ -60,8 +60,13 @@ func generateSSHKeyNameForCluster(clusterName string) string {
 	return "pipeline-eks-ssh-" + clusterName
 }
 
-func generateNodePoolStackName(clusterName string, asgName string) string {
-	return "pipeline-eks-nodepool-" + clusterName + "-" + asgName
+func generateNodePoolStackName(clusterName string, poolName string) string {
+	return "pipeline-eks-nodepool-" + clusterName + "-" + poolName
+}
+
+// getSecretName returns the name that identifies the  cluster user access key in Vault
+func getSecretName(userName string) string {
+	return fmt.Sprintf("%s-key", strings.ToLower(userName))
 }
 
 func generateK8sConfig(clusterName string, apiEndpoint string, certificateAuthorityData []byte,
@@ -145,10 +150,14 @@ type AutoscaleGroup struct {
 	NodeImage        string
 	NodeInstanceType string
 	Labels           map[string]string
+	Delete           bool
+	Create           bool
 }
 
 type SecretStore interface {
 	Get(orgnaizationID uint, secretID string) (*secret.SecretItemResponse, error)
 	GetByName(orgnaizationID uint, secretID string) (*secret.SecretItemResponse, error)
 	Store(organizationID uint, request *secret.CreateSecretRequest) (string, error)
+	Delete(organizationID uint, secretID string) error
+	Update(organizationID uint, secretID string, request *secret.CreateSecretRequest) error
 }

--- a/internal/providers/amazon/eks/workflow/create_cluster_user_access_key_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_cluster_user_access_key_activity.go
@@ -17,7 +17,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
@@ -168,7 +167,7 @@ func (a *CreateClusterUserAccessKeyActivity) Execute(ctx context.Context, input 
 		ver := int(clusterUserAccessKeySecret.Version)
 		secretRequest.Version = &ver
 
-		if err = secret.Store.Update(input.OrganizationID, clusterUserAccessKeySecret.ID, &secretRequest); err != nil {
+		if err = a.awsSessionFactory.GetSecretStore().Update(input.OrganizationID, clusterUserAccessKeySecret.ID, &secretRequest); err != nil {
 			return nil, errors.WrapIff(err, "failed to update secret: %s", secretName)
 		}
 		secretID = clusterUserAccessKeySecret.ID
@@ -182,9 +181,4 @@ func (a *CreateClusterUserAccessKeyActivity) Execute(ctx context.Context, input 
 	return &CreateClusterUserAccessKeyActivityOutput{
 		SecretID: secretID,
 	}, nil
-}
-
-// getSecretName returns the name that identifies the  cluster user access key in Vault
-func getSecretName(userName string) string {
-	return fmt.Sprintf("%s-key", strings.ToLower(userName))
 }

--- a/internal/providers/amazon/eks/workflow/create_infra.go
+++ b/internal/providers/amazon/eks/workflow/create_infra.go
@@ -54,6 +54,7 @@ type CreateInfrastructureWorkflowInput struct {
 }
 
 type CreateInfrastructureWorkflowOutput struct {
+	VpcID              string
 	NodeInstanceRoleID string
 	Subnets            []Subnet
 }
@@ -329,6 +330,7 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 	}
 
 	output := CreateInfrastructureWorkflowOutput{
+		VpcID:              vpcActivityOutput.VpcID,
 		NodeInstanceRoleID: iamRolesActivityOutput.NodeInstanceRoleID,
 		Subnets:            existingAndNewSubnets,
 	}

--- a/internal/providers/amazon/eks/workflow/delete_cluster.go
+++ b/internal/providers/amazon/eks/workflow/delete_cluster.go
@@ -1,0 +1,186 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"time"
+
+	"emperror.dev/errors"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/workflow"
+
+	intClusterWorkflow "github.com/banzaicloud/pipeline/internal/cluster/workflow"
+)
+
+const DeleteClusterWorkflowName = "eks-delete-cluster"
+
+// DeleteClusterWorkflowInput holds data needed by the delete cluster workflow
+type DeleteClusterWorkflowInput struct {
+	OrganizationID uint
+	SecretID       string
+	Region         string
+
+	ClusterName string
+
+	ClusterID  uint
+	ClusterUID string
+
+	// the identifier of the kubeconfig secret of the cluster
+	K8sSecretID string
+
+	// force delete
+	Forced bool
+}
+
+// DeleteClusterWorkflow executes the Cadence workflow responsible for deleting an EKS cluster
+func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInput) error {
+	logger := workflow.GetLogger(ctx).Sugar()
+
+	cwo := workflow.ChildWorkflowOptions{
+		ExecutionStartToCloseTimeout: 1 * time.Hour,
+		TaskStartToCloseTimeout:      5 * time.Minute,
+	}
+
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: 10 * time.Minute,
+		StartToCloseTimeout:    5 * time.Minute,
+		WaitForCancellation:    true,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:          2 * time.Second,
+			BackoffCoefficient:       1.5,
+			MaximumInterval:          30 * time.Second,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", ErrReasonStackFailed},
+		},
+	}
+
+	ctx = workflow.WithChildOptions(ctx, cwo)
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	// delete K8s resources
+	{
+		if input.K8sSecretID != "" {
+			wfInput := intClusterWorkflow.DeleteK8sResourcesWorkflowInput{
+				OrganizationID: input.OrganizationID,
+				ClusterName:    input.ClusterName,
+				K8sSecretID:    input.K8sSecretID,
+			}
+			if err := workflow.ExecuteChildWorkflow(ctx, intClusterWorkflow.DeleteK8sResourcesWorkflowName, wfInput).Get(ctx, nil); err != nil {
+				if input.Forced {
+					logger.Errorw("deleting k8s resources failed", "error", err)
+				} else {
+					if cadence.IsCustomError(err) {
+						cerr := err.(*cadence.CustomError)
+						if cerr.HasDetails() {
+							var errDetails string
+							if err = errors.WrapIf(cerr.Details(&errDetails), "couldn't get error details that caused Kubernetes resources deletion to fail"); err != nil {
+								return err
+							}
+
+							return errors.New(errDetails)
+						}
+					}
+					return err
+				}
+			}
+		}
+	}
+
+	// delete cluster DNS records
+	{
+		activityInput := intClusterWorkflow.DeleteClusterDNSRecordsActivityInput{
+			OrganizationID: input.OrganizationID,
+			ClusterUID:     input.ClusterUID,
+		}
+		if err := workflow.ExecuteActivity(ctx, intClusterWorkflow.DeleteClusterDNSRecordsActivityName, activityInput).Get(ctx, nil); err != nil {
+			if input.Forced {
+				logger.Errorw("deleting cluster DNS records failed", "error", err)
+			} else {
+				if cadence.IsCustomError(err) {
+					cerr := err.(*cadence.CustomError)
+					if cerr.HasDetails() {
+						var errDetails string
+						if err = errors.WrapIf(cerr.Details(&errDetails), "couldn't get error details that caused cluster DNS records deletion to fail"); err != nil {
+							return err
+						}
+
+						return errors.New(errDetails)
+					}
+				}
+				return err
+			}
+		}
+	}
+
+	// delete infra child workflow
+	{
+		infraInput := DeleteInfrastructureWorkflowInput{
+			OrganizationID: input.OrganizationID,
+			SecretID:       input.SecretID,
+			Region:         input.Region,
+			ClusterName:    input.ClusterName,
+		}
+
+		err := workflow.ExecuteChildWorkflow(ctx, DeleteInfraWorkflowName, infraInput).Get(ctx, nil)
+		if err != nil {
+			if input.Forced {
+				logger.Errorw("deleting cluster infrastructure failed", "error", err)
+			} else {
+				if cadence.IsCustomError(err) {
+					cerr := err.(*cadence.CustomError)
+					if cerr.HasDetails() {
+						var errDetails string
+						if err = errors.WrapIf(cerr.Details(&errDetails), "couldn't get error details that caused the deletion of cluster infrastructure to fail"); err != nil {
+							return err
+						}
+
+						return errors.New(errDetails)
+					}
+				}
+				return err
+			}
+		}
+	}
+
+	// delete unused secrets
+	{
+		activityInput := intClusterWorkflow.DeleteUnusedClusterSecretsActivityInput{
+			OrganizationID: input.OrganizationID,
+			ClusterUID:     input.ClusterUID,
+		}
+		if err := workflow.ExecuteActivity(ctx, intClusterWorkflow.DeleteUnusedClusterSecretsActivityName, activityInput).Get(ctx, nil); err != nil {
+			if input.Forced {
+				logger.Errorw("failed to delete unused cluster secrets", "error", err)
+			} else {
+				if cadence.IsCustomError(err) {
+					cerr := err.(*cadence.CustomError)
+					if cerr.HasDetails() {
+						var errDetails string
+						if err = errors.WrapIf(cerr.Details(&errDetails), "couldn't get error details that caused the deletion of unused cluster secrets to fail"); err != nil {
+							return err
+						}
+
+						return errors.New(errDetails)
+					}
+				}
+				return err
+			}
+		}
+	}
+
+	//TODO: DeleteClusterFromStoreActivityName  child workflow
+
+	return nil
+}

--- a/internal/providers/amazon/eks/workflow/delete_cluster.go
+++ b/internal/providers/amazon/eks/workflow/delete_cluster.go
@@ -32,7 +32,8 @@ type DeleteClusterWorkflowInput struct {
 	SecretID       string
 	Region         string
 
-	ClusterName string
+	ClusterName   string
+	NodePoolNames []string
 
 	ClusterID  uint
 	ClusterUID string
@@ -130,7 +131,9 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 			OrganizationID: input.OrganizationID,
 			SecretID:       input.SecretID,
 			Region:         input.Region,
+			ClusterUID:     input.ClusterUID,
 			ClusterName:    input.ClusterName,
+			NodePoolNames:  input.NodePoolNames,
 		}
 
 		err := workflow.ExecuteChildWorkflow(ctx, DeleteInfraWorkflowName, infraInput).Get(ctx, nil)

--- a/internal/providers/amazon/eks/workflow/delete_cluster.go
+++ b/internal/providers/amazon/eks/workflow/delete_cluster.go
@@ -40,6 +40,7 @@ type DeleteClusterWorkflowInput struct {
 
 	// the identifier of the kubeconfig secret of the cluster
 	K8sSecretID string
+	DefaultUser bool
 
 	// force delete
 	Forced bool
@@ -134,6 +135,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 			ClusterUID:     input.ClusterUID,
 			ClusterName:    input.ClusterName,
 			NodePoolNames:  input.NodePoolNames,
+			DefaultUser:    input.DefaultUser,
 		}
 
 		err := workflow.ExecuteChildWorkflow(ctx, DeleteInfraWorkflowName, infraInput).Get(ctx, nil)

--- a/internal/providers/amazon/eks/workflow/delete_cluster_user_access_key_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_cluster_user_access_key_activity.go
@@ -1,0 +1,116 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/secret"
+
+	"github.com/banzaicloud/pipeline/pkg/amazon"
+)
+
+const DeleteClusterUserAccessKeyActivityName = "eks-delete-cluster-user-access-key"
+
+// DeleteClusterUserAccessKeyActivity responsible for deleting cluster user access key &  cluster secret from
+// secret store
+type DeleteClusterUserAccessKeyActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type DeleteClusterUserAccessKeyActivityInput struct {
+	EKSActivityInput
+}
+
+//   DeleteClusterUserAccessKeyActivityOutput holds the output data of the DeleteStackActivity
+type DeleteClusterUserAccessKeyActivityOutput struct {
+}
+
+//   NewDeleteClusterUserAccessKeyActivity instantiates a new DeleteClusterUserAccessKeyActivity
+func NewDeleteClusterUserAccessKeyActivity(awsSessionFactory *AWSSessionFactory) *DeleteClusterUserAccessKeyActivity {
+	return &DeleteClusterUserAccessKeyActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *DeleteClusterUserAccessKeyActivity) Execute(ctx context.Context, input DeleteClusterUserAccessKeyActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	logger.Info("deleting cluster user access key")
+
+	iamSvc := iam.New(awsSession)
+	clusterUserName := aws.String(input.ClusterName)
+
+	awsAccessKeys, err := amazon.GetUserAccessKeys(iamSvc, clusterUserName)
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == iam.ErrCodeNoSuchEntityException {
+				return nil
+			}
+		}
+		logger.Errorf("querying IAM user '%s' access keys failed: %s", *clusterUserName, err)
+		return errors.Wrapf(err, "querying IAM user '%s' access keys failed", *clusterUserName)
+	}
+
+	for _, awsAccessKey := range awsAccessKeys {
+		if err := amazon.DeleteUserAccessKey(iamSvc, awsAccessKey.UserName, awsAccessKey.AccessKeyId); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == iam.ErrCodeNoSuchEntityException {
+					continue
+				}
+			}
+
+			logger.Errorf("deleting Amazon user access key '%s', user '%s' failed: %s",
+				aws.StringValue(awsAccessKey.AccessKeyId),
+				aws.StringValue(awsAccessKey.UserName), err)
+
+			return errors.Wrapf(err, "deleting Amazon access key '%s', user '%s' failed",
+				aws.StringValue(awsAccessKey.AccessKeyId),
+				aws.StringValue(awsAccessKey.UserName))
+		}
+	}
+
+	// delete from secret store
+	secretName := getSecretName(input.ClusterName)
+	secretItem, err := a.awsSessionFactory.secretStore.GetByName(input.OrganizationID, secretName)
+
+	if err != nil {
+		if err == secret.ErrSecretNotExists {
+			return nil
+		}
+		return errors.Wrapf(err, "retrieving secret with name '%s' from Vault failed", secretName)
+	}
+
+	err = a.awsSessionFactory.secretStore.Delete(input.OrganizationID, secretItem.ID)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
@@ -1,0 +1,128 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"go.uber.org/cadence/activity"
+)
+
+const DeleteControlPlaneActivityName = "eks-delete-control-plane"
+
+// DeleteControlPlaneActivity responsible for deleting asg
+type DeleteControlPlaneActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type DeleteControlPlaneActivityInput struct {
+	EKSActivityInput
+}
+
+//   DeleteControlPlaneActivityOutput holds the output data of the DeleteControlPlaneActivity
+type DeleteControlPlaneActivityOutput struct {
+}
+
+//   DeleteControlPlaneActivity instantiates a new DeleteControlPlaneActivity
+func NewDeleteControlPlaneActivity(awsSessionFactory *AWSSessionFactory) *DeleteControlPlaneActivity {
+	return &DeleteControlPlaneActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *DeleteControlPlaneActivity) Execute(ctx context.Context, input DeleteControlPlaneActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	logger.Info("deleting EKS control plane")
+
+	eksSrv := eks.New(awsSession)
+	deleteClusterInput := &eks.DeleteClusterInput{
+		Name: aws.String(input.ClusterName),
+	}
+	_, err = eksSrv.DeleteCluster(deleteClusterInput)
+
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == eks.ErrCodeResourceNotFoundException {
+			return nil
+		}
+	}
+
+	// wait until cluster exists
+	startTime := time.Now()
+	logger.Info("waiting for EKS control plane deletion")
+	describeClusterInput := &eks.DescribeClusterInput{
+		Name: aws.String(input.ClusterName),
+	}
+	err = a.waitUntilClusterExists(aws.BackgroundContext(), awsSession, describeClusterInput)
+	if err != nil {
+		return err
+	}
+	endTime := time.Now()
+	logger.Info("EKS control plane deleted successfully in", endTime.Sub(startTime).String())
+
+	return nil
+}
+
+func (a *DeleteControlPlaneActivity) waitUntilClusterExists(ctx aws.Context, awsSession *session.Session, input *eks.DescribeClusterInput, opts ...request.WaiterOption) error {
+	eksSvc := eks.New(awsSession)
+
+	w := request.Waiter{
+		Name:        "WaitUntilClusterExists",
+		MaxAttempts: 30,
+		Delay:       request.ConstantWaiterDelay(30 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:    request.SuccessWaiterState,
+				Matcher:  request.StatusWaiterMatch,
+				Expected: 404,
+			},
+			{
+				State:    request.RetryWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+		},
+		Logger: eksSvc.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *eks.DescribeClusterInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := eksSvc.DescribeClusterRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}

--- a/internal/providers/amazon/eks/workflow/delete_infra.go
+++ b/internal/providers/amazon/eks/workflow/delete_infra.go
@@ -1,0 +1,117 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"time"
+
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/workflow"
+)
+
+const DeleteInfraWorkflowName = "eks-delete-infra"
+
+// DeleteInfrastructureWorkflowInput holds data needed by the delete EKS cluster infrastructure workflow
+type DeleteInfrastructureWorkflowInput struct {
+	OrganizationID uint
+	SecretID       string
+	Region         string
+
+	ClusterName string
+}
+
+// DeleteInfrastructureWorkflow executes the Cadence workflow responsible for deleting EKS
+// cluster infrastructure such as VPC, subnets, EKS master nodes, worker nodes, etc
+func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructureWorkflowInput) error {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: 10 * time.Minute,
+		StartToCloseTimeout:    5 * time.Minute,
+		WaitForCancellation:    true,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:          2 * time.Second,
+			BackoffCoefficient:       1.5,
+			MaximumInterval:          30 * time.Second,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", ErrReasonStackFailed},
+		},
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	eksActivityInput := EKSActivityInput{
+		OrganizationID: input.OrganizationID,
+		SecretID:       input.SecretID,
+		Region:         input.Region,
+		ClusterName:    input.ClusterName,
+	}
+
+	// get VPC ID
+	var getVpcConfigActivityOutput GetVpcConfigActivityOutput
+	{
+		activityInput := GetVpcConfigActivityInput{
+			EKSActivityInput: eksActivityInput,
+			StackName:        generateStackNameForCluster(input.ClusterName),
+		}
+
+		if err := workflow.ExecuteActivity(ctx, GetVpcConfigActivityName, activityInput).Get(ctx, &getVpcConfigActivityOutput); err != nil {
+			return err
+		}
+	}
+
+	// get ELBs created by the EKS cluster
+	var ownedELBsOutput GetOwnedELBsActivityOutput
+	{
+		activityInput := GetOwnedELBsActivityInput{
+			OrganizationID: input.OrganizationID,
+			SecretID:       input.SecretID,
+			Region:         input.Region,
+			ClusterName:    input.ClusterName,
+			VpcID:          getVpcConfigActivityOutput.VpcID,
+		}
+
+		if err := workflow.ExecuteActivity(ctx, GetOwnedELBsActivityName, activityInput).Get(ctx, &ownedELBsOutput); err != nil {
+			return err
+		}
+
+	}
+
+	// wait for ELBs to be releases by EKS
+	{
+		if len(ownedELBsOutput.LoadBalancerNames) > 0 {
+			activityInput := WaitELBsDeletionActivityActivityInput{
+				OrganizationID:    input.OrganizationID,
+				SecretID:          input.SecretID,
+				Region:            input.Region,
+				ClusterName:       input.ClusterName,
+				LoadBalancerNames: ownedELBsOutput.LoadBalancerNames,
+			}
+
+			if err := workflow.ExecuteActivity(ctx, WaitELBsDeletionActivityName, activityInput).Get(ctx, nil); err != nil {
+				return err
+			}
+		}
+	}
+
+	//TODO: delete node pools
+	//TODO: delete EKS control plane
+	//TODO: delete SSH key
+	//TODO: delete cluster user
+	//TODO: delete orphan NICs
+	//TODO: delete subnets
+	//TODO: delete VPC
+	//TODO: delete IAM user and roles
+
+	return nil
+}

--- a/internal/providers/amazon/eks/workflow/delete_infra.go
+++ b/internal/providers/amazon/eks/workflow/delete_infra.go
@@ -33,6 +33,7 @@ type DeleteInfrastructureWorkflowInput struct {
 	ClusterName    string
 	ClusterUID     string
 	NodePoolNames  []string
+	DefaultUser    bool
 }
 
 // DeleteInfrastructureWorkflow executes the Cadence workflow responsible for deleting EKS
@@ -269,6 +270,7 @@ func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructu
 	{
 		activityInput := DeleteClusterUserAccessKeyActivityInput{
 			EKSActivityInput: eksActivityInput,
+			DefaultUser:      input.DefaultUser,
 		}
 		deleteClusterUserAccessKeyActivityFeature = workflow.ExecuteActivity(ctx, DeleteClusterUserAccessKeyActivityName, activityInput)
 	}

--- a/internal/providers/amazon/eks/workflow/delete_infra.go
+++ b/internal/providers/amazon/eks/workflow/delete_infra.go
@@ -17,6 +17,8 @@ package workflow
 import (
 	"time"
 
+	"emperror.dev/errors"
+
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
 )
@@ -28,13 +30,19 @@ type DeleteInfrastructureWorkflowInput struct {
 	OrganizationID uint
 	SecretID       string
 	Region         string
-
-	ClusterName string
+	ClusterName    string
+	ClusterUID     string
+	NodePoolNames  []string
 }
 
 // DeleteInfrastructureWorkflow executes the Cadence workflow responsible for deleting EKS
 // cluster infrastructure such as VPC, subnets, EKS master nodes, worker nodes, etc
 func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructureWorkflowInput) error {
+	logger := workflow.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: 10 * time.Minute,
 		StartToCloseTimeout:    5 * time.Minute,
@@ -51,10 +59,11 @@ func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructu
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
 	eksActivityInput := EKSActivityInput{
-		OrganizationID: input.OrganizationID,
-		SecretID:       input.SecretID,
-		Region:         input.Region,
-		ClusterName:    input.ClusterName,
+		OrganizationID:            input.OrganizationID,
+		SecretID:                  input.SecretID,
+		Region:                    input.Region,
+		ClusterName:               input.ClusterName,
+		AWSClientRequestTokenBase: input.ClusterUID,
 	}
 
 	// get VPC ID
@@ -70,48 +79,203 @@ func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructu
 		}
 	}
 
-	// get ELBs created by the EKS cluster
-	var ownedELBsOutput GetOwnedELBsActivityOutput
-	{
-		activityInput := GetOwnedELBsActivityInput{
-			OrganizationID: input.OrganizationID,
-			SecretID:       input.SecretID,
-			Region:         input.Region,
-			ClusterName:    input.ClusterName,
-			VpcID:          getVpcConfigActivityOutput.VpcID,
-		}
-
-		if err := workflow.ExecuteActivity(ctx, GetOwnedELBsActivityName, activityInput).Get(ctx, &ownedELBsOutput); err != nil {
-			return err
-		}
-
-	}
-
-	// wait for ELBs to be releases by EKS
-	{
-		if len(ownedELBsOutput.LoadBalancerNames) > 0 {
-			activityInput := WaitELBsDeletionActivityActivityInput{
-				OrganizationID:    input.OrganizationID,
-				SecretID:          input.SecretID,
-				Region:            input.Region,
-				ClusterName:       input.ClusterName,
-				LoadBalancerNames: ownedELBsOutput.LoadBalancerNames,
+	if getVpcConfigActivityOutput.VpcID != "" {
+		// get ELBs created by the EKS cluster
+		var ownedELBsOutput GetOwnedELBsActivityOutput
+		{
+			activityInput := GetOwnedELBsActivityInput{
+				EKSActivityInput: eksActivityInput,
+				VpcID:            getVpcConfigActivityOutput.VpcID,
 			}
 
-			if err := workflow.ExecuteActivity(ctx, WaitELBsDeletionActivityName, activityInput).Get(ctx, nil); err != nil {
+			if err := workflow.ExecuteActivity(ctx, GetOwnedELBsActivityName, activityInput).Get(ctx, &ownedELBsOutput); err != nil {
+				return err
+			}
+
+		}
+
+		// wait for ELBs to be releases by EKS
+		{
+			if len(ownedELBsOutput.LoadBalancerNames) > 0 {
+				activityInput := WaitELBsDeletionActivityActivityInput{
+					EKSActivityInput:  eksActivityInput,
+					LoadBalancerNames: ownedELBsOutput.LoadBalancerNames,
+				}
+
+				if err := workflow.ExecuteActivity(ctx, WaitELBsDeletionActivityName, activityInput).Get(ctx, nil); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// retrieve node pool stack names
+	var getNodepoolStacksActivityOutput GetNodepoolStacksActivityOutput
+	{
+		activityInput := GetNodepoolStacksActivityInput{
+			EKSActivityInput: eksActivityInput,
+			NodePoolNames:    input.NodePoolNames,
+		}
+
+		if err := workflow.ExecuteActivity(ctx, GetNodepoolStacksActivityName, activityInput).Get(ctx, &getNodepoolStacksActivityOutput); err != nil {
+			return err
+		}
+	}
+
+	// delete node pool stacks
+	asgDeleteFutures := make([]workflow.Future, 0)
+	for _, stackName := range getNodepoolStacksActivityOutput.StackNames {
+		logger.With("nodePoolStackName", stackName).Info("node pool stack will be deleted")
+
+		activityInput := DeleteStackActivityInput{
+			EKSActivityInput: eksActivityInput,
+			StackName:        stackName,
+		}
+		f := workflow.ExecuteActivity(ctx, DeleteStackActivityName, activityInput)
+		asgDeleteFutures = append(asgDeleteFutures, f)
+	}
+
+	// wait for ASG's to be deleted
+	errs := make([]error, len(asgDeleteFutures))
+	for i, future := range asgDeleteFutures {
+		errs[i] = future.Get(ctx, nil)
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
+	}
+
+	// delete EKS control plane
+	{
+		activityInput := DeleteControlPlaneActivityInput{
+			EKSActivityInput: eksActivityInput,
+		}
+
+		if err := workflow.ExecuteActivity(ctx, DeleteControlPlaneActivityName, activityInput).Get(ctx, nil); err != nil {
+			return err
+		}
+	}
+
+	// delete SSH key
+	var deleteSSHKeyAcitivityFeature workflow.Future
+	{
+		activityInput := DeleteSshKeyActivityInput{
+			EKSActivityInput: eksActivityInput,
+			SSHKeyName:       generateSSHKeyNameForCluster(input.ClusterName),
+		}
+		deleteSSHKeyAcitivityFeature = workflow.ExecuteActivity(ctx, DeleteSshKeyActivityName, activityInput)
+	}
+
+	if getVpcConfigActivityOutput.VpcID != "" {
+		// retrieve orphan NICs
+		var getNicsOutput GetOrphanNICsActivityOutput
+		{
+			securityGroups := []string{getVpcConfigActivityOutput.NodeSecurityGroupID, getVpcConfigActivityOutput.SecurityGroupID}
+			activityInput := GetOrphanNICsActivityInput{
+				EKSActivityInput: eksActivityInput,
+				VpcID:            getVpcConfigActivityOutput.VpcID,
+				SecurityGroupIDs: securityGroups,
+			}
+
+			if err := workflow.ExecuteActivity(ctx, GetOrphanNICsActivityName, activityInput).Get(ctx, &getNicsOutput); err != nil {
 				return err
 			}
 		}
+
+		// delete orphan NIC's
+		deleteNICFutures := make([]workflow.Future, 0)
+		for _, nicID := range getNicsOutput.NicList {
+
+			activityInput := DeleteOrphanNICActivityInput{
+				EKSActivityInput: eksActivityInput,
+				NicID:            nicID,
+			}
+			f := workflow.ExecuteActivity(ctx, DeleteOrphanNICActivityName, activityInput)
+			deleteNICFutures = append(deleteNICFutures, f)
+		}
+
+		// wait for NIC's to be deleted
+		errs = make([]error, len(deleteNICFutures))
+		for i, future := range deleteNICFutures {
+			errs[i] = future.Get(ctx, nil)
+		}
+		if err := errors.Combine(errs...); err != nil {
+			return err
+		}
 	}
 
-	//TODO: delete node pools
-	//TODO: delete EKS control plane
-	//TODO: delete SSH key
-	//TODO: delete cluster user
-	//TODO: delete orphan NICs
-	//TODO: delete subnets
-	//TODO: delete VPC
-	//TODO: delete IAM user and roles
+	if err := deleteSSHKeyAcitivityFeature.Get(ctx, nil); err != nil {
+		return err
+	}
+
+	// get subnet stack names
+	var subnetStackOutput GetSubnetStacksActivityOutput
+	{
+		activityInput := GetSubnetStacksActivityInput{
+			eksActivityInput,
+		}
+
+		if err := workflow.ExecuteActivity(ctx, GetSubnetStacksActivityName, activityInput).Get(ctx, &subnetStackOutput); err != nil {
+			return err
+		}
+	}
+
+	// delete subnets
+	deleteSubnetFutures := make([]workflow.Future, 0)
+	for _, subnetStackName := range subnetStackOutput.StackNames {
+
+		activityInput := DeleteStackActivityInput{
+			EKSActivityInput: eksActivityInput,
+			StackName:        subnetStackName,
+		}
+		f := workflow.ExecuteActivity(ctx, DeleteStackActivityName, activityInput)
+		deleteSubnetFutures = append(deleteSubnetFutures, f)
+	}
+
+	// wait for stacks to be deleted
+	errs = make([]error, len(deleteSubnetFutures))
+	for i, future := range deleteSubnetFutures {
+		errs[i] = future.Get(ctx, nil)
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
+	}
+
+	// delete cluster stack (VPC, etc)
+	{
+		activityInput := DeleteStackActivityInput{
+			EKSActivityInput: eksActivityInput,
+			StackName:        generateStackNameForCluster(input.ClusterName),
+		}
+
+		if err := workflow.ExecuteActivity(ctx, DeleteStackActivityName, activityInput).Get(ctx, nil); err != nil {
+			return err
+		}
+	}
+
+	// delete IAM user and roles
+	{
+		activityInput := DeleteStackActivityInput{
+			EKSActivityInput: eksActivityInput,
+			StackName:        generateStackNameForIam(input.ClusterName),
+		}
+
+		if err := workflow.ExecuteActivity(ctx, DeleteStackActivityName, activityInput).Get(ctx, nil); err != nil {
+			return err
+		}
+	}
+
+	// delete cluster user acess key & sercret from secret store
+	var deleteClusterUserAccessKeyActivityFeature workflow.Future
+	{
+		activityInput := DeleteClusterUserAccessKeyActivityInput{
+			EKSActivityInput: eksActivityInput,
+		}
+		deleteClusterUserAccessKeyActivityFeature = workflow.ExecuteActivity(ctx, DeleteClusterUserAccessKeyActivityName, activityInput)
+	}
+
+	if err := deleteClusterUserAccessKeyActivityFeature.Get(ctx, nil); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/providers/amazon/eks/workflow/delete_infra_test.go
+++ b/internal/providers/amazon/eks/workflow/delete_infra_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/workflow"
+)
+
+type DeleteClusterInfraWorkflowTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestDeleteClusterInfraWorkflowTestSuite(t *testing.T) {
+	workflow.RegisterWithOptions(DeleteInfrastructureWorkflow, workflow.RegisterOptions{Name: DeleteInfraWorkflowName})
+
+	getVpcConfigActivity := NewGetVpcConfigActivity(nil)
+	activity.RegisterWithOptions(getVpcConfigActivity.Execute, activity.RegisterOptions{Name: GetVpcConfigActivityName})
+
+	getOwnedELBsActivity := NewGetOwnedELBsActivity(nil)
+	activity.RegisterWithOptions(getOwnedELBsActivity.Execute, activity.RegisterOptions{Name: GetOwnedELBsActivityName})
+
+	waitELBsDeletionActivity := NewWaitELBsDeletionActivity(nil)
+	activity.RegisterWithOptions(waitELBsDeletionActivity.Execute, activity.RegisterOptions{Name: WaitELBsDeletionActivityName})
+
+	suite.Run(t, new(DeleteClusterInfraWorkflowTestSuite))
+}
+
+func (s *DeleteClusterInfraWorkflowTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+}
+
+func (s *DeleteClusterInfraWorkflowTestSuite) AfterTest(suiteName, testName string) {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *DeleteClusterInfraWorkflowTestSuite) Test_Successful_Delete_Infra() {
+	workflowInput := DeleteInfrastructureWorkflowInput{
+		Region:         "us-west-1",
+		OrganizationID: 1,
+		SecretID:       "my-secret-id",
+		ClusterName:    "test-cluster-name",
+	}
+
+	eksActivityInput := EKSActivityInput{
+		OrganizationID: workflowInput.OrganizationID,
+		SecretID:       workflowInput.SecretID,
+		Region:         workflowInput.Region,
+		ClusterName:    workflowInput.ClusterName,
+	}
+
+	s.env.OnActivity(GetVpcConfigActivityName, mock.Anything, GetVpcConfigActivityInput{
+		EKSActivityInput: eksActivityInput,
+		StackName:        "pipeline-eks-test-cluster-name",
+	}).Return(&GetVpcConfigActivityOutput{
+		VpcID:               "test-vpc-id",
+		SecurityGroupID:     "test-control-plane-sg-id",
+		NodeSecurityGroupID: "test-node-sg-id",
+	}, nil)
+
+	s.env.OnActivity(GetOwnedELBsActivityName, mock.Anything, GetOwnedELBsActivityInput{
+		OrganizationID: 1,
+		SecretID:       "my-secret-id",
+		Region:         "us-west-1",
+		VpcID:          "test-vpc-id",
+		ClusterName:    workflowInput.ClusterName,
+	}).Return(&GetOwnedELBsActivityOutput{
+		LoadBalancerNames: []string{"test-lb-1", "test-lb-2"},
+	}, nil)
+
+	s.env.OnActivity(WaitELBsDeletionActivityName, mock.Anything, WaitELBsDeletionActivityActivityInput{
+		OrganizationID:    1,
+		SecretID:          "my-secret-id",
+		Region:            "us-west-1",
+		ClusterName:       workflowInput.ClusterName,
+		LoadBalancerNames: []string{"test-lb-1", "test-lb-2"},
+	}).Return(nil)
+
+	s.env.ExecuteWorkflow(DeleteInfraWorkflowName, workflowInput)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}

--- a/internal/providers/amazon/eks/workflow/delete_orphan_nic_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_orphan_nic_activity.go
@@ -1,0 +1,67 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"go.uber.org/cadence/activity"
+
+	zapadapter "logur.dev/adapter/zap"
+
+	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
+)
+
+const DeleteOrphanNICActivityName = "eks-delete-orphan-nic"
+
+// DeleteOrphanNICActivity responsible for deleting asg
+type DeleteOrphanNICActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type DeleteOrphanNICActivityInput struct {
+	EKSActivityInput
+	NicID string
+}
+
+type DeleteOrphanNICActivityOutput struct {
+}
+
+//   DeleteOrphanNICActivity instantiates a new DeleteOrphanNICActivity
+func NewDeleteOrphanNICActivity(awsSessionFactory *AWSSessionFactory) *DeleteOrphanNICActivity {
+	return &DeleteOrphanNICActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *DeleteOrphanNICActivity) Execute(ctx context.Context, input DeleteOrphanNICActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	netSvc := pkgEC2.NewNetworkSvc(ec2.New(awsSession), zapadapter.New(logger.Desugar()))
+	logger.Info("deleting network interface", map[string]interface{}{"nic": input.NicID})
+
+	return netSvc.DeleteNetworkInterface(input.NicID)
+}

--- a/internal/providers/amazon/eks/workflow/delete_ssh_key_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_ssh_key_activity.go
@@ -1,0 +1,74 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"go.uber.org/cadence/activity"
+)
+
+const DeleteSshKeyActivityName = "eks-delete-ssh-key"
+
+type DeleteSshKeyActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type DeleteSshKeyActivityInput struct {
+	EKSActivityInput
+	SSHKeyName string
+}
+
+type DeleteSshKeyActivityOutput struct {
+}
+
+//   DeleteStackActivity instantiates a new DeleteStackActivity
+func NewDeleteSshKeyActivity(awsSessionFactory *AWSSessionFactory) *DeleteSshKeyActivity {
+	return &DeleteSshKeyActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *DeleteSshKeyActivity) Execute(ctx context.Context, input DeleteSshKeyActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+		"sshKeyName", input.SSHKeyName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	logger.Info("deleting ssh key")
+
+	ec2srv := ec2.New(awsSession)
+	deleteKeyPairInput := &ec2.DeleteKeyPairInput{
+		KeyName: aws.String(input.SSHKeyName),
+	}
+	_, err = ec2srv.DeleteKeyPair(deleteKeyPairInput)
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == iam.ErrCodeNoSuchEntityException {
+			return nil
+		}
+	}
+	return nil
+}

--- a/internal/providers/amazon/eks/workflow/delete_stack_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_stack_activity.go
@@ -1,0 +1,106 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
+)
+
+const DeleteStackActivityName = "eks-delete-stack"
+
+// DeleteStackActivity responsible for deleting asg
+type DeleteStackActivity struct {
+	awsSessionFactory      *AWSSessionFactory
+	cloudFormationTemplate string
+}
+
+type DeleteStackActivityInput struct {
+	EKSActivityInput
+
+	// name of the cloud formation template stack
+	StackName string
+}
+
+//   DeleteStackActivityOutput holds the output data of the DeleteStackActivity
+type DeleteStackActivityOutput struct {
+}
+
+//   DeleteStackActivity instantiates a new DeleteStackActivity
+func NewDeleteStackActivity(awsSessionFactory *AWSSessionFactory, cloudFormationTemplate string) *DeleteStackActivity {
+	return &DeleteStackActivity{
+		awsSessionFactory:      awsSessionFactory,
+		cloudFormationTemplate: cloudFormationTemplate,
+	}
+}
+
+func (a *DeleteStackActivity) Execute(ctx context.Context, input DeleteStackActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+		"stackName", input.StackName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	cloudformationClient := cloudformation.New(awsSession)
+
+	logger.Info("deleting stack")
+
+	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, DeleteStackActivityName)
+	deleteStackInput := &cloudformation.DeleteStackInput{
+		ClientRequestToken: aws.String(clientRequestToken),
+		StackName:          aws.String(input.StackName),
+	}
+	_, err = cloudformationClient.DeleteStack(deleteStackInput)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == cloudformation.ErrCodeStackInstanceNotFoundException {
+				return nil
+			}
+		}
+		return err
+	}
+
+	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
+	err = cloudformationClient.WaitUntilStackDeleteComplete(describeStacksInput)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			if awsErr.Code() == request.WaiterResourceNotReadyErrorCode {
+				err = pkgCloudformation.NewAwsStackFailure(err, input.StackName, clientRequestToken, cloudformationClient)
+				err = errors.WrapIff(err, "waiting for %q CF stack create operation to complete failed", input.StackName)
+				if pkgCloudformation.IsErrorFinal(err) {
+					return cadence.NewCustomError(ErrReasonStackFailed, err.Error())
+				}
+				return errors.WrapIff(err, "waiting for %q CF stack create operation to complete failed", input.StackName)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/providers/amazon/eks/workflow/get_nodepool_stacks.go
+++ b/internal/providers/amazon/eks/workflow/get_nodepool_stacks.go
@@ -1,0 +1,108 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+
+	"github.com/banzaicloud/pipeline/internal/global"
+
+	"go.uber.org/cadence/activity"
+
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
+)
+
+const GetNodepoolStacksActivityName = "eks-get-nodepool-stacks"
+
+type GetNodepoolStacksActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type GetNodepoolStacksActivityInput struct {
+	EKSActivityInput
+	NodePoolNames []string
+}
+
+type GetNodepoolStacksActivityOutput struct {
+	StackNames []string
+}
+
+func NewGetNodepoolStacksActivity(awsSessionFactory *AWSSessionFactory) *GetNodepoolStacksActivity {
+	return &GetNodepoolStacksActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *GetNodepoolStacksActivity) Execute(ctx context.Context, input GetNodepoolStacksActivityInput) (*GetNodepoolStacksActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	stackNames := make([]string, 0)
+	uniqueMap := make(map[string]bool, 0)
+
+	for _, nodePool := range input.NodePoolNames {
+		nodePoolStackName := generateNodePoolStackName(input.ClusterName, nodePool)
+		stackNames = append(stackNames, nodePoolStackName)
+		uniqueMap[nodePoolStackName] = true
+	}
+
+	logger.Debugf("stack names from DB: %+v", stackNames)
+
+	oldTags := map[string]string{
+		"pipeline-created":      "true",
+		"pipeline-cluster-name": input.ClusterName,
+		"pipeline-stack-type":   "nodepool",
+	}
+	tags := map[string]string{
+		global.ManagedByPipelineTag:         global.ManagedByPipelineValue,
+		"banzaicloud-pipeline-cluster-name": input.ClusterName,
+		"banzaicloud-pipeline-stack-type":   "nodepool",
+	}
+
+	// for backward compatibility looks for node pool stacks tagged by earlier version of Pipeline
+	cfStackNamesByOldTags, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(awsSession), oldTags)
+	if err != nil {
+		return nil, err
+	}
+
+	cfStackNames, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(awsSession), tags)
+	if err != nil {
+		return nil, err
+	}
+	cfStackNames = append(cfStackNames, cfStackNamesByOldTags...)
+
+	for _, stackName := range cfStackNames {
+		if !uniqueMap[stackName] {
+			stackNames = append(stackNames, stackName)
+		}
+	}
+
+	logger.Debugf("stack names from DB + CF: %+v", stackNames)
+
+	output := GetNodepoolStacksActivityOutput{
+		StackNames: stackNames,
+	}
+	return &output, nil
+}

--- a/internal/providers/amazon/eks/workflow/get_orphan_nics_activity.go
+++ b/internal/providers/amazon/eks/workflow/get_orphan_nics_activity.go
@@ -1,0 +1,87 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"go.uber.org/cadence/activity"
+
+	zapadapter "logur.dev/adapter/zap"
+
+	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
+)
+
+const GetOrphanNICsActivityName = "eks-get-orphan-nics"
+
+type GetOrphanNICsActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type GetOrphanNICsActivityInput struct {
+	EKSActivityInput
+
+	VpcID            string
+	SecurityGroupIDs []string
+}
+
+type GetOrphanNICsActivityOutput struct {
+	NicList []string
+}
+
+func NewGetOrphanNICsActivity(awsSessionFactory *AWSSessionFactory) *GetOrphanNICsActivity {
+	return &GetOrphanNICsActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *GetOrphanNICsActivity) Execute(ctx context.Context, input GetOrphanNICsActivityInput) (*GetOrphanNICsActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	if input.VpcID == "" || len(input.SecurityGroupIDs) == 0 {
+		return nil, nil
+	}
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	netSvc := pkgEC2.NewNetworkSvc(ec2.New(awsSession), zapadapter.New(logger.Desugar()))
+
+	// collect orphan ENIs
+	// CNI plugin applies the following tags to ENIs https://aws.amazon.com/blogs/opensource/vpc-cni-plugin-v1-1-available/
+	tagsFilter := map[string][]string{
+		"node.k8s.amazonaws.com/instance_id": nil,
+	}
+	nics, err := netSvc.GetUnusedNetworkInterfaces(input.VpcID, input.SecurityGroupIDs, tagsFilter)
+	if err != nil {
+		return nil, errors.WrapIf(err, "searching for unused network interfaces failed")
+	}
+
+	logger.Infof("NIC's used by cluster: '%s'", nics)
+
+	output := GetOrphanNICsActivityOutput{
+		NicList: nics,
+	}
+
+	return &output, nil
+}

--- a/internal/providers/amazon/eks/workflow/get_owned_elbs_activity.go
+++ b/internal/providers/amazon/eks/workflow/get_owned_elbs_activity.go
@@ -1,0 +1,129 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"go.uber.org/cadence/activity"
+)
+
+const GetOwnedELBsActivityName = "eks-get-owned-elbs"
+
+// GetOwnedELBsActivity collects all ELBs that were created by the EKS cluster
+type GetOwnedELBsActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+// GetOwnedELBsActivityInput holds fields needed to retrieve all ELBs provisioned by
+// an EKS cluster
+type GetOwnedELBsActivityInput struct {
+	OrganizationID uint
+	SecretID       string
+	Region         string
+
+	VpcID       string
+	ClusterName string
+}
+
+type GetOwnedELBsActivityOutput struct {
+	LoadBalancerNames []string
+}
+
+// NewGetOwnedELBsActivity instantiates a new GetOwnedELBsActivity
+func NewGetOwnedELBsActivity(awsSessionFactory *AWSSessionFactory) *GetOwnedELBsActivity {
+	return &GetOwnedELBsActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *GetOwnedELBsActivity) Execute(ctx context.Context, input GetOwnedELBsActivityInput) (*GetOwnedELBsActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"region", input.Region,
+		"vpcID", input.VpcID,
+		"cluster", input.ClusterName,
+	)
+
+	session, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	elbService := elb.New(session)
+	clusterTag := "kubernetes.io/cluster/" + input.ClusterName
+
+	logger.Infof("search for ELBs with tag '%s'", clusterTag)
+
+	var loadBalancerNames []*string
+	describeLoadBalancers := &elb.DescribeLoadBalancersInput{}
+	var output GetOwnedELBsActivityOutput
+
+	err = elbService.DescribeLoadBalancersPagesWithContext(ctx, describeLoadBalancers,
+		func(page *elb.DescribeLoadBalancersOutput, lastPage bool) bool {
+
+			for _, lb := range page.LoadBalancerDescriptions {
+				if aws.StringValue(lb.VPCId) == input.VpcID {
+					loadBalancerNames = append(loadBalancerNames, lb.LoadBalancerName)
+				}
+			}
+
+			return lastPage
+		})
+
+	if err != nil {
+		return nil, errors.WrapIf(err, "couldn't describe ELBs")
+	}
+
+	if len(loadBalancerNames) == 0 {
+		return &output, nil
+	}
+
+	// according to https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeTags.html
+	// tags can be queried for up to 20 ELBs in one call
+	maxELBNames := 20
+	for low := 0; low < len(loadBalancerNames); low += maxELBNames {
+		high := low + maxELBNames
+
+		if high > len(loadBalancerNames) {
+			high = len(loadBalancerNames)
+		}
+
+		describeTagsInput := &elb.DescribeTagsInput{
+			LoadBalancerNames: loadBalancerNames[low:high],
+		}
+
+		describeTagsOutput, err := elbService.DescribeTagsWithContext(ctx, describeTagsInput)
+		if err != nil {
+			return nil, errors.WrapIf(err, "couldn't describe ELB tags")
+		}
+
+		for _, tagDescription := range describeTagsOutput.TagDescriptions {
+			for _, tag := range tagDescription.Tags {
+				if aws.StringValue(tag.Key) == clusterTag {
+					output.LoadBalancerNames = append(output.LoadBalancerNames, aws.StringValue(tagDescription.LoadBalancerName))
+				}
+			}
+		}
+
+	}
+
+	logger.Infof("ELBs owned by cluster: '%s'", output.LoadBalancerNames)
+
+	return &output, nil
+}

--- a/internal/providers/amazon/eks/workflow/get_owned_elbs_activity.go
+++ b/internal/providers/amazon/eks/workflow/get_owned_elbs_activity.go
@@ -33,12 +33,9 @@ type GetOwnedELBsActivity struct {
 // GetOwnedELBsActivityInput holds fields needed to retrieve all ELBs provisioned by
 // an EKS cluster
 type GetOwnedELBsActivityInput struct {
-	OrganizationID uint
-	SecretID       string
-	Region         string
+	EKSActivityInput
 
-	VpcID       string
-	ClusterName string
+	VpcID string
 }
 
 type GetOwnedELBsActivityOutput struct {

--- a/internal/providers/amazon/eks/workflow/get_subnet_stacks_activity.go
+++ b/internal/providers/amazon/eks/workflow/get_subnet_stacks_activity.go
@@ -1,0 +1,80 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/internal/global"
+
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
+)
+
+const GetSubnetStacksActivityName = "eks-get-subnet-stacks"
+
+// GetSubnetStacksActivity collects all subnet stack names
+type GetSubnetStacksActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+type GetSubnetStacksActivityInput struct {
+	EKSActivityInput
+}
+
+type GetSubnetStacksActivityOutput struct {
+	StackNames []string
+}
+
+func NewGetSubnetStacksActivity(awsSessionFactory *AWSSessionFactory) *GetSubnetStacksActivity {
+	return &GetSubnetStacksActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *GetSubnetStacksActivity) Execute(ctx context.Context, input GetSubnetStacksActivityInput) (*GetSubnetStacksActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"region", input.Region,
+		"cluster", input.ClusterName,
+	)
+
+	session, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	tags := map[string]string{
+		global.ManagedByPipelineTag:         global.ManagedByPipelineValue,
+		"banzaicloud-pipeline-cluster-name": input.ClusterName,
+		"banzaicloud-pipeline-stack-type":   "subnet",
+	}
+
+	cfStackNames, err := pkgCloudformation.GetExistingTaggedStackNames(cloudformation.New(session), tags)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Infof("Subnets used by cluster: '%s'", cfStackNames)
+	output := GetSubnetStacksActivityOutput{
+		StackNames: cfStackNames,
+	}
+
+	return &output, nil
+}

--- a/internal/providers/amazon/eks/workflow/get_vpc_config_activity.go
+++ b/internal/providers/amazon/eks/workflow/get_vpc_config_activity.go
@@ -39,6 +39,7 @@ type GetVpcConfigActivityInput struct {
 
 // GetVpcConfigActivityOutput holds the output data of the GetVpcConfigActivityOutput
 type GetVpcConfigActivityOutput struct {
+	VpcID               string
 	SecurityGroupID     string
 	NodeSecurityGroupID string
 }
@@ -59,32 +60,24 @@ func (a *GetVpcConfigActivity) Execute(ctx context.Context, input GetVpcConfigAc
 
 	cloudformationClient := cloudformation.New(session)
 
-	describeStackResourcesInput := &cloudformation.DescribeStackResourcesInput{
-		StackName: aws.String(input.StackName),
-	}
-
-	stackResources, err := cloudformationClient.DescribeStackResources(describeStackResourcesInput)
+	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
+	describeStacksOutput, err := cloudformationClient.DescribeStacksWithContext(ctx, describeStacksInput)
 	if err != nil {
-		return nil, errors.WrapIfWithDetails(err, "failed to get stack resources", "stack", input.StackName)
+		return nil, errors.WrapIfWithDetails(err, "failed to describe stack", "stack", input.StackName)
 	}
 
-	stackResourceMap := make(map[string]cloudformation.StackResource)
-	for _, res := range stackResources.StackResources {
-		stackResourceMap[*res.LogicalResourceId] = *res
-	}
+	var output GetVpcConfigActivityOutput
 
-	securityGroupResource, found := stackResourceMap["ControlPlaneSecurityGroup"]
-	if !found {
-		return nil, errors.New("unable to find ControlPlaneSecurityGroup resource")
+	for _, outputPrm := range describeStacksOutput.Stacks[0].Outputs {
+		switch aws.StringValue(outputPrm.OutputKey) {
+		case "VpcId":
+			output.VpcID = aws.StringValue(outputPrm.OutputValue)
+		case "SecurityGroups":
+			output.SecurityGroupID = aws.StringValue(outputPrm.OutputValue)
+		case "NodeSecurityGroup":
+			output.NodeSecurityGroupID = aws.StringValue(outputPrm.OutputValue)
+		}
 	}
-	nodeSecurityGroup, found := stackResourceMap["NodeSecurityGroup"]
-	if !found {
-		return nil, errors.New("unable to find NodeSecurityGroup resource")
-	}
-
-	output := GetVpcConfigActivityOutput{}
-	output.SecurityGroupID = aws.StringValue(securityGroupResource.PhysicalResourceId)
-	output.NodeSecurityGroupID = aws.StringValue(nodeSecurityGroup.PhysicalResourceId)
 
 	return &output, nil
 }

--- a/internal/providers/amazon/eks/workflow/update_asg_activity.go
+++ b/internal/providers/amazon/eks/workflow/update_asg_activity.go
@@ -1,0 +1,245 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/prometheus/common/log"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+
+	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
+)
+
+const UpdateAsgActivityName = "eks-update-asg"
+
+const awsNoUpdatesError = "No updates are to be performed."
+
+// UpdateAsgActivity responsible for creating IAM roles
+type UpdateAsgActivity struct {
+	awsSessionFactory *AWSSessionFactory
+	// body of the cloud formation template for setting up the VPC
+	cloudFormationTemplate     string
+	asgFulfillmentWaitAttempts int
+	asgFulfillmentWaitInterval time.Duration
+}
+
+// UpdateAsgActivityInput holds data needed for setting up IAM roles
+type UpdateAsgActivityInput struct {
+	EKSActivityInput
+
+	// name of the cloud formation template stack
+	StackName        string
+	ScaleEnabled     bool
+	Name             string
+	NodeSpotPrice    string
+	Autoscaling      bool
+	NodeMinCount     int
+	NodeMaxCount     int
+	Count            int
+	NodeImage        string
+	NodeInstanceType string
+	Labels           map[string]string
+}
+
+// UpdateAsgActivityOutput holds the output data of the UpdateAsgActivityOutput
+type UpdateAsgActivityOutput struct {
+}
+
+// UpdateAsgActivity instantiates a new UpdateAsgActivity
+func NewUpdateAsgActivity(awsSessionFactory *AWSSessionFactory, cloudFormationTemplate string, asgFulfillmentWaitAttempts int, asgFulfillmentWaitInterval time.Duration) *UpdateAsgActivity {
+	return &UpdateAsgActivity{
+		awsSessionFactory:          awsSessionFactory,
+		cloudFormationTemplate:     cloudFormationTemplate,
+		asgFulfillmentWaitAttempts: asgFulfillmentWaitAttempts,
+		asgFulfillmentWaitInterval: asgFulfillmentWaitInterval,
+	}
+}
+
+func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivityInput) (*UpdateAsgActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+		"secret", input.SecretID,
+		"ami", input.NodeImage,
+		"nodePool", input.Name,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	cloudformationClient := cloudformation.New(awsSession)
+
+	if input.Autoscaling {
+		autoscalingSrv := autoscaling.New(awsSession)
+		// get current Desired count from ASG linked to nodeGroup stack if Autoscaling is enabled,
+		// as we don't to override in this case only min/max counts
+		asg, err := getAutoScalingGroup(cloudformationClient, autoscalingSrv, input.StackName)
+		if err != nil {
+			return nil, errors.WrapIff(err, "unable to find ASG for node pool %q", input.Name)
+		}
+
+		// override nodePool.Count with current DesiredCapacity in case of autoscale, as we don't want allow direct
+		// setting of DesiredCapacity via API, however we have to limit it to be between new min, max values.
+		if asg != nil {
+			if asg.DesiredCapacity != nil {
+				input.Count = int(*asg.DesiredCapacity)
+			}
+			if input.Count < input.NodeMinCount {
+				input.Count = input.NodeMinCount
+			} else if input.Count > input.NodeMaxCount {
+				input.Count = input.NodeMaxCount
+			}
+			log.Infof("DesiredCapacity for %v will be: %v", aws.StringValue(asg.AutoScalingGroupARN), input.Count)
+		}
+
+	}
+
+	logger.With("stackName", input.StackName).Info("updating stack")
+
+	// update stack
+	clusterAutoscalerEnabled := false
+	terminationDetachEnabled := false
+
+	if input.Autoscaling {
+		clusterAutoscalerEnabled = true
+	}
+
+	// if ScaleOptions is enabled on cluster, ClusterAutoscaler is disabled on all node pools
+	if input.ScaleEnabled {
+		clusterAutoscalerEnabled = false
+		terminationDetachEnabled = true
+	}
+
+	tags := getNodePoolStackTags(input.ClusterName)
+
+	stackParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:     aws.String("KeyName"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeImageId"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeInstanceType"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeSpotPrice"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:   aws.String("NodeAutoScalingGroupMinSize"),
+			ParameterValue: aws.String(fmt.Sprintf("%d", input.NodeMinCount)),
+		},
+		{
+			ParameterKey:   aws.String("NodeAutoScalingGroupMaxSize"),
+			ParameterValue: aws.String(fmt.Sprintf("%d", input.NodeMaxCount)),
+		},
+		{
+			ParameterKey:   aws.String("NodeAutoScalingInitSize"),
+			ParameterValue: aws.String(fmt.Sprintf("%d", input.Count)),
+		},
+		{
+			ParameterKey:     aws.String("ClusterName"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeGroupName"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("ClusterControlPlaneSecurityGroup"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeSecurityGroup"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("VpcId"),
+			UsePreviousValue: aws.Bool(true),
+		}, {
+			ParameterKey:     aws.String("Subnets"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String("NodeInstanceRoleId"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
+			ParameterValue: aws.String(fmt.Sprint(clusterAutoscalerEnabled)),
+		},
+		{
+			ParameterKey:   aws.String("TerminationDetachEnabled"),
+			ParameterValue: aws.String(fmt.Sprint(terminationDetachEnabled)),
+		},
+		{
+			ParameterKey:     aws.String("BootstrapArguments"),
+			UsePreviousValue: aws.Bool(true),
+		},
+	}
+
+	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, UpdateAsgActivityName)
+
+	// we don't reuse the creation time template, since it may have changed
+	updateStackInput := &cloudformation.UpdateStackInput{
+		ClientRequestToken: aws.String(clientRequestToken),
+		StackName:          aws.String(input.StackName),
+		Capabilities:       []*string{aws.String(cloudformation.CapabilityCapabilityIam)},
+		Parameters:         stackParams,
+		Tags:               tags,
+		TemplateBody:       aws.String(a.cloudFormationTemplate),
+	}
+
+	_, err = cloudformationClient.UpdateStack(updateStackInput)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ValidationError" && strings.HasPrefix(awsErr.Message(), awsNoUpdatesError) {
+			// Get error details
+			log.Warnf("nothing changed during update!")
+			err = nil // nolint: ineffassign
+		} else {
+			var awsErr awserr.Error
+			if errors.As(err, &awsErr) {
+				if awsErr.Code() == request.WaiterResourceNotReadyErrorCode {
+					err = pkgCloudformation.NewAwsStackFailure(err, input.StackName, clientRequestToken, cloudformationClient)
+					err = errors.WrapIff(err, "waiting for %q CF stack create operation to complete failed", input.StackName)
+					if pkgCloudformation.IsErrorFinal(err) {
+						return nil, cadence.NewCustomError(ErrReasonStackFailed, err.Error())
+					}
+					return nil, errors.WrapIff(err, "waiting for %q CF stack create operation to complete failed", input.StackName)
+				}
+			}
+		}
+	}
+
+	outParams := UpdateAsgActivityOutput{}
+	return &outParams, nil
+}

--- a/internal/providers/amazon/eks/workflow/update_cluster.go
+++ b/internal/providers/amazon/eks/workflow/update_cluster.go
@@ -1,0 +1,218 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/workflow"
+)
+
+const UpdateClusterWorkflowName = "eks-update-cluster"
+
+// UpdateClusterstructureWorkflowInput holds data needed to update EKS cluster worker node pools
+type UpdateClusterstructureWorkflowInput struct {
+	Region         string
+	OrganizationID uint
+	SecretID       string
+
+	ClusterUID   string
+	ClusterName  string
+	ScaleEnabled bool
+
+	Subnets          []Subnet
+	ASGSubnetMapping map[string][]Subnet
+
+	NodeInstanceRoleID string
+	AsgList            []AutoscaleGroup
+}
+
+// UpdateClusterstructureWorkflow executes the Cadence workflow responsible for updating EKS worker nodes
+func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterstructureWorkflowInput) error {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: 10 * time.Minute,
+		StartToCloseTimeout:    5 * time.Minute,
+		WaitForCancellation:    true,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:          2 * time.Second,
+			BackoffCoefficient:       1.5,
+			MaximumInterval:          30 * time.Second,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic"},
+		},
+	}
+
+	logger := workflow.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+	)
+
+	commonActivityInput := EKSActivityInput{
+		OrganizationID:            input.OrganizationID,
+		SecretID:                  input.SecretID,
+		Region:                    input.Region,
+		ClusterName:               input.ClusterName,
+		AWSClientRequestTokenBase: input.ClusterUID,
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var vpcActivityOutput GetVpcConfigActivityOutput
+	{
+		activityInput := &GetVpcConfigActivityInput{
+			EKSActivityInput: commonActivityInput,
+			StackName:        generateStackNameForCluster(input.ClusterName),
+		}
+		err := workflow.ExecuteActivity(ctx, GetVpcConfigActivityName, activityInput).Get(ctx, &vpcActivityOutput)
+		if err != nil {
+			return err
+		}
+	}
+
+	asgFutures := make([]workflow.Future, 0)
+
+	sshKeyName := generateSSHKeyNameForCluster(input.ClusterName)
+
+	for _, nodePool := range input.AsgList {
+
+		log := logger.With("nodePool", nodePool.Name)
+
+		if nodePool.Delete {
+
+			log.Info("node pool will be deleted")
+
+			activityInput := DeleteStackActivityInput{
+				EKSActivityInput: commonActivityInput,
+				StackName:        generateNodePoolStackName(input.ClusterName, nodePool.Name),
+			}
+			f := workflow.ExecuteActivity(ctx, DeleteStackActivityName, activityInput)
+			asgFutures = append(asgFutures, f)
+
+		} else if nodePool.Create {
+
+			log.Info("node pool will be created")
+
+			asgSubnets := input.ASGSubnetMapping[nodePool.Name]
+			for i := range asgSubnets {
+				for _, sn := range input.Subnets {
+					if (asgSubnets[i].SubnetID == "" && sn.Cidr == asgSubnets[i].Cidr) ||
+						(asgSubnets[i].SubnetID != "" && sn.SubnetID == asgSubnets[i].SubnetID) {
+						asgSubnets[i].SubnetID = sn.SubnetID
+						asgSubnets[i].Cidr = sn.Cidr
+						asgSubnets[i].AvailabilityZone = sn.AvailabilityZone
+					}
+				}
+			}
+
+			activityInput := CreateAsgActivityInput{
+				EKSActivityInput: commonActivityInput,
+				StackName:        generateNodePoolStackName(input.ClusterName, nodePool.Name),
+
+				ScaleEnabled: input.ScaleEnabled,
+				SSHKeyName:   sshKeyName,
+
+				Subnets: asgSubnets,
+
+				VpcID:               vpcActivityOutput.VpcID,
+				SecurityGroupID:     vpcActivityOutput.SecurityGroupID,
+				NodeSecurityGroupID: vpcActivityOutput.NodeSecurityGroupID,
+				NodeInstanceRoleID:  input.NodeInstanceRoleID,
+
+				Name:             nodePool.Name,
+				NodeSpotPrice:    nodePool.NodeSpotPrice,
+				Autoscaling:      nodePool.Autoscaling,
+				NodeMinCount:     nodePool.NodeMinCount,
+				NodeMaxCount:     nodePool.NodeMaxCount,
+				Count:            nodePool.Count,
+				NodeImage:        nodePool.NodeImage,
+				NodeInstanceType: nodePool.NodeInstanceType,
+				Labels:           nodePool.Labels,
+			}
+			f := workflow.ExecuteActivity(ctx, CreateAsgActivityName, activityInput)
+			asgFutures = append(asgFutures, f)
+		} else {
+			// update nodePool
+			log.Info("node pool will be updated")
+
+			activityInput := UpdateAsgActivityInput{
+				EKSActivityInput: commonActivityInput,
+				StackName:        generateNodePoolStackName(input.ClusterName, nodePool.Name),
+				ScaleEnabled:     input.ScaleEnabled,
+				Name:             nodePool.Name,
+				NodeSpotPrice:    nodePool.NodeSpotPrice,
+				Autoscaling:      nodePool.Autoscaling,
+				NodeMinCount:     nodePool.NodeMinCount,
+				NodeMaxCount:     nodePool.NodeMaxCount,
+				Count:            nodePool.Count,
+				NodeImage:        nodePool.NodeImage,
+				NodeInstanceType: nodePool.NodeInstanceType,
+				Labels:           nodePool.Labels,
+			}
+			f := workflow.ExecuteActivity(ctx, UpdateAsgActivityName, activityInput)
+			asgFutures = append(asgFutures, f)
+		}
+	}
+
+	// wait for AutoScalingGroups to be created
+	errs := make([]error, len(asgFutures))
+	for i, future := range asgFutures {
+		var activityOutput CreateAsgActivityOutput
+		errs[i] = future.Get(ctx, &activityOutput)
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getAutoScalingGroup(cloudformationSrv *cloudformation.CloudFormation, autoscalingSrv *autoscaling.AutoScaling, stackName string) (*autoscaling.Group, error) {
+	describeStackResourceInput := &cloudformation.DescribeStackResourcesInput{
+		StackName: aws.String(stackName),
+	}
+	stackResources, err := cloudformationSrv.DescribeStackResources(describeStackResourceInput)
+	if err != nil {
+		return nil, errors.WrapIfWithDetails(err, "failed to get stack resources", "stack", stackName)
+	}
+
+	var asgId *string
+	for _, res := range stackResources.StackResources {
+		if aws.StringValue(res.LogicalResourceId) == "NodeGroup" {
+			asgId = res.PhysicalResourceId
+			break
+		}
+	}
+
+	if asgId == nil {
+		return nil, nil
+	}
+
+	describeAutoScalingGroupsInput := autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			asgId,
+		},
+	}
+	describeAutoScalingGroupsOutput, err := autoscalingSrv.DescribeAutoScalingGroups(&describeAutoScalingGroupsInput)
+	if err != nil {
+		return nil, err
+	}
+
+	return describeAutoScalingGroupsOutput.AutoScalingGroups[0], nil
+}

--- a/internal/providers/amazon/eks/workflow/wait_elbs_deletion_activity.go
+++ b/internal/providers/amazon/eks/workflow/wait_elbs_deletion_activity.go
@@ -1,0 +1,115 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"go.uber.org/cadence/activity"
+)
+
+const WaitELBsDeletionActivityName = "eks-wait-elbs-deletion"
+
+// WaitELBsDeletionActivity waits for the deletion of a list of ELBs identified by name
+type WaitELBsDeletionActivity struct {
+	awsSessionFactory *AWSSessionFactory
+}
+
+// WaitELBsDeletionActivity holds the names of the ELBs to wait for to be deleted
+type WaitELBsDeletionActivityActivityInput struct {
+	OrganizationID uint
+	SecretID       string
+	Region         string
+
+	ClusterName string
+
+	LoadBalancerNames []string
+}
+
+// NewWaitELBsDeletionActivity instantiates a new NewWaitELBsDeletionActivity
+func NewWaitELBsDeletionActivity(awsSessionFactory *AWSSessionFactory) *WaitELBsDeletionActivity {
+	return &WaitELBsDeletionActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *WaitELBsDeletionActivity) Execute(ctx context.Context, input WaitELBsDeletionActivityActivityInput) error {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"region", input.Region,
+		"cluster", input.ClusterName,
+	)
+
+	session, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	elbService := elb.New(session)
+	loadBalancersToWait := input.LoadBalancerNames
+
+	i := 0
+	for {
+		var remaining []string
+
+		select {
+		case <-ticker.C:
+			if i < 5 {
+				i++
+
+				logger.With("ELBs", loadBalancersToWait).Info("waiting for ELBs to be deleted")
+
+				for _, lbName := range loadBalancersToWait {
+					describeLoadBalancers := &elb.DescribeLoadBalancersInput{
+						LoadBalancerNames: aws.StringSlice([]string{lbName}),
+					}
+
+					_, err := elbService.DescribeLoadBalancersWithContext(ctx, describeLoadBalancers)
+					if err != nil {
+						var awsErr awserr.Error
+						if errors.As(err, &awsErr) && awsErr.Code() == elb.ErrCodeAccessPointNotFoundException {
+							continue
+						}
+
+						if err = errors.WrapIf(err, "couldn't describe ELBs"); err != nil {
+							return err
+						}
+
+					}
+
+					remaining = append(remaining, lbName)
+				}
+
+				loadBalancersToWait = remaining
+				if len(loadBalancersToWait) == 0 {
+					return nil
+				}
+			} else {
+				return errors.New("waiting for ELBs to be deleted timed out")
+			}
+		case <-ctx.Done():
+			return nil
+
+		}
+	}
+}

--- a/internal/providers/amazon/eks/workflow/wait_elbs_deletion_activity.go
+++ b/internal/providers/amazon/eks/workflow/wait_elbs_deletion_activity.go
@@ -34,12 +34,7 @@ type WaitELBsDeletionActivity struct {
 
 // WaitELBsDeletionActivity holds the names of the ELBs to wait for to be deleted
 type WaitELBsDeletionActivityActivityInput struct {
-	OrganizationID uint
-	SecretID       string
-	Region         string
-
-	ClusterName string
-
+	EKSActivityInput
 	LoadBalancerNames []string
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
EKS cluster update & delete flow re-implemented using Cadence workflow


### Why?
Cadence workflow adds more resiliency to EKS cluster delete & update and ability to continue the flow in case an error occurred after the error has been remedied.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
