### PR TITLE
tiller: eliminate possible tunnel leaks

### DIFF
--- a/internal/kubernetes/client_factory.go
+++ b/internal/kubernetes/client_factory.go
@@ -106,6 +106,9 @@ func (f HelmClientFactory) FromSecret(ctx context.Context, secretID string) (*ba
 	f.logger.Debug("create kubernetes tunnel")
 	tillerTunnel, err := portforwarder.New("kube-system", client, config)
 	if err != nil {
+		if tillerTunnel != nil {
+			tillerTunnel.Close()
+		}
 		return nil, errors.WrapIf(err, "failed to create kubernetes tunnel")
 	}
 

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -46,6 +46,9 @@ func NewClient(kubeConfig []byte, logger logrus.FieldLogger) (*Client, error) {
 	logger.Debug("create kubernetes tunnel")
 	tillerTunnel, err := portforwarder.New("kube-system", client, config)
 	if err != nil {
+		if tillerTunnel != nil {
+			tillerTunnel.Close()
+		}
 		return nil, errors.WrapIf(err, "failed to create kubernetes tunnel")
 	}
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Closing `tillerTunnel` even when an error is returned, because it can be possibly open:
```go
// New creates a new and initialized tunnel.
func New(namespace string, client kubernetes.Interface, config *rest.Config) (*kube.Tunnel, error) {
	podName, err := GetTillerPodName(client.CoreV1(), namespace)
        // in this case there is no leak
	if err != nil {
		return nil, err
	}
	t := kube.NewTunnel(client.CoreV1().RESTClient(), config, namespace, podName, environment.DefaultTillerPort)
        // in this case there is a tunnel even if ForwardPort returns an error,
        // and that tunnel is possibly looping
	return t, t.ForwardPort()
}
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To prevent connection leaks.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
