### PR TITLE
Fix config secret ID in azure PKE cluster setup

### DIFF
--- a/internal/providers/azure/pke/workflow/create_cluster.go
+++ b/internal/providers/azure/pke/workflow/create_cluster.go
@@ -26,6 +26,7 @@ import (
 	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/azure/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow"
+	"github.com/banzaicloud/pipeline/pkg/brn"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
@@ -133,7 +134,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 
 	{
 		workflowInput := clustersetup.WorkflowInput{
-			ConfigSecretID: configSecretID,
+			ConfigSecretID: brn.New(input.OrganizationID, brn.SecretResourceType, configSecretID).String(),
 			Cluster: clustersetup.Cluster{
 				ID:   input.ClusterID,
 				UID:  input.ClusterUID,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2535
| License         | Apache 2.0


### What's in this PR?

This PR fixes the Azure PKE cluster create flow to pass a BRN to the cluster setup workflow.


### Why?
Cluster setup workflow needs a BRN formatted secret ID.