### PR TITLE
Set cluster status on legacy cluster create workflow failure

### DIFF
--- a/src/cluster/manager_create.go
+++ b/src/cluster/manager_create.go
@@ -256,6 +256,8 @@ func (m *Manager) createCluster(
 
 		err = exec.Get(ctx, nil)
 		if err != nil {
+			_ = cluster.SetStatus(pkgCluster.Error, "failed to run setup jobs")
+
 			return emperror.Wrap(err, "running setup jobs failed")
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Set cluster status when the legacy cluster create workflow fails.

### Why?
The cluster status was not set when the workflow failed, thus clusters could be stuck in creating status.

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
