### PR TITLE
Relocate label nodes posthook

### DIFF
--- a/cluster/ack.go
+++ b/cluster/ack.go
@@ -43,7 +43,6 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/ack"
 	"github.com/banzaicloud/pipeline/pkg/cluster/ack/action"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/providers/alibaba"
@@ -90,7 +89,7 @@ func (c *ACKCluster) SetTTL(ttl time.Duration) {
 	c.modelCluster.TtlMinutes = uint(ttl.Minutes())
 }
 
-func (c *ACKCluster) ListNodeNames() (pkgCommon.NodeNames, error) {
+func (c *ACKCluster) ListNodeNames() (map[string][]string, error) {
 	essClient, err := c.GetAlibabaESSClient(nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *ACKCluster) ListNodeNames() (pkgCommon.NodeNames, error) {
 	describeInstancesRequest.SetContentType(requests.Json)
 	describeInstancesRequest.RegionId = c.modelCluster.ACK.RegionID
 
-	nodes := make(pkgCommon.NodeNames, 0)
+	nodes := make(map[string][]string, 0)
 	for _, nodepool := range c.modelCluster.ACK.NodePools {
 		request.ScalingGroupId = nodepool.AsgID
 		request.ScalingConfigurationId = nodepool.ScalingConfigID

--- a/cluster/aks.go
+++ b/cluster/aks.go
@@ -37,7 +37,6 @@ import (
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgClusterAzure "github.com/banzaicloud/pipeline/pkg/cluster/aks"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgAzure "github.com/banzaicloud/pipeline/pkg/providers/azure"
 	"github.com/banzaicloud/pipeline/secret"
@@ -961,7 +960,7 @@ func (c *AKSCluster) RequiresSshPublicKey() bool {
 }
 
 // ListNodeNames returns node names to label them
-func (c *AKSCluster) ListNodeNames() (labels pkgCommon.NodeNames, err error) {
+func (c *AKSCluster) ListNodeNames() (labels map[string][]string, err error) {
 	cc, err := c.getCloudConnection()
 	if err != nil {
 		return nil, emperror.Wrap(err, "failed to create cloud connection")

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -90,7 +90,7 @@ type CommonCluster interface {
 	// Cluster info
 	GetStatus() (*pkgCluster.GetClusterStatusResponse, error)
 	IsReady() (bool, error)
-	ListNodeNames() (pkgCommon.NodeNames, error)
+	ListNodeNames() (map[string][]string, error)
 	NodePoolExists(nodePoolName string) bool
 
 	SetStatus(status, statusMessage string) error

--- a/cluster/common.go
+++ b/cluster/common.go
@@ -90,7 +90,6 @@ type CommonCluster interface {
 	// Cluster info
 	GetStatus() (*pkgCluster.GetClusterStatusResponse, error)
 	IsReady() (bool, error)
-	ListNodeNames() (map[string][]string, error)
 	NodePoolExists(nodePoolName string) bool
 
 	SetStatus(status, statusMessage string) error

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/secret"
 )
 
@@ -237,7 +236,7 @@ func (c *DummyCluster) GetK8sConfig() ([]byte, error) {
 }
 
 // ListNodeNames returns node names to label them
-func (c *DummyCluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (c *DummyCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	return
 }
 

--- a/cluster/dummy.go
+++ b/cluster/dummy.go
@@ -235,11 +235,6 @@ func (c *DummyCluster) GetK8sConfig() ([]byte, error) {
 	return c.DownloadK8sConfig()
 }
 
-// ListNodeNames returns node names to label them
-func (c *DummyCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	return
-}
-
 // RbacEnabled returns true if rbac enabled on the cluster
 func (c *DummyCluster) RbacEnabled() bool {
 	return c.modelCluster.RbacEnabled

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -732,18 +732,6 @@ func (c *EC2ClusterPKE) GetNodePools() []PKENodePool {
 	return pools
 }
 
-// ListNodeNames returns node names to label them
-func (c *EC2ClusterPKE) ListNodeNames() (map[string][]string, error) {
-	var nodes = make(map[string][]string)
-	for _, nodepool := range c.model.NodePools {
-		nodes[nodepool.Name] = []string{}
-		for _, host := range nodepool.Hosts {
-			nodes[nodepool.Name] = append(nodes[nodepool.Name], host.Name)
-		}
-	}
-	return nodes, nil
-}
-
 // ListNodePools returns node pool names.
 func (c *EC2ClusterPKE) ListNodePools() ([]string, error) {
 	var nodePools = make([]string, 0, len(c.model.NodePools))

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -744,6 +744,17 @@ func (c *EC2ClusterPKE) ListNodeNames() (map[string][]string, error) {
 	return nodes, nil
 }
 
+// ListNodePools returns node pool names.
+func (c *EC2ClusterPKE) ListNodePools() ([]string, error) {
+	var nodePools = make([]string, 0, len(c.model.NodePools))
+
+	for _, nodePool := range c.model.NodePools {
+		nodePools = append(nodePools, nodePool.Name)
+	}
+
+	return nodePools, nil
+}
+
 func (c *EC2ClusterPKE) NodePoolExists(nodePoolName string) bool {
 	for _, np := range c.model.NodePools {
 		if np.Name == nodePoolName {

--- a/cluster/ec2_pke.go
+++ b/cluster/ec2_pke.go
@@ -44,7 +44,6 @@ import (
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/pke"
-	"github.com/banzaicloud/pipeline/pkg/common"
 	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
@@ -734,7 +733,7 @@ func (c *EC2ClusterPKE) GetNodePools() []PKENodePool {
 }
 
 // ListNodeNames returns node names to label them
-func (c *EC2ClusterPKE) ListNodeNames() (common.NodeNames, error) {
+func (c *EC2ClusterPKE) ListNodeNames() (map[string][]string, error) {
 	var nodes = make(map[string][]string)
 	for _, nodepool := range c.model.NodePools {
 		nodes[nodepool.Name] = []string{}

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -44,7 +44,6 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgEks "github.com/banzaicloud/pipeline/pkg/cluster/eks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/eks/action"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgEC2 "github.com/banzaicloud/pipeline/pkg/providers/amazon/ec2"
 	"github.com/banzaicloud/pipeline/secret"
@@ -924,7 +923,7 @@ func (c *EKSCluster) DeleteFromDatabase() error {
 }
 
 // ListNodeNames returns node names to label them
-func (c *EKSCluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (c *EKSCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	// nodes are labeled in create request
 	return
 }

--- a/cluster/eks.go
+++ b/cluster/eks.go
@@ -922,12 +922,6 @@ func (c *EKSCluster) DeleteFromDatabase() error {
 	return nil
 }
 
-// ListNodeNames returns node names to label them
-func (c *EKSCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	// nodes are labeled in create request
-	return
-}
-
 // SetStatus sets the cluster's status
 func (c *EKSCluster) SetStatus(status string, statusMessage string) error {
 	return c.modelCluster.UpdateStatus(status, statusMessage)

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -2015,12 +2015,6 @@ func waitForOperation(getter operationInfoer, operationName string, logger logru
 	return nil
 }
 
-// ListNodeNames returns node names to label them
-func (c *GKECluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	// nodes are labeled in create request
-	return
-}
-
 // RbacEnabled returns true if rbac enabled on the cluster
 func (c *GKECluster) RbacEnabled() bool {
 	return c.model.Cluster.RbacEnabled

--- a/cluster/gke.go
+++ b/cluster/gke.go
@@ -2016,7 +2016,7 @@ func waitForOperation(getter operationInfoer, operationName string, logger logru
 }
 
 // ListNodeNames returns node names to label them
-func (c *GKECluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (c *GKECluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	// nodes are labeled in create request
 	return
 }

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -41,10 +41,6 @@ var HookMap = map[string]PostFunctioner{
 		f:            InstallHorizontalPodAutoscalerPostHook,
 		ErrorHandler: ErrorHandler{},
 	},
-	pkgCluster.LabelNodesWithNodePoolName: &BasePostFunction{
-		f:            LabelNodesWithNodePoolName,
-		ErrorHandler: ErrorHandler{},
-	},
 	pkgCluster.RestoreFromBackup: &PostFunctionWithParam{
 		f:            RestoreFromBackup,
 		ErrorHandler: ErrorHandler{},
@@ -74,7 +70,6 @@ var HookMap = map[string]PostFunctioner{
 // BasePostHookFunctions default posthook functions after cluster create
 // nolint: gochecknoglobals
 var BasePostHookFunctions = []string{
-	// pkgCluster.LabelNodesWithNodePoolName,
 	pkgCluster.InstallNodePoolLabelSetOperator,
 	pkgCluster.SetupNodePoolLabelsSet,
 	pkgCluster.InstallIngressControllerPostHook,

--- a/cluster/hookfunctions.go
+++ b/cluster/hookfunctions.go
@@ -74,7 +74,7 @@ var HookMap = map[string]PostFunctioner{
 // BasePostHookFunctions default posthook functions after cluster create
 // nolint: gochecknoglobals
 var BasePostHookFunctions = []string{
-	pkgCluster.LabelNodesWithNodePoolName,
+	// pkgCluster.LabelNodesWithNodePoolName,
 	pkgCluster.InstallNodePoolLabelSetOperator,
 	pkgCluster.SetupNodePoolLabelsSet,
 	pkgCluster.InstallIngressControllerPostHook,

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -31,7 +31,6 @@ import (
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/secret"
 	"github.com/banzaicloud/pipeline/secret/verify"
@@ -319,7 +318,7 @@ func (c *KubeCluster) GetK8sConfig() ([]byte, error) {
 }
 
 // ListNodeNames returns node names to label them
-func (c *KubeCluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (c *KubeCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	return
 }
 

--- a/cluster/kubernetes.go
+++ b/cluster/kubernetes.go
@@ -317,11 +317,6 @@ func (c *KubeCluster) GetK8sConfig() ([]byte, error) {
 	return c.DownloadK8sConfig()
 }
 
-// ListNodeNames returns node names to label them
-func (c *KubeCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	return
-}
-
 // RbacEnabled returns true if rbac enabled on the cluster
 func (c *KubeCluster) RbacEnabled() bool {
 	return c.modelCluster.RbacEnabled

--- a/cluster/manager_common_updater.go
+++ b/cluster/manager_common_updater.go
@@ -201,8 +201,15 @@ func labelNodesWithNodePoolName(commonCluster CommonCluster) error {
 		return err
 	}
 
+	nodeNameLister, ok := commonCluster.(nodeNameLister)
+	if !ok {
+		log.Debug("cluster does not expose node names")
+
+		return nil
+	}
+
 	log.Debug("list node names")
-	nodeNames, err := commonCluster.ListNodeNames()
+	nodeNames, err := nodeNameLister.ListNodeNames()
 	if err != nil {
 		return err
 	}

--- a/cluster/manager_common_updater.go
+++ b/cluster/manager_common_updater.go
@@ -189,6 +189,13 @@ func labelNodesWithNodePoolName(commonCluster CommonCluster) error {
 		return nil
 	}
 
+	nodeNameLister, ok := commonCluster.(nodeNameLister)
+	if !ok {
+		log.Debug("cluster does not expose node names")
+
+		return nil
+	}
+
 	log.Debug("get K8S config")
 	kubeConfig, err := commonCluster.GetK8sConfig()
 	if err != nil {
@@ -199,13 +206,6 @@ func labelNodesWithNodePoolName(commonCluster CommonCluster) error {
 	client, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
 	if err != nil {
 		return err
-	}
-
-	nodeNameLister, ok := commonCluster.(nodeNameLister)
-	if !ok {
-		log.Debug("cluster does not expose node names")
-
-		return nil
 	}
 
 	log.Debug("list node names")

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -558,12 +558,6 @@ func (o *OKECluster) GetPoolQuantityValues(count uint, networkValues network.Net
 	return qps, subnetIDS
 }
 
-// ListNodeNames returns node names to label them
-func (o *OKECluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	// nodes are labeled in create request
-	return
-}
-
 // RbacEnabled returns true if rbac enabled on the cluster
 func (o *OKECluster) RbacEnabled() bool {
 	return true

--- a/cluster/oke.go
+++ b/cluster/oke.go
@@ -25,7 +25,6 @@ import (
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/model"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
-	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	oracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/cluster"
 	oracleClusterManager "github.com/banzaicloud/pipeline/pkg/providers/oracle/cluster/manager"
 	modelOracle "github.com/banzaicloud/pipeline/pkg/providers/oracle/model"
@@ -560,7 +559,7 @@ func (o *OKECluster) GetPoolQuantityValues(count uint, networkValues network.Net
 }
 
 // ListNodeNames returns node names to label them
-func (o *OKECluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (o *OKECluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	// nodes are labeled in create request
 	return
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -295,6 +295,9 @@ func main() {
 		setupPrivilegesActivity := cluster.NewSetupPrivilegesActivity(clusteradapter.NewClientFactory(commonSecretStore), clusterManager)
 		activity.RegisterWithOptions(setupPrivilegesActivity.Execute, activity.RegisterOptions{Name: cluster.SetupPrivilegesActivityName})
 
+		labelNodesWithNodepoolNameActivity := cluster.NewLabelNodesWithNodepoolNameActivity(clusteradapter.NewClientFactory(commonSecretStore), clusterManager)
+		activity.RegisterWithOptions(labelNodesWithNodepoolNameActivity.Execute, activity.RegisterOptions{Name: cluster.LabelNodesWithNodepoolNameActivityName})
+
 		workflow.RegisterWithOptions(cluster.RunPostHooksWorkflow, workflow.RegisterOptions{Name: cluster.RunPostHooksWorkflowName})
 
 		runPostHookActivity := cluster.NewRunPostHookActivity(clusterManager)

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -244,7 +244,7 @@ func (a *AzurePkeCluster) IsReady() (bool, error) {
 	return true, nil
 }
 
-func (a *AzurePkeCluster) ListNodeNames() (nodeNames pkgCommon.NodeNames, err error) {
+func (a *AzurePkeCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
 	// nodes are labeled in create request
 	return
 }

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -249,6 +249,17 @@ func (a *AzurePkeCluster) ListNodeNames() (nodeNames map[string][]string, err er
 	return
 }
 
+// ListNodePools returns node pool names.
+func (a *AzurePkeCluster) ListNodePools() ([]string, error) {
+	var nodePools = make([]string, 0, len(a.model.NodePools))
+
+	for _, nodePool := range a.model.NodePools {
+		nodePools = append(nodePools, nodePool.Name)
+	}
+
+	return nodePools, nil
+}
+
 func (a *AzurePkeCluster) NodePoolExists(nodePoolName string) bool {
 	for _, np := range a.model.NodePools {
 		if np.Name == nodePoolName {

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -244,11 +244,6 @@ func (a *AzurePkeCluster) IsReady() (bool, error) {
 	return true, nil
 }
 
-func (a *AzurePkeCluster) ListNodeNames() (nodeNames map[string][]string, err error) {
-	// nodes are labeled in create request
-	return
-}
-
 // ListNodePools returns node pool names.
 func (a *AzurePkeCluster) ListNodePools() ([]string, error) {
 	var nodePools = make([]string, 0, len(a.model.NodePools))

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -76,7 +76,6 @@ const (
 	InstallKubernetesDashboardPostHook     = "InstallKubernetesDashboardPostHook"
 	InstallClusterAutoscalerPostHook       = "InstallClusterAutoscalerPostHook"
 	InstallHorizontalPodAutoscalerPostHook = "InstallHorizontalPodAutoscalerPostHook"
-	LabelNodesWithNodePoolName             = "LabelNodesWithNodePoolName"
 	RestoreFromBackup                      = "RestoreFromBackup"
 	InitSpotConfig                         = "InitSpotConfig"
 	DeployInstanceTerminationHandler       = "DeployInstanceTerminationHandler"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -45,9 +45,6 @@ type CreatorBaseFields struct {
 	CreatorId   uint      `json:"creatorId,omitempty"`
 }
 
-// NodeNames describes node names
-type NodeNames map[string][]string
-
 // Validate checks whether the node pool labels collide with labels
 // set by Pipeline and also if these are valid Kubernetes labels
 func ValidateNodePoolLabels(labels map[string]string) error {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Relocate label nodes posthook to legacy cluster create workflow


### Why?
Posthooks are deprecated

### Additional context
It's moved to legacy cluster create instead of cluster setup, because it's limited to AKS and ACK.

After https://github.com/Azure/AKS/issues/1088 it will be ACK only.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
