### PR TITLE
improve / fix misleading error messages while deleting VPC stacks

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
+++ b/internal/providers/pke/pkeworkflow/delete_vpc_activity.go
@@ -77,7 +77,7 @@ func (a *DeleteVPCActivity) Execute(ctx context.Context, input DeleteVPCActivity
 		}
 	}
 
-	return errors.WrapIf(pkgCloudformation.NewAwsStackFailure(err, stackName, clientRequestToken, cfClient), "waiting for termination")
+	return nil
 }
 
 const WaitForDeleteVPCActivityName = "wait-for-pke-delete-vpc-activity"
@@ -119,5 +119,5 @@ func (a *WaitForDeleteVPCActivity) Execute(ctx context.Context, input DeleteVPCA
 		&cloudformation.DescribeStacksInput{StackName: &stackName},
 		request.WithWaiterRequestOptions(WithHeartBeatOption(ctx)))
 
-	return errors.WrapIf(pkgCloudformation.NewAwsStackFailure(err, stackName, clientRequestToken, cfClient), "waiting for termination")
+	return errors.WrapIf(pkgCloudformation.NewAwsStackFailure(err, stackName, clientRequestToken, cfClient), "failure while waiting for vpc stack deletion to complete")
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix the delete VPC activity return value and made error messages cleaner

### Why?
Delete VPC activity erroneously reported error when initiating deletion
