### PR TITLE
Anchore-policy-validator upgrade

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -634,7 +634,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::securityScan::anchore::user", "")
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.5.3")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.5.6")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	//v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/anchore-image-validator/pull/55
| License         | Apache 2.0


### What's in this PR?
Updating `anchore-policy-validator` chart to 0.5.6 which contains `anchore-engine` version 0.6.x support.