### PR TITLE
Check for service re-activation

### DIFF
--- a/internal/integratedservices/service.go
+++ b/internal/integratedservices/service.go
@@ -131,7 +131,7 @@ func (s IntegratedServiceService) Details(ctx context.Context, clusterID uint, i
 	return integratedService, nil
 }
 
-// Activate activates a integrated service.
+// Activate activates an integrated service.
 func (s IntegratedServiceService) Activate(ctx context.Context, clusterID uint, integratedServiceName string, spec map[string]interface{}) error {
 	logger := s.logger.WithContext(ctx).WithFields(map[string]interface{}{"clusterId": clusterID, "integrated service": integratedServiceName})
 	logger.Info("processing integrated service activation request")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | maybe
| New feature?    | maybe
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Return an error when the user is trying to activate an already active service.


### Why?
Integrated services have an "activate once, update many" semantic.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
