### PR TITLE
eks: fix resource id path handling in IAM

### DIFF
--- a/internal/providers/amazon/eks/workflow/amazon.go
+++ b/internal/providers/amazon/eks/workflow/amazon.go
@@ -142,7 +142,7 @@ func packageCFError(err error, stackName string, clientRequestToken string, clou
 	if errors.As(err, &awsErr) {
 		if awsErr.Code() == request.WaiterResourceNotReadyErrorCode {
 			err = pkgCloudformation.NewAwsStackFailure(err, stackName, clientRequestToken, cloudformationClient)
-			err = errors.WrapIff(err, errMessage, stackName)
+			err = errors.WrapIfWithDetails(err, errMessage, "stackName", stackName)
 			if pkgCloudformation.IsErrorFinal(err) {
 				return cadence.NewCustomError(ErrReasonStackFailed, err.Error())
 			}

--- a/internal/providers/amazon/eks/workflow/create_iam_roles_activity_test.go
+++ b/internal/providers/amazon/eks/workflow/create_iam_roles_activity_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitResourceId(t *testing.T) {
+	id, path := splitResourceId("/dog/cat/parrot")
+
+	assert.Equal(t, "parrot", id)
+	assert.Equal(t, "/dog/cat/", path)
+
+	id, path = splitResourceId("dog/cat/parrot")
+
+	assert.Equal(t, "parrot", id)
+	assert.Equal(t, "/dog/cat/", path)
+
+	id, path = splitResourceId("parrot")
+
+	assert.Equal(t, "parrot", id)
+	assert.Equal(t, "/", path)
+
+	id, path = splitResourceId("/parrot")
+
+	assert.Equal(t, "parrot", id)
+	assert.Equal(t, "/", path)
+
+	id, path = splitResourceId("")
+
+	assert.Equal(t, "", id)
+	assert.Equal(t, "", path)
+}

--- a/templates/eks/amazon-eks-iam-cf.yaml
+++ b/templates/eks/amazon-eks-iam-cf.yaml
@@ -11,14 +11,29 @@ Parameters:
     Description: The user ID provided to set as cluster admin.
     Default: ""
 
+  UserPath:
+    Type: String
+    Description: The path of the provided user to set as cluster admin.
+    Default: ""
+
   ClusterRoleId:
     Type: String
     Description: The role ID provided to set for the EKS cluster.
     Default: ""
 
+  ClusterRolePath:
+    Type: String
+    Description: The path of the provided role to set for the EKS cluster.
+    Default: ""
+
   NodeInstanceRoleId:
     Type: String
     Description: The role ID provided to set for the EKS nodes.
+    Default: ""
+
+  NodeInstanceRolePath:
+    Type: String
+    Description: The path of the provided role to set for the EKS nodes.
     Default: ""
 
 Conditions:
@@ -109,16 +124,16 @@ Resources:
 Outputs:
   ClusterRoleArn:
     Description: The ClusterRole ARN
-    Value: !If [ CreateClusterRole, !GetAtt ClusterRole.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:role/${ClusterRoleId}" ]
+    Value: !If [ CreateClusterRole, !GetAtt ClusterRole.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:role${ClusterRolePath}${ClusterRoleId}" ]
 
   NodeInstanceRoleId:
     Description: The NodeInstanceRole ID
-    Value: !If [ CreateNodeInstanceRole, !Ref NodeInstanceRole, !Sub "${NodeInstanceRoleId}" ] 
+    Value: !If [ CreateNodeInstanceRole, !Ref NodeInstanceRole, !Sub "${NodeInstanceRoleId}" ]
 
   NodeInstanceRoleArn:
     Description: The NodeInstanceRole ARN
-    Value: !If [ CreateNodeInstanceRole, !GetAtt NodeInstanceRole.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:role/${NodeInstanceRoleId}" ] 
+    Value: !If [ CreateNodeInstanceRole, !GetAtt NodeInstanceRole.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:role${NodeInstanceRolePath}${NodeInstanceRoleId}" ]
 
   ClusterUserArn:
     Description: Cluster user's ARN
-    Value: !If [ CreateUser, !GetAtt ClusterUser.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:user/${UserId}" ]
+    Value: !If [ CreateUser, !GetAtt ClusterUser.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:user${UserPath}${UserId}" ]

--- a/templates/eks/amazon-eks-iam-cf.yaml
+++ b/templates/eks/amazon-eks-iam-cf.yaml
@@ -14,7 +14,7 @@ Parameters:
   UserPath:
     Type: String
     Description: The path of the provided user to set as cluster admin.
-    Default: ""
+    Default: "/"
 
   ClusterRoleId:
     Type: String
@@ -24,7 +24,7 @@ Parameters:
   ClusterRolePath:
     Type: String
     Description: The path of the provided role to set for the EKS cluster.
-    Default: ""
+    Default: "/"
 
   NodeInstanceRoleId:
     Type: String
@@ -34,7 +34,7 @@ Parameters:
   NodeInstanceRolePath:
     Type: String
     Description: The path of the provided role to set for the EKS nodes.
-    Default: ""
+    Default: "/"
 
 Conditions:
   CreateUser: !Equals [ !Ref UserId, "" ]


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The EKS code couldn't handle IAM resources defined by full path, this PR fixes that.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To handle resources under paths (other than "/").

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Also this fixes `packageCFError` formatting.

Splitting is possible in CF as well and also selection from an array, but selecting the last element from and array/list is not possible easily, so the extraction is done in the surrounding Go code.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
