### PR TITLE
Bump chart version

### DIFF
--- a/charts/pipeline/Chart.yaml
+++ b/charts/pipeline/Chart.yaml
@@ -1,6 +1,6 @@
 name: pipeline
 home: https://banzaicloud.com
-version: 0.5.1
+version: 0.5.3
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline


### PR DESCRIPTION
Version 0.5.2 has been tagged accidentally, thus skipped.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bump chart version