### PR TITLE
fix k8s cluster deleter registration key

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -443,7 +443,7 @@ func main() {
 						Deleter: commonClusterDeleter,
 					},
 					clusteradapter.ClusterDeleterEntry{
-						Key:     clusteradapter.MakeClusterDeleterKey(pkgCluster.Kubernetes, ""),
+						Key:     clusteradapter.MakeClusterDeleterKey(pkgCluster.Kubernetes, pkgCluster.Unknown),
 						Deleter: commonClusterDeleter,
 					},
 					clusteradapter.ClusterDeleterEntry{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Register cluster deleter for imported k8s clusters with cloud `kubernetes` and distribution `unknown`.

### Why?
The deleter for imported k8s clusters was registered under the wrong key.


### Checklist
- [x] Implementation tested (with at least one cloud provider)
