### PR TITLE
vault-is: fix service account token visibility race-condition

### DIFF
--- a/internal/integratedservices/services/vault/common_test.go
+++ b/internal/integratedservices/services/vault/common_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
+	"github.com/dgrijalva/jwt-go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srest "k8s.io/client-go/rest"
@@ -160,6 +161,13 @@ func (s *dummyKubernetesService) EnsureObject(ctx context.Context, clusterID uin
 	switch v := o.(type) {
 	case *corev1.ServiceAccount:
 		v.Secrets = []corev1.ObjectReference{{Name: "some-token-1234", Namespace: "default"}}
+	case *corev1.Secret:
+		token, err := jwt.New(jwt.SigningMethodHS256).SignedString([]byte("random-key"))
+		if err != nil {
+			return err
+		}
+
+		v.Data = map[string][]byte{corev1.ServiceAccountTokenKey: []byte(token)}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #2726 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Retrying to query the service account token for vault for doing token reviews until the actual token material becomes visible in the Data field.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
**squash please**

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
