### PR TITLE
fix nodepool API returning 500 errors when PKE clusters are not ready

### DIFF
--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -235,6 +235,10 @@ func (a *AzurePkeCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, err
 }
 
 func (a *AzurePkeCluster) IsReady() (bool, error) {
+	// cluster is not ready in case there's no config secret yet
+	if len(a.GetConfigSecretId()) == 0 {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/internal/providers/azure/pke/driver/commoncluster/cluster.go
+++ b/internal/providers/azure/pke/driver/commoncluster/cluster.go
@@ -236,7 +236,7 @@ func (a *AzurePkeCluster) GetStatus() (*pkgCluster.GetClusterStatusResponse, err
 
 func (a *AzurePkeCluster) IsReady() (bool, error) {
 	// cluster is not ready in case there's no config secret yet
-	if len(a.GetConfigSecretId()) == 0 {
+	if a.GetConfigSecretId() == "" {
 		return false, nil
 	}
 	return true, nil

--- a/src/cluster/ec2_pke.go
+++ b/src/cluster/ec2_pke.go
@@ -673,7 +673,10 @@ func (c *EC2ClusterPKE) GetStatus() (*pkgCluster.GetClusterStatusResponse, error
 
 // IsReady checks if the cluster is running according to the cloud provider.
 func (c *EC2ClusterPKE) IsReady() (bool, error) {
-	// TODO: is this a correct implementation?
+	// cluster is not ready in case there's no config secret yet
+	if len(c.GetConfigSecretId()) == 0 {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/src/cluster/ec2_pke.go
+++ b/src/cluster/ec2_pke.go
@@ -674,7 +674,7 @@ func (c *EC2ClusterPKE) GetStatus() (*pkgCluster.GetClusterStatusResponse, error
 // IsReady checks if the cluster is running according to the cloud provider.
 func (c *EC2ClusterPKE) IsReady() (bool, error) {
 	// cluster is not ready in case there's no config secret yet
-	if len(c.GetConfigSecretId()) == 0 {
+	if c.GetConfigSecretId() == "" {
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
When cluster is not ready, like there's no k8s secret yet, node pool labels are not available as they are stored on cluster. They are only fetched in case the cluster isReady, which is not implemented yet on PKE clusters, resulting in errors codes, instead of 206 StatusPartialContent codes.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
