### PR TITLE
security scan integrated service - output provided with more precise information

### DIFF
--- a/internal/integratedservices/services/securityscan/manager.go
+++ b/internal/integratedservices/services/securityscan/manager.go
@@ -64,12 +64,12 @@ func (f IntegratedServiceManager) GetOutput(ctx context.Context, clusterID uint,
 	// todo read these through the helm service?
 	out := map[string]interface{}{
 		"anchore": map[string]interface{}{
-			// todo this is the chart version ?!
-			"version": f.webhookConfig.Version,
+			// leave this for backwards compatibility
+			// to be populated (externally) via direct call to the configured anchore service
+			"version": "",
 		},
 		"imageValidator": map[string]interface{}{
-			// todo image validator version! probably these two need to be exchanged
-			"version": imageValidatorVersion,
+			"version": f.webhookConfig.Version,
 		},
 	}
 

--- a/internal/integratedservices/services/securityscan/operator.go
+++ b/internal/integratedservices/services/securityscan/operator.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	imageValidatorVersion = "0.3.6"
-
 	// the label key on the namespaces that is watched by the webhook
 	labelKey = "scan"
 


### PR DESCRIPTION
…re version removed (to be populated with direct call)

| Q               | A
| --------------- | ---
| Bug fix?        |no
| New feature?    | no|
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
- the security scan service output is provided with the correct image validator (chart) version
- the anchore engine version is removed from the output

### Why?
the servicce related output was wrong (and statically added)


### Additional context
the anchore version can be retrieved dinamically instead of using wired or configuratio-provided value

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline (TODO)

