### PR TITLE
Remove subnet guessing from node pool API

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19548,7 +19548,7 @@ components:
       type: array
     HelmRepoListItem:
       example:
-        cache: statestore/<cluster_name>/helm/repository/cache/stabl-index.yaml
+        cache: statestore/<cluster_name>/helm/repository/cache/stable-index.yaml
         caFile: caFile
         passwordSecretRef: passwordSecretRef
         keyFile: keyFile
@@ -19561,7 +19561,7 @@ components:
           example: stable
           type: string
         cache:
-          example: statestore/<cluster_name>/helm/repository/cache/stabl-index.yaml
+          example: statestore/<cluster_name>/helm/repository/cache/stable-index.yaml
           type: string
         url:
           example: https://kubernetes-charts.storage.googleapis.com
@@ -22588,8 +22588,9 @@ components:
             spot instances.
           example: "0.2"
           type: string
-        subnet:
-          $ref: '#/components/schemas/EKSSubnet'
+        subnetId:
+          example: subnet-xxxxxxxxxxxxxx
+          type: string
       required:
       - instanceType
     CreateEKSProperties_eks:

--- a/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
@@ -23,5 +23,5 @@ type EksNodePoolAllOf struct {
 	// The upper limit price for the requested spot instance. If this field is left empty or 0 passed in on-demand instances used instead of spot instances.
 	SpotPrice string `json:"spotPrice,omitempty"`
 
-	Subnet EksSubnet `json:"subnet,omitempty"`
+	SubnetId string `json:"subnetId,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_node_pool.go
+++ b/.gen/pipeline/pipeline/model_node_pool.go
@@ -32,5 +32,5 @@ type NodePool struct {
 	// The upper limit price for the requested spot instance. If this field is left empty or 0 passed in on-demand instances used instead of spot instances.
 	SpotPrice string `json:"spotPrice,omitempty"`
 
-	Subnet EksSubnet `json:"subnet,omitempty"`
+	SubnetId string `json:"subnetId,omitempty"`
 }

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4450,8 +4450,9 @@ components:
                             description: The upper limit price for the requested spot instance. If this field is left empty or 0 passed in on-demand instances used instead of spot instances.
                             type: string
                             example: "0.2"
-                        subnet:
-                            $ref: '#/components/schemas/EKSSubnet'
+                        subnetId:
+                            type: string
+                            example: "subnet-xxxxxxxxxxxxxx"
 
         EKSNodePool:
             type: object

--- a/apis/pipeline/postman.json
+++ b/apis/pipeline/postman.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "90add52b-5b26-4b0d-8dc8-1c94a9d78fc9",
+		"_postman_id": "ba8e1f03-3676-465c-87b7-a3fdee186055",
 		"name": "Pipeline API",
 		"description": "Collection for K8S Cluster CRUD operations through the Banzai Cloud Pipeline API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1045,7 +1045,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"name\":\"pool{{$randomInt}}\",\n    \"size\": 3,\n    \"instanceType\": \"t2.medium\",\n    \"labels\": {\n  \t  \"key\": \"value\"\n    },\n    \"autoscaling\": {\n  \t  \"enabled\": true,\n  \t  \"minSize\": 3,\n  \t  \"maxSize\": 5\n    },\n    \"image\": \"\",\n    \"spotPrice\": \"\",\n    \"subnet\": {\n\t\t\"subnetId\": \"\",\n\t\t\"cidr\": \"\",\n\t\t\"availabilityZone\": \"\"\n    }\n}",
+											"raw": "{\n    \"name\":\"pool{{$randomInt}}\",\n    \"size\": 3,\n    \"instanceType\": \"t2.medium\",\n    \"labels\": {\n  \t  \"key\": \"value\"\n    },\n    \"autoscaling\": {\n  \t  \"enabled\": true,\n  \t  \"minSize\": 3,\n  \t  \"maxSize\": 5\n    },\n    \"image\": \"\",\n    \"spotPrice\": \"\",\n    \"subnetId\": \"\"\n}",
 											"options": {
 												"raw": {
 													"language": "json"

--- a/internal/cluster/clusterworkflow/activity_create_node_pool.go
+++ b/internal/cluster/clusterworkflow/activity_create_node_pool.go
@@ -157,9 +157,7 @@ func (a CreateNodePoolActivity) Execute(ctx context.Context, input CreateNodePoo
 
 			Subnets: []eksworkflow.Subnet{
 				{
-					SubnetID:         nodePool.Subnet.SubnetId,
-					Cidr:             nodePool.Subnet.Cidr,
-					AvailabilityZone: nodePool.Subnet.AvailabilityZone,
+					SubnetID: nodePool.SubnetID,
 				},
 			},
 

--- a/internal/cluster/distribution/eks/eksadapter/node_pool_processor.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_processor.go
@@ -85,27 +85,14 @@ func (p nodePoolProcessor) ProcessNew(
 	}
 
 	// Resolve subnet ID or fallback to one
-	if nodePool.Subnet.SubnetId == "" && nodePool.Subnet.Cidr != "" && nodePool.Subnet.AvailabilityZone != "" {
-		for _, s := range eksCluster.Subnets {
-			if s.Cidr != nil && *s.Cidr == nodePool.Subnet.Cidr && s.AvailabilityZone != nil && *s.AvailabilityZone == nodePool.Subnet.AvailabilityZone {
-				rawNodePool["subnet"] = map[string]interface{}{
-					"subnetId":         *s.SubnetId,
-					"cidr":             nodePool.Subnet.Cidr,
-					"availabilityZone": nodePool.Subnet.AvailabilityZone,
-				}
-			}
-		}
-	} else if nodePool.Subnet.SubnetId == "" {
+	if nodePool.SubnetID == "" {
 		// TODO: is this necessary?
 		if len(eksCluster.Subnets) == 0 {
 			return rawNodePool, errors.New("cannot resolve subnet")
 		}
 
-		rawNodePool["subnet"] = map[string]interface{}{
-			"subnetId":         *eksCluster.Subnets[0].SubnetId,
-			"cidr":             *eksCluster.Subnets[0].Cidr,
-			"availabilityZone": *eksCluster.Subnets[0].AvailabilityZone,
-		}
+		// TODO: better algorithm for choosing a subnet?
+		rawNodePool["subnetId"] = *eksCluster.Subnets[0].SubnetId
 	}
 
 	return rawNodePool, nil

--- a/internal/cluster/distribution/eks/eksadapter/node_pool_validator.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_validator.go
@@ -83,35 +83,20 @@ func (v nodePoolValidator) ValidateNew(
 		)
 	}
 
-	hasSubnet := false
-	validSubnet := false
-
-	if nodePool.Subnet.SubnetId != "" {
-		hasSubnet = true
+	if nodePool.SubnetID != "" {
+		validSubnet := false
 
 		for _, s := range eksCluster.Subnets {
-			if s.SubnetId != nil && *s.SubnetId == nodePool.Subnet.SubnetId {
+			if s.SubnetId != nil && *s.SubnetId == nodePool.SubnetID {
 				validSubnet = true
 
 				break
 			}
 		}
-	} else if nodePool.Subnet.Cidr != "" && nodePool.Subnet.AvailabilityZone != "" {
-		hasSubnet = true
 
-		for _, s := range eksCluster.Subnets {
-			if s.Cidr != nil && *s.Cidr == nodePool.Subnet.Cidr && s.AvailabilityZone != nil && *s.AvailabilityZone == nodePool.Subnet.AvailabilityZone {
-				validSubnet = true
-
-				break
-			}
+		if !validSubnet {
+			violations = append(violations, "subnet cannot be found in the cluster")
 		}
-	} else if nodePool.Subnet.Cidr != "" || nodePool.Subnet.AvailabilityZone != "" {
-		violations = append(violations, "cidr and availability zone must be specified together")
-	}
-
-	if hasSubnet && !validSubnet {
-		violations = append(violations, "subnet cannot be found in the cluster")
 	}
 
 	if len(violations) > 0 {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -435,11 +435,11 @@ func WaitForASGToBeFulfilled(
 					if autoscaling.IsErrorFinal(err) {
 						return errors.WithDetails(err, "nodePoolName", nodePoolName, "stackName", aws.StringValue(asGroup.AutoScalingGroupName))
 					}
-					//log.Debug(err)
+					// log.Debug(err)
 					continue
 				}
 				if ok {
-					//log.Debug("ASG is healthy")
+					// log.Debug("ASG is healthy")
 					return nil
 				}
 			} else {

--- a/internal/cluster/distribution/eks/node_pool.go
+++ b/internal/cluster/distribution/eks/node_pool.go
@@ -33,11 +33,7 @@ type NewNodePool struct {
 	InstanceType string `mapstructure:"instanceType"`
 	Image        string `mapstructure:"image"`
 	SpotPrice    string `mapstructure:"spotPrice"`
-	Subnet       struct {
-		SubnetId         string `mapstructure:"subnetId"`
-		Cidr             string `mapstructure:"cidr"`
-		AvailabilityZone string `mapstructure:"availabilityZone"`
-	} `mapstructure:"subnet"`
+	SubnetID     string `mapstructure:"subnetId"`
 }
 
 // Validate semantically validates the new node pool.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

The cluster create API supports guessing subnet IDs for node pools
when the subnet is created during cluster create
(based on CIDR an AZ).

In the subnet API this is not necessary,
because it does not allow adding new subnets to the cluster.


### Why?
Guessing the correct subnet ID is necessary when the subnet is not yet created.
It's not necessary when adding new node pools.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
