### PR TITLE
EKS update: use workflow id as token base, add mutex to ASG fulfilment wait

### DIFF
--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"github.com/gofrs/uuid"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
 
@@ -97,12 +96,13 @@ func EKSUpdateClusterWorkflow(ctx workflow.Context, input EKSUpdateClusterstruct
 		"cluster", input.ClusterName,
 	)
 
+	workflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
 	commonActivityInput := eksWorkflow.EKSActivityInput{
 		OrganizationID:            input.OrganizationID,
 		SecretID:                  input.SecretID,
 		Region:                    input.Region,
 		ClusterName:               input.ClusterName,
-		AWSClientRequestTokenBase: uuid.Must(uuid.NewV4()).String(),
+		AWSClientRequestTokenBase: workflowID,
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, ao)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- use workflow id as token base for update actions
- exit from update activity when there's no change in stack
- add mutex to ASG fulfilment wait timer map

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
