### PR TITLE
[Monitoring] Enable service monitor in pushgateway

### DIFF
--- a/internal/integratedservices/services/monitoring/operator.go
+++ b/internal/integratedservices/services/monitoring/operator.go
@@ -149,17 +149,17 @@ func (op IntegratedServiceOperator) Apply(ctx context.Context, clusterID uint, s
 		}
 	}
 
+	// install Prometheus Operator
+	if err := op.installPrometheusOperator(ctx, cluster, logger, boundSpec, grafanaSecretID, prometheusSecretName, alertmanagerSecretName); err != nil {
+		return errors.WrapIf(err, "failed to install Prometheus operator")
+	}
+
 	// Pushgateway
 	if boundSpec.Pushgateway.Enabled {
 		// install Prometheus Pushgateway
 		if err := op.installPrometheusPushGateway(ctx, cluster, boundSpec.Pushgateway, logger); err != nil {
 			return errors.WrapIf(err, "failed to install Prometheus Pushgateway")
 		}
-	}
-
-	// install Prometheus Operator
-	if err := op.installPrometheusOperator(ctx, cluster, logger, boundSpec, grafanaSecretID, prometheusSecretName, alertmanagerSecretName); err != nil {
-		return errors.WrapIf(err, "failed to install Prometheus operator")
 	}
 
 	return nil
@@ -221,6 +221,10 @@ func (op IntegratedServiceOperator) installPrometheusPushGateway(
 		Image: imageValues{
 			Repository: op.config.Images.Pushgateway.Repository,
 			Tag:        op.config.Images.Pushgateway.Tag,
+		},
+		ServiceMonitor: serviceMonitorValues{
+			Enabled:   true,
+			Namespace: op.config.Namespace,
 		},
 	}
 

--- a/internal/integratedservices/services/monitoring/values.go
+++ b/internal/integratedservices/services/monitoring/values.go
@@ -36,7 +36,13 @@ type imageValues struct {
 }
 
 type prometheusPushgatewayValues struct {
-	Image imageValues `json:"image"`
+	Image          imageValues          `json:"image"`
+	ServiceMonitor serviceMonitorValues `json:"serviceMonitor"`
+}
+
+type serviceMonitorValues struct {
+	Enabled   bool   `json:"enabled"`
+	Namespace string `json:"namespace"`
 }
 
 type baseValues struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Enable service monitor in pushgateway
- Change install process, firstly we install Prometheus operator and then Pushgateway


### Checklist

- [x] Implementation tested (with at least one cloud provider)

