### PR TITLE
Fix anchore-engine URL in TestMakeAnchoreClient.

### DIFF
--- a/internal/security/anchore_client_test.go
+++ b/internal/security/anchore_client_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestMakeAnchoreClient(t *testing.T) {
 	anchoreCli := anchore.NewAPIClient(&anchore.Configuration{
-		BasePath:      "https://alpha.dev.banzaicloud.com/imagecheck",
+		BasePath:      "https://alpha.dev.banzaicloud.com/anchore",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Pipeline/go",
 	})


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pipeline-installer/pull/89
| License         | Apache 2.0


### What's in this PR?
Fix `anchore-engine` URL in the TestMakeAnchoreClient.