### PR TITLE
Remove superfluous Azure PKE prefixes

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -387,9 +387,9 @@ func main() {
 
 	cloudInfoClient := cloudinfo.NewClient(config.Cloudinfo.Endpoint, logrusLogger)
 
-	gormAzurePKEClusterStore := azurePKEAdapter.NewGORMAzurePKEClusterStore(db, commonLogger)
+	azurePKEClusterStore := azurePKEAdapter.NewClusterStore(db, commonLogger)
 	clusterCreators := api.ClusterCreators{
-		PKEOnAzure: azurePKEDriver.MakeAzurePKEClusterCreator(
+		PKEOnAzure: azurePKEDriver.MakeClusterCreator(
 			azurePKEDriver.ClusterCreatorConfig{
 				OIDCIssuerURL:               config.Auth.OIDC.Issuer,
 				PipelineExternalURL:         externalBaseURL,
@@ -398,18 +398,18 @@ func main() {
 			logrusLogger,
 			authdriver.NewOrganizationGetter(db),
 			secret.Store,
-			gormAzurePKEClusterStore,
+			azurePKEClusterStore,
 			workflowClient,
 		),
 	}
 	clusterDeleters := api.ClusterDeleters{
-		PKEOnAzure: azurePKEDriver.MakeAzurePKEClusterDeleter(
+		PKEOnAzure: azurePKEDriver.MakeClusterDeleter(
 			clusterEvents,
 			clusterManager.GetKubeProxyCache(),
 			logrusLogger,
 			secret.Store,
 			statusChangeDurationMetric,
-			gormAzurePKEClusterStore,
+			azurePKEClusterStore,
 			workflowClient,
 		),
 	}
@@ -423,12 +423,12 @@ func main() {
 	clusterGroupManager.RegisterFeatureHandler(deployment.FeatureName, deploymentManager)
 	clusterGroupManager.RegisterFeatureHandler(cgFeatureIstio.FeatureName, serviceMeshFeatureHandler)
 	clusterUpdaters := api.ClusterUpdaters{
-		PKEOnAzure: azurePKEDriver.MakeAzurePKEClusterUpdater(
+		PKEOnAzure: azurePKEDriver.MakeClusterUpdater(
 			logrusLogger,
 			externalBaseURL,
 			externalURLInsecure,
 			secret.Store,
-			gormAzurePKEClusterStore,
+			azurePKEClusterStore,
 			workflowClient,
 		),
 	}

--- a/cmd/worker/azure.go
+++ b/cmd/worker/azure.go
@@ -24,7 +24,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow/pkeworkflowadapter"
 )
 
-func registerAzureWorkflows(secretStore pkeworkflow.SecretStore, tokenGenerator pkeworkflowadapter.TokenGenerator, store pke.AzurePKEClusterStore) {
+func registerAzureWorkflows(secretStore pkeworkflow.SecretStore, tokenGenerator pkeworkflowadapter.TokenGenerator, store pke.ClusterStore) {
 
 	// Azure PKE
 	workflow.RegisterWithOptions(azurepkeworkflow.CreateClusterWorkflow, workflow.RegisterOptions{Name: azurepkeworkflow.CreateClusterWorkflowName})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -330,7 +330,7 @@ func main() {
 		// Register amazon specific workflows and activities
 		registerAwsWorkflows(clusters, tokenGenerator, secretStore)
 
-		azurePKEClusterStore := azurePKEAdapter.NewGORMAzurePKEClusterStore(db, commonadapter.NewLogger(logger))
+		azurePKEClusterStore := azurePKEAdapter.NewClusterStore(db, commonadapter.NewLogger(logger))
 
 		{
 			passwordSecrets := intpkeworkflowadapter.NewPasswordSecretStore(commonSecretStore)

--- a/internal/providers/azure/pke/adapter/gorm_store_test.go
+++ b/internal/providers/azure/pke/adapter/gorm_store_test.go
@@ -28,18 +28,19 @@ func TestFillClusterFromClusterModel(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    clusteradapter.ClusterModel
-		expected pke.PKEOnAzureCluster
+		expected pke.Cluster
 	}{
 		{
 			name:     "empty cluster model",
 			input:    clusteradapter.ClusterModel{},
-			expected: pke.PKEOnAzureCluster{},
+			expected: pke.Cluster{},
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var result pke.PKEOnAzureCluster
-			fillClusterFromClusterModel(&result, tc.input)
+			var result pke.Cluster
+			fillClusterFromCommonClusterModel(&result, tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/providers/azure/pke/cluster.go
+++ b/internal/providers/azure/pke/cluster.go
@@ -89,8 +89,8 @@ func (a APIServerAccessPoints) Exists(name string) bool {
 	return false
 }
 
-// PKEOnAzureCluster defines fields for PKE-on-Azure clusters
-type PKEOnAzureCluster struct {
+// Cluster defines fields for PKE-on-Azure clusters
+type Cluster struct {
 	intCluster.ClusterBase
 
 	Location         string
@@ -107,7 +107,7 @@ type PKEOnAzureCluster struct {
 	APIServerAccessPoints APIServerAccessPoints
 }
 
-func (c PKEOnAzureCluster) HasActiveWorkflow() bool {
+func (c Cluster) HasActiveWorkflow() bool {
 	return c.ActiveWorkflowID != ""
 }
 

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -45,15 +45,15 @@ import (
 const pkeVersion = "0.4.17"
 const MasterNodeTaint = pkgPKE.TaintKeyMaster + ":" + string(corev1.TaintEffectNoSchedule)
 
-func MakeAzurePKEClusterCreator(
+func MakeClusterCreator(
 	config ClusterCreatorConfig,
 	logger logrus.FieldLogger,
 	organizations OrganizationStore,
 	secrets ClusterCreatorSecretStore,
-	store pke.AzurePKEClusterStore,
+	store pke.ClusterStore,
 	workflowClient client.Client,
-) AzurePKEClusterCreator {
-	return AzurePKEClusterCreator{
+) ClusterCreator {
+	return ClusterCreator{
 		config:         config,
 		logger:         logger,
 		organizations:  organizations,
@@ -63,13 +63,13 @@ func MakeAzurePKEClusterCreator(
 	}
 }
 
-// AzurePKEClusterCreator creates new PKE-on-Azure clusters
-type AzurePKEClusterCreator struct {
+// ClusterCreator creates new PKE-on-Azure clusters
+type ClusterCreator struct {
 	config         ClusterCreatorConfig
 	logger         logrus.FieldLogger
 	organizations  OrganizationStore
 	secrets        ClusterCreatorSecretStore
-	store          pke.AzurePKEClusterStore
+	store          pke.ClusterStore
 	workflowClient client.Client
 }
 
@@ -137,8 +137,8 @@ type Subnet struct {
 	CIDR string
 }
 
-// AzurePKEClusterCreationParams defines parameters for PKE-on-Azure cluster creation
-type AzurePKEClusterCreationParams struct {
+// ClusterCreationParams defines parameters for PKE-on-Azure cluster creation
+type ClusterCreationParams struct {
 	CreatedBy             uint
 	Kubernetes            intPKE.Kubernetes
 	Name                  string
@@ -155,7 +155,7 @@ type AzurePKEClusterCreationParams struct {
 }
 
 // Create
-func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClusterCreationParams) (cl pke.PKEOnAzureCluster, err error) {
+func (cc ClusterCreator) Create(ctx context.Context, params ClusterCreationParams) (cl pke.Cluster, err error) {
 	sir, err := cc.secrets.Get(params.OrganizationID, params.SecretID)
 	if err = errors.WrapIf(err, "failed to get secret"); err != nil {
 		return
@@ -166,7 +166,7 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 		return
 	}
 
-	if err = MakeAzurePKEClusterCreationParamsPreparer(conn, cc.logger).Prepare(ctx, &params); err != nil {
+	if err = MakeClusterCreationParamsPreparer(conn, cc.logger).Prepare(ctx, &params); err != nil {
 		return
 	}
 
@@ -454,28 +454,28 @@ func (cc AzurePKEClusterCreator) Create(ctx context.Context, params AzurePKEClus
 	return
 }
 
-func (cc AzurePKEClusterCreator) handleError(clusterID uint, err error) error {
+func (cc ClusterCreator) handleError(clusterID uint, err error) error {
 	return handleClusterError(cc.logger, cc.store, pkgCluster.Error, clusterID, err)
 }
 
-// AzurePKEClusterCreationParamsPreparer implements AzurePKEClusterCreationParams preparation
-type AzurePKEClusterCreationParamsPreparer struct {
+// ClusterCreationParamsPreparer implements ClusterCreationParams preparation
+type ClusterCreationParamsPreparer struct {
 	connection  *pkgAzure.CloudConnection
 	k8sPreparer intPKE.KubernetesPreparer
 	logger      logrus.FieldLogger
 }
 
-// MakeAzurePKEClusterCreationParamsPreparer returns an instance of AzurePKEClusterCreationParamsPreparer
-func MakeAzurePKEClusterCreationParamsPreparer(connection *pkgAzure.CloudConnection, logger logrus.FieldLogger) AzurePKEClusterCreationParamsPreparer {
-	return AzurePKEClusterCreationParamsPreparer{
+// MakeClusterCreationParamsPreparer returns an instance of ClusterCreationParamsPreparer
+func MakeClusterCreationParamsPreparer(connection *pkgAzure.CloudConnection, logger logrus.FieldLogger) ClusterCreationParamsPreparer {
+	return ClusterCreationParamsPreparer{
 		connection:  connection,
 		k8sPreparer: intPKE.MakeKubernetesPreparer(logger, "Kubernetes"),
 		logger:      logger,
 	}
 }
 
-// Prepare validates and provides defaults for AzurePKEClusterCreationParams fields
-func (p AzurePKEClusterCreationParamsPreparer) Prepare(ctx context.Context, params *AzurePKEClusterCreationParams) error {
+// Prepare validates and provides defaults for ClusterCreationParams fields
+func (p ClusterCreationParamsPreparer) Prepare(ctx context.Context, params *ClusterCreationParams) error {
 	if params.Name == "" {
 		return validationErrorf("Name cannot be empty")
 	}
@@ -568,7 +568,7 @@ func (p AzurePKEClusterCreationParamsPreparer) Prepare(ctx context.Context, para
 	return nil
 }
 
-func (p AzurePKEClusterCreationParamsPreparer) getVNetPreparer(cloudConnection *pkgAzure.CloudConnection, clusterName, resourceGroupName string) VirtualNetworkPreparer {
+func (p ClusterCreationParamsPreparer) getVNetPreparer(cloudConnection *pkgAzure.CloudConnection, clusterName, resourceGroupName string) VirtualNetworkPreparer {
 	return VirtualNetworkPreparer{
 		clusterName:       clusterName,
 		connection:        cloudConnection,
@@ -578,7 +578,7 @@ func (p AzurePKEClusterCreationParamsPreparer) getVNetPreparer(cloudConnection *
 	}
 }
 
-func (p AzurePKEClusterCreationParamsPreparer) getNodePoolsPreparer(dataProvider nodePoolsDataProvider) NodePoolsPreparer {
+func (p ClusterCreationParamsPreparer) getNodePoolsPreparer(dataProvider nodePoolsDataProvider) NodePoolsPreparer {
 	return NodePoolsPreparer{
 		logger:       p.logger,
 		namespace:    "NodePools",

--- a/internal/providers/azure/pke/driver/common.go
+++ b/internal/providers/azure/pke/driver/common.go
@@ -175,7 +175,7 @@ func (f nodePoolTemplateFactory) getTemplates(np NodePool) (workflow.VirtualMach
 		}
 }
 
-func handleClusterError(logger logrus.FieldLogger, store pke.AzurePKEClusterStore, status string, clusterID uint, err error) error {
+func handleClusterError(logger logrus.FieldLogger, store pke.ClusterStore, status string, clusterID uint, err error) error {
 	if clusterID != 0 && err != nil {
 		if err := store.SetStatus(clusterID, status, err.Error()); err != nil {
 			logger.Errorf("failed to set cluster error status: %s", err.Error())

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -33,9 +33,9 @@ import (
 )
 
 type AzurePkeCluster struct {
-	model   pke.PKEOnAzureCluster
+	model   pke.Cluster
 	secrets SecretStore
-	store   pke.AzurePKEClusterStore
+	store   pke.ClusterStore
 }
 
 type SecretStore interface {
@@ -45,10 +45,10 @@ type SecretStore interface {
 
 type CommonClusterGetter struct {
 	secrets SecretStore
-	store   pke.AzurePKEClusterStore
+	store   pke.ClusterStore
 }
 
-func MakeCommonClusterGetter(secrets SecretStore, store pke.AzurePKEClusterStore) CommonClusterGetter {
+func MakeCommonClusterGetter(secrets SecretStore, store pke.ClusterStore) CommonClusterGetter {
 	return CommonClusterGetter{
 		secrets: secrets,
 		store:   store,
@@ -302,6 +302,6 @@ func (a *AzurePkeCluster) GetCAHash() (string, error) {
 	return fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:])), nil
 }
 
-func (a *AzurePkeCluster) GetPKEOnAzureCluster() pke.PKEOnAzureCluster {
+func (a *AzurePkeCluster) GetPKEOnAzureCluster() pke.Cluster {
 	return a.model
 }

--- a/internal/providers/azure/pke/driver/ssh.go
+++ b/internal/providers/azure/pke/driver/ssh.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetOrCreateSSHKeyPair creates and saves a new SSH key pair for the cluster or gets the cluster's SSH key pair if it already exists
-func GetOrCreateSSHKeyPair(cluster pke.PKEOnAzureCluster, secrets secretStore, store pke.AzurePKEClusterStore) (ssh.KeyPair, error) {
+func GetOrCreateSSHKeyPair(cluster pke.Cluster, secrets secretStore, store pke.ClusterStore) (ssh.KeyPair, error) {
 
 	keyPair, secretID, err := intSecret.GetOrCreateSSHKeyPair(secrets, getOrCreateSSHKeyPairClusterAdapter(cluster))
 	if err != nil {
@@ -43,7 +43,7 @@ type secretStore interface {
 	Store(organizationID uint, request *secret.CreateSecretRequest) (string, error)
 }
 
-type getOrCreateSSHKeyPairClusterAdapter pke.PKEOnAzureCluster
+type getOrCreateSSHKeyPairClusterAdapter pke.Cluster
 
 func (a getOrCreateSSHKeyPairClusterAdapter) GetID() uint {
 	return a.ID

--- a/internal/providers/azure/pke/store.go
+++ b/internal/providers/azure/pke/store.go
@@ -40,13 +40,13 @@ type CreateParams struct {
 	APIServerAccessPoints APIServerAccessPoints
 }
 
-// AzurePKEClusterStore defines behaviors of PKEOnAzureCluster persistent storage
-type AzurePKEClusterStore interface {
-	Create(params CreateParams) (PKEOnAzureCluster, error)
+// ClusterStore defines behaviors of Cluster persistent storage
+type ClusterStore interface {
+	Create(params CreateParams) (Cluster, error)
 	CreateNodePool(clusterID uint, nodePool NodePool) error
 	Delete(clusterID uint) error
 	DeleteNodePool(clusterID uint, nodePoolName string) error
-	GetByID(clusterID uint) (PKEOnAzureCluster, error)
+	GetByID(clusterID uint) (Cluster, error)
 	SetStatus(clusterID uint, status, message string) error
 	SetActiveWorkflowID(clusterID uint, workflowID string) error
 	SetConfigSecretID(clusterID uint, secretID string) error

--- a/internal/providers/azure/pke/workflow/delete_cluster_from_store_activity.go
+++ b/internal/providers/azure/pke/workflow/delete_cluster_from_store_activity.go
@@ -23,10 +23,10 @@ import (
 const DeleteClusterFromStoreActivityName = "pke-azure-delete-cluster-from-store"
 
 type DeleteClusterFromStoreActivity struct {
-	store pke.AzurePKEClusterStore
+	store pke.ClusterStore
 }
 
-func MakeDeleteClusterFromStoreActivity(store pke.AzurePKEClusterStore) DeleteClusterFromStoreActivity {
+func MakeDeleteClusterFromStoreActivity(store pke.ClusterStore) DeleteClusterFromStoreActivity {
 	return DeleteClusterFromStoreActivity{
 		store: store,
 	}

--- a/internal/providers/azure/pke/workflow/delete_nodepool_from_store_activity.go
+++ b/internal/providers/azure/pke/workflow/delete_nodepool_from_store_activity.go
@@ -25,10 +25,10 @@ import (
 const DeleteNodePoolFromStoreActivityName = "pke-azure-delete-node-pool-from-store"
 
 type DeleteNodePoolFromStoreActivity struct {
-	store pke.AzurePKEClusterStore
+	store pke.ClusterStore
 }
 
-func MakeDeleteNodePoolFromStoreActivity(store pke.AzurePKEClusterStore) DeleteNodePoolFromStoreActivity {
+func MakeDeleteNodePoolFromStoreActivity(store pke.ClusterStore) DeleteNodePoolFromStoreActivity {
 	return DeleteNodePoolFromStoreActivity{
 		store: store,
 	}

--- a/internal/providers/azure/pke/workflow/set_cluster_status_activity.go
+++ b/internal/providers/azure/pke/workflow/set_cluster_status_activity.go
@@ -26,10 +26,10 @@ import (
 const SetClusterStatusActivityName = "pke-azure-set-cluster-status"
 
 type SetClusterStatusActivity struct {
-	store pke.AzurePKEClusterStore
+	store pke.ClusterStore
 }
 
-func MakeSetClusterStatusActivity(store pke.AzurePKEClusterStore) SetClusterStatusActivity {
+func MakeSetClusterStatusActivity(store pke.ClusterStore) SetClusterStatusActivity {
 	return SetClusterStatusActivity{
 		store: store,
 	}

--- a/internal/providers/azure/pke/workflow/update_cluster_accesspoints_activity.go
+++ b/internal/providers/azure/pke/workflow/update_cluster_accesspoints_activity.go
@@ -25,10 +25,10 @@ import (
 const UpdateClusterAccessPointsActivityName = "pke-azure-upd-cluster-accesspoints"
 
 type UpdateClusterAccessPointsActivity struct {
-	store pke.AzurePKEClusterStore
+	store pke.ClusterStore
 }
 
-func MakeUpdateClusterAccessPointsActivity(store pke.AzurePKEClusterStore) UpdateClusterAccessPointsActivity {
+func MakeUpdateClusterAccessPointsActivity(store pke.ClusterStore) UpdateClusterAccessPointsActivity {
 	return UpdateClusterAccessPointsActivity{
 		store: store,
 	}

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -66,15 +66,15 @@ type ClusterAPI struct {
 }
 
 type ClusterCreators struct {
-	PKEOnAzure driver.AzurePKEClusterCreator
+	PKEOnAzure driver.ClusterCreator
 }
 
 type ClusterDeleters struct {
-	PKEOnAzure driver.AzurePKEClusterDeleter
+	PKEOnAzure driver.ClusterDeleter
 }
 
 type ClusterUpdaters struct {
-	PKEOnAzure driver.AzurePKEClusterUpdater
+	PKEOnAzure driver.ClusterUpdater
 }
 
 // NewClusterAPI returns a new ClusterAPI instance.

--- a/src/api/cluster/pke_azure.go
+++ b/src/api/cluster/pke_azure.go
@@ -26,7 +26,7 @@ const PKEOnAzure = pke.PKEOnAzure
 
 type CreatePKEOnAzureClusterRequest pipeline.CreatePkeOnAzureClusterRequest
 
-func (req CreatePKEOnAzureClusterRequest) ToAzurePKEClusterCreationParams(organizationID, userID uint) driver.AzurePKEClusterCreationParams {
+func (req CreatePKEOnAzureClusterRequest) ToAzurePKEClusterCreationParams(organizationID, userID uint) driver.ClusterCreationParams {
 	var accessPoints pke.AccessPoints
 	for _, apName := range req.AccessPoints {
 		accessPoints = append(accessPoints, pke.AccessPoint{Name: apName})
@@ -37,7 +37,7 @@ func (req CreatePKEOnAzureClusterRequest) ToAzurePKEClusterCreationParams(organi
 		apiServerAccessPoints = append(apiServerAccessPoints, pke.APIServerAccessPoint(ap))
 	}
 
-	return driver.AzurePKEClusterCreationParams{
+	return driver.ClusterCreationParams{
 		Name:           req.Name,
 		OrganizationID: organizationID,
 		CreatedBy:      userID,
@@ -96,8 +96,8 @@ func clientPKEClusterHTTPProxyOptionsToPKEHTTPProxyOptions(o pipeline.PkeCluster
 
 type UpdatePKEOnAzureClusterRequest pipeline.UpdatePkeOnAzureClusterRequest
 
-func (req UpdatePKEOnAzureClusterRequest) ToAzurePKEClusterUpdateParams(clusterID, userID uint) driver.AzurePKEClusterUpdateParams {
-	return driver.AzurePKEClusterUpdateParams{
+func (req UpdatePKEOnAzureClusterRequest) ToAzurePKEClusterUpdateParams(clusterID, userID uint) driver.ClusterUpdateParams {
+	return driver.ClusterUpdateParams{
 		ClusterID: clusterID,
 		NodePools: requestToClusterNodepools(req.Nodepools, userID),
 	}

--- a/src/api/cluster/pke_azure_test.go
+++ b/src/api/cluster/pke_azure_test.go
@@ -86,12 +86,12 @@ func TestToAzurePKEClusterCreationParams(t *testing.T) {
 	var conversionTest = []struct {
 		Name string
 		in   CreatePKEOnAzureClusterRequest
-		out  driver.AzurePKEClusterCreationParams
+		out  driver.ClusterCreationParams
 	}{
 		{
 			Name: "EmptyRequest",
 			in:   CreatePKEOnAzureClusterRequest{},
-			out: driver.AzurePKEClusterCreationParams{
+			out: driver.ClusterCreationParams{
 				OrganizationID: orgID,
 				CreatedBy:      userID,
 				NodePools:      []driver.NodePool{},
@@ -119,7 +119,7 @@ func TestToAzurePKEClusterCreationParams(t *testing.T) {
 				AccessPoints:          []string{"private", "public"},
 				ApiServerAccessPoints: []string{"private", "public"},
 			},
-			out: driver.AzurePKEClusterCreationParams{
+			out: driver.ClusterCreationParams{
 				CreatedBy: userID,
 				Kubernetes: pke.Kubernetes{
 					Version: Version,

--- a/src/cluster/autoscale.go
+++ b/src/cluster/autoscale.go
@@ -145,7 +145,7 @@ func getAzureNodeGroups(cluster CommonCluster) ([]nodeGroup, error) {
 		}
 	case pkgCluster.PKE:
 		i, ok := cluster.(interface {
-			GetPKEOnAzureCluster() pke.PKEOnAzureCluster
+			GetPKEOnAzureCluster() pke.Cluster
 		})
 		if !ok {
 			return nil, errors.New("Azure/PKE cluster does not implement method GetPKEOnAzureCluster")

--- a/src/cluster/common.go
+++ b/src/cluster/common.go
@@ -174,7 +174,7 @@ func StoreKubernetesConfig(cluster CommonCluster, config []byte) error {
 	var configYaml string
 
 	if azurePKEClusterGetter, ok := cluster.(interface {
-		GetPKEOnAzureCluster() pke.PKEOnAzureCluster
+		GetPKEOnAzureCluster() pke.Cluster
 	}); ok {
 		azurePKECluster := azurePKEClusterGetter.GetPKEOnAzureCluster()
 
@@ -306,7 +306,7 @@ func GetCommonClusterFromModel(modelCluster *model.ClusterModel) (CommonCluster,
 	if modelCluster.Distribution == pkgCluster.PKE && modelCluster.Cloud == pkgCluster.Azure {
 		logger := commonadapter.NewLogger(logrusadapter.New(log))
 		logger.Debug("azure adapter stuff")
-		return pkeAzureAdapter.MakeCommonClusterGetter(secret.Store, adapter.NewGORMAzurePKEClusterStore(db, logger)).GetByID(modelCluster.ID)
+		return pkeAzureAdapter.MakeCommonClusterGetter(secret.Store, adapter.NewClusterStore(db, logger)).GetByID(modelCluster.ID)
 	} else if modelCluster.Distribution == pkgCluster.PKE {
 		return createCommonClusterWithDistributionFromModel(modelCluster)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Removed `AzurePKE` and `PKEOnAzure` prefixes where they were unnecessary.

### Why?
Their package already indicates the same thing.
