### PR TITLE
remove kubernetes.io from forbidden domains & add forbidden labels list

### DIFF
--- a/charts/pipeline/Chart.yaml
+++ b/charts/pipeline/Chart.yaml
@@ -1,6 +1,6 @@
 name: pipeline
 home: https://banzaicloud.com
-version: 0.5.0
+version: 0.5.1
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline

--- a/charts/pipeline/values.yaml
+++ b/charts/pipeline/values.yaml
@@ -108,19 +108,6 @@ configuration:
           key: ""
           cert: ""
 
-    labels:
-      forbiddenDomains:
-        - k8s.io
-        - kubernetes.io
-        - google.com
-        - coreos.com
-        - oraclecloud.com
-        - node.info
-        - azure.com
-        - agentpool
-        - storageprofile
-        - storagetier
-
     securityScan:
       anchore:
         enabled: false

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -53,8 +53,6 @@ import (
 	zaplog "logur.dev/integration/zap"
 	"logur.dev/logur"
 
-	"github.com/banzaicloud/pipeline/internal/global/nplabels"
-
 	cloudinfoapi "github.com/banzaicloud/pipeline/.gen/cloudinfo"
 	anchore2 "github.com/banzaicloud/pipeline/internal/anchore"
 	"github.com/banzaicloud/pipeline/internal/app/frontend"
@@ -86,6 +84,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/federation"
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/internal/global/globalcluster"
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 	"github.com/banzaicloud/pipeline/internal/helm"
 	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
@@ -859,8 +858,7 @@ func main() {
 				clusterStore := clusteradapter.NewStore(db, clusters)
 
 				labelValidator := kubernetes2.LabelValidator{
-					ForbiddenDomains:   append([]string{config.Cluster.Labels.Domain}, config.Cluster.Labels.ForbiddenDomains...),
-					ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
+					ForbiddenDomains: append([]string{config.Cluster.Labels.Domain}, config.Cluster.Labels.ForbiddenDomains...),
 				}
 
 				nplabels.SetNodePoolLabelValidator(labelValidator)

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -53,6 +53,8 @@ import (
 	zaplog "logur.dev/integration/zap"
 	"logur.dev/logur"
 
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
+
 	cloudinfoapi "github.com/banzaicloud/pipeline/.gen/cloudinfo"
 	anchore2 "github.com/banzaicloud/pipeline/internal/anchore"
 	"github.com/banzaicloud/pipeline/internal/app/frontend"
@@ -857,8 +859,11 @@ func main() {
 				clusterStore := clusteradapter.NewStore(db, clusters)
 
 				labelValidator := kubernetes2.LabelValidator{
-					ForbiddenDomains: append([]string{config.Cluster.Labels.Domain}, config.Cluster.Labels.ForbiddenDomains...),
+					ForbiddenDomains:   append([]string{config.Cluster.Labels.Domain}, config.Cluster.Labels.ForbiddenDomains...),
+					ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
 				}
+
+				nplabels.SetNodePoolLabelValidator(labelValidator)
 
 				nplsApi := api.NewNodepoolManagerAPI(
 					commonClusterGetter,

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -324,7 +324,6 @@ func Configure(v *viper.Viper, _ *pflag.FlagSet) {
 	v.SetDefault("cluster::labels::domain", "banzaicloud.io")
 	v.SetDefault("cluster::labels::forbiddenDomains", []string{
 		"k8s.io",
-		"kubernetes.io",
 		"google.com",
 		"coreos.com",
 		"oraclecloud.com",

--- a/internal/global/nplabels/label_validator.go
+++ b/internal/global/nplabels/label_validator.go
@@ -24,23 +24,6 @@ var nplLabelValidator LabelValidator
 // nolint: gochecknoglobals
 var nplLabelValidatorMu sync.Mutex
 
-//ForbiddenLabelKeys list of forbidden node pool label keys
-// nolint: gochecknoglobals
-var ForbiddenLabelKeys = []string{
-	"node-role.kubernetes.io/master",
-	"kubernetes.io/arch",
-	"kubernetes.io/os",
-	"beta.kubernetes.io/arch",
-	"beta.kubernetes.io/os",
-	"kubernetes.io/hostname",
-	"beta.kubernetes.io/instance-type",
-	"node.kubernetes.io/instance-type",
-	"failure-domain.beta.kubernetes.io/region",
-	"failure-domain.beta.kubernetes.io/zone",
-	"topology.kubernetes.io/region",
-	"topology.kubernetes.io/zone",
-}
-
 type LabelValidator interface {
 	ValidateKey(key string) error
 	ValidateValue(value string) error

--- a/internal/global/nplabels/label_validator.go
+++ b/internal/global/nplabels/label_validator.go
@@ -24,21 +24,21 @@ var nplLabelValidator LabelValidator
 // nolint: gochecknoglobals
 var nplLabelValidatorMu sync.Mutex
 
-func GetForbiddenLabelKeys() []string {
-	return []string{
-		"node-role.kubernetes.io/master",
-		"kubernetes.io/arch",
-		"kubernetes.io/os",
-		"beta.kubernetes.io/arch",
-		"beta.kubernetes.io/os",
-		"kubernetes.io/hostname",
-		"beta.kubernetes.io/instance-type",
-		"node.kubernetes.io/instance-type",
-		"failure-domain.beta.kubernetes.io/region",
-		"failure-domain.beta.kubernetes.io/zone",
-		"topology.kubernetes.io/region",
-		"topology.kubernetes.io/zone",
-	}
+//ForbiddenLabelKeys list of forbidden node pool label keys
+// nolint: gochecknoglobals
+var ForbiddenLabelKeys = []string{
+	"node-role.kubernetes.io/master",
+	"kubernetes.io/arch",
+	"kubernetes.io/os",
+	"beta.kubernetes.io/arch",
+	"beta.kubernetes.io/os",
+	"kubernetes.io/hostname",
+	"beta.kubernetes.io/instance-type",
+	"node.kubernetes.io/instance-type",
+	"failure-domain.beta.kubernetes.io/region",
+	"failure-domain.beta.kubernetes.io/zone",
+	"topology.kubernetes.io/region",
+	"topology.kubernetes.io/zone",
 }
 
 type LabelValidator interface {

--- a/internal/global/nplabels/label_validator.go
+++ b/internal/global/nplabels/label_validator.go
@@ -1,0 +1,63 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nplabels
+
+import (
+	"sync"
+)
+
+// nolint: gochecknoglobals
+var nplLabelValidator LabelValidator
+
+// nolint: gochecknoglobals
+var nplLabelValidatorMu sync.Mutex
+
+func GetForbiddenLabelKeys() []string {
+	return []string{
+		"node-role.kubernetes.io/master",
+		"kubernetes.io/arch",
+		"kubernetes.io/os",
+		"beta.kubernetes.io/arch",
+		"beta.kubernetes.io/os",
+		"kubernetes.io/hostname",
+		"beta.kubernetes.io/instance-type",
+		"node.kubernetes.io/instance-type",
+		"failure-domain.beta.kubernetes.io/region",
+		"failure-domain.beta.kubernetes.io/zone",
+		"topology.kubernetes.io/region",
+		"topology.kubernetes.io/zone",
+	}
+}
+
+type LabelValidator interface {
+	ValidateKey(key string) error
+	ValidateValue(value string) error
+}
+
+// NodePoolLabelValidator returns a global node pool validator.
+func NodePoolLabelValidator() LabelValidator {
+	nplLabelValidatorMu.Lock()
+	defer nplLabelValidatorMu.Unlock()
+
+	return nplLabelValidator
+}
+
+// SetNodePoolLabelValidator configures a global node pool validator.
+func SetNodePoolLabelValidator(v LabelValidator) {
+	nplLabelValidatorMu.Lock()
+	defer nplLabelValidatorMu.Unlock()
+
+	nplLabelValidator = v
+}

--- a/internal/global/nplabels/label_validator.go
+++ b/internal/global/nplabels/label_validator.go
@@ -27,6 +27,8 @@ var nplLabelValidatorMu sync.Mutex
 type LabelValidator interface {
 	ValidateKey(key string) error
 	ValidateValue(value string) error
+	ValidateLabel(key string, value string) error
+	ValidateLabels(labels map[string]string) error
 }
 
 // NodePoolLabelValidator returns a global node pool validator.

--- a/internal/providers/azure/pke/driver/preparers.go
+++ b/internal/providers/azure/pke/driver/preparers.go
@@ -184,7 +184,7 @@ func (p NodePoolPreparer) Prepare(ctx context.Context, nodePool *NodePool) error
 		return validationErrorf("%s.Name must be specified", p.namespace)
 	}
 
-	err := common.ValidateNodePoolLabels(nodePool.Labels)
+	err := common.ValidateNodePoolLabels(nodePool.Name, nodePool.Labels)
 	if err != nil {
 		return validationErrorf(err.Error())
 	}

--- a/pkg/cluster/aks/aks.go
+++ b/pkg/cluster/aks/aks.go
@@ -78,7 +78,7 @@ func (azure *CreateClusterAKS) Validate() error {
 		return pkgErrors.ErrorResourceGroupRequired
 	}
 
-	for _, np := range azure.NodePools {
+	for npName, np := range azure.NodePools {
 
 		// ---- [ Min & Max count fields are required in case of autoscaling ] ---- //
 		if np.Autoscaling {
@@ -105,7 +105,7 @@ func (azure *CreateClusterAKS) Validate() error {
 			return pkgErrors.ErrorInstancetypeFieldIsEmpty
 		}
 
-		if err := pkgCommon.ValidateNodePoolLabels(np.Labels); err != nil {
+		if err := pkgCommon.ValidateNodePoolLabels(npName, np.Labels); err != nil {
 			return err
 		}
 	}

--- a/pkg/cluster/eks/eks.go
+++ b/pkg/cluster/eks/eks.go
@@ -206,7 +206,7 @@ func (eks *CreateClusterEKS) Validate() error {
 	}
 
 	// validate node pools
-	errs := make([]error, 0)
+	var errs []error
 	for npName, np := range eks.NodePools {
 		if err := np.Validate(npName); err != nil {
 			errs = append(errs, err)
@@ -276,7 +276,7 @@ func (eks *UpdateClusterAmazonEKS) Validate() error {
 	}
 
 	// validate node pools
-	errs := make([]error, 0)
+	var errs []error
 	for npName, np := range eks.NodePools {
 		if err := np.ValidateForUpdate(npName); err != nil {
 			errs = append(errs, err)

--- a/pkg/cluster/eks/eks.go
+++ b/pkg/cluster/eks/eks.go
@@ -93,7 +93,7 @@ const (
 )
 
 // Validate checks Amazon's node fields
-func (a *NodePool) Validate() error {
+func (a *NodePool) Validate(npName string) error {
 	// ---- [ Node instanceType check ] ---- //
 	if len(a.InstanceType) == 0 {
 		return pkgErrors.ErrorInstancetypeFieldIsEmpty
@@ -141,7 +141,7 @@ func (a *NodePool) Validate() error {
 	}
 
 	// --- [Label validation]--- //
-	if err := pkgCommon.ValidateNodePoolLabels(a.Labels); err != nil {
+	if err := pkgCommon.ValidateNodePoolLabels(npName, a.Labels); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func (a *NodePool) Validate() error {
 }
 
 // ValidateForUpdate checks Amazon's node fields
-func (a *NodePool) ValidateForUpdate() error {
+func (a *NodePool) ValidateForUpdate(npName string) error {
 
 	// ---- [ Min & Max count fields are required in case of autoscaling ] ---- //
 	if a.Autoscaling {
@@ -183,7 +183,7 @@ func (a *NodePool) ValidateForUpdate() error {
 	}
 
 	// --- [Label validation]--- //
-	if err := pkgCommon.ValidateNodePoolLabels(a.Labels); err != nil {
+	if err := pkgCommon.ValidateNodePoolLabels(npName, a.Labels); err != nil {
 		return err
 	}
 
@@ -205,10 +205,15 @@ func (eks *CreateClusterEKS) Validate() error {
 		return pkgErrors.ErrorNotValidKubernetesVersion
 	}
 
-	for _, np := range eks.NodePools {
-		if err := np.Validate(); err != nil {
-			return err
+	// validate node pools
+	errs := make([]error, 0)
+	for npName, np := range eks.NodePools {
+		if err := np.Validate(npName); err != nil {
+			errs = append(errs, err)
 		}
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
 	}
 
 	return nil
@@ -270,10 +275,15 @@ func (eks *UpdateClusterAmazonEKS) Validate() error {
 		return pkgErrors.ErrorAmazonEksFieldIsEmpty
 	}
 
-	for _, np := range eks.NodePools {
-		if err := np.ValidateForUpdate(); err != nil {
-			return err
+	// validate node pools
+	errs := make([]error, 0)
+	for npName, np := range eks.NodePools {
+		if err := np.ValidateForUpdate(npName); err != nil {
+			errs = append(errs, err)
 		}
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cluster/gke/gke.go
+++ b/pkg/cluster/gke/gke.go
@@ -17,7 +17,7 @@ package gke
 import (
 	"regexp"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
@@ -61,6 +61,29 @@ type UpdateClusterGoogle struct {
 	Master      *Master              `json:"master,omitempty"`
 }
 
+func validateNodePool(npName string, nodePool *NodePool) error {
+
+	// ---- [ Min & Max count fields are required in case of auto scaling ] ---- //
+	if nodePool.Autoscaling {
+		if nodePool.MaxCount == 0 {
+			return pkgErrors.ErrorMaxFieldRequiredError
+		}
+		if nodePool.MaxCount < nodePool.MinCount {
+			return pkgErrors.ErrorNodePoolMinMaxFieldError
+		}
+	}
+
+	if nodePool.Count == 0 {
+		nodePool.Count = pkgCommon.DefaultNodeMinCount
+	}
+
+	if err := pkgCommon.ValidateNodePoolLabels(npName, nodePool.Labels); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Validate validates Google cluster create request
 func (g *CreateClusterGKE) Validate() error {
 
@@ -100,25 +123,15 @@ func (g *CreateClusterGKE) Validate() error {
 		return pkgErrors.ErrorGkeVPCRequiredFieldIsEmpty
 	}
 
-	for _, nodePool := range g.NodePools {
-
-		// ---- [ Min & Max count fields are required in case of auto scaling ] ---- //
-		if nodePool.Autoscaling {
-			if nodePool.MaxCount == 0 {
-				return pkgErrors.ErrorMaxFieldRequiredError
-			}
-			if nodePool.MaxCount < nodePool.MinCount {
-				return pkgErrors.ErrorNodePoolMinMaxFieldError
-			}
+	// validate node pools
+	errs := make([]error, 0)
+	for npName, np := range g.NodePools {
+		if err := validateNodePool(npName, np); err != nil {
+			errs = append(errs, err)
 		}
-
-		if nodePool.Count == 0 {
-			nodePool.Count = pkgCommon.DefaultNodeMinCount
-		}
-
-		if err := pkgCommon.ValidateNodePoolLabels(nodePool.Labels); err != nil {
-			return err
-		}
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
 	}
 
 	return nil
@@ -146,6 +159,17 @@ func (a *UpdateClusterGoogle) Validate() error {
 	// if nodepools are provided in the update request check that it's not empty
 	if a.NodePools != nil && len(a.NodePools) == 0 {
 		return pkgErrors.ErrorNodePoolNotProvided
+	}
+
+	// validate node pools
+	errs := make([]error, 0)
+	for npName, np := range a.NodePools {
+		if err := validateNodePool(npName, np); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := errors.Combine(errs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cluster/gke/gke.go
+++ b/pkg/cluster/gke/gke.go
@@ -124,7 +124,7 @@ func (g *CreateClusterGKE) Validate() error {
 	}
 
 	// validate node pools
-	errs := make([]error, 0)
+	var errs []error
 	for npName, np := range g.NodePools {
 		if err := validateNodePool(npName, np); err != nil {
 			errs = append(errs, err)
@@ -162,7 +162,7 @@ func (a *UpdateClusterGoogle) Validate() error {
 	}
 
 	// validate node pools
-	errs := make([]error, 0)
+	var errs []error
 	for npName, np := range a.NodePools {
 		if err := validateNodePool(npName, np); err != nil {
 			errs = append(errs, err)

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -39,8 +39,8 @@ type UpdateClusterPKE struct {
 func (a *UpdateClusterPKE) Validate() error {
 	// TODO implement
 
-	for _, np := range a.NodePools {
-		if err := common.ValidateNodePoolLabels(np.Labels); err != nil {
+	for npName, np := range a.NodePools {
+		if err := common.ValidateNodePoolLabels(npName, np.Labels); err != nil {
 			return err
 		}
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,13 +15,15 @@
 package common
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"emperror.dev/errors"
 	"github.com/gin-gonic/gin"
-	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 )
 
 // BanzaiResponse describes Pipeline's responses
@@ -42,26 +44,6 @@ type CreatorBaseFields struct {
 	CreatedAt   time.Time `json:"createdAt,omitempty"`
 	CreatorName string    `json:"creatorName,omitempty"`
 	CreatorId   uint      `json:"creatorId,omitempty"`
-}
-
-// Validate checks whether the node pool labels collide with labels
-// set by Pipeline and also if these are valid Kubernetes labels
-func ValidateNodePoolLabels(labels map[string]string) error {
-	for name, value := range labels {
-		// validate node label name
-		errs := validation.IsQualifiedName(name)
-		if len(errs) > 0 {
-			return errors.WrapIfWithDetails(errors.New(strings.Join(errs, "\n")), "invalid node label name", map[string]string{"labelName": name})
-		}
-
-		// validate node label value
-		errs = validation.IsValidLabelValue(value)
-		if len(errs) > 0 {
-			return errors.WrapIfWithDetails(errors.New(strings.Join(errs, "\n")), "invalid node label value", map[string]string{"labelValue": value})
-		}
-	}
-
-	return nil
 }
 
 // ### [ Constants to common cluster default values ] ### //
@@ -101,4 +83,57 @@ func ErrorResponseWithStatus(c *gin.Context, status int, err error) {
 		Message: err.Error(),
 		Error:   errors.Cause(err).Error(),
 	})
+}
+
+// ValidationError is returned when a request is semantically invalid.
+type ValidationError struct {
+	message    string
+	violations []string
+}
+
+// Error implements the error interface.
+func (e ValidationError) Error() string {
+	errMsg := e.message
+	if len(e.violations) > 0 {
+		errMsg = errMsg + ": " + strings.Join(e.violations, ", ")
+	}
+	return errMsg
+}
+
+// unwrapViolations is a helper func to unwrap violations from a validation error
+func unwrapViolations(err error) []string {
+	var verr interface {
+		Violations() []string
+	}
+
+	if errors.As(err, &verr) {
+		return verr.Violations()
+	}
+
+	return []string{err.Error()}
+}
+
+// Validate checks whether the node pool labels collide with labels
+// set by Pipeline and also if these are valid Kubernetes labels
+func ValidateNodePoolLabels(nodePoolName string, labels map[string]string) error {
+	var violations []string
+
+	for key, value := range labels {
+		if err := nplabels.NodePoolLabelValidator().ValidateKey(key); err != nil {
+			violations = append(violations, unwrapViolations(err)...)
+		}
+
+		if err := nplabels.NodePoolLabelValidator().ValidateValue(value); err != nil {
+			violations = append(violations, unwrapViolations(err)...)
+		}
+	}
+
+	if len(violations) > 0 {
+		return errors.WithStack(ValidationError{
+			message:    fmt.Sprintf("invalid labels on %s node pool", nodePoolName),
+			violations: violations,
+		})
+	}
+
+	return nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -95,7 +95,7 @@ type ValidationError struct {
 func (e ValidationError) Error() string {
 	errMsg := e.message
 	if len(e.violations) > 0 {
-		errMsg = errMsg + ": " + strings.Join(e.violations, ", ")
+		errMsg += ": " + strings.Join(e.violations, ", ")
 	}
 	return errMsg
 }

--- a/pkg/kubernetes/label_validator.go
+++ b/pkg/kubernetes/label_validator.go
@@ -20,12 +20,13 @@ import (
 
 	"emperror.dev/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 )
 
 // LabelValidator validates Kubernetes object labels.
 type LabelValidator struct {
-	ForbiddenDomains   []string
-	ForbiddenLabelKeys []string
+	ForbiddenDomains []string
 }
 
 // ValidateKey validates a label key.
@@ -51,7 +52,7 @@ func (v LabelValidator) ValidateKey(key string) error {
 		}
 	}
 
-	for _, labelKey := range v.ForbiddenLabelKeys {
+	for _, labelKey := range nplabels.ForbiddenLabelKeys {
 		if key == labelKey {
 			violations = append(violations, fmt.Sprintf("label key %q is not allowed", key))
 		}

--- a/pkg/kubernetes/label_validator.go
+++ b/pkg/kubernetes/label_validator.go
@@ -24,7 +24,8 @@ import (
 
 // LabelValidator validates Kubernetes object labels.
 type LabelValidator struct {
-	ForbiddenDomains []string
+	ForbiddenDomains   []string
+	ForbiddenLabelKeys []string
 }
 
 // ValidateKey validates a label key.
@@ -47,6 +48,12 @@ func (v LabelValidator) ValidateKey(key string) error {
 
 		if keyDomain == domain || strings.HasSuffix(keyDomain, "."+domain) {
 			violations = append(violations, fmt.Sprintf("forbidden label key domain in %q: %q domain is not allowed", key, domain))
+		}
+	}
+
+	for _, labelKey := range v.ForbiddenLabelKeys {
+		if key == labelKey {
+			violations = append(violations, fmt.Sprintf("label key %q is not allowed", key))
 		}
 	}
 

--- a/pkg/kubernetes/label_validator.go
+++ b/pkg/kubernetes/label_validator.go
@@ -20,9 +20,26 @@ import (
 
 	"emperror.dev/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
-
-	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 )
+
+// A list of forbidden node pool label keys
+//
+// Note: this isn't configurable on purpose. These labels should never be configured by a user.
+// nolint: gochecknoglobals
+var forbiddenLabelKeys = []string{
+	"node-role.kubernetes.io/master",
+	"kubernetes.io/arch",
+	"kubernetes.io/os",
+	"beta.kubernetes.io/arch",
+	"beta.kubernetes.io/os",
+	"kubernetes.io/hostname",
+	"beta.kubernetes.io/instance-type",
+	"node.kubernetes.io/instance-type",
+	"failure-domain.beta.kubernetes.io/region",
+	"failure-domain.beta.kubernetes.io/zone",
+	"topology.kubernetes.io/region",
+	"topology.kubernetes.io/zone",
+}
 
 // LabelValidator validates Kubernetes object labels.
 type LabelValidator struct {
@@ -52,7 +69,7 @@ func (v LabelValidator) ValidateKey(key string) error {
 		}
 	}
 
-	for _, labelKey := range nplabels.ForbiddenLabelKeys {
+	for _, labelKey := range forbiddenLabelKeys {
 		if key == labelKey {
 			violations = append(violations, fmt.Sprintf("label key %q is not allowed", key))
 		}

--- a/pkg/kubernetes/label_validator.go
+++ b/pkg/kubernetes/label_validator.go
@@ -48,6 +48,18 @@ type LabelValidator struct {
 
 // ValidateKey validates a label key.
 func (v LabelValidator) ValidateKey(key string) error {
+	violations := v.validateKey(key)
+
+	if len(violations) > 0 {
+		return errors.WithStack(LabelValidationError{
+			violations: violations,
+		})
+	}
+
+	return nil
+}
+
+func (v LabelValidator) validateKey(key string) []string {
 	var violations []string
 
 	for _, v := range validation.IsQualifiedName(key) {
@@ -75,6 +87,13 @@ func (v LabelValidator) ValidateKey(key string) error {
 		}
 	}
 
+	return violations
+}
+
+// ValidateValue validates a label value.
+func (v LabelValidator) ValidateValue(value string) error {
+	violations := v.validateValue(value)
+
 	if len(violations) > 0 {
 		return errors.WithStack(LabelValidationError{
 			violations: violations,
@@ -84,13 +103,22 @@ func (v LabelValidator) ValidateKey(key string) error {
 	return nil
 }
 
-// ValidateValue validates a label value.
-func (v LabelValidator) ValidateValue(value string) error {
+func (v LabelValidator) validateValue(value string) []string {
 	var violations []string
 
 	for _, v := range validation.IsValidLabelValue(value) {
 		violations = append(violations, fmt.Sprintf("invalid label value %q: %s", value, v))
 	}
+
+	return violations
+}
+
+// ValidateLabel validates both a label key and a value.
+func (v LabelValidator) ValidateLabel(key string, value string) error {
+	var violations []string
+
+	violations = append(violations, v.validateKey(key)...)
+	violations = append(violations, v.validateValue(value)...)
 
 	if len(violations) > 0 {
 		return errors.WithStack(LabelValidationError{

--- a/pkg/kubernetes/label_validator.go
+++ b/pkg/kubernetes/label_validator.go
@@ -115,10 +115,7 @@ func (v LabelValidator) validateValue(value string) []string {
 
 // ValidateLabel validates both a label key and a value.
 func (v LabelValidator) ValidateLabel(key string, value string) error {
-	var violations []string
-
-	violations = append(violations, v.validateKey(key)...)
-	violations = append(violations, v.validateValue(value)...)
+	violations := v.validateLabel(key, value)
 
 	if len(violations) > 0 {
 		return errors.WithStack(LabelValidationError{
@@ -129,13 +126,46 @@ func (v LabelValidator) ValidateLabel(key string, value string) error {
 	return nil
 }
 
+func (v LabelValidator) validateLabel(key string, value string) []string {
+	var violations []string
+
+	violations = append(violations, v.validateKey(key)...)
+	violations = append(violations, v.validateValue(value)...)
+
+	return violations
+}
+
+// ValidateLabels validates a set of label key-value pairs.
+func (v LabelValidator) ValidateLabels(labels map[string]string) error {
+	var violations []string
+
+	for key, value := range labels {
+		violations = append(violations, v.validateLabel(key, value)...)
+	}
+
+	if len(violations) > 0 {
+		return errors.WithStack(LabelValidationError{
+			message:    "invalid labels",
+			violations: violations,
+		})
+	}
+
+	return nil
+}
+
 // LabelValidationError is returned (with a set of underlying violations) when a label is invalid.
 type LabelValidationError struct {
+	message string
+
 	violations []string
 }
 
 // Error implements the error interface.
 func (e LabelValidationError) Error() string {
+	if e.message != "" {
+		return e.message
+	}
+
 	return "invalid label"
 }
 

--- a/pkg/kubernetes/label_validator_test.go
+++ b/pkg/kubernetes/label_validator_test.go
@@ -20,6 +20,8 @@ import (
 	"emperror.dev/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 )
 
 func TestLabelValidator_ValidateKey(t *testing.T) {
@@ -45,10 +47,17 @@ func TestLabelValidator_ValidateKey(t *testing.T) {
 				"forbidden label key domain in \"node.example.com/key\": \"example.com\" domain is not allowed",
 			},
 		},
+		{
+			key: "node-role.kubernetes.io/master",
+			errors: []string{
+				"label key \"node-role.kubernetes.io/master\" is not allowed",
+			},
+		},
 	}
 
 	validator := LabelValidator{
-		ForbiddenDomains: []string{"example.com"},
+		ForbiddenDomains:   []string{"example.com"},
+		ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
 	}
 
 	for _, test := range tests {

--- a/pkg/kubernetes/label_validator_test.go
+++ b/pkg/kubernetes/label_validator_test.go
@@ -20,8 +20,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 )
 
 func TestLabelValidator_ValidateKey(t *testing.T) {
@@ -56,8 +54,7 @@ func TestLabelValidator_ValidateKey(t *testing.T) {
 	}
 
 	validator := LabelValidator{
-		ForbiddenDomains:   []string{"example.com"},
-		ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
+		ForbiddenDomains: []string{"example.com"},
 	}
 
 	for _, test := range tests {

--- a/pkg/providers/oracle/cluster/cluster.go
+++ b/pkg/providers/oracle/cluster/cluster.go
@@ -158,7 +158,7 @@ func (c *Cluster) Validate(update bool) error {
 			return errors.WithDetails(errors.New("node shape must be specified"), "nodepool", name)
 		}
 
-		if err := pkgCommon.ValidateNodePoolLabels(nodePool.Labels); err != nil {
+		if err := pkgCommon.ValidateNodePoolLabels(name, nodePool.Labels); err != nil {
 			return err
 		}
 	}

--- a/src/cluster/ack.go
+++ b/src/cluster/ack.go
@@ -38,12 +38,11 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/banzaicloud/pipeline/pkg/common"
-
 	"github.com/banzaicloud/pipeline/internal/secret/ssh/sshadapter"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/ack"
 	"github.com/banzaicloud/pipeline/pkg/cluster/ack/action"
+	"github.com/banzaicloud/pipeline/pkg/common"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 	"github.com/banzaicloud/pipeline/pkg/providers/alibaba"

--- a/src/cluster/ack.go
+++ b/src/cluster/ack.go
@@ -38,6 +38,8 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/banzaicloud/pipeline/pkg/common"
+
 	"github.com/banzaicloud/pipeline/internal/secret/ssh/sshadapter"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/ack"
@@ -1033,7 +1035,7 @@ func (c *ACKCluster) ValidateCreationFields(r *pkgCluster.CreateClusterRequest) 
 		return err
 	}
 
-	for _, np := range r.Properties.CreateClusterACK.NodePools {
+	for npName, np := range r.Properties.CreateClusterACK.NodePools {
 		var (
 			instanceType = np.InstanceType
 			// diskCategory = np.SystemDiskCategory
@@ -1046,6 +1048,11 @@ func (c *ACKCluster) ValidateCreationFields(r *pkgCluster.CreateClusterRequest) 
 
 		err = c.validateSystemDiskCategories(region, zone, diskCategory)
 		if err != nil {
+			return err
+		}
+
+		// --- [Label validation]--- //
+		if err := common.ValidateNodePoolLabels(npName, np.Labels); err != nil {
 			return err
 		}
 	}

--- a/src/cluster/common_test.go
+++ b/src/cluster/common_test.go
@@ -90,8 +90,7 @@ var (
 func TestCreateCommonClusterFromRequest(t *testing.T) {
 
 	labelValidator := kubernetes2.LabelValidator{
-		ForbiddenDomains:   []string{},
-		ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
+		ForbiddenDomains: []string{},
 	}
 
 	nplabels.SetNodePoolLabelValidator(labelValidator)

--- a/src/cluster/common_test.go
+++ b/src/cluster/common_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/cluster/aks"
 	"github.com/banzaicloud/pipeline/pkg/cluster/dummy"
@@ -27,6 +28,7 @@ import (
 	"github.com/banzaicloud/pipeline/pkg/cluster/gke"
 	"github.com/banzaicloud/pipeline/pkg/cluster/kubernetes"
 	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
+	kubernetes2 "github.com/banzaicloud/pipeline/pkg/kubernetes"
 	"github.com/banzaicloud/pipeline/src/cluster"
 	"github.com/banzaicloud/pipeline/src/model"
 	"github.com/banzaicloud/pipeline/src/secret"
@@ -86,6 +88,13 @@ var (
 )
 
 func TestCreateCommonClusterFromRequest(t *testing.T) {
+
+	labelValidator := kubernetes2.LabelValidator{
+		ForbiddenDomains:   []string{},
+		ForbiddenLabelKeys: nplabels.GetForbiddenLabelKeys(),
+	}
+
+	nplabels.SetNodePoolLabelValidator(labelValidator)
 
 	cases := []struct {
 		name          string

--- a/src/cluster/ec2_pke.go
+++ b/src/cluster/ec2_pke.go
@@ -331,7 +331,7 @@ func (c *EC2ClusterPKE) ValidateCreationFields(r *pkgCluster.CreateClusterReques
 	// TODO(Ecsy): implement me
 
 	for _, np := range r.Properties.CreateClusterPKE.NodePools {
-		if err := common.ValidateNodePoolLabels(np.Labels); err != nil {
+		if err := common.ValidateNodePoolLabels(np.Name, np.Labels); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially related to [#2172](https://github.com/banzaicloud/pipeline-web/issues/2172)
| License         | Apache 2.0

### What's in this PR?
- remove kubernetes.io from forbidden domains
- add validation for known forbidden label keys like  kubernetes.io labels used by kubelet 
- use the same labelValidator in all cluster node pool validations

UI needs to be modified so that reserved labels (banzacloud.io) are filtered out from a cluster update request which is addressed by  [#2172](https://github.com/banzaicloud/pipeline-web/issues/2172)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
