### PR TITLE
[Logging] Update resources instead of deleting and recreating

### DIFF
--- a/internal/integratedservices/services/logging/common_test.go
+++ b/internal/integratedservices/services/logging/common_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter"
@@ -181,5 +182,13 @@ func (s *dummyKubernetesService) EnsureObject(ctx context.Context, clusterID uin
 }
 
 func (s *dummyKubernetesService) List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error {
+	return nil
+}
+
+func (s *dummyKubernetesService) Update(ctx context.Context, clusterID uint, o runtime.Object) error {
+	return nil
+}
+
+func (s *dummyKubernetesService) GetObject(ctx context.Context, clusterID uint, objRef corev1.ObjectReference, obj runtime.Object) error {
 	return nil
 }

--- a/internal/integratedservices/services/logging/kubernetes.go
+++ b/internal/integratedservices/services/logging/kubernetes.go
@@ -17,6 +17,7 @@ package logging
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -24,8 +25,14 @@ type KubernetesService interface {
 	// EnsureObject makes sure that a given Object is on the cluster and returns it.
 	EnsureObject(ctx context.Context, clusterID uint, o runtime.Object) error
 
+	// Update updates a given Object on the cluster and returns it.
+	Update(ctx context.Context, clusterID uint, o runtime.Object) error
+
 	// DeleteObject deletes an Object from a specific cluster.
 	DeleteObject(ctx context.Context, clusterID uint, o runtime.Object) error
+
+	// GetObject gets an Object from a specific cluster.
+	GetObject(ctx context.Context, clusterID uint, objRef corev1.ObjectReference, obj runtime.Object) error
 
 	// List lists Objects on specific cluster.
 	List(ctx context.Context, clusterID uint, labels map[string]string, o runtime.Object) error


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Update `Logging` and `ClusterFlow` resources instead of deleting and recreating

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

