### PR TITLE
kubefed: use latest banzai image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,5 +195,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.2
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.17.2
 	k8s.io/sample-controller => k8s.io/sample-controller v0.17.2
-	sigs.k8s.io/kubefed => github.com/banzaicloud/kubefed v0.1.0-rc2.0.20200121120031-f51ecb598a2d
+	sigs.k8s.io/kubefed => github.com/banzaicloud/kubefed v0.1.0-rc6.1.0.20200210184657-03ba7b7e85c9
 )

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/banzaicloud/istio-operator v0.0.0-20200120100557-309b8a34e9eb h1:0+9w
 github.com/banzaicloud/istio-operator v0.0.0-20200120100557-309b8a34e9eb/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
 github.com/banzaicloud/kubefed v0.1.0-rc2.0.20200121120031-f51ecb598a2d h1:+M0ol8U7OyW8g1Z8YiI/UMejN+3E5fq+W6LB2NvgcGQ=
 github.com/banzaicloud/kubefed v0.1.0-rc2.0.20200121120031-f51ecb598a2d/go.mod h1:Kha8l/jZw8NYFEftmqGehhCTwfvEHQLzwS4M/FI88io=
+github.com/banzaicloud/kubefed v0.1.0-rc6.1.0.20200210184657-03ba7b7e85c9 h1:nF0G4ub85718896NPYKPiEEu732wnV03ruXlT5JFY6Y=
+github.com/banzaicloud/kubefed v0.1.0-rc6.1.0.20200210184657-03ba7b7e85c9/go.mod h1:Kha8l/jZw8NYFEftmqGehhCTwfvEHQLzwS4M/FI88io=
 github.com/banzaicloud/logging-operator/pkg/sdk v0.1.1 h1:qXmP4D3hbW0GT+rMLDqAnAJY0NcqqDhE2UmQxPieRfQ=
 github.com/banzaicloud/logging-operator/pkg/sdk v0.1.1/go.mod h1:1pRU2dbp3jA+d6Ha6l/8+K+5g6Gfs8zZoC9xQgo9+VQ=
 github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f h1:WeGZeO6I+lI1IG2vm1iXTeMrHLcMUjfoYm+rubBM5c4=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -786,8 +786,8 @@ traefik:
 	v.SetDefault("cluster::federation::charts::kubefed::version", "0.1.0-rc6")
 	v.SetDefault("cluster::federation::charts::kubefed::values", map[string]interface{}{
 		"controllermanager": map[string]interface{}{
-			"repository": "quay.io/kubernetes-multicluster",
-			"tag":        "v0.1.0-rc6",
+			"repository": "banzaicloud",
+			"tag":        "v0.1.0-rc6.1",
 		},
 	})
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related to #2688 
| License         | Apache 2.0


### What's in this PR?
Use latest v0.1.0-rc6.1 kubefed image.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
