### PR TITLE
replace decode hook for custom wrapper type

### DIFF
--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/banzaicloud/pipeline/internal/platform/log"
-	"github.com/banzaicloud/pipeline/pkg/values"
 )
 
 // Config is a global config instance.
@@ -95,7 +94,7 @@ type Configuration struct {
 				Enabled bool
 				Chart   string
 				Version string
-				Values  values.Config
+				Values  map[string]interface{}
 			}
 
 			Dashboard struct {

--- a/pkg/cluster/base_values_config.go
+++ b/pkg/cluster/base_values_config.go
@@ -14,10 +14,6 @@
 
 package cluster
 
-import (
-	"github.com/banzaicloud/pipeline/pkg/values"
-)
-
 type PostHookConfig struct {
 	// ingress controller config
 	Ingress IngressControllerConfig
@@ -66,5 +62,5 @@ type BaseConfig struct {
 type IngressControllerConfig struct {
 	BasePostHookConfig `mapstructure:",squash"`
 
-	Values values.Config
+	Values map[string]interface{}
 }

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -26,7 +26,7 @@ func DecodeHookWithDefaults() viper.DecoderConfigOption {
 		mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
-			values.DecodeHook(),
+			values.StringToMapStringInterface(),
 		),
 	)
 }

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -23,18 +23,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-type Config map[string]interface{}
-
-func DecodeHook() mapstructure.DecodeHookFunc {
-	return func(a reflect.Type, b reflect.Type, d interface{}) (interface{}, error) {
-
-		// parse values config
-		if a.Kind() == reflect.String && b == reflect.TypeOf(new(Config)).Elem() {
-
-			if data, ok := d.(string); ok {
-
-				var output map[string]interface{}
-				if err := yaml.Unmarshal([]byte(strings.TrimSpace(data)), &output); err != nil {
+func StringToMapStringInterface() mapstructure.DecodeHookFunc {
+	return func(srcType, dstType reflect.Type, srcVal interface{}) (interface{}, error) {
+		var output map[string]interface{}
+		if srcType.Kind() == reflect.String && dstType == reflect.TypeOf(output) {
+			if str, ok := srcVal.(string); ok {
+				if err := yaml.Unmarshal([]byte(strings.TrimSpace(str)), &output); err != nil {
 					return nil, errors.WrapIf(err, "failed to convert string to map")
 				}
 
@@ -43,6 +37,6 @@ func DecodeHook() mapstructure.DecodeHookFunc {
 
 		}
 
-		return d, nil
+		return srcVal, nil
 	}
 }

--- a/src/cluster/hooks_ingress.go
+++ b/src/cluster/hooks_ingress.go
@@ -129,7 +129,7 @@ func InstallIngressControllerPostHook(cluster CommonCluster) error {
 		}
 	}
 
-	valuesBytes, err := mergeValues(ingressValues, map[string]interface{}(config.Ingress.Values))
+	valuesBytes, err := mergeValues(ingressValues, config.Ingress.Values)
 	if err != nil {
 		return errors.WrapIf(err, "failed to merge treafik values with config")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
A replacement for the `mapstructure` decode hook for the custom `type Config map[string]interface{}` wrapper type.

### Why?
The new hook makes it possible to define YAML/JSON object values in the config as strings that will be unmarshalled to `map[string]interface{}` typed fields without changing the code to use a custom type.