### PR TITLE
Return 404 when a secret cannot be found

### DIFF
--- a/src/api/secrets.go
+++ b/src/api/secrets.go
@@ -320,15 +320,21 @@ func GetSecret(c *gin.Context) {
 
 	secretID := getSecretID(c)
 
-	if secret, err := restricted.GlobalSecretStore.Get(organizationID, secretID); err != nil {
+	if s, err := restricted.GlobalSecretStore.Get(organizationID, secretID); err != nil {
+		status := http.StatusBadRequest
+
+		if errors.Is(err, secret.ErrSecretNotExists) {
+			status = http.StatusNotFound
+		}
+
 		log.Errorf("Error during getting secret: %s", err.Error())
-		c.AbortWithStatusJSON(http.StatusBadRequest, common.ErrorResponse{
-			Code:    http.StatusBadRequest,
+		c.AbortWithStatusJSON(status, common.ErrorResponse{
+			Code:    status,
 			Message: "Error during listing secret",
 			Error:   err.Error(),
 		})
 	} else {
-		c.JSON(http.StatusOK, secret)
+		c.JSON(http.StatusOK, s)
 	}
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2770
| License         | Apache 2.0


### What's in this PR?
This PR fixes the Secret API and returns 404 for GET requests when a secret cannot be found.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
