### PR TITLE
delete node pool labels in case Label map is empty

### DIFF
--- a/src/cluster/nodelabels.go
+++ b/src/cluster/nodelabels.go
@@ -58,10 +58,10 @@ func (n NodePoolLabels) GetLabels() map[string]string {
 	return n.CustomLabels
 }
 
-// GetDesiredLabelsForCluster returns desired set of labels for each node pool name, adding Banzaicloud prefixed labels like:
-// head node, ondemand labels + cloudinfo to user defined labels in specified nodePools map.
-// noReturnIfNoUserLabels = true, means if there are no labels specified in NodePoolStatus, no labels are returned for that node pool
-// is not returned, to avoid overriding already exisisting user specified labels.
+// GetDesiredLabelsForCluster returns desired set of labels for each node pool name,
+// adding reserved labels like: head node, ondemand labels + cloudinfo to user defined labels in specified nodePools map.
+// All user labels are deleted in case Label map is empty in NodePoolLabels, however in case Label map is nil
+// no labels are returned to avoid overriding already exisisting user specified labels.
 func GetDesiredLabelsForCluster(ctx context.Context, cluster CommonCluster, nodePoolLabels []NodePoolLabels) (map[string]map[string]string, error) {
 	desiredLabels := make(map[string]map[string]string)
 
@@ -92,7 +92,8 @@ func getLabelsForNodePool(
 	distribution string,
 	region string,
 ) map[string]string {
-	if len(nodePool.CustomLabels) == 0 && nodePool.Existing {
+
+	if nodePool.CustomLabels == nil && nodePool.Existing {
 		return make(map[string]string)
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no

### What's in this PR?
In case of cluster update, label map is not sent if there are no changes in labels, however in case of an empty label map all existing user labels should be deleted.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

