### PR TITLE
EKS: fix nil reference when creating EKS control plane

### DIFF
--- a/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
+++ b/internal/providers/amazon/eks/workflow/create_eks_control_plane_activity.go
@@ -100,6 +100,10 @@ func (a *CreateEksControlPlaneActivity) Execute(ctx context.Context, input Creat
 			if awsErr.Code() == eks.ErrCodeResourceNotFoundException {
 				createCluster = true
 			} else {
+				// sometimes error is different then ErrCodeResourceNotFoundException and Cluster is nil in describeClusterOutput
+				if describeClusterOutput.Cluster == nil {
+					return nil, errors.WrapIff(err, "could not get the status of EKS cluster %s in region %s", input.ClusterName, input.Region)
+				}
 				switch clusterStatus := aws.StringValue(describeClusterOutput.Cluster.Status); clusterStatus {
 				case eks.ClusterStatusActive:
 					logger.Infof("EKS cluster is in %s state", clusterStatus)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Catch nil pointer errors when there's no cluster info returned in details and error is different than ErrCodeResourceNotFoundException.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
