### PR TITLE
set CWD for VSCode launch targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}/cmd/pipeline/main.go",
+            "cwd": "${workspaceRoot}",
             "env": {
                 "PIPELINE_CONFIG_DIR": "${workspaceRoot}/config",
                 "VAULT_ADDR": "http://127.0.0.1:8200"
@@ -19,6 +20,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}/cmd/worker/main.go",
+            "cwd": "${workspaceRoot}",
             "env": {
                 "PIPELINE_CONFIG_DIR": "${workspaceRoot}/config",
                 "VAULT_ADDR": "http://127.0.0.1:8200"


### PR DESCRIPTION
Otherwise templates are not found.