### PR TITLE
[Monitoring] Add datasources field to Grafana chart values

### DIFF
--- a/internal/integratedservices/services/logging/output_definition_loki.go
+++ b/internal/integratedservices/services/logging/output_definition_loki.go
@@ -15,6 +15,8 @@
 package logging
 
 import (
+	"fmt"
+
 	"github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
 	"github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
 )
@@ -27,7 +29,7 @@ func (o outputDefinitionManagerLoki) getOutputSpec(_ bucketSpec, _ bucketOptions
 	return v1beta1.ClusterOutputSpec{
 		OutputSpec: v1beta1.OutputSpec{
 			LokiOutput: &output.LokiOutput{
-				Url:                       o.serviceURL,
+				Url:                       fmt.Sprintf("http://%s", o.serviceURL),
 				ConfigureKubernetesLabels: true,
 			},
 		},

--- a/internal/integratedservices/services/monitoring/operator.go
+++ b/internal/integratedservices/services/monitoring/operator.go
@@ -593,6 +593,11 @@ func (m chartValuesManager) generateGrafanaChartValues(
 			Persistence: persistenceValues{
 				Enabled: true,
 			},
+			Datasources: datasourcesValues{
+				Enabled:         true,
+				Label:           "grafana_datasource",
+				SearchNamespace: "ALL",
+			},
 		}
 	}
 

--- a/internal/integratedservices/services/monitoring/values.go
+++ b/internal/integratedservices/services/monitoring/values.go
@@ -53,6 +53,13 @@ type grafanaValues struct {
 	DefaultDashboardsEnabled bool              `json:"defaultDashboardsEnabled"`
 	Image                    imageValues       `json:"image"`
 	Persistence              persistenceValues `json:"persistence"`
+	Datasources              datasourcesValues `json:"datasources"`
+}
+
+type datasourcesValues struct {
+	Enabled         bool   `json:"enabled"`
+	Label           string `json:"label"`
+	SearchNamespace string `json:"searchNamespace"`
 }
 
 type persistenceValues struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
 Add `datasources` field to Grafana chart values


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
