### PR TITLE
Optionally enable removing credentials from EKS kubeconfigs

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -382,6 +382,9 @@ dex:
 #    eks:
 #        # EKS Cloud Formation template location
 #        templateLocation: ./templates/eks
+#        # Expose admin kubeconfig over the API by default.
+#        # Set this to false to remove credentials from the config and make the user responsible for how they authenticate.
+#        exposeAdminKubeconfig: true
 
 cloudinfo:
     # Format: {baseUrl}/api/v1

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -551,6 +551,7 @@ func Configure(v *viper.Viper, _ *pflag.FlagSet) {
 	v.SetDefault("cloud::alibaba::defaultRegion", "eu-central-1")
 
 	v.SetDefault("distribution::eks::templateLocation", "./templates/eks")
+	v.SetDefault("distribution::eks::exposeAdminKubeconfig", true)
 
 	v.SetDefault("cloudinfo::endpoint", "")
 	v.SetDefault("hollowtrees::endpoint", "")

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -283,7 +283,8 @@ type Configuration struct {
 
 	Distribution struct {
 		EKS struct {
-			TemplateLocation string
+			TemplateLocation      string
+			ExposeAdminKubeconfig bool
 		}
 	}
 

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -118,8 +118,7 @@ func GetClusterConfig(c *gin.Context) {
 	if ok != true {
 		return
 	}
-	// Use GetK8sUserConfig once we figure out the correct way on how to do it
-	config, err := commonCluster.GetK8sConfig()
+	config, err := commonCluster.GetK8sUserConfig()
 	if err != nil {
 		log.Debugf("error during getting config: %s", err.Error())
 		c.JSON(http.StatusBadRequest, pkgCommon.ErrorResponse{

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/banzaicloud/pipeline/internal/global"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -550,6 +551,10 @@ func (c *EKSCluster) GetK8sUserConfig() ([]byte, error) {
 	adminConfig, err := c.CommonClusterBase.getConfig(c)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to get raw kubernetes config")
+	}
+
+	if global.Config.Distribution.EKS.ExposeAdminKubeconfig {
+		return adminConfig, nil
 	}
 
 	parsedAdminConfig, err := clientcmd.Load(adminConfig)

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -24,9 +24,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/banzaicloud/pipeline/internal/global"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/banzaicloud/pipeline/internal/global"
 
 	"github.com/banzaicloud/pipeline/pkg/k8sutil"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Adds a configuration flag to remove credentials from EKS kubeconfig exposed through the API.

### Why?
To avoid exposing shared secrets accidentally in case the administrator explicitly wants this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
