### PR TITLE
db: diff postgres migrations with migra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,11 +190,15 @@ jobs:
 
             -
                 run:
-                    name: Test PostgreSQL database schema diff
+                    name: Install migra for PostgreSQL database diffs
                     command: |
-                        pg_dump -s -h localhost -U postgres -d pipeline_migrations > pipeline_migrations.txt
-                        pg_dump -s -h localhost -U postgres -d pipeline_automigrate > pipeline_automigrate.txt
-                        diff -U 10 pipeline_migrations.txt pipeline_automigrate.txt || exit 0
+                        apt-get install -y python-pip
+                        pip install migra[pg]
+            
+            -
+                run:
+                    name: Test PostgreSQL database schema diff
+                    command: migra postgresql://postgres:postgres@localhost/pipeline_automigrate postgresql://postgres:postgres@localhost/pipeline_migrations --unsafe
 
             -
                 run:
@@ -206,11 +210,7 @@ jobs:
             -
                 run:
                     name: Test PostgreSQL database schema diff again
-                    command: |
-                        pg_dump -s -h localhost -U postgres -d pipeline_migrations > pipeline_migrations.txt
-                        pg_dump -s -h localhost -U postgres -d pipeline_automigrate > pipeline_automigrate.txt
-                        diff -U 10 pipeline_migrations.txt pipeline_automigrate.txt || exit 0
-
+                    command: migra postgresql://postgres:postgres@localhost/pipeline_automigrate postgresql://postgres:postgres@localhost/pipeline_migrations --unsafe
             -
                 save_cache:
                     name: Save Go build cache


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   |yes
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Re-enabling Postgres schema diffs with migra.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The current Postgres differ (pgdump + plain diff) shows a lot of false positives (negatives?). Migra works better and is a widespread Postgres differ tool: https://github.com/djrobstep/migra

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
