### PR TITLE
Relocate kube system label posthook

### DIFF
--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -25,10 +25,6 @@ import (
 // HookMap for api hook endpoints
 // nolint: gochecknoglobals
 var HookMap = map[string]PostFunctioner{
-	pkgCluster.LabelKubeSystemNamespacePostHook: &BasePostFunction{
-		f:            LabelKubeSystemNamespacePostHook,
-		ErrorHandler: ErrorHandler{},
-	},
 	pkgCluster.InstallIngressControllerPostHook: &BasePostFunction{
 		f:            InstallIngressControllerPostHook,
 		ErrorHandler: ErrorHandler{},
@@ -79,7 +75,6 @@ var HookMap = map[string]PostFunctioner{
 // nolint: gochecknoglobals
 var BasePostHookFunctions = []string{
 	pkgCluster.LabelNodesWithNodePoolName,
-	pkgCluster.LabelKubeSystemNamespacePostHook,
 	pkgCluster.InstallNodePoolLabelSetOperator,
 	pkgCluster.SetupNodePoolLabelsSet,
 	pkgCluster.InstallIngressControllerPostHook,

--- a/cluster/hooks.go
+++ b/cluster/hooks.go
@@ -290,22 +290,6 @@ func InstallHorizontalPodAutoscalerPostHook(cluster CommonCluster) error {
 		"hpa-operator", valuesOverride, chartVersion, false)
 }
 
-func LabelKubeSystemNamespacePostHook(cluster CommonCluster) error {
-	kubeConfig, err := cluster.GetK8sConfig()
-	if err != nil {
-		log.Errorf("Unable to fetch config for posthook: %s", err.Error())
-		return err
-	}
-
-	client, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
-	if err != nil {
-		log.Errorf("Could not get kubernetes client: %s", err)
-		return err
-	}
-
-	return k8sutil.EnsureLabelsOnNamespace(client, k8sutil.KubeSystemNamespace, map[string]string{"name": k8sutil.KubeSystemNamespace})
-}
-
 // LabelNodesWithNodePoolName add node pool name labels for all nodes.
 // It's used only used in case of ACK etc. when we're not able to add labels via API.
 func LabelNodesWithNodePoolName(commonCluster CommonCluster) error {

--- a/internal/cluster/clustersetup/activity_label_kube_system_namespace.go
+++ b/internal/cluster/clustersetup/activity_label_kube_system_namespace.go
@@ -1,0 +1,74 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustersetup
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/banzaicloud/pipeline/internal/cluster"
+	"github.com/banzaicloud/pipeline/pkg/k8sutil"
+)
+
+const LabelKubeSystemNamespaceActivityName = "label-kube-system-namespace"
+
+type LabelKubeSystemNamespaceActivity struct {
+	clientFactory cluster.ClientFactory
+}
+
+// NewLabelKubeSystemNamespaceActivity returns a new LabelKubeSystemNamespaceActivity.
+func NewLabelKubeSystemNamespaceActivity(
+	clientFactory cluster.ClientFactory,
+) LabelKubeSystemNamespaceActivity {
+	return LabelKubeSystemNamespaceActivity{
+		clientFactory: clientFactory,
+	}
+}
+
+type LabelKubeSystemNamespaceActivityInput struct {
+	// Kubernetes cluster config secret ID.
+	ConfigSecretID string
+}
+
+func (a LabelKubeSystemNamespaceActivity) Execute(ctx context.Context, input LabelKubeSystemNamespaceActivityInput) error {
+	client, err := a.clientFactory.FromSecret(ctx, input.ConfigSecretID)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := client.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
+	}
+
+	labels := map[string]string{"name": k8sutil.KubeSystemNamespace}
+
+	if namespace.Labels == nil {
+		namespace.Labels = make(map[string]string, len(labels))
+	}
+
+	for k, v := range labels {
+		namespace.Labels[k] = v
+	}
+
+	_, err = client.CoreV1().Namespaces().Update(namespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to update namespace")
+	}
+
+	return nil
+}

--- a/internal/cluster/clustersetup/activity_label_kube_system_namespace_test.go
+++ b/internal/cluster/clustersetup/activity_label_kube_system_namespace_test.go
@@ -1,0 +1,119 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustersetup
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/testsuite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/testing_frameworks/integration"
+
+	"github.com/banzaicloud/pipeline/internal/cluster"
+	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+)
+
+// nolint: gochecknoglobals
+var labelKubeSystemNamespaceTestActivity = LabelKubeSystemNamespaceActivity{}
+
+func testLabelKubeSystemNamespaceActivityExecute(ctx context.Context, input LabelKubeSystemNamespaceActivityInput) error {
+	return labelKubeSystemNamespaceTestActivity.Execute(ctx, input)
+}
+
+// nolint: gochecknoinits
+func init() {
+	activity.RegisterWithOptions(testLabelKubeSystemNamespaceActivityExecute, activity.RegisterOptions{Name: LabelKubeSystemNamespaceActivityName})
+}
+
+type LabelKubeSystemNamespaceActivityTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestActivityEnvironment
+
+	controlPlane *integration.ControlPlane
+
+	client kubernetes.Interface
+}
+
+func testLabelKubeSystemNamespaceActivity(t *testing.T) {
+	if os.Getenv("TEST_ASSET_KUBE_APISERVER") == "" || os.Getenv("TEST_ASSET_ETCD") == "" {
+		t.Skip("control plane binaries are missing")
+	}
+
+	suite.Run(t, new(LabelKubeSystemNamespaceActivityTestSuite))
+}
+
+func (s *LabelKubeSystemNamespaceActivityTestSuite) SetupSuite() {
+	s.controlPlane = &integration.ControlPlane{}
+
+	err := s.controlPlane.Start()
+	s.Require().NoError(err)
+}
+
+func (s *LabelKubeSystemNamespaceActivityTestSuite) TearDownSuite() {
+	_ = s.controlPlane.Stop()
+}
+
+func (s *LabelKubeSystemNamespaceActivityTestSuite) SetupTest() {
+	s.env = s.NewTestActivityEnvironment()
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: s.controlPlane.APIURL().String()}},
+	).ClientConfig()
+	s.Require().NoError(err)
+
+	client, err := k8sclient.NewClientFromConfig(config)
+	s.Require().NoError(err)
+
+	s.client = client
+}
+
+func (s *LabelKubeSystemNamespaceActivityTestSuite) Test_Execute() {
+	clientFactory := new(cluster.MockClientFactory)
+	clientFactory.On("FromSecret", mock.Anything, "secret").Return(s.client, nil)
+
+	labelKubeSystemNamespaceTestActivity = NewLabelKubeSystemNamespaceActivity(clientFactory)
+
+	_, err := s.env.ExecuteActivity(
+		LabelKubeSystemNamespaceActivityName,
+		LabelKubeSystemNamespaceActivityInput{
+			ConfigSecretID: "secret",
+		},
+	)
+
+	s.Require().NoError(err)
+
+	namespace, err := s.client.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	s.Assert().Equal(
+		map[string]string{
+			"name": "kube-system",
+		},
+		namespace.Labels,
+	)
+
+	clientFactory.AssertExpectations(s.T())
+}

--- a/internal/cluster/clustersetup/integration_test.go
+++ b/internal/cluster/clustersetup/integration_test.go
@@ -26,4 +26,5 @@ func TestIntegration(t *testing.T) {
 	}
 
 	t.Run("CreatePipelineNamespaceActivity", testCreatePipelineNamespaceActivity)
+	t.Run("LabelKubeSystemNamespaceActivity", testLabelKubeSystemNamespaceActivity)
 }

--- a/internal/cluster/clustersetup/workflow.go
+++ b/internal/cluster/clustersetup/workflow.go
@@ -96,6 +96,17 @@ func (w Workflow) Execute(ctx workflow.Context, input WorkflowInput) error {
 	}
 
 	{
+		activityInput := LabelKubeSystemNamespaceActivityInput{
+			ConfigSecretID: input.ConfigSecretID,
+		}
+
+		err := workflow.ExecuteActivity(ctx, LabelKubeSystemNamespaceActivityName, activityInput).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	{
 		activityInput := InstallTillerActivityInput{
 			ConfigSecretID: input.ConfigSecretID,
 			Distribution:   input.Cluster.Distribution,

--- a/internal/cluster/clustersetup/workflow_test.go
+++ b/internal/cluster/clustersetup/workflow_test.go
@@ -67,6 +67,12 @@ func (s *WorkflowTestSuite) Test_Success() {
 	).Return(nil)
 
 	s.env.OnActivity(
+		LabelKubeSystemNamespaceActivityName,
+		mock.Anything,
+		LabelKubeSystemNamespaceActivityInput{ConfigSecretID: "secret"},
+	).Return(nil)
+
+	s.env.OnActivity(
 		InstallTillerActivityName,
 		mock.Anything,
 		InstallTillerActivityInput{ConfigSecretID: "secret", Distribution: testCluster.Distribution},
@@ -106,6 +112,12 @@ func (s *WorkflowTestSuite) Test_Success_InstallInitManifest() {
 		CreatePipelineNamespaceActivityName,
 		mock.Anything,
 		CreatePipelineNamespaceActivityInput{ConfigSecretID: "secret"},
+	).Return(nil)
+
+	s.env.OnActivity(
+		LabelKubeSystemNamespaceActivityName,
+		mock.Anything,
+		LabelKubeSystemNamespaceActivityInput{ConfigSecretID: "secret"},
 	).Return(nil)
 
 	s.env.OnActivity(

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -72,7 +72,6 @@ const (
 
 // constants for posthooks
 const (
-	LabelKubeSystemNamespacePostHook       = "LabelKubeSystemNamespacePostHook"
 	InstallIngressControllerPostHook       = "InstallIngressControllerPostHook"
 	InstallKubernetesDashboardPostHook     = "InstallKubernetesDashboardPostHook"
 	InstallClusterAutoscalerPostHook       = "InstallClusterAutoscalerPostHook"

--- a/pkg/k8sutil/namespace.go
+++ b/pkg/k8sutil/namespace.go
@@ -83,27 +83,3 @@ func EnsureNamespaceWithLabelWithRetry(client kubernetes.Interface, namespace st
 	}, backoffPolicy)
 	return
 }
-
-// EnsureLabelsOnNamespace adds a set of labels a namespace, overwriting existing label keys
-func EnsureLabelsOnNamespace(client kubernetes.Interface, namespace string, labels map[string]string) error {
-
-	namespaceObj, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
-	if err != nil {
-		return emperror.Wrap(err, "failed to get namespace")
-	}
-
-	if namespaceObj.Labels == nil {
-		namespaceObj.Labels = make(map[string]string, len(labels))
-	}
-
-	for k, v := range labels {
-		namespaceObj.Labels[k] = v
-	}
-
-	_, err = client.CoreV1().Namespaces().Update(namespaceObj)
-	if err != nil {
-		return emperror.Wrap(err, "failed to update namespace")
-	}
-
-	return nil
-}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Relocate kube system label posthook to cluster setup workflow


### Why?
Posthooks are deprecated

