### PR TITLE
hpa: use latest hpa chart, fix Prometheus url

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -288,7 +288,7 @@ dex:
 #
 #            hpaOperator:
 #                chart: "banzaicloud-stable/hpa-operator"
-#                version: "0.0.16"
+#                version: "0.2.2"
 #
 #                # See https://github.com/banzaicloud/banzai-charts/tree/master/hpa-operator for details
 #                values: {}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -654,7 +654,7 @@ ssl:
 	v.SetDefault("cluster::ingress::cert::path", "config/certs")
 
 	v.SetDefault("cluster::autoscale::namespace", "")
-	v.SetDefault("cluster::autoscale::hpa::prometheus::serviceName", "monitor-prometheus-server")
+	v.SetDefault("cluster::autoscale::hpa::prometheus::serviceName", "monitor-prometheus-operato-prometheus")
 	v.SetDefault("cluster::autoscale::hpa::prometheus::serviceContext", "prometheus")
 	v.SetDefault("cluster::autoscale::hpa::prometheus::localPort", 9090)
 	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::chart", "stable/cluster-autoscaler")
@@ -694,7 +694,7 @@ ssl:
 	})
 
 	v.SetDefault("cluster::autoscale::charts::hpaOperator::chart", "banzaicloud-stable/hpa-operator")
-	v.SetDefault("cluster::autoscale::charts::hpaOperator::version", "0.1.0")
+	v.SetDefault("cluster::autoscale::charts::hpaOperator::version", "0.2.2")
 	v.SetDefault("cluster::autoscale::charts::hpaOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::securityScan::enabled", true)

--- a/src/api/hpa.go
+++ b/src/api/hpa.go
@@ -214,12 +214,12 @@ func (a HPAAPI) isMonitoringEnabled(ctx context.Context, clusterID uint) (bool, 
 
 func runPrometheusQuery(config *rest.Config, client kubernetes.Interface, query string) (model.Value, error) {
 	prometheusEndpointPort := global.Config.Cluster.Autoscale.HPA.Prometheus.LocalPort
+	prometheusServiceName := global.Config.Cluster.Autoscale.HPA.Prometheus.ServiceName
 	pipelineSystemNamespace := global.Config.Cluster.Namespace
 	serviceContext := global.Config.Cluster.Autoscale.HPA.Prometheus.ServiceContext
-	promethuesPodLabels := labels.Set{"app": "prometheus", "component": "server"}
-
-	log.Debugf("create kubernetes tunnel for %v", promethuesPodLabels)
-	tunnel, err := k8sutil.NewKubeTunnel(pipelineSystemNamespace, client, config, promethuesPodLabels.AsSelector(), prometheusEndpointPort)
+	prometheusPodLabels := labels.Set{"app": "prometheus", "prometheus": prometheusServiceName}
+	log.Debugf("create kubernetes tunnel for %v", prometheusPodLabels)
+	tunnel, err := k8sutil.NewKubeTunnel(pipelineSystemNamespace, client, config, prometheusPodLabels.AsSelector(), prometheusEndpointPort)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to create kubernetes tunnel")
 	}

--- a/src/cluster/hooks.go
+++ b/src/cluster/hooks.go
@@ -266,9 +266,8 @@ func InstallHorizontalPodAutoscalerPostHook(cluster CommonCluster) error {
 				"url": fmt.Sprintf("http://%s.%s.svc:%d/%s", promServiceName, infraNamespace, prometheusPort, serviceContext),
 			},
 			"enableExternalMetricsApi": true,
-			"enableCustomMetricsApi": false,
+			"enableCustomMetricsApi":   false,
 		},
-
 	}
 
 	// install metricsServer for Amazon & Azure & Alibaba & Oracle only if metrics.k8s.io endpoint is not available already


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2785 2748
| License         | Apache 2.0


### What's in this PR?
- Use latest hpa-operator & kube-metrics-adapter chart, which is basedon latest controller runtime, custom metrics endpoint is no longer used
- Fix Prometheus url setup for kube-metrics-adapter 

### Why?
Some helm based operators may fail, in case custom metrics endopoint exists, but doesn't return any items, as described in: https://github.com/banzaicloud/pipeline/issues/2748


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Related Helm chart(s) updated (if needed)