### PR TITLE
Add missing azure storage account secret type

### DIFF
--- a/internal/app/pipeline/secrettype/types.go
+++ b/internal/app/pipeline/secrettype/types.go
@@ -47,12 +47,20 @@ type Service interface {
 	GetSecretType(ctx context.Context, secretType string) (secretTypeDef TypeDefinition, err error)
 }
 
+type publicSecretType interface {
+	Public() bool
+}
+
 // NewService returns a new Service.
 func NewService(typeList secret.TypeList) Service {
 	types := typeList.Types()
 	typeDefs := make(map[string]TypeDefinition, len(types))
 
 	for _, st := range types {
+		if pst, ok := st.(publicSecretType); ok && !pst.Public() {
+			continue
+		}
+
 		var typeDef TypeDefinition
 		for _, field := range st.Definition().Fields {
 			typeDef.Fields = append(typeDef.Fields, TypeField(field))

--- a/internal/secret/types/type_azure_storage_account.go
+++ b/internal/secret/types/type_azure_storage_account.go
@@ -1,0 +1,49 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/banzaicloud/pipeline/internal/secret"
+)
+
+const azureStorageAccount = "azureStorageAccount"
+
+const (
+	FieldAzureStorageAccount          = "storageAccount"
+	FieldAzureStorageAccountAccessKey = "accessKey"
+)
+
+type AzureStorageAccountType struct{}
+
+func (AzureStorageAccountType) Name() string {
+	return azureStorageAccount
+}
+
+func (AzureStorageAccountType) Definition() secret.TypeDefinition {
+	return secret.TypeDefinition{
+		Fields: []secret.FieldDefinition{
+			{Name: FieldAzureStorageAccount, Required: true},
+			{Name: FieldAzureStorageAccountAccessKey, Required: true},
+		},
+	}
+}
+
+func (t AzureStorageAccountType) Validate(data map[string]string) error {
+	return validateDefinition(data, t.Definition())
+}
+
+func (AzureStorageAccountType) Public() bool {
+	return false
+}

--- a/internal/secret/types/type_azure_storage_account_test.go
+++ b/internal/secret/types/type_azure_storage_account_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/banzaicloud/pipeline/internal/secret"
+)
+
+func TestAzureStorageAccountType(t *testing.T) {
+	assert.Implements(t, (*secret.Type)(nil), new(AzureStorageAccountType))
+}
+
+func TestAzureStorageAccountType_Validate(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]string
+
+		message    string
+		violations []string
+	}{
+		{
+			name:    "Empty",
+			message: "missing key: " + FieldAzureStorageAccount,
+			violations: []string{
+				"missing key: " + FieldAzureStorageAccount,
+				"missing key: " + FieldAzureStorageAccountAccessKey,
+			},
+		},
+		{
+			name: "Valid",
+			data: map[string]string{
+				FieldAzureStorageAccount:          "",
+				FieldAzureStorageAccountAccessKey: "",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			typ := AzureStorageAccountType{}
+
+			err := typ.Validate(test.data)
+
+			if test.message != "" {
+				assert.EqualError(t, err, test.message)
+			}
+
+			if len(test.violations) > 0 {
+				var verr secret.ValidationError
+				if !errors.As(err, &verr) {
+					t.Fatal("error is expected to be a ValidationError")
+				}
+
+				assert.Equal(t, test.violations, verr.Violations())
+			}
+		})
+	}
+}

--- a/internal/secret/types/types.go
+++ b/internal/secret/types/types.go
@@ -32,6 +32,7 @@ func NewDefaultTypeList(config DefaultTypeListConfig) secret.TypeList {
 		AlibabaType{},
 		AmazonType{},
 		AzureType{},
+		AzureStorageAccountType{},
 		CloudflareType{},
 		DigitalOceanType{},
 		FnType{},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
We store azure storage accounts in the public secret store. This PR adds a new secret type for that.
