### PR TITLE
fix (err) variable scope in the cluster delete workflow

### DIFF
--- a/internal/providers/pke/pkeworkflow/delete_cluster.go
+++ b/internal/providers/pke/pkeworkflow/delete_cluster.go
@@ -48,8 +48,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 		ClusterID: input.ClusterID,
 	}
 
-	var err error
-	if err = workflow.ExecuteActivity(ctx, ListNodePoolsActivityName, listNodePoolsActivityInput).Get(ctx, &nodePools); err != nil {
+	if err := workflow.ExecuteActivity(ctx, ListNodePoolsActivityName, listNodePoolsActivityInput).Get(ctx, &nodePools); err != nil {
 		return err
 	}
 
@@ -65,8 +64,8 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 				}
 
 				// initiate deletion
-				if e := workflow.ExecuteActivity(ctx, DeletePoolActivityName, deletePoolActivityInput).Get(ctx, nil); err != nil {
-					errs = append(errs, errors.Wrapf(e, "couldn't initiate worker node pool deletion"))
+				if err := workflow.ExecuteActivity(ctx, DeletePoolActivityName, deletePoolActivityInput).Get(ctx, nil); err != nil {
+					errs = append(errs, errors.Wrapf(err, "couldn't initiate worker node pool deletion"))
 					continue
 				}
 
@@ -99,10 +98,10 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	deleteNLBActivityInput := &DeleteNLBActivityInput{
 		ClusterID: input.ClusterID,
 	}
-	if err = workflow.ExecuteActivity(ctx, DeleteNLBActivityName, deleteNLBActivityInput).Get(ctx, nil); err != nil {
+	if err := workflow.ExecuteActivity(ctx, DeleteNLBActivityName, deleteNLBActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
-	if err = workflow.ExecuteActivity(
+	if err := workflow.ExecuteActivity(
 		workflow.WithStartToCloseTimeout(
 			workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
 			1*time.Hour),
@@ -123,8 +122,8 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 				}
 
 				// initiate deletion
-				if e := workflow.ExecuteActivity(ctx, DeletePoolActivityName, deletePoolActivityInput).Get(ctx, nil); err != nil {
-					errs = append(errs, errors.Wrapf(e, "couldn't initiate master node pool deletion"))
+				if err := workflow.ExecuteActivity(ctx, DeletePoolActivityName, deletePoolActivityInput).Get(ctx, nil); err != nil {
+					errs = append(errs, errors.Wrapf(err, "couldn't initiate master node pool deletion"))
 					continue
 				}
 
@@ -164,7 +163,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	deleteElasticIPActivityInput := &DeleteElasticIPActivityInput{
 		ClusterID: input.ClusterID,
 	}
-	if err = workflow.ExecuteActivity(ctx, DeleteElasticIPActivityName, deleteElasticIPActivityInput).Get(ctx, nil); err != nil {
+	if err := workflow.ExecuteActivity(ctx, DeleteElasticIPActivityName, deleteElasticIPActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
 
@@ -173,11 +172,11 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	deleteVPCActivityInput := &DeleteVPCActivityInput{
 		ClusterID: input.ClusterID,
 	}
-	if err = workflow.ExecuteActivity(ctx, DeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
+	if err := workflow.ExecuteActivity(ctx, DeleteVPCActivityName, deleteVPCActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
 
-	if err = workflow.ExecuteActivity(
+	if err := workflow.ExecuteActivity(
 		workflow.WithStartToCloseTimeout(
 			workflow.WithHeartbeatTimeout(ctx, 1*time.Minute),
 			1*time.Hour),
@@ -190,7 +189,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 	deleteDexClientActivityInput := &DeleteDexClientActivityInput{
 		ClusterID: input.ClusterID,
 	}
-	if err = workflow.ExecuteActivity(ctx, DeleteDexClientActivityName, deleteDexClientActivityInput).Get(ctx, nil); err != nil {
+	if err := workflow.ExecuteActivity(ctx, DeleteDexClientActivityName, deleteDexClientActivityInput).Get(ctx, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
fix error variable scope in the cluster delete workflow

### Why?
due to the too wide scope of a declared error variable error flow was handled inconsistently


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

