### PR TITLE
allowing deleting of a cluster when it's last member of a cluster group

### DIFF
--- a/internal/federation/reconcile_member_clusters.go
+++ b/internal/federation/reconcile_member_clusters.go
@@ -139,7 +139,9 @@ func (m *FederationReconciler) labelRegisteredCluster(c cluster.CommonCluster) e
 	clusterLabels[clusterLabelId] = fmt.Sprintf("%v", clusterId)
 	clusterLabels[clusterLabelCloud] = c.GetCloud()
 	clusterLabels[clusterLabelDistribution] = c.GetDistribution()
-	clusterLabels[clusterLabelLocation] = c.GetLocation()
+	if c.GetLocation() != "" && c.GetLocation() != "n/a" {
+		clusterLabels[clusterLabelLocation] = c.GetLocation()
+	}
 	clusterLabels[clusterLabelGroupName] = m.ClusterGroupName
 
 	cluster := &fedv1b1.KubeFedCluster{}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Delete cluster group when somebody want's to delete a cluster which is the last member of a cluster group.

### Why?
Initially we didn't want to allow to delete last member cluster of a cluster group, because if the cluster group has no member it will be invisible on the UI, users can not attach new cluster to it, so the the flow was to delete the cluster group first. Apparently this creates too much confusion, it's easier to delete the whole cluster group in case somebody want to remove it's last cluster.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
