### PR TITLE
[Logging] Add service labels to output definitions and flow

### DIFF
--- a/internal/clusterfeature/features/logging/common.go
+++ b/internal/clusterfeature/features/logging/common.go
@@ -50,7 +50,7 @@ const (
 
 	lokiOutputDefinitionName = "loki-output"
 	flowResourceName         = "banzai-logging-flow"
-	resourceLabelKey         = "service"
+	resourceLabelKey         = "banzaicloud.io/service"
 )
 
 func getLokiSecretName(clusterID uint) string {

--- a/internal/clusterfeature/features/logging/common.go
+++ b/internal/clusterfeature/features/logging/common.go
@@ -50,6 +50,7 @@ const (
 
 	lokiOutputDefinitionName = "loki-output"
 	flowResourceName         = "banzai-logging-flow"
+	resourceLabelKey         = "service"
 )
 
 func getLokiSecretName(clusterID uint) string {

--- a/internal/clusterfeature/features/logging/operator_flow_resource.go
+++ b/internal/clusterfeature/features/logging/operator_flow_resource.go
@@ -28,6 +28,7 @@ func (op FeatureOperator) createClusterFlowResource(ctx context.Context, manager
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      flowResourceName,
 			Namespace: op.config.Namespace,
+			Labels:    map[string]string{resourceLabelKey: featureName},
 		},
 	}); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to delete flow resource")
@@ -48,6 +49,7 @@ func (op FeatureOperator) generateFlowResource(definitions []outputDefinitionMan
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      flowResourceName,
 			Namespace: op.config.Namespace,
+			Labels:    map[string]string{resourceLabelKey: featureName},
 		},
 		Spec: v1beta1.FlowSpec{
 			Selectors:  map[string]string{},

--- a/internal/clusterfeature/features/logging/operator_output_definition.go
+++ b/internal/clusterfeature/features/logging/operator_output_definition.go
@@ -56,9 +56,9 @@ func (op FeatureOperator) createClusterOutputDefinitions(ctx context.Context, sp
 		})
 	}
 
-	// remove old output definitions
+	// remove old output definitions with feature labels
 	var outputList v1beta1.ClusterOutputList
-	if err := op.kubernetesService.List(ctx, cl.GetID(), nil, &outputList); err != nil {
+	if err := op.kubernetesService.List(ctx, cl.GetID(), map[string]string{resourceLabelKey: featureName}, &outputList); err != nil {
 		return nil, errors.WrapIf(err, "failed to list output definitions")
 	}
 

--- a/internal/clusterfeature/features/logging/output_definition.go
+++ b/internal/clusterfeature/features/logging/output_definition.go
@@ -85,6 +85,7 @@ func generateOutputDefinition(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.getName(),
 			Namespace: namespace,
+			Labels:    map[string]string{resourceLabelKey: featureName},
 		},
 		Spec: m.getOutputSpec(spec.Bucket, *bucketOptions),
 	}, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add service labels to output definitions and flow

### Why?
In case of service update now we delete all previously created `ClusterOutput`-s and `ClusterFlow`. With this change we can granted to delete only those `ClusterOutput`-s and `ClusterFlow` that we created with Pipeline


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
