### PR TITLE
[Vsphere] Add force delete check to error handling

### DIFF
--- a/internal/providers/vsphere/pke/workflow/delete_cluster.go
+++ b/internal/providers/vsphere/pke/workflow/delete_cluster.go
@@ -97,7 +97,7 @@ func DeleteClusterWorkflow(ctx workflow.Context, input DeleteClusterWorkflowInpu
 			err := workflow.ExecuteActivity(ctx, DeleteNodeActivityName, activityInput).Get(ctx, nil)
 			if err != nil {
 				if input.Forced {
-					logger.Errorw("delete node failed", "error", err)
+					logger.Errorw("delete node failed", "error", err, "node", node.Name)
 				} else {
 					e := errors.WrapIff(err, "deleting node %q", node.Name)
 					_ = setClusterErrorStatus(ctx, input.ClusterID, e)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add force delete check to every error case in case of Vsphere cluster delete

### Why?
To delete Vsphere clusters in case of errors too


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)