### PR TITLE
vsphere: add storage secret field to cluster create request

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -18819,7 +18819,7 @@ components:
           type: integer
         template:
           description: Name of VM template available on vSphere to clone as the base
-            of nodes.
+            of nodes. Overrides the default one in main cluster secret.
           example: '[{"simple":{"value":"centos-7-pke-201910021808","summary":"Name
             of template to use when it''s unambigious."}},{"absolute":{"value":"/Datacenter/vm/centos-7-pke-201910021808"}}]'
           type: string
@@ -22935,8 +22935,19 @@ components:
           type: string
     CreatePKEOnVsphereClusterRequest_allOf:
       properties:
+        storageSecretId:
+          description: Secret ID used to setup VSphere storage classes. Overrides
+            the default settings in main cluster secret.
+          example: 62bc3c75-91fb-4670-bad4-24b401a9deac
+          type: string
+        storageSecretName:
+          description: Secret name used to setup VSphere storage classes. Overrides
+            the default one in main cluster secret.
+          example: my-vsphere-storage-secret
+          type: string
         folder:
-          description: Folder to create nodes in.
+          description: Folder to create nodes in. Overrides the default one in main
+            cluster secret.
           example: '[{"simple":{"value":"my-folder","summary":"The name of the folder
             anywhere in the hierarchy when it''s unambigious."}},{"absolute":{"value":"/Datacenter/vm/my-folder","summary":"Absolute
             path to the folder. Most vSphere installations use paths prefixed with
@@ -22944,10 +22955,12 @@ components:
           type: string
         datastore:
           description: Name of datastore or datastore cluster to place VM disks on.
+            Overrides the default one in main cluster secret.
           example: Datastore-cluster
           type: string
         resourcePool:
-          description: Virtual machines will be created in this resource pool.
+          description: Virtual machines will be created in this resource pool. Overrides
+            the default one in main cluster secret.
           example: my-resource-pool
           type: string
         nodePools:

--- a/.gen/pipeline/pipeline/model_create_pke_on_vsphere_cluster_request.go
+++ b/.gen/pipeline/pipeline/model_create_pke_on_vsphere_cluster_request.go
@@ -28,13 +28,19 @@ type CreatePkeOnVsphereClusterRequest struct {
 
 	Proxy PkeClusterHttpProxy `json:"proxy,omitempty"`
 
-	// Folder to create nodes in.
+	// Secret ID used to setup VSphere storage classes. Overrides the default settings in main cluster secret.
+	StorageSecretId string `json:"storageSecretId,omitempty"`
+
+	// Secret name used to setup VSphere storage classes. Overrides the default one in main cluster secret.
+	StorageSecretName string `json:"storageSecretName,omitempty"`
+
+	// Folder to create nodes in. Overrides the default one in main cluster secret.
 	Folder string `json:"folder,omitempty"`
 
-	// Name of datastore or datastore cluster to place VM disks on.
+	// Name of datastore or datastore cluster to place VM disks on. Overrides the default one in main cluster secret.
 	Datastore string `json:"datastore,omitempty"`
 
-	// Virtual machines will be created in this resource pool.
+	// Virtual machines will be created in this resource pool. Overrides the default one in main cluster secret.
 	ResourcePool string `json:"resourcePool,omitempty"`
 
 	NodePools []PkeOnVsphereNodePool `json:"nodePools,omitempty"`

--- a/.gen/pipeline/pipeline/model_create_pke_on_vsphere_cluster_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_create_pke_on_vsphere_cluster_request_all_of.go
@@ -12,13 +12,19 @@ package pipeline
 
 type CreatePkeOnVsphereClusterRequestAllOf struct {
 
-	// Folder to create nodes in.
+	// Secret ID used to setup VSphere storage classes. Overrides the default settings in main cluster secret.
+	StorageSecretId string `json:"storageSecretId,omitempty"`
+
+	// Secret name used to setup VSphere storage classes. Overrides the default one in main cluster secret.
+	StorageSecretName string `json:"storageSecretName,omitempty"`
+
+	// Folder to create nodes in. Overrides the default one in main cluster secret.
 	Folder string `json:"folder,omitempty"`
 
-	// Name of datastore or datastore cluster to place VM disks on.
+	// Name of datastore or datastore cluster to place VM disks on. Overrides the default one in main cluster secret.
 	Datastore string `json:"datastore,omitempty"`
 
-	// Virtual machines will be created in this resource pool.
+	// Virtual machines will be created in this resource pool. Overrides the default one in main cluster secret.
 	ResourcePool string `json:"resourcePool,omitempty"`
 
 	NodePools []PkeOnVsphereNodePool `json:"nodePools,omitempty"`

--- a/.gen/pipeline/pipeline/model_pke_on_vsphere_node_pool.go
+++ b/.gen/pipeline/pipeline/model_pke_on_vsphere_node_pool.go
@@ -26,7 +26,7 @@ type PkeOnVsphereNodePool struct {
 	// MiBs of RAM to attach to each node.
 	Ram int32 `json:"ram"`
 
-	// Name of VM template available on vSphere to clone as the base of nodes.
+	// Name of VM template available on vSphere to clone as the base of nodes. Overrides the default one in main cluster secret.
 	Template string `json:"template,omitempty"`
 
 	// Name of admin user to deploy the generated SSH public key for. No key will be deployed if omitted.

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4447,9 +4447,17 @@ components:
                   required:
                         - resourceGroup
                   properties:
+                        storageSecretId:
+                            type: string
+                            example: "62bc3c75-91fb-4670-bad4-24b401a9deac"
+                            description: "Secret ID used to setup VSphere storage classes. Overrides the default settings in main cluster secret."
+                        storageSecretName:
+                            type: string
+                            example: "my-vsphere-storage-secret"
+                            description: "Secret name used to setup VSphere storage classes. Overrides the default one in main cluster secret."
                         folder:
                             type: string
-                            description: "Folder to create nodes in."
+                            description: "Folder to create nodes in. Overrides the default one in main cluster secret."
                             example:
                                - simple:
                                      value: "my-folder"
@@ -4459,11 +4467,11 @@ components:
                                      summary: "Absolute path to the folder. Most vSphere installations use paths prefixed with /Datacenter/vm/."
                         datastore:
                             type: string
-                            description: "Name of datastore or datastore cluster to place VM disks on."
+                            description: "Name of datastore or datastore cluster to place VM disks on. Overrides the default one in main cluster secret."
                             example: Datastore-cluster
                         resourcePool:
                             type: string
-                            description: "Virtual machines will be created in this resource pool."
+                            description: "Virtual machines will be created in this resource pool. Overrides the default one in main cluster secret."
                             example: "my-resource-pool"
                         nodePools:
                             type: array
@@ -4505,7 +4513,7 @@ components:
                     description: MiBs of RAM to attach to each node.
                 template:
                     type: string
-                    description: "Name of VM template available on vSphere to clone as the base of nodes."
+                    description: "Name of VM template available on vSphere to clone as the base of nodes. Overrides the default one in main cluster secret."
                     example:
                         - simple:
                               value: "centos-7-pke-201910021808"

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4454,10 +4454,10 @@ components:
                         storageSecretName:
                             type: string
                             example: "my-vsphere-storage-secret"
-                            description: "Secret name used to setup VSphere storage classes. Overrides the default one in main cluster secret."
+                            description: "Secret name used to setup VSphere storage classes. Overrides default value from the main cluster secret."
                         folder:
                             type: string
-                            description: "Folder to create nodes in. Overrides the default one in main cluster secret."
+                            description: "Folder to create nodes in. Overrides default value from the main cluster secret."
                             example:
                                - simple:
                                      value: "my-folder"
@@ -4467,11 +4467,11 @@ components:
                                      summary: "Absolute path to the folder. Most vSphere installations use paths prefixed with /Datacenter/vm/."
                         datastore:
                             type: string
-                            description: "Name of datastore or datastore cluster to place VM disks on. Overrides the default one in main cluster secret."
+                            description: "Name of datastore or datastore cluster to place VM disks on. Overrides default value from the main cluster secret."
                             example: Datastore-cluster
                         resourcePool:
                             type: string
-                            description: "Virtual machines will be created in this resource pool. Overrides the default one in main cluster secret."
+                            description: "Virtual machines will be created in this resource pool. Overrides default value from the main cluster secret."
                             example: "my-resource-pool"
                         nodePools:
                             type: array
@@ -4513,7 +4513,7 @@ components:
                     description: MiBs of RAM to attach to each node.
                 template:
                     type: string
-                    description: "Name of VM template available on vSphere to clone as the base of nodes. Overrides the default one in main cluster secret."
+                    description: "Name of VM template available on vSphere to clone as the base of nodes. Overrides default value from the main cluster secret."
                     example:
                         - simple:
                               value: "centos-7-pke-201910021808"

--- a/cmd/worker/vsphere.go
+++ b/cmd/worker/vsphere.go
@@ -29,7 +29,7 @@ func registerVsphereWorkflows(secretStore pkeworkflow.SecretStore, tokenGenerato
 
 	vsphereClientFactory := vsphereworkflow.NewVMOMIClientFactory(secretStore)
 
-	createNodeActivity := vsphereworkflow.MakeCreateNodeActivity(vsphereClientFactory, tokenGenerator)
+	createNodeActivity := vsphereworkflow.MakeCreateNodeActivity(vsphereClientFactory, tokenGenerator, secretStore)
 	activity.RegisterWithOptions(createNodeActivity.Execute, activity.RegisterOptions{Name: vsphereworkflow.CreateNodeActivityName})
 
 	waitForIpActivity := vsphereworkflow.MakeWaitForIPActivity(vsphereClientFactory)

--- a/database/migrations/mysql/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.down.sql
+++ b/database/migrations/mysql/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `vsphere_pke_clusters` DROP COLUMN `storage_secret_id`;

--- a/database/migrations/mysql/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.up.sql
+++ b/database/migrations/mysql/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `vsphere_pke_clusters` ADD COLUMN `storage_secret_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/database/migrations/postgres/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.down.sql
+++ b/database/migrations/postgres/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "vsphere_pke_clusters" DROP COLUMN "storage_secret_id";

--- a/database/migrations/postgres/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.up.sql
+++ b/database/migrations/postgres/1586548268_add_storage_secret_column_from_vsphere_pke_clusters_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "vsphere_pke_clusters" ADD "storage_secret_id" text;

--- a/internal/providers/vsphere/pke/adapter/gorm_store.go
+++ b/internal/providers/vsphere/pke/adapter/gorm_store.go
@@ -76,11 +76,12 @@ func (nodePoolModel) TableName() string {
 }
 
 type vspherePkeCluster struct {
-	ID        uint                      `gorm:"primary_key"`
-	ClusterID uint                      `gorm:"unique_index:idx_vsphere_pke_cluster_id"`
-	Cluster   clustermodel.ClusterModel `gorm:"foreignkey:ClusterID"`
-	Spec      ProviderSpec              `gorm:"type:json"`
-	NodePools []nodePoolModel           `gorm:"foreignkey:ClusterID;association_foreignkey:ClusterID"`
+	ID              uint                      `gorm:"primary_key"`
+	ClusterID       uint                      `gorm:"unique_index:idx_vsphere_pke_cluster_id"`
+	Cluster         clustermodel.ClusterModel `gorm:"foreignkey:ClusterID"`
+	Spec            ProviderSpec              `gorm:"type:json"`
+	NodePools       []nodePoolModel           `gorm:"foreignkey:ClusterID;association_foreignkey:ClusterID"`
+	StorageSecretID string
 }
 
 func (vspherePkeCluster) TableName() string {

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -24,13 +24,12 @@ import (
 	"go.uber.org/cadence/client"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
-
 	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/vsphere/pke"
 	vspherePKE "github.com/banzaicloud/pipeline/internal/providers/vsphere/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/vsphere/pke/driver/commoncluster"
 	"github.com/banzaicloud/pipeline/internal/providers/vsphere/pke/workflow"
+	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgPKE "github.com/banzaicloud/pipeline/pkg/cluster/pke"
 	"github.com/banzaicloud/pipeline/src/auth"
@@ -352,14 +351,15 @@ func (p VspherePKEClusterCreationParamsPreparer) Prepare(ctx context.Context, pa
 }
 
 func (p VspherePKEClusterCreationParamsPreparer) verifySecretIsOfType(orgID uint, secretID string, secretType string) error {
-	if secretID != "" {
-		secret, err := p.secrets.Get(orgID, secretID)
-		if err != nil {
-			return validationErrorf("failed to get secret %s", secretID)
-		}
-		if secret.Type != secretType {
-			return validationErrorf("%s should be of type VSphere", secretID)
-		}
+	if secretID == "" {
+		return nil
+	}
+	secret, err := p.secrets.Get(orgID, secretID)
+	if err != nil {
+		return validationErrorf("failed to get secret %s", secretID)
+	}
+	if secret.Type != secretType {
+		return validationErrorf("%s should be of type VSphere", secretID)
 	}
 	return nil
 }

--- a/internal/providers/vsphere/pke/store.go
+++ b/internal/providers/vsphere/pke/store.go
@@ -26,6 +26,7 @@ type CreateParams struct {
 	OrganizationID    uint
 	CreatedBy         uint
 	SecretID          string
+	StorageSecretID   string
 	SSHSecretID       string
 	RBAC              bool
 	OIDC              bool

--- a/internal/providers/vsphere/pke/workflow/create_cluster.go
+++ b/internal/providers/vsphere/pke/workflow/create_cluster.go
@@ -48,6 +48,7 @@ type CreateClusterWorkflowInput struct {
 	FolderName       string
 	DatastoreName    string
 	SecretID         string
+	StorageSecretID  string
 	OIDCEnabled      bool
 	PostHooks        pkgCluster.PostHooks
 	Nodes            []Node
@@ -130,6 +131,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 			activityInput := CreateNodeActivityInput{
 				OrganizationID:   input.OrganizationID,
 				SecretID:         input.SecretID,
+				StorageSecretID:  input.StorageSecretID,
 				ClusterID:        input.ClusterID,
 				ClusterName:      input.ClusterName,
 				ResourcePoolName: input.ResourcePoolName,

--- a/internal/providers/vsphere/pke/workflow/create_node_activity.go
+++ b/internal/providers/vsphere/pke/workflow/create_node_activity.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
+	"text/template"
 
 	"emperror.dev/errors"
 	"github.com/ghodss/yaml"
@@ -30,12 +32,8 @@ import (
 	"go.uber.org/cadence/activity"
 
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow"
-	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
-
 	"github.com/banzaicloud/pipeline/internal/providers/pke/pkeworkflow/pkeworkflowadapter"
-
-	"strings"
-	"text/template"
+	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 )
 
 // CreateNodeActivityName is the default registration name of the activity

--- a/internal/secret/secrettype/secret.go
+++ b/internal/secret/secrettype/secret.go
@@ -87,9 +87,15 @@ const (
 
 // vSphere keys
 const (
-	VsphereURL      = "url"
-	VsphereUser     = "user"
-	VspherePassword = "password"
+	VsphereURL                 = "url"
+	VsphereUser                = "user"
+	VspherePassword            = "password"
+	VsphereFingerprint         = "fingerprint"
+	VsphereDatacenter          = "datacenter"
+	VsphereDatastore           = "datastore"
+	VsphereResourcePool        = "resourcePool"
+	VsphereFolder              = "folder"
+	VsphereDefaultNodeTemplate = "defaultNodeTemplate"
 )
 
 // Kubernetes keys
@@ -273,6 +279,12 @@ var DefaultRules = map[string]Meta{
 			{Name: VsphereURL, Required: true, Description: "The URL endpoint of the vSphere instance to use (don't include auth info)"},
 			{Name: VsphereUser, Required: true, Description: "Username to use for vSphere authentication"},
 			{Name: VspherePassword, Required: true, Description: "Password to use for vSphere authentication"},
+			{Name: VsphereFingerprint, Required: true, Description: "Fingerprint of the server certificate of vCenter"},
+			{Name: VsphereDatacenter, Required: true, Description: "Datacenter to use to store persistent volumes"},
+			{Name: VsphereDatastore, Required: true, Description: "Datastore that is in the given datacenter, and is available on all nodes"},
+			{Name: VsphereResourcePool, Required: true, Description: "Resource pool to create  VMs"},
+			{Name: VsphereFolder, Required: true, Description: "The name of the folder (aka blue folder) to create VMs"},
+			{Name: VsphereDefaultNodeTemplate, Required: true, Description: "The name of the default template name for VMs"},
 		},
 	},
 	SSHSecretType: {

--- a/internal/secret/types/type_vsphere.go
+++ b/internal/secret/types/type_vsphere.go
@@ -21,9 +21,15 @@ import (
 const Vsphere = "vsphere"
 
 const (
-	FieldVsphereURL      = "url"
-	FieldVsphereUser     = "user"
-	FieldVspherePassword = "password"
+	FieldVsphereURL                 = "url"
+	FieldVsphereUser                = "user"
+	FieldVspherePassword            = "password"
+	FieldVsphereFingerprint         = "fingerprint"
+	FieldVsphereDatacenter          = "datacenter"
+	FieldVsphereDatastore           = "datastore"
+	FieldVsphereResourcePool        = "resourcePool"
+	FieldVsphereFolder              = "folder"
+	FieldVsphereDefaultNodeTemplate = "defaultNodeTemplate"
 )
 
 type VsphereType struct{}
@@ -38,6 +44,12 @@ func (VsphereType) Definition() secret.TypeDefinition {
 			{Name: FieldVsphereURL, Required: true, Description: "The URL endpoint of the vSphere instance to use (don't include auth info)"},
 			{Name: FieldVsphereUser, Required: true, Description: "Username to use for vSphere authentication"},
 			{Name: FieldVspherePassword, Required: true, Description: "Password to use for vSphere authentication"},
+			{Name: FieldVsphereFingerprint, Required: true, Description: "Fingerprint of the server certificate of vCenter"},
+			{Name: FieldVsphereDatacenter, Required: true, Description: "Datacenter to use to store persistent volumes"},
+			{Name: FieldVsphereDatastore, Required: true, Description: "Datastore that is in the given datacenter, and is available on all nodes"},
+			{Name: FieldVsphereResourcePool, Required: true, Description: "Resource pool to create  VMs"},
+			{Name: FieldVsphereFolder, Required: true, Description: "The name of the folder (aka blue folder) to create VMs"},
+			{Name: FieldVsphereDefaultNodeTemplate, Required: true, Description: "The name of the default template name for VMs"},
 		},
 	}
 }

--- a/src/api/cluster/pke_vsphere.go
+++ b/src/api/cluster/pke_vsphere.go
@@ -20,6 +20,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/providers/vsphere/pke"
 	"github.com/banzaicloud/pipeline/internal/providers/vsphere/pke/driver"
 	"github.com/banzaicloud/pipeline/pkg/cluster"
+	"github.com/banzaicloud/pipeline/src/secret"
 )
 
 const PKEOnVsphere = pke.PKEOnVsphere
@@ -27,6 +28,11 @@ const PKEOnVsphere = pke.PKEOnVsphere
 type CreatePKEOnVsphereClusterRequest pipeline.CreatePkeOnVsphereClusterRequest
 
 func (req CreatePKEOnVsphereClusterRequest) ToVspherePKEClusterCreationParams(organizationID, userID uint) driver.VspherePKEClusterCreationParams {
+	storagetSecretID := req.StorageSecretId
+	if storagetSecretID == "" && req.StorageSecretName != "" {
+		storagetSecretID = secret.GenerateSecretIDFromName(req.StorageSecretName)
+	}
+
 	return driver.VspherePKEClusterCreationParams{
 		Name:           req.Name,
 		OrganizationID: organizationID,
@@ -40,8 +46,9 @@ func (req CreatePKEOnVsphereClusterRequest) ToVspherePKEClusterCreationParams(or
 			Excludes:            req.ScaleOptions.Excludes,
 			KeepDesiredCapacity: req.ScaleOptions.KeepDesiredCapacity,
 		},
-		SecretID:    req.SecretId,
-		SSHSecretID: req.SshSecretId,
+		SecretID:        req.SecretId,
+		StorageSecretID: storagetSecretID,
+		SSHSecretID:     req.SshSecretId,
 		Kubernetes: intPKE.Kubernetes{
 			Version: req.Kubernetes.Version,
 			RBAC:    req.Kubernetes.Rbac,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add a separate secret id/name field to vSphere create request to allow using different url, username, pwd, datacenter, datastore, res. pool, folder settings for vSphere storage class setup. This is optional, by default all these setting come from the main cluster secret.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] OpenAPI and Postman files updated (if needed)
