### PR TITLE
Fix: collecting AWS stack failures when PKE VPC creation fails is broken

### DIFF
--- a/internal/providers/pke/pkeworkflow/wait_for_cf_completion_activity.go
+++ b/internal/providers/pke/pkeworkflow/wait_for_cf_completion_activity.go
@@ -17,7 +17,7 @@ package pkeworkflow
 import (
 	"context"
 
-	"emperror.dev/emperror"
+	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 
@@ -53,12 +53,12 @@ func (a *WaitCFCompletionActivity) Execute(ctx context.Context, input WaitCFComp
 
 	err = cfClient.WaitUntilStackCreateCompleteWithContext(ctx, describeStacksInput)
 	if err != nil {
-		return nil, emperror.Wrap(pkgCloudformation.NewAwsStackFailure(err, "", input.StackID, cfClient), "error waiting Cloud Formation template")
+		return nil, errors.WrapIf(pkgCloudformation.NewAwsStackFailure(err, input.StackID, "", cfClient), "error waiting Cloud Formation template")
 	}
 
 	output, err := cfClient.DescribeStacks(describeStacksInput)
 	if err != nil {
-		return nil, emperror.Wrap(err, "error fetching Cloud Formation template")
+		return nil, errors.WrapIf(err, "error fetching Cloud Formation template")
 	}
 
 	outputMap := make(map[string]string)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
