### PR TITLE
Fix error handling of legacy cluster create workflow

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -370,7 +370,7 @@ func main() {
 		errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 	}
 
-	clusterManager := cluster.NewManager(clusters, secretValidator, clusterEvents, statusChangeDurationMetric, clusterTotalMetric, workflowClient, logrusLogger, errorHandler)
+	clusterManager := cluster.NewManager(clusters, secretValidator, clusterEvents, statusChangeDurationMetric, clusterTotalMetric, workflowClient, logrusLogger, errorHandler, clusteradapter.NewStore(db, clusters))
 	commonClusterGetter := common.NewClusterGetter(clusterManager, logrusLogger, errorHandler)
 
 	clusterTTLController := cluster.NewTTLController(clusterManager, clusterEventBus, logrusLogger.WithField("subsystem", "ttl-controller"), errorHandler)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -196,8 +196,9 @@ func main() {
 		}
 		global.SetDB(db)
 
+		clusterRepo := clusteradapter.NewClusters(db)
 		clusterManager := cluster.NewManager(
-			clusteradapter.NewClusters(db),
+			clusterRepo,
 			nil,
 			nil,
 			nil,
@@ -205,6 +206,7 @@ func main() {
 			nil,
 			logrusLogger,
 			errorHandler,
+			clusteradapter.NewStore(db, clusterRepo),
 		)
 		tokenStore := bauth.NewVaultTokenStore("pipeline")
 		tokenManager := pkgAuth.NewTokenManager(

--- a/pkg/cadence/client_error.go
+++ b/pkg/cadence/client_error.go
@@ -15,6 +15,8 @@
 package cadence
 
 import (
+	"fmt"
+
 	"emperror.dev/errors"
 	"go.uber.org/cadence"
 )
@@ -36,5 +38,17 @@ func WrapClientError(err error) error {
 		}
 	}
 
+	return err
+}
+
+// UnwrapError returns a new detailed error based on the wrapped string in a ClientError,
+// or the original error otherwise
+func UnwrapError(err error) error {
+	if detailser, ok := err.(interface{ Details(d ...interface{}) error }); ok {
+		var str string
+		if detailser.Details(&str) == nil {
+			return fmt.Errorf("client error: %s", str)
+		}
+	}
 	return err
 }

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -120,7 +120,8 @@ func getClusterFromRequest(c *gin.Context) (cluster.CommonCluster, bool) {
 	// TODO: move these to a struct and create them only once upon application init
 	clusters := clusteradapter.NewClusters(global.DB())
 	secretValidator := providers.NewSecretValidator(secret.Store)
-	clusterManager := cluster.NewManager(clusters, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler)
+	clusterStore := clusteradapter.NewStore(global.DB(), clusters)
+	clusterManager := cluster.NewManager(clusters, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore)
 	clusterGetter := common.NewClusterGetter(clusterManager, log, errorHandler)
 
 	return clusterGetter.GetClusterFromRequest(c)

--- a/src/api/secrets.go
+++ b/src/api/secrets.go
@@ -546,7 +546,9 @@ func IsValidSecretType(secretType string) error {
 func checkClustersBeforeDelete(orgId uint, secretId string) error {
 	// TODO: move these to a struct and create them only once upon application init
 	secretValidator := providers.NewSecretValidator(secret.Store)
-	clusterManager := cluster.NewManager(clusteradapter.NewClusters(global.DB()), secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler)
+	clusterRepo := clusteradapter.NewClusters(global.DB())
+	clusterStore := clusteradapter.NewStore(global.DB(), clusterRepo)
+	clusterManager := cluster.NewManager(clusterRepo, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore)
 
 	clusters, err := clusterManager.GetClustersBySecretID(context.Background(), orgId, secretId)
 	if err != nil {

--- a/src/cluster/manager.go
+++ b/src/cluster/manager.go
@@ -66,16 +66,24 @@ type Manager struct {
 	workflowClient             client.Client
 	logger                     logrus.FieldLogger
 	errorHandler               emperror.Handler
+	clusterStore               interface {
+		SetStatus(ctx context.Context, id uint, status, message string) error
+	}
 }
 
-func NewManager(clusters clusterRepository,
+func NewManager(
+	clusters clusterRepository,
 	secrets secretValidator,
 	events clusterEvents,
 	statusChangeDurationMetric metrics.ClusterStatusChangeDurationMetric,
 	clusterTotalMetric *prometheus.CounterVec,
 	workflowClient client.Client,
 	logger logrus.FieldLogger,
-	errorHandler emperror.Handler) *Manager {
+	errorHandler emperror.Handler,
+	clusterStore interface {
+		SetStatus(ctx context.Context, id uint, status, message string) error
+	},
+) *Manager {
 	return &Manager{
 		clusters:                   clusters,
 		secrets:                    secrets,
@@ -86,6 +94,7 @@ func NewManager(clusters clusterRepository,
 		workflowClient:             workflowClient,
 		logger:                     logger,
 		errorHandler:               errorHandler,
+		clusterStore:               clusterStore,
 	}
 }
 

--- a/src/cluster/manager_create.go
+++ b/src/cluster/manager_create.go
@@ -64,7 +64,11 @@ type clusterCreator interface {
 }
 
 // CreateCluster creates a new cluster in the background.
-func (m *Manager) CreateCluster(ctx context.Context, creationCtx CreationContext, creator clusterCreator) (CommonCluster, error) {
+func (m *Manager) CreateCluster(
+	ctx context.Context,
+	creationCtx CreationContext,
+	creator clusterCreator,
+) (CommonCluster, error) {
 	logger := m.getLogger(ctx).WithFields(logrus.Fields{
 		"organization": creationCtx.OrganizationID,
 		"user":         creationCtx.UserID,
@@ -256,6 +260,8 @@ func (m *Manager) createCluster(
 
 		err = exec.Get(ctx, nil)
 		if err != nil {
+			_ = m.clusterStore.SetStatus(ctx, cluster.GetID(), pkgCluster.Error, err.Error())
+
 			return emperror.Wrap(err, "running setup jobs failed")
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Set error status when the legacy workflow fails, and don't retry config download 30 times when permission errors occur.

### Checklist

- [x] Implementation tested (with at least one cloud provider)