### PR TITLE
bump the vault-secrets-webhook chart version for the vault integrated…

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -176,7 +176,7 @@ dex:
 #        charts:
 #            webhook:
 #                chart: "banzaicloud-stable/vault-secrets-webhook"
-#                version: "0.6.0"
+#                version: "0.8.0"
 #
 #                # See https://github.com/banzaicloud/bank-vaults/tree/master/charts/vault-secrets-webhook for details
 #                values: {}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -342,11 +342,11 @@ func Configure(v *viper.Viper, _ *pflag.FlagSet) {
 	v.SetDefault("cluster::vault::managed::enabled", false)
 	v.SetDefault("cluster::vault::managed::endpoint", "")
 	v.SetDefault("cluster::vault::charts::webhook::chart", "banzaicloud-stable/vault-secrets-webhook")
-	v.SetDefault("cluster::vault::charts::webhook::version", "0.6.0")
+	v.SetDefault("cluster::vault::charts::webhook::version", "0.7.1")
 	v.SetDefault("cluster::vault::charts::webhook::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": "banzaicloud/vault-secrets-webhook",
-			"tag":        "0.6.0",
+			"tag":        "0.8.0",
 		},
 	})
 


### PR DESCRIPTION
… service

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Switch to the latest `vault-secrets-webhook` chart

### Why?
To stay up to date and have the greatest version from each component.


