### PR TITLE
Fix: EKS create flow doesn't accept user provided custom AMI

### DIFF
--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -730,7 +730,7 @@ func (c *EKSCluster) GenerateK8sConfig() *clientcmdapi.Config {
 			{
 				Name: c.modelCluster.Name,
 				Cluster: clientcmdapi.Cluster{
-					Server:                   c.APIEndpoint,
+					Server: c.APIEndpoint,
 					CertificateAuthorityData: c.CertificateAuthorityData,
 				},
 			},
@@ -974,17 +974,6 @@ func (c *EKSCluster) ValidateCreationFields(r *pkgCluster.CreateClusterRequest) 
 		return pkgErrors.ErrorNotValidLocation
 	}
 
-	image, err := ListEksImages(r.Properties.CreateClusterEKS.Version, r.Location)
-	if err != nil {
-		return errors.WrapIf(err, "failed to get EKS AMI")
-	}
-
-	for name, nodePool := range r.Properties.CreateClusterEKS.NodePools {
-		if image != nodePool.Image {
-			return errors.WithDetails(pkgErrors.ErrorNotValidNodeImage, "image", nodePool.Image, "nodePool", name, "region", r.Location)
-		}
-	}
-
 	// validate VPC
 	awsCred, err := c.createAWSCredentialsFromSecret()
 	if err != nil {
@@ -1181,17 +1170,6 @@ func (c *EKSCluster) GetK8sConfig() ([]byte, error) {
 // the cluster
 func (c *EKSCluster) RequiresSshPublicKey() bool {
 	return true
-}
-
-// ListEksImages returns AMIs for EKS
-func ListEksImages(version, region string) (string, error) {
-	// TODO: revise this once CloudInfo can provide the correct EKS AMIs dynamically at runtime
-	ami, err := pkgEks.GetDefaultImageID(region, version)
-	if err != nil {
-		return "", errors.WrapIff(err, "couldn't get EKS AMI for Kubernetes version %q in region %q", version, region)
-	}
-
-	return ami, nil
 }
 
 // RbacEnabled returns true if rbac enabled on the cluster

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -730,7 +730,7 @@ func (c *EKSCluster) GenerateK8sConfig() *clientcmdapi.Config {
 			{
 				Name: c.modelCluster.Name,
 				Cluster: clientcmdapi.Cluster{
-					Server: c.APIEndpoint,
+					Server:                   c.APIEndpoint,
 					CertificateAuthorityData: c.CertificateAuthorityData,
 				},
 			},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Let through user-provided custom AMI in EKS create cluster request

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
User-provided custom AMIs were checked against AMIs published by AWS during cluster create and rejected not matched any of those. This verification is not needed to allow users to pass their own custom AMIs.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
