### PR TITLE
add retry policy to the cluster delete workflow activities

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
 )
 
@@ -32,6 +33,9 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		ScheduleToStartTimeout: 5 * time.Minute,
 		StartToCloseTimeout:    5 * time.Minute,
 		WaitForCancellation:    true,
+		RetryPolicy: &cadence.RetryPolicy{
+			MaximumAttempts: 5,
+		},
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, ao)


### PR DESCRIPTION
…re version removed (to be populated with direct call)

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no|
| Related tickets | fixes #2683
| License         | Apache 2.0


### What's in this PR?
Timing out activities have been provided with rety policy in the cluster delete workflow

### Why?
Timing out activities caused the workflow to quit, leaving resources undeleted in the cloud


### Additional context
Affects PKE clusters

### Checklist

- [X] Implementation tested (with at least one cloud provider)
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline (TODO)

