### PR TITLE
Add update to Kubernetes service

### DIFF
--- a/internal/clusterfeature/features/logging/common_test.go
+++ b/internal/clusterfeature/features/logging/common_test.go
@@ -18,9 +18,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8srest "k8s.io/client-go/rest"
 
 	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/pkg/helm"
@@ -170,19 +168,6 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 }
 
 type dummyKubernetesService struct {
-}
-
-// GetKubeConfig gets a kube config for a specific cluster.
-func (s *dummyKubernetesService) GetKubeConfig(ctx context.Context, clusterID uint) (*k8srest.Config, error) {
-	return &k8srest.Config{
-		Host:            "https://127.0.0.1:6443",
-		TLSClientConfig: k8srest.TLSClientConfig{CAData: []byte("BLABLA")},
-	}, nil
-}
-
-// GetObject gets an Object from a specific cluster.
-func (s *dummyKubernetesService) GetObject(ctx context.Context, clusterID uint, objRef corev1.ObjectReference, o runtime.Object) error {
-	return nil
 }
 
 // DeleteObject deletes an Object from a specific cluster.

--- a/internal/clusterfeature/features/logging/kubernetes.go
+++ b/internal/clusterfeature/features/logging/kubernetes.go
@@ -1,0 +1,32 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type KubernetesService interface {
+	// EnsureObject makes sure that a given Object is on the cluster and returns it.
+	EnsureObject(ctx context.Context, clusterID uint, o runtime.Object) error
+
+	// DeleteObject deletes an Object from a specific cluster.
+	DeleteObject(ctx context.Context, clusterID uint, o runtime.Object) error
+
+	// List lists Objects on specific cluster.
+	List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error
+}

--- a/internal/clusterfeature/features/logging/operator.go
+++ b/internal/clusterfeature/features/logging/operator.go
@@ -42,7 +42,7 @@ type FeatureOperator struct {
 	clusterGetter     clusterfeatureadapter.ClusterGetter
 	clusterService    clusterfeature.ClusterService
 	helmService       features.HelmService
-	kubernetesService features.KubernetesService
+	kubernetesService KubernetesService
 	endpointsService  endpoints.EndpointService
 	config            Config
 	logger            common.Logger
@@ -54,7 +54,7 @@ func MakeFeatureOperator(
 	clusterGetter clusterfeatureadapter.ClusterGetter,
 	clusterService clusterfeature.ClusterService,
 	helmService features.HelmService,
-	kubernetesService features.KubernetesService,
+	kubernetesService KubernetesService,
 	endpointsService endpoints.EndpointService,
 	config Config,
 	logger common.Logger,

--- a/internal/clusterfeature/features/monitoring/common_test.go
+++ b/internal/clusterfeature/features/monitoring/common_test.go
@@ -18,9 +18,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8srest "k8s.io/client-go/rest"
 
 	"github.com/banzaicloud/pipeline/internal/clusterfeature/clusterfeatureadapter"
 	"github.com/banzaicloud/pipeline/pkg/helm"
@@ -176,34 +174,6 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 }
 
 type dummyKubernetesService struct {
-}
-
-// GetKubeConfig gets a kube config for a specific cluster.
-func (s *dummyKubernetesService) GetKubeConfig(ctx context.Context, clusterID uint) (*k8srest.Config, error) {
-	return &k8srest.Config{
-		Host:            "https://127.0.0.1:6443",
-		TLSClientConfig: k8srest.TLSClientConfig{CAData: []byte("BLABLA")},
-	}, nil
-}
-
-// GetObject gets an Object from a specific cluster.
-func (s *dummyKubernetesService) GetObject(ctx context.Context, clusterID uint, objRef corev1.ObjectReference, o runtime.Object) error {
-	return nil
-}
-
-// DeleteObject deletes an Object from a specific cluster.
-func (s *dummyKubernetesService) DeleteObject(ctx context.Context, clusterID uint, o runtime.Object) error {
-	return nil
-}
-
-// EnsureObject makes sure that a given Object is on the cluster and returns it.
-func (s *dummyKubernetesService) EnsureObject(ctx context.Context, clusterID uint, o runtime.Object) error {
-	switch v := o.(type) {
-	case *corev1.ServiceAccount:
-		v.Secrets = []corev1.ObjectReference{{Name: "some-token-1234", Namespace: "default"}}
-	}
-
-	return nil
 }
 
 func (s *dummyKubernetesService) List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error {

--- a/internal/clusterfeature/features/monitoring/kubernetes.go
+++ b/internal/clusterfeature/features/monitoring/kubernetes.go
@@ -1,0 +1,26 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type KubernetesService interface {
+	// List lists Objects on specific cluster.
+	List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error
+}

--- a/internal/clusterfeature/features/monitoring/operator.go
+++ b/internal/clusterfeature/features/monitoring/operator.go
@@ -41,7 +41,7 @@ type FeatureOperator struct {
 	clusterGetter     clusterfeatureadapter.ClusterGetter
 	clusterService    clusterfeature.ClusterService
 	helmService       features.HelmService
-	kubernetesService features.KubernetesService
+	kubernetesService KubernetesService
 	config            Config
 	logger            common.Logger
 	secretStore       features.SecretStore
@@ -57,7 +57,7 @@ func MakeFeatureOperator(
 	clusterGetter clusterfeatureadapter.ClusterGetter,
 	clusterService clusterfeature.ClusterService,
 	helmService features.HelmService,
-	kubernetesService features.KubernetesService,
+	kubernetesService KubernetesService,
 	config Config,
 	logger common.Logger,
 	secretStore features.SecretStore,

--- a/internal/clusterfeature/features/vault/common_test.go
+++ b/internal/clusterfeature/features/vault/common_test.go
@@ -149,11 +149,6 @@ func (s *dummyKubernetesService) GetKubeConfig(ctx context.Context, clusterID ui
 	}, nil
 }
 
-// GetObject gets an Object from a specific cluster.
-func (s *dummyKubernetesService) GetObject(ctx context.Context, clusterID uint, objRef corev1.ObjectReference, o runtime.Object) error {
-	return nil
-}
-
 // DeleteObject deletes an Object from a specific cluster.
 func (s *dummyKubernetesService) DeleteObject(ctx context.Context, clusterID uint, o runtime.Object) error {
 
@@ -167,9 +162,5 @@ func (s *dummyKubernetesService) EnsureObject(ctx context.Context, clusterID uin
 		v.Secrets = []corev1.ObjectReference{{Name: "some-token-1234", Namespace: "default"}}
 	}
 
-	return nil
-}
-
-func (s *dummyKubernetesService) List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error {
 	return nil
 }

--- a/internal/clusterfeature/features/vault/kubernetes.go
+++ b/internal/clusterfeature/features/vault/kubernetes.go
@@ -12,30 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package features
+package vault
 
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srest "k8s.io/client-go/rest"
 )
 
-// KubernetesService provides an interface for using the Kubernetes API on a specific cluster.
 type KubernetesService interface {
 	// GetKubeConfig gets a kube config for a specific cluster.
 	GetKubeConfig(ctx context.Context, clusterID uint) (*k8srest.Config, error)
-
-	// GetObject gets an Object from a specific cluster.
-	GetObject(ctx context.Context, clusterID uint, objectRef corev1.ObjectReference, o runtime.Object) error
 
 	// EnsureObject makes sure that a given Object is on the cluster and returns it.
 	EnsureObject(ctx context.Context, clusterID uint, o runtime.Object) error
 
 	// DeleteObject deletes an Object from a specific cluster.
 	DeleteObject(ctx context.Context, clusterID uint, o runtime.Object) error
-
-	// List lists Objects on specific cluster.
-	List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error
 }

--- a/internal/clusterfeature/features/vault/operator.go
+++ b/internal/clusterfeature/features/vault/operator.go
@@ -38,7 +38,7 @@ type FeatureOperator struct {
 	clusterGetter     clusterfeatureadapter.ClusterGetter
 	clusterService    clusterfeature.ClusterService
 	helmService       features.HelmService
-	kubernetesService features.KubernetesService
+	kubernetesService KubernetesService
 	secretStore       features.SecretStore
 	config            Config
 	logger            common.Logger
@@ -49,7 +49,7 @@ func MakeFeatureOperator(
 	clusterGetter clusterfeatureadapter.ClusterGetter,
 	clusterService clusterfeature.ClusterService,
 	helmService features.HelmService,
-	kubernetesService features.KubernetesService,
+	kubernetesService KubernetesService,
 	secretStore features.SecretStore,
 	config Config,
 	logger common.Logger,

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -138,3 +138,22 @@ func (s *Service) List(ctx context.Context, clusterID uint, labels map[string]st
 		LabelSelector: k8slabels.SelectorFromSet(labels),
 	}, obj)
 }
+
+// Update updates a given Object on the cluster and returns it.
+func (s *Service) Update(ctx context.Context, clusterID uint, o runtime.Object) error {
+	kubeClient, err := s.newClientForCluster(ctx, clusterID)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create Kubernetes client")
+	}
+
+	if err := kubeClient.Update(ctx, o); err != nil {
+		return errors.WrapIf(err, "failed to update Object")
+	}
+
+	objectKey, err := client.ObjectKeyFromObject(o)
+	if err != nil {
+		return errors.WrapIf(err, "failed to create ObjectKey")
+	}
+
+	return kubeClient.Get(ctx, objectKey, o)
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Use own Kubernetes service in each intergrated service
- Add `Update` to Kubernetes service


### Additional context
Currently we can't update our Kubernetes resources. The next PR will contain these changes in each intergrated service (where it's needed)

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
