### PR TITLE
cluster-autoscaler: use latest chart

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -262,7 +262,7 @@ dex:
 #        charts:
 #            clusterAutoscaler:
 #                chart: "stable/cluster-autoscaler"
-#                version: "6.2.0"
+#                version: "7.1.0"
 #                imageVersionConstraints:
 #                    - k8sVersion: "<=1.12.x"
 #                      tag: "v1.12.8"

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -658,7 +658,7 @@ ssl:
 	v.SetDefault("cluster::autoscale::hpa::prometheus::serviceContext", "prometheus")
 	v.SetDefault("cluster::autoscale::hpa::prometheus::localPort", 9090)
 	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::chart", "stable/cluster-autoscaler")
-	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::version", "6.2.0")
+	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::version", "7.1.0")
 	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::values", map[string]interface{}{})
 	v.SetDefault("cluster::autoscale::charts::clusterAutoscaler::imageVersionConstraints", []interface{}{
 		map[string]interface{}{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Use latest cluster autoscaler with latest RBAC to fix RBAC problem on latest K8s 1.17.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)