### PR TITLE
wait for deletion to complete (aws-pke) - long running activities

### DIFF
--- a/cmd/worker/aws.go
+++ b/cmd/worker/aws.go
@@ -71,6 +71,9 @@ func registerAwsWorkflows(
 	deletePoolActivity := pkeworkflow.NewDeletePoolActivity(clusters)
 	activity.RegisterWithOptions(deletePoolActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeletePoolActivityName})
 
+	waitForDeletePoolActivity := pkeworkflow.NewWaitForDeletePoolActivity(clusters)
+	activity.RegisterWithOptions(waitForDeletePoolActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.WaitForDeletePoolActivityName})
+
 	updatePoolActivity := pkeworkflow.NewUpdatePoolActivity(awsClientFactory)
 	activity.RegisterWithOptions(updatePoolActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.UpdatePoolActivityName})
 

--- a/cmd/worker/aws.go
+++ b/cmd/worker/aws.go
@@ -84,10 +84,13 @@ func registerAwsWorkflows(
 	activity.RegisterWithOptions(deleteNLBActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteNLBActivityName})
 
 	waitForDeleteNLBActivity := pkeworkflow.NewWaitForDeleteNLBActivity(clusters)
-	activity.RegisterWithOptions(waitForDeleteNLBActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteNLBActivityName})
+	activity.RegisterWithOptions(waitForDeleteNLBActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.WaitForDeleteNLBActivityName})
 
 	deleteVPCActivity := pkeworkflow.NewDeleteVPCActivity(clusters)
 	activity.RegisterWithOptions(deleteVPCActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteVPCActivityName})
+
+	waitForDeleteVPCActivity := pkeworkflow.NewWaitForDeleteVPCActivity(clusters)
+	activity.RegisterWithOptions(waitForDeleteVPCActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.WaitForDeleteVPCActivityName})
 
 	uploadSshKeyPairActivity := pkeworkflow.NewUploadSSHKeyPairActivity(clusters)
 	activity.RegisterWithOptions(uploadSshKeyPairActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.UploadSSHKeyPairActivityName})

--- a/cmd/worker/aws.go
+++ b/cmd/worker/aws.go
@@ -83,6 +83,9 @@ func registerAwsWorkflows(
 	deleteNLBActivity := pkeworkflow.NewDeleteNLBActivity(clusters)
 	activity.RegisterWithOptions(deleteNLBActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteNLBActivityName})
 
+	waitForDeleteNLBActivity := pkeworkflow.NewWaitForDeleteNLBActivity(clusters)
+	activity.RegisterWithOptions(waitForDeleteNLBActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteNLBActivityName})
+
 	deleteVPCActivity := pkeworkflow.NewDeleteVPCActivity(clusters)
 	activity.RegisterWithOptions(deleteVPCActivity.Execute, activity.RegisterOptions{Name: pkeworkflow.DeleteVPCActivityName})
 

--- a/internal/ark/client/client.go
+++ b/internal/ark/client/client.go
@@ -16,15 +16,15 @@ package client
 
 import (
 	"emperror.dev/errors"
+	arkAPI "github.com/heptio/ark/pkg/apis/ark/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	arkAPI "github.com/heptio/ark/pkg/apis/ark/v1" 
 
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 )
 
-func init() { 
+func init() {
 	_ = arkAPI.AddToScheme(scheme.Scheme)
 }
 

--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -97,6 +97,12 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	if err = workflow.ExecuteActivity(ctx, DeleteNLBActivityName, deleteNLBActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
+	if err = workflow.ExecuteActivity(
+		workflow.WithHeartbeatTimeout(ctx, 5*time.Minute),
+		WaitForDeleteNLBActivityName,
+		deleteNLBActivityInput).Get(ctx, nil); err != nil {
+		return err
+	}
 
 	// terminate master nodes
 	{

--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -55,7 +55,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 	// terminate worker nodes
 	{
-		futures := make([]workflow.Future, 0, 2*len(nodePools))
+		futures := make([]workflow.Future, 0, len(nodePools))
 		errs := make([]error, 0, 2*len(nodePools))
 		for _, np := range nodePools {
 			if !np.Master && np.Worker {
@@ -113,7 +113,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 	// terminate master nodes
 	{
-		futures := make([]workflow.Future, 0, 2*len(nodePools))
+		futures := make([]workflow.Future, 0, len(nodePools))
 		errs := make([]error, 0, 2*len(nodePools))
 		for _, np := range nodePools {
 			if np.Master || !np.Worker {

--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -71,9 +71,12 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 				}
 
 				// initiate wait for deletion to complete
-				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
-					WaitForDeletePoolActivityName,
-					deletePoolActivityInput))
+				futures = append(futures,
+					workflow.ExecuteActivity(
+						workflow.WithStartToCloseTimeout(
+							workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+							1*time.Hour),
+						WaitForDeletePoolActivityName, deletePoolActivityInput))
 			}
 		}
 
@@ -100,7 +103,9 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		return err
 	}
 	if err = workflow.ExecuteActivity(
-		workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+		workflow.WithStartToCloseTimeout(
+			workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+			1*time.Hour),
 		WaitForDeleteNLBActivityName,
 		deleteNLBActivityInput).Get(ctx, nil); err != nil {
 		return err
@@ -124,7 +129,10 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 				}
 
 				// initiate wait for deletion to complete
-				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+				futures = append(futures, workflow.ExecuteActivity(
+					workflow.WithStartToCloseTimeout(
+						workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+						1*time.Hour),
 					WaitForDeletePoolActivityName,
 					deletePoolActivityInput))
 			}
@@ -169,7 +177,11 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		return err
 	}
 
-	if err = workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute), WaitForDeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
+	if err = workflow.ExecuteActivity(
+		workflow.WithStartToCloseTimeout(
+			workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
+			1*time.Hour),
+		WaitForDeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
 

--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -68,7 +68,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 				// set the heartbeat timeout!
 				// initiate wait for deletion to complete
-				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 5*time.Minute),
+				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
 					WaitForDeletePoolActivityName,
 					deletePoolActivityInput))
 			}
@@ -98,7 +98,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		return err
 	}
 	if err = workflow.ExecuteActivity(
-		workflow.WithHeartbeatTimeout(ctx, 5*time.Minute),
+		workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
 		WaitForDeleteNLBActivityName,
 		deleteNLBActivityInput).Get(ctx, nil); err != nil {
 		return err
@@ -120,7 +120,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 
 				// set the heartbeat timeout!
 				// initiate wait for deletion to complete
-				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 5*time.Minute),
+				futures = append(futures, workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
 					WaitForDeletePoolActivityName,
 					deletePoolActivityInput))
 			}
@@ -163,6 +163,10 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		ClusterID: input.ClusterID,
 	}
 	if err = workflow.ExecuteActivity(ctx, DeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
+		return err
+	}
+
+	if err = workflow.ExecuteActivity(workflow.WithHeartbeatTimeout(ctx, 1*time.Minute), WaitForDeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
 

--- a/internal/providers/pke/pkeworkflow/delete_nlb.go
+++ b/internal/providers/pke/pkeworkflow/delete_nlb.go
@@ -77,3 +77,45 @@ func (a *DeleteNLBActivity) Execute(ctx context.Context, input DeleteNLBActivity
 
 	return nil
 }
+
+const WaitForDeleteNLBActivityName = "wait-for-pke-delete-nlb-activity"
+
+type WaitForDeleteNLBActivity struct {
+	DeleteNLBActivity
+}
+
+func NewWaitForDeleteNLBActivity(clusters Clusters) *WaitForDeleteNLBActivity {
+	return &WaitForDeleteNLBActivity{
+		DeleteNLBActivity{clusters: clusters},
+	}
+}
+
+func (a *WaitForDeleteNLBActivity) Execute(ctx context.Context, input DeleteNLBActivityInput) error {
+	c, err := a.clusters.GetCluster(ctx, input.ClusterID)
+	if err != nil {
+		return err
+	}
+	awsCluster, ok := c.(AWSCluster)
+	if !ok {
+		return errors.New(fmt.Sprintf("failed to set up wait for delete NLB for cluster type %t", c))
+	}
+
+	client, err := awsCluster.GetAWSClient()
+	if err != nil {
+		return errors.WrapIf(err, "failed to connect to AWS")
+	}
+
+	cfClient := cloudformation.New(client)
+
+	clusterName := c.GetName()
+	stackName := "pke-nlb-" + clusterName
+
+	err = cfClient.WaitUntilStackDeleteCompleteWithContext(ctx,
+		&cloudformation.DescribeStacksInput{StackName: &stackName},
+		WithHeartBeatOption(ctx))
+	if err != nil {
+		return errors.WrapIf(err, "waiting for termination")
+	}
+
+	return nil
+}

--- a/internal/providers/pke/pkeworkflow/delete_nlb.go
+++ b/internal/providers/pke/pkeworkflow/delete_nlb.go
@@ -70,11 +70,6 @@ func (a *DeleteNLBActivity) Execute(ctx context.Context, input DeleteNLBActivity
 		}
 	}
 
-	err = cfClient.WaitUntilStackDeleteCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{StackName: &stackName})
-	if err != nil {
-		return errors.WrapIf(err, "waiting for termination")
-	}
-
 	return nil
 }
 

--- a/internal/providers/pke/pkeworkflow/delete_nlb.go
+++ b/internal/providers/pke/pkeworkflow/delete_nlb.go
@@ -20,6 +20,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
@@ -76,12 +77,12 @@ func (a *DeleteNLBActivity) Execute(ctx context.Context, input DeleteNLBActivity
 const WaitForDeleteNLBActivityName = "wait-for-pke-delete-nlb-activity"
 
 type WaitForDeleteNLBActivity struct {
-	DeleteNLBActivity
+	clusters Clusters
 }
 
 func NewWaitForDeleteNLBActivity(clusters Clusters) *WaitForDeleteNLBActivity {
 	return &WaitForDeleteNLBActivity{
-		DeleteNLBActivity{clusters: clusters},
+		clusters: clusters,
 	}
 }
 
@@ -107,7 +108,7 @@ func (a *WaitForDeleteNLBActivity) Execute(ctx context.Context, input DeleteNLBA
 
 	err = cfClient.WaitUntilStackDeleteCompleteWithContext(ctx,
 		&cloudformation.DescribeStacksInput{StackName: &stackName},
-		WithHeartBeatOption(ctx))
+		request.WithWaiterRequestOptions(WithHeartBeatOption(ctx)))
 	if err != nil {
 		return errors.WrapIf(err, "waiting for termination")
 	}

--- a/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
+++ b/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
@@ -21,6 +21,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/gofrs/uuid"
 
@@ -116,8 +117,7 @@ func (a *WaitForDeleteVPCActivity) Execute(ctx context.Context, input DeleteVPCA
 
 	err = cfClient.WaitUntilStackDeleteCompleteWithContext(ctx,
 		&cloudformation.DescribeStacksInput{StackName: &stackName},
-		WithHeartBeatOption(ctx),
-	)
+		request.WithWaiterRequestOptions(WithHeartBeatOption(ctx)))
 
 	return errors.WrapIf(pkgCloudformation.NewAwsStackFailure(err, stackName, clientRequestToken, cfClient), "waiting for termination")
 }

--- a/internal/providers/pke/pkeworkflow/heartbeat_option.go
+++ b/internal/providers/pke/pkeworkflow/heartbeat_option.go
@@ -1,0 +1,29 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkeworkflow
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"go.uber.org/cadence/activity"
+)
+
+// WithHeartBeatOption injects the heart beat function into the aws waiter
+func WithHeartBeatOption(ctx context.Context) request.WaiterOption {
+	return func(w *request.Waiter) {
+		activity.RecordHeartbeat(ctx)
+	}
+}

--- a/internal/providers/pke/pkeworkflow/heartbeat_option.go
+++ b/internal/providers/pke/pkeworkflow/heartbeat_option.go
@@ -27,4 +27,3 @@ func WithHeartBeatOption(ctx context.Context) request.WaiterOption {
 		activity.RecordHeartbeat(ctx)
 	}
 }
-

--- a/internal/providers/pke/pkeworkflow/heartbeat_option.go
+++ b/internal/providers/pke/pkeworkflow/heartbeat_option.go
@@ -27,3 +27,4 @@ func WithHeartBeatOption(ctx context.Context) request.WaiterOption {
 		activity.RecordHeartbeat(ctx)
 	}
 }
+

--- a/internal/providers/pke/pkeworkflow/heartbeat_option.go
+++ b/internal/providers/pke/pkeworkflow/heartbeat_option.go
@@ -22,8 +22,8 @@ import (
 )
 
 // WithHeartBeatOption injects the heart beat function into the aws waiter
-func WithHeartBeatOption(ctx context.Context) request.WaiterOption {
-	return func(w *request.Waiter) {
+func WithHeartBeatOption(ctx context.Context) request.Option {
+	return func(_ *request.Request) {
 		activity.RecordHeartbeat(ctx)
 	}
 }

--- a/internal/providers/pke/pkeworkflow/update_cluster.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster.go
@@ -84,9 +84,9 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 
 	// delete removed nodepools
 	{
-		futures := make([]workflow.Future, len(input.NodePoolsToDelete))
+		futures := make([]workflow.Future, 0, len(input.NodePoolsToDelete))
 
-		for i, np := range input.NodePoolsToDelete {
+		for _, np := range input.NodePoolsToDelete {
 			if np.Master || !np.Worker {
 				continue
 			}
@@ -97,13 +97,17 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 				Pool:      np,
 			}
 
-			futures[i] = workflow.ExecuteActivity(ctx, DeletePoolActivityName, activityInput)
+			futures = append(futures, workflow.ExecuteActivity(ctx, DeletePoolActivityName, activityInput))
+			futures = append(futures, workflow.ExecuteActivity(ctx, WaitForDeletePoolActivityName, activityInput))
+
 		}
 
 		errs := make([]error, len(futures))
-		for i, future := range futures {
+		for _, future := range futures {
 			if future != nil {
-				errs[i] = errors.Wrapf(future.Get(ctx, nil), "couldn't delete node pool %q", input.NodePoolsToDelete[i].Name)
+				if e := future.Get(ctx, nil); e != nil {
+					errs = append(errs, errors.Wrap(e, "couldn't delete node pool"))
+				}
 			}
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
On cluster deletions (aws - pke) waiting for the deletion to complete is factored out into a dedicated activity. The activity sends heartbeats to the cadence server while waits for the aws lib specific blocking call.

### Why?
The deletion workflow gets more robust with this approach; the possibility of failures due to timeouts is reduced.

### Additional context
This is a WIP it is to be extended to other blocking calls too

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline (TODO)
