### PR TITLE
Pass missing field to cluster setup workflow

### DIFF
--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -384,6 +384,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 		OrganizationName:  org.Name,
 		ResourceGroupName: params.ResourceGroup,
 		SecretID:          params.SecretID,
+		Distribution:      pkgCluster.PKE,
 		OIDCEnabled:       cl.Kubernetes.OIDC.Enabled,
 		VirtualNetworkTemplate: workflow.VirtualNetworkTemplate{
 			Name: params.Network.Name,

--- a/internal/providers/azure/pke/workflow/create_cluster.go
+++ b/internal/providers/azure/pke/workflow/create_cluster.go
@@ -41,6 +41,7 @@ type CreateClusterWorkflowInput struct {
 	OrganizationName                string
 	ResourceGroupName               string
 	SecretID                        string
+	Distribution                    string
 	OIDCEnabled                     bool
 	VirtualNetworkTemplate          VirtualNetworkTemplate
 	LoadBalancerTemplates           []LoadBalancerTemplate
@@ -137,9 +138,10 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		workflowInput := clustersetup.WorkflowInput{
 			ConfigSecretID: brn.New(input.OrganizationID, brn.SecretResourceType, configSecretID).String(),
 			Cluster: clustersetup.Cluster{
-				ID:   input.ClusterID,
-				UID:  input.ClusterUID,
-				Name: input.ClusterName,
+				ID:           input.ClusterID,
+				UID:          input.ClusterUID,
+				Name:         input.ClusterName,
+				Distribution: input.Distribution,
 			},
 			Organization: clustersetup.Organization{
 				ID:   input.OrganizationID,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Pass cluster distribution to cluster setup workflow in Azure PKE cluster creation workflow.

### Why?
Without the distribution value the Tiller install activity does not get executed correctly.
