### PR TITLE
cicdDB is optional

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -281,9 +281,11 @@ func main() {
 	emperror.Panic(errors.WithMessage(err, "failed to initialize db"))
 	global.SetDB(db)
 
-	// TODO: make this optional when CICD is disabled
-	cicdDB, err := database.Connect(config.CICD.Database)
-	emperror.Panic(errors.WithMessage(err, "failed to initialize CICD db"))
+	var cicdDB *gorm.DB
+	if config.CICD.Enabled {
+		cicdDB, err = database.Connect(config.CICD.Database)
+		emperror.Panic(errors.WithMessage(err, "failed to initialize CICD db"))
+	}
 
 	publisher, subscriber := watermill.NewPubSub(logger)
 	defer publisher.Close()


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Make cicdDB optional.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If CICD is not enabled, we still try to connect to its database.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
