### PR TITLE
Fix: set rollingUpdate to null if type is Recreate

### DIFF
--- a/charts/pipeline/values.yaml
+++ b/charts/pipeline/values.yaml
@@ -6,6 +6,9 @@ replicaCount: 1
 # Upgrade strategy
 strategy:
   type: Recreate
+  # this must be set to aviod issues when the chart is upgraded from rollingUpdate type
+  # https://github.com/helm/helm/issues/5144#issuecomment-512758270
+  rollingUpdate: null
 
 ## Additional entries to the hosts
 hostAliases: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bugfix to set the `strategy.rollingUpdate` field to avoid a conflict on upgrades from rollingUpdate strategy.
