### PR TITLE
EKS: send heartbeats when waiting for stack create, update

### DIFF
--- a/internal/providers/amazon/eks/workflow/amazon.go
+++ b/internal/providers/amazon/eks/workflow/amazon.go
@@ -18,9 +18,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/zap"
+
+	"github.com/banzaicloud/pipeline/pkg/providers/amazon/autoscaling"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -32,12 +38,19 @@ import (
 
 	"github.com/banzaicloud/pipeline/src/secret"
 
+	zapadapter "logur.dev/adapter/zap"
+
 	internalAmazon "github.com/banzaicloud/pipeline/internal/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
 // ErrReasonStackFailed cadence custom error reason that denotes a stack operation that resulted a stack failure
 const ErrReasonStackFailed = "CLOUDFORMATION_STACK_FAILED"
+
+const asgWaitLoopSleep = 5 * time.Second
+const asgFulfillmentTimeout = 2 * time.Minute
+const asgFulfillmentWaitAttempts = asgFulfillmentTimeout / asgWaitLoopSleep
+const asgFulfillmentWaitInterval = asgWaitLoopSleep
 
 // getStackTags returns the tags that are placed onto CF template stacks.
 // These tags  are propagated onto the resources created by the CF template.
@@ -198,4 +211,252 @@ type EksCluster interface {
 	DeleteFromDatabase() error
 	GetConfigSecretId() string
 	SaveConfigSecretId(secretID string) error
+}
+
+func WaitUntilStackCreateCompleteWithContext(cf *cloudformation.CloudFormation, ctx aws.Context, input *cloudformation.DescribeStacksInput, opts ...request.WaiterOption) error {
+	count := 0
+	w := request.Waiter{
+		Name:        "WaitUntilStackCreateComplete",
+		MaxAttempts: 120,
+		Delay:       request.ConstantWaiterDelay(30 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAllWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "CREATE_COMPLETE",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "CREATE_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "DELETE_COMPLETE",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "DELETE_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "ROLLBACK_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "ROLLBACK_COMPLETE",
+			},
+			{
+				State:    request.FailureWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+		},
+		Logger: cf.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
+			var inCpy *cloudformation.DescribeStacksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := cf.DescribeStacksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}
+
+func WaitUntilStackUpdateCompleteWithContext(cf *cloudformation.CloudFormation, ctx aws.Context, input *cloudformation.DescribeStacksInput, opts ...request.WaiterOption) error {
+	count := 0
+	w := request.Waiter{
+		Name:        "WaitUntilStackUpdateComplete",
+		MaxAttempts: 120,
+		Delay:       request.ConstantWaiterDelay(30 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAllWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_COMPLETE",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_ROLLBACK_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_ROLLBACK_COMPLETE",
+			},
+			{
+				State:    request.FailureWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+		},
+		Logger: cf.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
+			var inCpy *cloudformation.DescribeStacksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := cf.DescribeStacksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}
+
+func WaitUntilStackDeleteCompleteWithContext(cf *cloudformation.CloudFormation, ctx aws.Context, input *cloudformation.DescribeStacksInput, opts ...request.WaiterOption) error {
+	count := 0
+	w := request.Waiter{
+		Name:        "WaitUntilStackDeleteComplete",
+		MaxAttempts: 120,
+		Delay:       request.ConstantWaiterDelay(30 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAllWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "DELETE_COMPLETE",
+			},
+			{
+				State:    request.SuccessWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "DELETE_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "CREATE_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "ROLLBACK_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_ROLLBACK_IN_PROGRESS",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_ROLLBACK_FAILED",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Stacks[].StackStatus",
+				Expected: "UPDATE_ROLLBACK_COMPLETE",
+			},
+		},
+		Logger: cf.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
+			var inCpy *cloudformation.DescribeStacksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := cf.DescribeStacksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}
+
+// WaitForASGToBeFulfilled waits until an ASG has the desired amount of healthy nodes
+func WaitForASGToBeFulfilled(
+	ctx context.Context,
+	logger *zap.SugaredLogger,
+	awsSession *session.Session,
+	stackName string,
+	nodePoolName string) error {
+
+	logger = logger.With("stackName", stackName)
+	logger.Info("wait for ASG to be fulfilled")
+
+	m := autoscaling.NewManager(awsSession, autoscaling.MetricsEnabled(true), autoscaling.Logger{
+		Logger: zapadapter.New(logger.Desugar()),
+	})
+
+	ticker := time.NewTicker(asgFulfillmentWaitInterval)
+	defer ticker.Stop()
+
+	i := 0
+	for {
+		select {
+		case <-ticker.C:
+			if i <= int(asgFulfillmentWaitAttempts) {
+				i++
+				activity.RecordHeartbeat(ctx, i)
+
+				asGroup, err := m.GetAutoscalingGroupByStackName(stackName)
+				if err != nil {
+					if aerr, ok := err.(awserr.Error); ok {
+						if aerr.Code() == "ValidationError" || aerr.Code() == "ASGNotFoundInResponse" {
+							continue
+						}
+					}
+					return errors.WrapIfWithDetails(err, "could not get ASG", "stackName", stackName)
+				}
+
+				ok, err := asGroup.IsHealthy()
+				if err != nil {
+					if autoscaling.IsErrorFinal(err) {
+						return errors.WithDetails(err, "nodePoolName", nodePoolName, "stackName", aws.StringValue(asGroup.AutoScalingGroupName))
+					}
+					//log.Debug(err)
+					continue
+				}
+				if ok {
+					//log.Debug("ASG is healthy")
+					return nil
+				}
+			} else {
+				return errors.Errorf("waiting for ASG to be fulfilled timed out after %d x %s", asgFulfillmentWaitAttempts, asgFulfillmentWaitInterval)
+			}
+		case <-ctx.Done(): // wait for ASG fulfillment cancelled
+			return nil
+		}
+	}
+
 }

--- a/internal/providers/amazon/eks/workflow/amazon.go
+++ b/internal/providers/amazon/eks/workflow/amazon.go
@@ -21,27 +21,22 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"go.uber.org/cadence/activity"
-	"go.uber.org/zap"
-
-	"github.com/banzaicloud/pipeline/pkg/providers/amazon/autoscaling"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/zap"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api/v1"
-
-	"github.com/banzaicloud/pipeline/src/model"
-
-	"github.com/banzaicloud/pipeline/src/secret"
-
 	zapadapter "logur.dev/adapter/zap"
 
 	internalAmazon "github.com/banzaicloud/pipeline/internal/providers/amazon"
+	"github.com/banzaicloud/pipeline/pkg/providers/amazon/autoscaling"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
+	"github.com/banzaicloud/pipeline/src/model"
+	"github.com/banzaicloud/pipeline/src/secret"
 )
 
 // ErrReasonStackFailed cadence custom error reason that denotes a stack operation that resulted a stack failure

--- a/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
@@ -217,7 +217,7 @@ func waitUntilClusterCreateCompleteWithContext(eksSvc *eks.EKS, ctx aws.Context,
 		Logger: eksSvc.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 
-			count = count + 1
+			count++
 			activity.RecordHeartbeat(ctx, count)
 
 			var inCpy *eks.DescribeClusterInput

--- a/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
@@ -187,6 +187,7 @@ func (a *CreateEksControlPlaneActivity) Execute(ctx context.Context, input Creat
 
 func waitUntilClusterCreateCompleteWithContext(eksSvc *eks.EKS, ctx aws.Context, input *eks.DescribeClusterInput, opts ...request.WaiterOption) error {
 	// wait for 15 mins
+	count := 0
 	w := request.Waiter{
 		Name:        "WaitUntilClusterCreateComplete",
 		MaxAttempts: 30,
@@ -215,6 +216,10 @@ func waitUntilClusterCreateCompleteWithContext(eksSvc *eks.EKS, ctx aws.Context,
 		},
 		Logger: eksSvc.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
+
+			count = count + 1
+			activity.RecordHeartbeat(ctx, count)
+
 			var inCpy *eks.DescribeClusterInput
 			if input != nil {
 				tmp := *input

--- a/internal/providers/amazon/eks/workflow/create_iam_roles_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_iam_roles_activity.go
@@ -119,7 +119,7 @@ func (a *CreateIamRolesActivity) Execute(ctx context.Context, input CreateIamRol
 	}
 
 	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
-	err = cloudformationClient.WaitUntilStackCreateComplete(describeStacksInput)
+	err = WaitUntilStackCreateCompleteWithContext(cloudformationClient, ctx, describeStacksInput)
 	if err != nil {
 		return nil, packageCFError(err, input.StackName, clientRequestToken, cloudformationClient, "failed to describe stack")
 	}

--- a/internal/providers/amazon/eks/workflow/create_subnet_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_subnet_activity.go
@@ -129,7 +129,7 @@ func (a *CreateSubnetActivity) Execute(ctx context.Context, input CreateSubnetAc
 		}
 
 		describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
-		err = cloudformationClient.WaitUntilStackCreateComplete(describeStacksInput)
+		err = WaitUntilStackCreateCompleteWithContext(cloudformationClient, ctx, describeStacksInput)
 
 		if err != nil {
 			return nil, packageCFError(err, input.StackName, clientRequestToken, cloudformationClient, "failed to create subnet with cidr")

--- a/internal/providers/amazon/eks/workflow/create_vpc_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_vpc_activity.go
@@ -135,7 +135,7 @@ func (a *CreateVpcActivity) Execute(ctx context.Context, input CreateVpcActivity
 	}
 
 	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
-	err = cloudformationClient.WaitUntilStackCreateCompleteWithContext(ctx, describeStacksInput)
+	err = WaitUntilStackCreateCompleteWithContext(cloudformationClient, ctx, describeStacksInput)
 	if err != nil {
 		var awsErr awserr.Error
 		if errors.As(err, &awsErr) {

--- a/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
@@ -99,7 +99,7 @@ func (a *DeleteControlPlaneActivity) Execute(ctx context.Context, input DeleteCo
 }
 
 func (a *DeleteControlPlaneActivity) waitUntilClusterExists(ctx aws.Context, eksSvc *eks.EKS, input *eks.DescribeClusterInput, opts ...request.WaiterOption) error {
-	count := 1
+	count := 0
 	w := request.Waiter{
 		Name:        "WaitUntilClusterExists",
 		MaxAttempts: 30,

--- a/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_control_plane_activity.go
@@ -88,7 +88,7 @@ func (a *DeleteControlPlaneActivity) Execute(ctx context.Context, input DeleteCo
 	describeClusterInput := &eks.DescribeClusterInput{
 		Name: aws.String(input.ClusterName),
 	}
-	err = a.waitUntilClusterExists(aws.BackgroundContext(), eksSvc, describeClusterInput)
+	err = a.waitUntilClusterExists(ctx, eksSvc, describeClusterInput)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (a *DeleteControlPlaneActivity) Execute(ctx context.Context, input DeleteCo
 }
 
 func (a *DeleteControlPlaneActivity) waitUntilClusterExists(ctx aws.Context, eksSvc *eks.EKS, input *eks.DescribeClusterInput, opts ...request.WaiterOption) error {
-
+	count := 1
 	w := request.Waiter{
 		Name:        "WaitUntilClusterExists",
 		MaxAttempts: 30,
@@ -118,6 +118,10 @@ func (a *DeleteControlPlaneActivity) waitUntilClusterExists(ctx aws.Context, eks
 		},
 		Logger: eksSvc.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
+
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
 			var inCpy *eks.DescribeClusterInput
 			if input != nil {
 				tmp := *input

--- a/internal/providers/amazon/eks/workflow/delete_stack_activity.go
+++ b/internal/providers/amazon/eks/workflow/delete_stack_activity.go
@@ -85,7 +85,7 @@ func (a *DeleteStackActivity) Execute(ctx context.Context, input DeleteStackActi
 	}
 
 	describeStacksInput := &cloudformation.DescribeStacksInput{StackName: aws.String(input.StackName)}
-	err = cloudformationClient.WaitUntilStackDeleteComplete(describeStacksInput)
+	err = WaitUntilStackDeleteCompleteWithContext(cloudformationClient, ctx, describeStacksInput)
 	if err != nil {
 		var awsErr awserr.Error
 		if errors.As(err, &awsErr) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- send heartbeat when waiting for AWS CF stack create, update, delete complete and meanwhile waiting for spot fulfilment
- set heartbeat timeout for related actions

### Why?

At the moment we set 5 minute timeout most of stack related actions and 20 minutes for EKS control plane create, which means in case of a worker restart these actions are not retried until this time out occurs. By setting a short heartbeat timeout 45 sec and sending heartbeats each 30 sec, meanwhile waiting these action are retried in a much shorter timeframe. There are no separate actions created for stack complete wait, as it would over complicate the workflow code, plus the stack create/delete/update actions should terminate within seconds and right after that the first heartbeat is sent with first stack describe request. There's also no harm with rerunning these action as these are idempotent when running with the same request id.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)