### PR TITLE
[Vsphere] Set missing cluster error status  

### DIFF
--- a/internal/providers/vsphere/pke/workflow/create_cluster.go
+++ b/internal/providers/vsphere/pke/workflow/create_cluster.go
@@ -89,6 +89,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		}
 		err := workflow.ExecuteActivity(ctx, pkeworkflow.CreateDexClientActivityName, activityInput).Get(ctx, nil)
 		if err != nil {
+			_ = setClusterErrorStatus(ctx, input.ClusterID, err)
 			return err
 		}
 	}
@@ -104,6 +105,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		}
 		var output intPKEWorkflow.AssembleHTTPProxySettingsActivityOutput
 		if err := workflow.ExecuteActivity(ctx, intPKEWorkflow.AssembleHTTPProxySettingsActivityName, activityInput).Get(ctx, &output); err != nil {
+			_ = setClusterErrorStatus(ctx, input.ClusterID, err)
 			return err
 		}
 		httpProxy = output.Settings
@@ -145,6 +147,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		}
 
 		if err := errors.Combine(errs...); err != nil {
+			_ = setClusterErrorStatus(ctx, input.ClusterID, err)
 			return err
 		}
 	}
@@ -160,7 +163,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		return err
 	}
 
-	setClusterStatus(ctx, input.ClusterID, pkgCluster.Creating, "waiting for Kubernetes master") // nolint: errcheck
+	_ = setClusterStatus(ctx, input.ClusterID, pkgCluster.Creating, "waiting for Kubernetes master") // nolint: errcheck
 
 	// Create worker nodes
 	{
@@ -200,6 +203,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 		}
 
 		if err := errors.Combine(errs...); err != nil {
+			_ = setClusterErrorStatus(ctx, input.ClusterID, err)
 			return err
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Set missing cluster error status in case of Vsphere cluster create and delete

### Why?
To avoid clusters stuck in `CREATING` and `DELETING` states


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
