### PR TITLE
auth: fix non-tls calls

### DIFF
--- a/src/auth/serviceaccount.go
+++ b/src/auth/serviceaccount.go
@@ -31,6 +31,10 @@ func NewServiceAccountService() ServiceAccountService {
 }
 
 func (s serviceAccountService) ExtractServiceAccount(r *http.Request) *User {
+	if r.TLS == nil {
+		return nil
+	}
+
 	var cert *x509.Certificate
 
 chains:


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #2805
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix panic when non-TLS clients call Pipeline, was introduced by #2805 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We need to support non-TLS requests as well.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
