### PR TITLE
[Logging] Add service label to Logging resource

### DIFF
--- a/internal/clusterfeature/features/logging/operator.go
+++ b/internal/clusterfeature/features/logging/operator.go
@@ -441,12 +441,12 @@ func mergeValuesWithConfig(chartValues interface{}, configValues interface{}) ([
 }
 
 func (op FeatureOperator) createLoggingResource(ctx context.Context, clusterID uint, spec featureSpec) error {
-	// TODO (colin): add labels
 	var tlsEnabled = spec.Logging.TLS
 	var loggingResource = &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      loggingResourceName,
 			Namespace: op.config.Namespace,
+			Labels:    map[string]string{resourceLabelKey: featureName},
 		},
 		Spec: v1beta1.LoggingSpec{
 			FluentbitSpec: &v1beta1.FluentbitSpec{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add service label to Logging resource

### Why?
We add this label to `ClusterFlow`-s and `ClusterOutput`-s too

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

