### PR TITLE
revert returning k8s user config 

### DIFF
--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -118,7 +118,8 @@ func GetClusterConfig(c *gin.Context) {
 	if ok != true {
 		return
 	}
-	config, err := commonCluster.GetK8sUserConfig()
+	// Use GetK8sUserConfig once we figure out the correct way on how to do it
+	config, err := commonCluster.GetK8sConfig()
 	if err != nil {
 		log.Debugf("error during getting config: %s", err.Error())
 		c.JSON(http.StatusBadRequest, pkgCommon.ErrorResponse{


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Return admin kubernetes config for the AWS EKS clusters as before.


### Why?
AWS does not provide a clean way to manage users other than configuring the auth configmap on the cluster, which requires admin privileges (and a shared secret) to access the cluster, which we wanted to avoid in the first place.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

