### PR TITLE
[Logging service] Create flow resource in case of non empty output list

### DIFF
--- a/internal/integratedservices/services/logging/operator_flow_resource.go
+++ b/internal/integratedservices/services/logging/operator_flow_resource.go
@@ -25,6 +25,11 @@ import (
 )
 
 func (op IntegratedServiceOperator) createClusterFlowResource(ctx context.Context, managers []outputDefinitionManager, clusterID uint) error {
+	if len(managers) == 0 {
+		// create flow only in case of non empty output list
+		return nil
+	}
+
 	var flowResource = op.generateFlowResource(managers)
 
 	var oldFlow v1beta1.ClusterFlow


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Create `ClusterFlow` resource in case of non empty output list

### Why?
to avoid this type of errors:
```
failed to create cluster flow resource: failed to create Object: ClusterFlow.logging.banzaicloud.io \"banzai-logging-flow\" is invalid: []: Invalid value: map[string]interface {}{\"apiVersion\":\"logging.banzaicloud.io/v1beta1\", \"kind\":\"ClusterFlow\", \"metadata\":map[string]interface {}{\"creationTimestamp\":\"2020-01-21T12:27:48Z\", \"generation\":1, \"labels\":map[string]interface {}{\"banzaicloud.io/service\":\"logging\"}, \"name\":\"banzai-logging-flow\", \"namespace\":\"pipeline-system\", \"uid\":\"6efdda87-3c49-11ea-87ba-42010a8e007e\"}, \"spec\":map[string]interface {}{\"outputRefs\":interface {}(nil), \"selectors\":map[string]interface {}{}}, \"status\":map[string]interface {}{}}: validation failure list:\nspec.outputRefs in body must be of type array: \"null\""
```


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
