### PR TITLE
Update EKS AMIs

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -175,7 +175,7 @@ K8S_VERSIONS=(
 
 for version in ${K8S_VERSIONS[@]}; do
 	echo "K8S Version:" $version
-	for region in `aws ec2 describe-regions --output text | cut -f4 | sort -V`; do
+	for region in `aws ec2 describe-regions --output text | cut -f3 | sort -V`; do
 	    aws ssm get-parameter --name /aws/service/eks/optimized-ami/${version}/amazon-linux-2/recommended/image_id --region ${region} --query Parameter.Value --output text | xargs -I "{}" echo \"$region\": \"{}\",
 	done
 done

--- a/pkg/cluster/eks/defaults.go
+++ b/pkg/cluster/eks/defaults.go
@@ -20,15 +20,11 @@ import (
 	"emperror.dev/emperror"
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
 // ### [ Constants to EKS cluster default values ] ### //
 const (
-	DefaultInstanceType = "m4.xlarge"
-	DefaultSpotPrice    = "0.0" // 0 spot price stands for on-demand instances
-	DefaultRegion       = endpoints.UsWest2RegionID
-	DefaultK8sVersion   = "1.14.6"
+	DefaultSpotPrice = "0.0" // 0 spot price stands for on-demand instances
 )
 
 func constraintForVersion(v string) *semver.Constraints {
@@ -49,96 +45,96 @@ var mappings = []struct {
 		constraintForVersion("1.11"),
 		map[string]string{
 			// Kubernetes Version 1.11.10
-			"ap-east-1":      "ami-01efe02a8386b4448", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-0acea8b886f0e3f8f", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-01e754bb06dedfd13", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-04aff8301e51a47e4", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-0cb611c369549e9c9", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-0fee6e6300019359b", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-011fae876f87ef80d", // Canada (Central).
-			"eu-central-1":   "ami-0157324517811932f", // EU (Frankfurt).
-			"eu-north-1":     "ami-019c885c71264830f", // EU (Stockholm).
-			"eu-west-1":      "ami-0ed6bcde59efbec8a", // EU (Ireland).
-			"eu-west-2":      "ami-0b2d004b35f3153c4", // EU (London).
-			"eu-west-3":      "ami-0c592c8c15d5a2824", // EU (Paris).
-			"me-south-1":     "ami-0f19239ec6bfc1fd4", // Middle East (Bahrain).
-			"sa-east-1":      "ami-08258a284e4edb286", // South America (Sao Paulo).
-			"us-east-1":      "ami-0277d42c17d2fd9f6", // US East (N. Virginia).
-			"us-east-2":      "ami-0f01aa60d08b56b51", // US East (Ohio).
-			"us-west-1":      "ami-0ea4bd52d952e37c2", // US West (N. California).
-			"us-west-2":      "ami-0e024bc930f00f7a2", // US West (Oregon).
+			"ap-east-1":      "ami-0e18a9300e3385073", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-0c5f7ed15d3ad01bf", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-0f8af14150481eea9", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-0c3982d02380f4057", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-0fb4518280a63a4f9", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-0cfcbd8cd1dcf0b86", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-05ffff48d99f02a77", // Canada (Central).
+			"eu-central-1":   "ami-062b278aa4f541381", // EU (Frankfurt).
+			"eu-north-1":     "ami-0ba8e7f06e6a019d2", // EU (Stockholm).
+			"eu-west-1":      "ami-045c779913c08c97f", // EU (Ireland).
+			"eu-west-2":      "ami-0c4ac9257aa949170", // EU (London).
+			"eu-west-3":      "ami-0ab23a43c29006f2c", // EU (Paris).
+			"me-south-1":     "ami-0f82cb40b1fffed23", // Middle East (Bahrain).
+			"sa-east-1":      "ami-0d3c5fab22805c5f3", // South America (Sao Paulo).
+			"us-east-1":      "ami-0010e840204e3182b", // US East (N. Virginia).
+			"us-east-2":      "ami-028dd95165fbe9bc1", // US East (Ohio).
+			"us-west-1":      "ami-08dc171b543edad80", // US West (N. California).
+			"us-west-2":      "ami-0731c2cf494afcd99", // US West (Oregon).
 		},
 	},
 	{
 		constraintForVersion("1.12"),
 		map[string]string{
 			// Kubernetes Version 1.12.10
-			"ap-east-1":      "ami-0fafd65fe31195cb5", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-08b2cecec9f2d5964", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-0bbe543cd7fc2acd1", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-07696966feacc8e7b", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-07621fc1a7675f06c", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-0d9c7adc50f0c3f04", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-08c7289082f4c81f5", // Canada (Central).
-			"eu-central-1":   "ami-0fe22fc725c19301f", // EU (Frankfurt).
-			"eu-north-1":     "ami-0586fb63f5c466e3c", // EU (Stockholm).
-			"eu-west-1":      "ami-0a6be9528ebb8999d", // EU (Ireland).
-			"eu-west-2":      "ami-0a8dc5b3290842d3e", // EU (London).
-			"eu-west-3":      "ami-01dbd2d713c939649", // EU (Paris).
-			"me-south-1":     "ami-08eab8b7cd9f43bd0", // Middle East (Bahrain).
-			"sa-east-1":      "ami-0426e4628be2eac14", // South America (Sao Paulo).
-			"us-east-1":      "ami-0259ce67309f76e0b", // US East (N. Virginia).
-			"us-east-2":      "ami-0d60b7264ed85e022", // US East (Ohio).
-			"us-west-1":      "ami-0b9861f042f244ac8", // US West (N. California).
-			"us-west-2":      "ami-0315dd35bf204311d", // US West (Oregon).
+			"ap-east-1":      "ami-0d8112a829ab1dbe3", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-02355b50897aa3aa1", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-02c654f7a3055a0b5", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-03a8ac8740d6ddcd1", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-0bf3d8667e090925b", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-0229b20de901562bb", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-072d30b45d3515f6a", // Canada (Central).
+			"eu-central-1":   "ami-033d1d6ff9131d9f1", // EU (Frankfurt).
+			"eu-north-1":     "ami-04e160b95d368ebc9", // EU (Stockholm).
+			"eu-west-1":      "ami-04b0486b375074f76", // EU (Ireland).
+			"eu-west-2":      "ami-0aed33d48fb4e1f41", // EU (London).
+			"eu-west-3":      "ami-048395c260672dd76", // EU (Paris).
+			"me-south-1":     "ami-05c110c75b8ae1fe3", // Middle East (Bahrain).
+			"sa-east-1":      "ami-02fcd63b41f21e854", // South America (Sao Paulo).
+			"us-east-1":      "ami-0ad6567ae0a817577", // US East (N. Virginia).
+			"us-east-2":      "ami-0243b86bf17bdf282", // US East (Ohio).
+			"us-west-1":      "ami-0bf8e913be03a3819", // US West (N. California).
+			"us-west-2":      "ami-0ec0eebfe09f8a641", // US West (Oregon).
 		},
 	},
 	{
 		constraintForVersion("1.13"),
 		map[string]string{
-			// Kubernetes Version 1.13.10
-			"ap-east-1":      "ami-056314bd2d2acbdc1", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-0262013b4d50142a2", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-0d9a543e7c4279c11", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-0013f4890e2ce167b", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-01cd15b342b7edf5e", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-00f4cff050d28ee2d", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-0c8695b5d2f053ad6", // Canada (Central).
-			"eu-central-1":   "ami-01ffee931e45bb6bf", // EU (Frankfurt).
-			"eu-north-1":     "ami-01d7a7c38f882ef68", // EU (Stockholm).
-			"eu-west-1":      "ami-00ea6211202297fe8", // EU (Ireland).
-			"eu-west-2":      "ami-0ef7099142dae7023", // EU (London).
-			"eu-west-3":      "ami-00cc28b5bcb9dc724", // EU (Paris).
-			"me-south-1":     "ami-0ae4a6a2950a3546e", // Middle East (Bahrain).
-			"sa-east-1":      "ami-0fa3e4c30b6ef5414", // South America (Sao Paulo).
-			"us-east-1":      "ami-08198f90fe8bc57f0", // US East (N. Virginia).
-			"us-east-2":      "ami-0355b5edf93d47112", // US East (Ohio).
-			"us-west-1":      "ami-0c646c8eee630aa1f", // US West (N. California).
-			"us-west-2":      "ami-0dc5bf48daa40eb35", // US West (Oregon).
+			// Kubernetes Version 1.13.11
+			"ap-east-1":      "ami-061c919d6ecc3fdb4", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-01fd7f32ab8a9e032", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-053959c7a4a9cb654", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-0baa81231c278c1ac", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-091a252b3e9cabcc2", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-0b667ccbbae9214e3", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-0808a5ff743eb2806", // Canada (Central).
+			"eu-central-1":   "ami-0a9ad7a4ae50e8e77", // EU (Frankfurt).
+			"eu-north-1":     "ami-0b9403c917e4f92b5", // EU (Stockholm).
+			"eu-west-1":      "ami-08684dce117829aa8", // EU (Ireland).
+			"eu-west-2":      "ami-07bf4afe6ca486eeb", // EU (London).
+			"eu-west-3":      "ami-095de5b6bd8b1acf0", // EU (Paris).
+			"me-south-1":     "ami-02ec1b153ae90c2c3", // Middle East (Bahrain).
+			"sa-east-1":      "ami-035e63ad35c591df8", // South America (Sao Paulo).
+			"us-east-1":      "ami-0795ae6584e7f8070", // US East (N. Virginia).
+			"us-east-2":      "ami-01505c630227fa3f8", // US East (Ohio).
+			"us-west-1":      "ami-02f3579ca4683a2ed", // US West (N. California).
+			"us-west-2":      "ami-04e247c4613de71fa", // US West (Oregon).
 		},
 	},
 	{
 		constraintForVersion("1.14"),
 		map[string]string{
-			// Kubernetes Version 1.14.6
-			"ap-east-1":      "ami-0fc4b0a16426993b5", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-055d09694b6e5591a", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-023bb403131889300", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-0d26e45a1e5422b8e", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-0d8e3da32bd74f39b", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-0e9f7f3edab94472d", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-078e7f0499f9e8860", // Canada (Central).
-			"eu-central-1":   "ami-0f64557dd6506a4aa", // EU (Frankfurt).
-			"eu-north-1":     "ami-0a4a5386eb62c775e", // EU (Stockholm).
-			"eu-west-1":      "ami-0497f6feb9d494baf", // EU (Ireland).
-			"eu-west-2":      "ami-010d34c5744286662", // EU (London).
-			"eu-west-3":      "ami-04fada31d8c50b7a8", // EU (Paris).
-			"me-south-1":     "ami-0b7e753bbd3a0ae24", // Middle East (Bahrain).
-			"sa-east-1":      "ami-0af97d6bb25294265", // South America (Sao Paulo).
-			"us-east-1":      "ami-08739803f18dcc019", // US East (N. Virginia).
-			"us-east-2":      "ami-0f841722be384ed96", // US East (Ohio).
-			"us-west-1":      "ami-0d1096db9016114f9", // US West (N. California).
-			"us-west-2":      "ami-038a987c6425a84ad", // US West (Oregon).
+			// Kubernetes Version 1.14.7
+			"ap-east-1":      "ami-0af3a70f827304d17", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-0b60cbd90564dfe00", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-0cf70ba01dfd0f782", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-0d275f57a60281ccc", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-0159ec8365aea1724", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-07e2a96e251e970bd", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-0ef56ecc6435d1f65", // Canada (Central).
+			"eu-central-1":   "ami-03fbd442f4f3aa689", // EU (Frankfurt).
+			"eu-north-1":     "ami-01feb408eb7fc7e23", // EU (Stockholm).
+			"eu-west-1":      "ami-02dca57ad67c7bf57", // EU (Ireland).
+			"eu-west-2":      "ami-0a69fbeff04e330e9", // EU (London).
+			"eu-west-3":      "ami-074b0da576fa9f5c9", // EU (Paris).
+			"me-south-1":     "ami-0fc6f1ff5cd458c95", // Middle East (Bahrain).
+			"sa-east-1":      "ami-010ffc66e06c843b2", // South America (Sao Paulo).
+			"us-east-1":      "ami-07d6c8e62ce328a10", // US East (N. Virginia).
+			"us-east-2":      "ami-053250833d1030033", // US East (Ohio).
+			"us-west-1":      "ami-062d2cddf8747e025", // US West (N. California).
+			"us-west-2":      "ami-07be7092831897fd6", // US West (Oregon).
 		},
 	},
 }
@@ -156,7 +152,7 @@ func GetDefaultImageID(region, kubernetesVersion string) (string, error) {
 				return ami, nil
 			}
 
-			return "", fmt.Errorf("no EKS AMI found for Kubernetes version %q in region %q", kubeVersion, region)
+			return "", errors.Errorf("no EKS AMI found for Kubernetes version %q in region %q", kubeVersion, region)
 		}
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


Update used EKS AMIs to the latest version. Tested with K8s 1.14.