### PR TITLE
auth: send initial token for cli in header

### DIFF
--- a/src/auth/authn.go
+++ b/src/auth/authn.go
@@ -62,6 +62,8 @@ const SessionCookieHTTPOnly = true
 // SessionCookieName is the name of the token that is stored in the session cookie
 const SessionCookieName = "Pipeline session token"
 
+const BanzaiCLIClient = "banzai-cli"
+
 // Init authorization
 // nolint: gochecknoglobals
 var (
@@ -311,11 +313,16 @@ func (sessionStorer *BanzaiSessionStorer) Update(w http.ResponseWriter, req *htt
 		return err
 	}
 
-	// Set the pipeline cookie
+	// Set the token as a pipeline session cookie
 	err = sessionStorer.SessionManager.Add(w, req, sessionStorer.SessionName, cookieToken)
 	if err != nil {
 		errorHandler.Handle(errors.Wrap(err, "failed to add user's session cookie to store"))
 		return err
+	}
+
+	// Add the token in a header to the CLI
+	if req.Header.Get("Client") == BanzaiCLIClient {
+		w.Header().Add("Authorization", cookieToken)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/banzai-cli/pull/229
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Send the initial login token in a header instead of a Cookie.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
So the CLI login flow can work.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
