### PR TITLE
Return a separate k8s config through the API that is used internally

### DIFF
--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -202,6 +202,10 @@ func (a *AzurePkeCluster) GetK8sConfig() ([]byte, error) {
 	return []byte(configStr), nil
 }
 
+func (a *AzurePkeCluster) GetK8sUserConfig() ([]byte, error) {
+	return a.GetK8sConfig()
+}
+
 func (a *AzurePkeCluster) RequiresSshPublicKey() bool {
 	return true
 }

--- a/internal/providers/pke/pkeworkflow/pkeworkflowadapter/cluster_manager.go
+++ b/internal/providers/pke/pkeworkflow/pkeworkflowadapter/cluster_manager.go
@@ -64,6 +64,10 @@ func (c *Cluster) GetK8sConfig() ([]byte, error) {
 	return c.CommonCluster.GetK8sConfig()
 }
 
+func (c *Cluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 func (c *Cluster) GetNodePools() []pkeworkflow.NodePool {
 	clusterNodePools := c.CommonCluster.(interface {
 		GetNodePools() []cluster.PKENodePool

--- a/pkg/k8sutil/configtemplate.go
+++ b/pkg/k8sutil/configtemplate.go
@@ -1,0 +1,76 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type AuthInfoFactory interface {
+	CreateAuthInfo(string) *clientcmdapi.AuthInfo
+}
+
+// CreateAuthInfoFunc creates a provider specific AuthInfo object for the given cluster
+type CreateAuthInfoFunc func(clusterName string) *clientcmdapi.AuthInfo
+
+// CreateAuthInfo implements AuthInfoFactory for CreateAuthInfoFunc
+func (f CreateAuthInfoFunc) CreateAuthInfo(clusterName string) *clientcmdapi.AuthInfo {
+	return f(clusterName)
+}
+
+type ConfigBase struct {
+	ClusterName              string
+	APIEndpoint              string
+	CertificateAuthorityData []byte
+}
+
+func ExtractConfigBase(config *clientcmdapi.Config) *ConfigBase {
+	configBase := &ConfigBase{}
+
+	currentContextName := config.CurrentContext
+	if currentContext, ok := config.Contexts[currentContextName]; ok {
+		if server, ok := config.Clusters[currentContext.Cluster]; ok {
+			configBase.APIEndpoint = server.Server
+			configBase.CertificateAuthorityData = server.CertificateAuthorityData
+			configBase.ClusterName = currentContext.Cluster
+		}
+	}
+
+	return configBase
+}
+
+// CreateConfigFromTemplate creates a minimal Kubernetes Config based on the given information
+func (configBase *ConfigBase) CreateConfigFromTemplate(authInfo AuthInfoFactory) *clientcmdapi.Config {
+	return &clientcmdapi.Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: configBase.ClusterName,
+		Clusters: map[string]*clientcmdapi.Cluster{
+			configBase.ClusterName: {
+				Server:                   configBase.APIEndpoint,
+				CertificateAuthorityData: configBase.CertificateAuthorityData,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			configBase.ClusterName: {
+				AuthInfo: configBase.ClusterName,
+				Cluster:  configBase.ClusterName,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			configBase.ClusterName: authInfo.CreateAuthInfo(configBase.ClusterName),
+		},
+	}
+}

--- a/pkg/k8sutil/configtemplate_test.go
+++ b/pkg/k8sutil/configtemplate_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil_test
+
+import (
+	"testing"
+
+	"github.com/banzaicloud/pipeline/pkg/k8sutil"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestCreateConfigFromTemplateIsValid(t *testing.T) {
+	configBase := &k8sutil.ConfigBase{
+		ClusterName:              "cluster",
+		APIEndpoint:              "https://asdf.as:123",
+		CertificateAuthorityData: []byte("aasdasdasd"),
+	}
+	config := configBase.CreateConfigFromTemplate(
+		k8sutil.CreateAuthInfoFunc(func(clusterName string) *api.AuthInfo {
+			return &api.AuthInfo{}
+		}))
+	err := clientcmd.Validate(*config)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+}

--- a/pkg/k8sutil/configtemplate_test.go
+++ b/pkg/k8sutil/configtemplate_test.go
@@ -17,9 +17,10 @@ package k8sutil_test
 import (
 	"testing"
 
-	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 )
 
 func TestCreateConfigFromTemplateIsValid(t *testing.T) {

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -118,7 +118,7 @@ func GetClusterConfig(c *gin.Context) {
 	if ok != true {
 		return
 	}
-	config, err := commonCluster.GetK8sConfig()
+	config, err := commonCluster.GetK8sUserConfig()
 	if err != nil {
 		log.Debugf("error during getting config: %s", err.Error())
 		c.JSON(http.StatusBadRequest, pkgCommon.ErrorResponse{

--- a/src/cluster/ack.go
+++ b/src/cluster/ack.go
@@ -1069,6 +1069,10 @@ func (c *ACKCluster) GetK8sConfig() ([]byte, error) {
 	return c.CommonClusterBase.getConfig(c)
 }
 
+func (c *ACKCluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 func (c *ACKCluster) createAlibabaCredentialsFromSecret() (*credentials.AccessKeyCredential, error) {
 	clusterSecret, err := c.GetSecretWithValidation()
 	if err != nil {

--- a/src/cluster/aks.go
+++ b/src/cluster/aks.go
@@ -955,6 +955,11 @@ func (c *AKSCluster) GetK8sConfig() ([]byte, error) {
 	return c.CommonClusterBase.getConfig(c)
 }
 
+// GetK8sUserConfig returns the Kubernetes config for external users
+func (c *AKSCluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 // RequiresSshPublicKey returns true if a public SSH key is needed for bootstrapping the cluster
 func (c *AKSCluster) RequiresSshPublicKey() bool {
 	return true

--- a/src/cluster/common.go
+++ b/src/cluster/common.go
@@ -84,6 +84,7 @@ type CommonCluster interface {
 	// Kubernetes
 	GetAPIEndpoint() (string, error)
 	GetK8sConfig() ([]byte, error)
+	GetK8sUserConfig() ([]byte, error)
 	RequiresSshPublicKey() bool
 	RbacEnabled() bool
 

--- a/src/cluster/dummy.go
+++ b/src/cluster/dummy.go
@@ -235,6 +235,11 @@ func (c *DummyCluster) GetK8sConfig() ([]byte, error) {
 	return c.DownloadK8sConfig()
 }
 
+// GetK8sUserConfig returns the Kubernetes config
+func (c *DummyCluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 // RbacEnabled returns true if rbac enabled on the cluster
 func (c *DummyCluster) RbacEnabled() bool {
 	return c.modelCluster.RbacEnabled

--- a/src/cluster/ec2_pke.go
+++ b/src/cluster/ec2_pke.go
@@ -629,6 +629,10 @@ func (c *EC2ClusterPKE) GetK8sConfig() ([]byte, error) {
 	return c.CommonClusterBase.getConfig(c)
 }
 
+func (c *EC2ClusterPKE) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 func (c *EC2ClusterPKE) RbacEnabled() bool {
 	return c.model.Kubernetes.RBACEnabled
 }

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -24,9 +24,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 
 	"github.com/banzaicloud/pipeline/pkg/cluster/eks/nodepools"
 
@@ -547,6 +548,10 @@ func (c *EKSCluster) GetK8sConfig() ([]byte, error) {
 // GetK8sUserConfig returns the Kubernetes config for external users
 func (c *EKSCluster) GetK8sUserConfig() ([]byte, error) {
 	adminConfig, err := c.CommonClusterBase.getConfig(c)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to get raw kubernetes config")
+	}
+
 	parsedAdminConfig, err := clientcmd.Load(adminConfig)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to load kubernetes API config")

--- a/src/cluster/gke.go
+++ b/src/cluster/gke.go
@@ -2012,6 +2012,11 @@ func (c *GKECluster) GetK8sConfig() ([]byte, error) {
 	return c.CommonClusterBase.getConfig(c)
 }
 
+// GetK8sUserConfig returns the Kubernetes config
+func (c *GKECluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 func waitForOperation(getter operationInfoer, operationName string, logger logrus.FieldLogger) error {
 
 	log := logger.WithFields(logrus.Fields{"operation": operationName})

--- a/src/cluster/kubernetes.go
+++ b/src/cluster/kubernetes.go
@@ -316,6 +316,11 @@ func (c *KubeCluster) GetK8sConfig() ([]byte, error) {
 	return c.DownloadK8sConfig()
 }
 
+// GetK8sUserConfig returns the Kubernetes config
+func (c *KubeCluster) GetK8sUserConfig() ([]byte, error) {
+	return c.GetK8sConfig()
+}
+
 // RbacEnabled returns true if rbac enabled on the cluster
 func (c *KubeCluster) RbacEnabled() bool {
 	return c.modelCluster.RbacEnabled

--- a/src/cluster/oke.go
+++ b/src/cluster/oke.go
@@ -522,6 +522,11 @@ func (o *OKECluster) GetK8sConfig() ([]byte, error) {
 	return o.CommonClusterBase.getConfig(o)
 }
 
+// GetK8sUserConfig returns the Kubernetes config
+func (o *OKECluster) GetK8sUserConfig() ([]byte, error) {
+	return o.GetK8sConfig()
+}
+
 // GetClusterManager creates a new oracleClusterManager.ClusterManager
 func (o *OKECluster) GetClusterManager() (manager *oracleClusterManager.ClusterManager, err error) {
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
It uses a separate Kubernetes config to return to users over the API. Not all provider implementations support this right now, but gradually we will upgrade all of them. Until then, they will provide the same config as before.

### Why?
This is necessary from a security perspective, because the Kubernetes config used internally has cluster admin privileges and contains non-expiring, explicit credentials that should not be exposed and shared between users.

### Additional context
In the current implementation the EKS kubeconfig is produced from the endpoint data available in the admin config, but we can expect to have implementations that will go to the provider's API to fetch the whole config when requested (e.g. OKE).


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

