### PR TITLE
Change Service URL format

### DIFF
--- a/internal/cluster/endpoints/endpoints.go
+++ b/internal/cluster/endpoints/endpoints.go
@@ -89,7 +89,7 @@ func (m *EndpointManager) GetServiceURL(kubeConfig []byte, serviceName string, n
 		return "", errors.WrapIf(err, "failed to list services")
 	}
 
-	return fmt.Sprintf("http://%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].Port), nil
+	return fmt.Sprintf("%s.%s.svc:%d", serviceName, namespace, service.Spec.Ports[0].Port), nil
 }
 
 func deploymentHasOwnLoadBalancer(serviceList *v1.ServiceList, releaseName string) bool {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Change service url format. After this change the service url will look like this: `loki.pipeline-system.svc:3100`


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

