### PR TITLE
helm3 unfied service adapter

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -101,6 +101,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/global/nplabels"
 	"github.com/banzaicloud/pipeline/internal/helm"
 	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
+	helm3adapter "github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/helm/helmdriver"
 	"github.com/banzaicloud/pipeline/internal/helm2"
 	helmadapter2 "github.com/banzaicloud/pipeline/internal/helm2/helmadapter"
@@ -513,19 +514,6 @@ func main() {
 	clientFactory := kubernetes.NewClientFactory(configFactory)
 	dynamicClientFactory := kubernetes.NewDynamicClientFactory(configFactory)
 
-	clusterAPI := api.NewClusterAPI(
-		clusterManager,
-		commonClusterGetter,
-		workflowClient,
-		logrusLogger,
-		errorHandler,
-		externalBaseURL,
-		externalURLInsecure,
-		clusterCreators,
-		clusterUpdaters,
-		dynamicClientFactory,
-	)
-
 	// Initialise Gin router
 	engine := gin.New()
 
@@ -682,8 +670,29 @@ func main() {
 		spotguideAPI = api.NewSpotguideAPI(logrusLogger, errorHandler, spotguideManager)
 	}
 
-	// set up helm facade for later use
 	helmFacade := setupHelmFacade(config, db, commonSecretStore, clusterManager, commonLogger)
+
+	var unifiedHelmReleaser helm.UnifiedReleaser
+	switch config.Helm.Version {
+	case "helm3":
+		unifiedHelmReleaser = helm3adapter.NewUnifiedHelm3Releaser(helmFacade, commonLogger)
+	default:
+		unifiedHelmReleaser = helm2.NewHelmService(helmadapter2.NewClusterService(clusterManager), commonadapter.NewLogger(logger))
+	}
+
+	clusterAPI := api.NewClusterAPI(
+		clusterManager,
+		commonClusterGetter,
+		workflowClient,
+		logrusLogger,
+		errorHandler,
+		externalBaseURL,
+		externalURLInsecure,
+		clusterCreators,
+		clusterUpdaters,
+		dynamicClientFactory,
+		unifiedHelmReleaser,
+	)
 
 	v1 := base.Group("api/v1")
 	apiRouter := router.PathPrefix("/api/v1").Subrouter()
@@ -887,8 +896,6 @@ func main() {
 					securityscan.MakeIntegratedServiceManager(commonLogger, config.Cluster.SecurityScan.Config),
 				}
 
-				helmService := helm2.NewHelmService(helmadapter2.NewClusterService(clusterManager), commonLogger)
-
 				if config.Cluster.DNS.Enabled {
 					integratedServiceManagers = append(integratedServiceManagers, integratedServiceDNS.NewIntegratedServicesManager(clusterPropertyGetter, clusterPropertyGetter, config.Cluster.DNS.Config))
 				}
@@ -902,7 +909,7 @@ func main() {
 						clusterGetter,
 						commonSecretStore,
 						endpointManager,
-						helmService,
+						unifiedHelmReleaser,
 						config.Cluster.Monitoring.Config,
 						commonLogger,
 					))
@@ -961,7 +968,7 @@ func main() {
 				if config.Cluster.Ingress.Enabled {
 					integratedServiceManagers = append(integratedServiceManagers, ingress.NewManager(
 						config.Cluster.Ingress.Config,
-						helmService,
+						unifiedHelmReleaser,
 						commonLogger,
 					))
 				}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -63,7 +63,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/federation"
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/internal/helm"
-	helmadapter2 "github.com/banzaicloud/pipeline/internal/helm/helmadapter"
+	helm3adapter "github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/helm2"
 	"github.com/banzaicloud/pipeline/internal/helm2/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
@@ -265,14 +265,13 @@ func main() {
 
 		commonSecretStore := commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))
 
-		var helmService integratedserviceadapter.AdaptedHelmService
+		var unifiedHelmReleaser helm.UnifiedReleaser
 		switch config.Helm.Version {
 		case "helm3":
 			helmFacade := setupHelmFacade(config, db, commonSecretStore, clusterManager, commonLogger)
-			helmService = integratedserviceadapter.NewHelmService(helmFacade, config.Cluster.Namespace, commonLogger)
-
+			unifiedHelmReleaser = helm3adapter.NewUnifiedHelm3Releaser(helmFacade, commonLogger)
 		default:
-			helmService = helm2.NewHelmService(helmadapter.NewClusterService(clusterManager), commonadapter.NewLogger(logger))
+			unifiedHelmReleaser = helm2.NewHelmService(helmadapter.NewClusterService(clusterManager), commonadapter.NewLogger(logger))
 		}
 
 		clusters := pkeworkflowadapter.NewClusterManagerAdapter(clusterManager)
@@ -355,7 +354,7 @@ func main() {
 
 			installNodePoolLabelSetOperatorActivity := clustersetup.NewInstallNodePoolLabelSetOperatorActivity(
 				config.Cluster.Labels,
-				helmService,
+				unifiedHelmReleaser,
 			)
 			activity.RegisterWithOptions(installNodePoolLabelSetOperatorActivity.Execute, activity.RegisterOptions{Name: clustersetup.InstallNodePoolLabelSetOperatorActivityName})
 
@@ -379,7 +378,7 @@ func main() {
 
 		workflow.RegisterWithOptions(cluster.RunPostHooksWorkflow, workflow.RegisterOptions{Name: cluster.RunPostHooksWorkflowName})
 
-		runPostHookActivity := cluster.NewRunPostHookActivity(clusterManager)
+		runPostHookActivity := cluster.NewRunPostHookActivity(clusterManager, unifiedHelmReleaser)
 		activity.RegisterWithOptions(runPostHookActivity.Execute, activity.RegisterOptions{Name: cluster.RunPostHookActivityName})
 
 		updateClusterStatusActivity := cluster.NewUpdateClusterStatusActivity(clusterManager)
@@ -652,7 +651,7 @@ func main() {
 				integratedServiceDNS.MakeIntegratedServiceOperator(
 					clusterGetter,
 					clusterService,
-					helmService,
+					unifiedHelmReleaser,
 					logger,
 					orgDomainService,
 					commonSecretStore,
@@ -662,7 +661,7 @@ func main() {
 					config.Cluster.SecurityScan.Config,
 					clusterGetter,
 					clusterService,
-					helmService,
+					unifiedHelmReleaser,
 					commonSecretStore,
 					featureAnchoreService,
 					featureWhitelistService,
@@ -671,7 +670,7 @@ func main() {
 				),
 				integratedServiceVault.MakeIntegratedServicesOperator(clusterGetter,
 					clusterService,
-					helmService,
+					unifiedHelmReleaser,
 					kubernetesService,
 					commonSecretStore,
 					config.Cluster.Vault.Config,
@@ -680,7 +679,7 @@ func main() {
 				integratedServiceMonitoring.MakeIntegratedServiceOperator(
 					clusterGetter,
 					clusterService,
-					helmService,
+					unifiedHelmReleaser,
 					kubernetesService,
 					config.Cluster.Monitoring.Config,
 					logger,
@@ -689,7 +688,7 @@ func main() {
 				integratedServiceLogging.MakeIntegratedServicesOperator(
 					clusterGetter,
 					clusterService,
-					helmService,
+					unifiedHelmReleaser,
 					kubernetesService,
 					endpointManager,
 					config.Cluster.Logging.Config,
@@ -701,7 +700,7 @@ func main() {
 					intsvcingressadapter.NewOperatorClusterStore(clusterStore),
 					clusterService,
 					config.Cluster.Ingress.Config,
-					helmService,
+					unifiedHelmReleaser,
 					intsvcingressadapter.NewOrgDomainService(config.Cluster.DNS.BaseDomain, orgGetter),
 				),
 			})
@@ -722,12 +721,12 @@ func main() {
 // setupHelmFacade utility function for assembling the helm facade
 func setupHelmFacade(config configuration, db *gorm.DB, commonSecretStore common2.SecretStore,
 	clusterManager *cluster.Manager, logger helm.Logger) helm.Service {
-	repoStore := helmadapter2.NewHelmRepoStore(db, logger)
-	secretStore := helmadapter2.NewSecretStore(commonSecretStore, logger)
-	orgService := helmadapter2.NewOrgService(logger)
+	repoStore := helm3adapter.NewHelmRepoStore(db, logger)
+	secretStore := helm3adapter.NewSecretStore(commonSecretStore, logger)
+	orgService := helm3adapter.NewOrgService(logger)
 	validator := helm.NewHelmRepoValidator()
-	releaser := helmadapter2.NewReleaser(logger)
-	clusterService := helmadapter2.NewClusterService(clusterManager)
+	releaser := helm3adapter.NewReleaser(logger)
+	clusterService := helm3adapter.NewClusterService(clusterManager)
 
 	var (
 		envService helm.EnvService
@@ -736,7 +735,7 @@ func setupHelmFacade(config configuration, db *gorm.DB, commonSecretStore common
 	switch config.Helm.Version {
 	case "helm3":
 		envResolver = helm.NewHelm3EnvResolver(envResolver)
-		envService = helmadapter2.NewHelm3EnvService(logger)
+		envService = helm3adapter.NewHelm3EnvService(logger)
 
 		// set up platform helm env
 		platformHelmEnv, _ := envResolver.ResolvePlatformEnv(context.Background())
@@ -747,7 +746,7 @@ func setupHelmFacade(config configuration, db *gorm.DB, commonSecretStore common
 
 	default:
 		envResolver = helm.NewHelm2EnvResolver(config.Helm.Home, orgService, logger)
-		envService = helmadapter2.NewHelmEnvService(helmadapter2.NewConfig(config.Helm.Repositories), logger)
+		envService = helm3adapter.NewHelmEnvService(helm3adapter.NewConfig(config.Helm.Repositories), logger)
 	}
 
 	service := helm.NewService(

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
+	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 
 	"github.com/banzaicloud/pipeline/internal/common"
 )
@@ -61,7 +62,7 @@ type Options struct {
 // +kit:endpoint:errorStrategy=service
 // +testify:mock:testOnly=true
 
-// Service manages Helm chart repositories.
+// Service manages Helm repositories, charts and releases
 type Service interface {
 	// helm repository management operations
 	repository
@@ -71,6 +72,38 @@ type Service interface {
 
 	// chart related operations
 	charter
+}
+
+// UnifiedReleaser unifies different helm release interfaces into a single interface
+type UnifiedReleaser interface {
+	// integrated services style
+	ApplyDeployment(
+		ctx context.Context,
+		clusterID uint,
+		namespace string,
+		chartName string,
+		releaseName string,
+		values []byte,
+		chartVersion string,
+	) error
+
+	// cluster setup style
+	InstallDeployment(
+		ctx context.Context,
+		clusterID uint,
+		namespace string,
+		chartName string,
+		releaseName string,
+		values []byte,
+		chartVersion string,
+		wait bool,
+	) error
+
+	// DeleteDeployment deletes a deployment from a specific cluster.
+	DeleteDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) error
+
+	// GetDeployment gets a deployment by release name from a specific cluster.
+	GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error)
 }
 
 // releaser collects and groups release related operations

--- a/internal/helm2/service.go
+++ b/internal/helm2/service.go
@@ -287,7 +287,7 @@ func (s *HelmService) ApplyDeployment(
 }
 
 // DeleteDeployment deletes a deployment from a specific cluster.
-func (s *HelmService) DeleteDeployment(ctx context.Context, clusterID uint, releaseName string) error {
+func (s *HelmService) DeleteDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) error {
 	logger := s.logger.WithContext(ctx).WithFields(map[string]interface{}{"release": releaseName})
 	logger.Info("deleting deployment")
 
@@ -316,7 +316,7 @@ func (s *HelmService) DeleteDeployment(ctx context.Context, clusterID uint, rele
 	return nil
 }
 
-func (s *HelmService) GetDeployment(ctx context.Context, clusterID uint, releaseName string) (*pkgHelm.GetDeploymentResponse, error) {
+func (s *HelmService) GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error) {
 	logger := s.logger.WithContext(ctx).WithFields(map[string]interface{}{"release": releaseName})
 	logger.Info("getting deployment")
 

--- a/internal/helm2/service_test.go
+++ b/internal/helm2/service_test.go
@@ -97,6 +97,7 @@ func TestIntegration(t *testing.T) {
 		context.Background(),
 		1,
 		"helm-service-test",
+		"",
 	)
 	require.NoError(t, err)
 }

--- a/internal/integratedservices/services/dns/operator.go
+++ b/internal/integratedservices/services/dns/operator.go
@@ -143,7 +143,7 @@ func (op IntegratedServiceOperator) Deactivate(ctx context.Context, clusterID ui
 		return err
 	}
 
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, ReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, ReleaseName, op.config.Namespace); err != nil {
 		return errors.WrapIf(err, "failed to delete deployment")
 	}
 

--- a/internal/integratedservices/services/helm.go
+++ b/internal/integratedservices/services/helm.go
@@ -28,15 +28,15 @@ type HelmService interface {
 		ctx context.Context,
 		clusterID uint,
 		namespace string,
-		deploymentName string,
+		chartName string,
 		releaseName string,
 		values []byte,
 		chartVersion string,
 	) error
 
 	// DeleteDeployment deletes a deployment from a specific cluster.
-	DeleteDeployment(ctx context.Context, clusterID uint, releaseName string) error
+	DeleteDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) error
 
 	// GetDeployment gets a deployment by release name from a specific cluster.
-	GetDeployment(ctx context.Context, clusterID uint, releaseName string) (*pkgHelm.GetDeploymentResponse, error)
+	GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error)
 }

--- a/internal/integratedservices/services/ingress/manager.go
+++ b/internal/integratedservices/services/ingress/manager.go
@@ -56,7 +56,7 @@ func (m Manager) GetOutput(ctx context.Context, clusterID uint, spec integrateds
 	case ControllerTraefik:
 		traefikOutput := make(map[string]interface{})
 
-		rel, err := m.helmService.GetDeployment(ctx, clusterID, m.config.ReleaseName)
+		rel, err := m.helmService.GetDeployment(ctx, clusterID, m.config.ReleaseName, m.config.Namespace)
 		if err != nil {
 			m.logger.Warn(err.Error(), map[string]interface{}{
 				"clusterId":   clusterID,

--- a/internal/integratedservices/services/ingress/traefik.go
+++ b/internal/integratedservices/services/ingress/traefik.go
@@ -65,7 +65,7 @@ func (m traefikManager) Deploy(ctx context.Context, clusterID uint, spec Spec) e
 }
 
 func (m traefikManager) Remove(ctx context.Context, clusterID uint) error {
-	return errors.WrapIf(m.helmService.DeleteDeployment(ctx, clusterID, m.config.ReleaseName), "failed to delete deployment")
+	return errors.WrapIf(m.helmService.DeleteDeployment(ctx, clusterID, m.config.ReleaseName, m.config.Namespace), "failed to delete deployment")
 }
 
 func (m traefikManager) compileChartValues(ctx context.Context, clusterID uint, spec Spec) (interface{}, error) {

--- a/internal/integratedservices/services/logging/operator.go
+++ b/internal/integratedservices/services/logging/operator.go
@@ -143,12 +143,12 @@ func (op IntegratedServiceOperator) Deactivate(ctx context.Context, clusterID ui
 	}
 
 	// delete Loki deployment
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, lokiReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, lokiReleaseName, op.config.Namespace); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to delete deployment", "release", lokiReleaseName)
 	}
 
 	// delete Logging-operator deployment
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, loggingOperatorReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, loggingOperatorReleaseName, op.config.Namespace); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to delete deployment", "release", loggingOperatorReleaseName)
 	}
 

--- a/internal/integratedservices/services/monitoring/operator.go
+++ b/internal/integratedservices/services/monitoring/operator.go
@@ -199,12 +199,12 @@ func (op IntegratedServiceOperator) Deactivate(ctx context.Context, clusterID ui
 	}
 
 	// delete prometheus operator deployment
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, prometheusOperatorReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, prometheusOperatorReleaseName, op.config.Namespace); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to delete deployment", "release", prometheusOperatorReleaseName)
 	}
 
 	// delete prometheus pushgateway deployment
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, prometheusPushgatewayReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, prometheusPushgatewayReleaseName, op.config.Namespace); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to delete deployment", "release", prometheusPushgatewayReleaseName)
 	}
 

--- a/internal/integratedservices/services/securityscan/operator.go
+++ b/internal/integratedservices/services/securityscan/operator.go
@@ -160,7 +160,7 @@ func (op IntegratedServiceOperator) Deactivate(ctx context.Context, clusterID ui
 		return errors.WrapIf(err, "failed to apply integrated service")
 	}
 
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, op.config.Webhook.Release); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, op.config.Webhook.Release, op.config.Webhook.Namespace); err != nil {
 		return errors.WrapIfWithDetails(err, "failed to uninstall integrated service", "integrated service", IntegratedServiceName,
 			"clusterID", clusterID)
 	}

--- a/internal/integratedservices/services/vault/operator.go
+++ b/internal/integratedservices/services/vault/operator.go
@@ -348,7 +348,7 @@ func (op IntegratedServicesOperator) Deactivate(ctx context.Context, clusterID u
 	logger := op.logger.WithContext(ctx).WithFields(map[string]interface{}{"cluster": clusterID, "integrated service": integratedServiceName})
 
 	// delete deployment
-	if err := op.helmService.DeleteDeployment(ctx, clusterID, vaultWebhookReleaseName); err != nil {
+	if err := op.helmService.DeleteDeployment(ctx, clusterID, vaultWebhookReleaseName, op.config.Namespace); err != nil {
 		logger.Info("failed to delete integrated service deployment")
 
 		return errors.WrapIf(err, "failed to uninstall integrated service")

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -61,6 +61,8 @@ type ClusterAPI struct {
 	errorHandler    emperror.Handler
 	clusterCreators ClusterCreators
 	clusterUpdaters ClusterUpdaters
+
+	helmService cluster.HelmService
 }
 
 type ClusterCreators struct {
@@ -91,6 +93,7 @@ func NewClusterAPI(
 	clusterCreators ClusterCreators,
 	clusterUpdaters ClusterUpdaters,
 	clientFactory common.DynamicClientFactory,
+	helmService cluster.HelmService,
 ) *ClusterAPI {
 	return &ClusterAPI{
 		clusterManager:          clusterManager,
@@ -103,6 +106,7 @@ func NewClusterAPI(
 		clusterCreators:         clusterCreators,
 		clusterUpdaters:         clusterUpdaters,
 		clientFactory:           clientFactory,
+		helmService:             helmService,
 	}
 }
 

--- a/src/api/cluster_update.go
+++ b/src/api/cluster_update.go
@@ -86,6 +86,7 @@ func (a *ClusterAPI) UpdateCluster(c *gin.Context) {
 				a.workflowClient,
 				a.externalBaseURL,
 				a.externalBaseURLInsecure,
+				a.helmService,
 			)
 			err = a.clusterManager.UpdateCluster(ctx, updateCtx, updater)
 		}

--- a/src/cluster/hook_workflow.go
+++ b/src/cluster/hook_workflow.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/cadence/workflow"
 
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgHelm "github.com/banzaicloud/pipeline/pkg/helm"
 )
 
 const RunPostHooksWorkflowName = "run-posthooks"
@@ -85,6 +86,29 @@ func RunPostHooksWorkflow(ctx workflow.Context, input RunPostHooksWorkflowInput)
 	return nil
 }
 
+// A generic interface for using Helm for hooks
+type HelmService interface {
+	ApplyDeployment(
+		ctx context.Context,
+		clusterID uint,
+		namespace string,
+		deploymentName string,
+		releaseName string,
+		values []byte,
+		chartVersion string,
+	) error
+
+	// DeleteDeployment deletes a deployment from a specific cluster.
+	DeleteDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) error
+
+	// GetDeployment gets a deployment by release name from a specific cluster.
+	GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error)
+}
+
+type HelmServiceInjector interface {
+	InjectHelmService(HelmService)
+}
+
 const RunPostHookActivityName = "run-posthook"
 
 type RunPostHookActivityInput struct {
@@ -95,12 +119,14 @@ type RunPostHookActivityInput struct {
 }
 
 type RunPostHookActivity struct {
-	manager *Manager
+	manager     *Manager
+	helmService HelmService
 }
 
-func NewRunPostHookActivity(manager *Manager) *RunPostHookActivity {
+func NewRunPostHookActivity(manager *Manager, helmService HelmService) *RunPostHookActivity {
 	return &RunPostHookActivity{
-		manager: manager,
+		manager:     manager,
+		helmService: helmService,
 	}
 }
 func (a *RunPostHookActivity) Execute(ctx context.Context, input RunPostHookActivityInput) error {
@@ -127,6 +153,10 @@ func (a *RunPostHookActivity) Execute(ctx context.Context, input RunPostHookActi
 		"workflowID", info.WorkflowExecution.ID,
 		"workflowRunID", info.WorkflowExecution.RunID,
 	)
+
+	if helmHook, ok := hook.(HelmServiceInjector); ok {
+		helmHook.InjectHelmService(a.helmService)
+	}
 
 	logger.Infow("starting posthook function", "param", input.HookParam)
 

--- a/src/cluster/hookfunctions.go
+++ b/src/cluster/hookfunctions.go
@@ -25,16 +25,13 @@ import (
 // HookMap for api hook endpoints
 // nolint: gochecknoglobals
 var HookMap = map[string]PostFunctioner{
-	pkgCluster.InstallIngressControllerPostHook: &BasePostFunction{
-		f:            InstallIngressControllerPostHook,
+	pkgCluster.InstallIngressControllerPostHook: &IngressControllerPostHook{
 		ErrorHandler: ErrorHandler{},
 	},
-	pkgCluster.InstallKubernetesDashboardPostHook: &BasePostFunction{
-		f:            InstallKubernetesDashboardPostHook,
+	pkgCluster.InstallKubernetesDashboardPostHook: &KubernetesDashboardPostHook{
 		ErrorHandler: ErrorHandler{},
 	},
-	pkgCluster.InstallClusterAutoscalerPostHook: &BasePostFunction{
-		f:            InstallClusterAutoscalerPostHook,
+	pkgCluster.InstallClusterAutoscalerPostHook: &ClusterAutoscalerPostHook{
 		ErrorHandler: ErrorHandler{},
 	},
 	pkgCluster.InstallHorizontalPodAutoscalerPostHook: &BasePostFunction{

--- a/src/cluster/hooks_ingress.go
+++ b/src/cluster/hooks_ingress.go
@@ -15,9 +15,11 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
@@ -53,8 +55,26 @@ type serviceTraefikValues struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// InstallIngressControllerPostHook post hooks can't return value, they can log error and/or update state?
-func InstallIngressControllerPostHook(cluster CommonCluster) error {
+type IngressControllerPostHook struct {
+	helmService HelmService
+	Priority
+	ErrorHandler
+	sync.Mutex
+}
+
+func (i *IngressControllerPostHook) InjectHelmService(h HelmService) {
+	i.Lock()
+	defer i.Unlock()
+
+	if i.helmService == nil {
+		i.helmService = h
+	}
+}
+
+func (i *IngressControllerPostHook) Do(cluster CommonCluster) error {
+	if i.helmService == nil {
+		return errors.New("missing helm service dependency")
+	}
 	var config = global.Config.Cluster.PostHook
 	if !config.Ingress.Enabled {
 		return nil
@@ -136,7 +156,7 @@ func InstallIngressControllerPostHook(cluster CommonCluster) error {
 
 	namespace := global.Config.Cluster.Namespace
 
-	return installDeployment(cluster, namespace, config.Ingress.Chart, "ingress", valuesBytes, config.Ingress.Version, false)
+	return i.helmService.ApplyDeployment(context.Background(), cluster.GetID(), namespace, config.Ingress.Chart, "ingress", valuesBytes, config.Ingress.Version)
 }
 
 func mergeValues(chartValues interface{}, configValues interface{}) ([]byte, error) {

--- a/src/cluster/manager_common_updater.go
+++ b/src/cluster/manager_common_updater.go
@@ -50,6 +50,7 @@ type commonUpdater struct {
 	workflowClient           client.Client
 	externalBaseURL          string
 	externalBaseURLInsecure  bool
+	helmService              HelmService
 }
 
 type commonUpdateValidationError struct {
@@ -80,6 +81,7 @@ func NewCommonClusterUpdater(
 	workflowClient client.Client,
 	externalBaseURL string,
 	externalBaseURLInsecure bool,
+	helmService HelmService,
 ) *commonUpdater {
 	return &commonUpdater{
 		request:                 request,
@@ -89,6 +91,7 @@ func NewCommonClusterUpdater(
 		workflowClient:          workflowClient,
 		externalBaseURL:         externalBaseURL,
 		externalBaseURLInsecure: externalBaseURLInsecure,
+		helmService:             helmService,
 	}
 }
 
@@ -303,7 +306,7 @@ func (c *commonUpdater) Update(ctx context.Context) error {
 		return err
 	}
 
-	if err := DeployClusterAutoscaler(c.cluster); err != nil {
+	if err := DeployClusterAutoscaler(c.cluster, c.helmService); err != nil {
 		return errors.WrapIf(err, "deploying cluster autoscaler failed")
 	}
 


### PR DESCRIPTION
Provide a unified helm releaser interface that can be used in integrated services, posthooks and clustersetup jobs as well.