### PR TITLE
Helm repository api regression fixes

### DIFF
--- a/.gen/pipeline/pipeline/model_helm_repos_add_request.go
+++ b/.gen/pipeline/pipeline/model_helm_repos_add_request.go
@@ -1,7 +1,7 @@
 /*
  * Pipeline API
  *
- * Pipeline is a feature rich application platform, built for containers on top of Kubernetes to automate the DevOps experience, continuous application development and the lifecycle of deployments. 
+ * Pipeline is a feature rich application platform, built for containers on top of Kubernetes to automate the DevOps experience, continuous application development and the lifecycle of deployments.
  *
  * API version: latest
  * Contact: info@banzaicloud.com
@@ -11,7 +11,6 @@
 package pipeline
 
 type HelmReposAddRequest struct {
-
 	Name string `json:"name"`
 
 	Url string `json:"url"`

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -51,6 +51,7 @@ func CreateUnifiedHelmReleaser(
 	if !helmConfig.V3 {
 		envService := helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), logger)
 		service := helm.NewService(
+			helmConfig,
 			repoStore,
 			secretStore,
 			validator,
@@ -75,6 +76,7 @@ func CreateUnifiedHelmReleaser(
 	}
 
 	service := helm.NewService(
+		helmConfig,
 		repoStore,
 		secretStore,
 		validator,

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -49,12 +49,13 @@ func CreateUnifiedHelmReleaser(
 	helm2EnvResolver := helm.NewHelm2EnvResolver(helmConfig.Home, orgService, logger)
 
 	if !helmConfig.V3 {
+		envService := helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), logger)
 		service := helm.NewService(
 			repoStore,
 			secretStore,
 			validator,
-			helm2EnvResolver,
-			helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), logger),
+			helm.NewEnsuringEnvResolver(helm2EnvResolver, envService, helmConfig.Repositories, logger),
+			envService,
 			releaser,
 			clusterService,
 			logger)

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -57,16 +57,9 @@ func RegisterHTTPHandlers(endpoints Endpoints, router *mux.Router, options ...ki
 		options...,
 	))
 
-	router.Methods(http.MethodPatch).Path("/repos/{name}").Handler(kithttp.NewServer(
-		endpoints.PatchRepository,
-		decodePatchRepositoryHTTPRequest,
-		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusAccepted), errorEncoder),
-		options...,
-	))
-
 	router.Methods(http.MethodPut).Path("/repos/{name}").Handler(kithttp.NewServer(
-		endpoints.UpdateRepository,
-		decodeUpdateRepositoryHTTPRequest,
+		endpoints.ModifyRepository,
+		decodeModifyRepositoryHTTPRequest,
 		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusAccepted), errorEncoder),
 		options...,
 	))
@@ -239,25 +232,25 @@ func decodeAddRepositoryHTTPRequest(_ context.Context, r *http.Request) (interfa
 		}}, nil
 }
 
-func decodePatchRepositoryHTTPRequest(_ context.Context, r *http.Request) (interface{}, error) {
+func decodeModifyRepositoryHTTPRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	orgID, e := extractUintParamFromRequest("orgId", r)
 	if e != nil {
-		return nil, errors.WrapIf(e, "failed to decode patch repository request")
+		return nil, errors.WrapIf(e, "failed to decode modify repository request")
 	}
 
 	repoName, err := extractStringParamFromRequest("name", r)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to decode patch repository request")
+		return nil, errors.WrapIf(err, "failed to decode modify repository request")
 	}
 
 	var request pipeline.HelmReposAddRequest
 
 	dErr := json.NewDecoder(r.Body).Decode(&request)
 	if dErr != nil {
-		return nil, errors.WrapIf(dErr, "failed to decode patch repository request")
+		return nil, errors.WrapIf(dErr, "failed to decode modify repository request")
 	}
 
-	return PatchRepositoryRequest{
+	return ModifyRepositoryRequest{
 		OrganizationID: orgID,
 		Repository: helm.Repository{
 			Name:             repoName,

--- a/internal/helm/helmdriver/zz_generated.endpoint.go
+++ b/internal/helm/helmdriver/zz_generated.endpoint.go
@@ -37,7 +37,7 @@ type Endpoints struct {
 	ListCharts          endpoint.Endpoint
 	ListReleases        endpoint.Endpoint
 	ListRepositories    endpoint.Endpoint
-	PatchRepository     endpoint.Endpoint
+	ModifyRepository    endpoint.Endpoint
 	UpdateRepository    endpoint.Endpoint
 	UpgradeRelease      endpoint.Endpoint
 }
@@ -59,7 +59,7 @@ func MakeEndpoints(service helm.Service, middleware ...endpoint.Middleware) Endp
 		ListCharts:          kitxendpoint.OperationNameMiddleware("helm.ListCharts")(mw(MakeListChartsEndpoint(service))),
 		ListReleases:        kitxendpoint.OperationNameMiddleware("helm.ListReleases")(mw(MakeListReleasesEndpoint(service))),
 		ListRepositories:    kitxendpoint.OperationNameMiddleware("helm.ListRepositories")(mw(MakeListRepositoriesEndpoint(service))),
-		PatchRepository:     kitxendpoint.OperationNameMiddleware("helm.PatchRepository")(mw(MakePatchRepositoryEndpoint(service))),
+		ModifyRepository:    kitxendpoint.OperationNameMiddleware("helm.ModifyRepository")(mw(MakeModifyRepositoryEndpoint(service))),
 		UpdateRepository:    kitxendpoint.OperationNameMiddleware("helm.UpdateRepository")(mw(MakeUpdateRepositoryEndpoint(service))),
 		UpgradeRelease:      kitxendpoint.OperationNameMiddleware("helm.UpgradeRelease")(mw(MakeUpgradeReleaseEndpoint(service))),
 	}
@@ -501,37 +501,37 @@ func MakeListRepositoriesEndpoint(service helm.Service) endpoint.Endpoint {
 	}
 }
 
-// PatchRepositoryRequest is a request struct for PatchRepository endpoint.
-type PatchRepositoryRequest struct {
+// ModifyRepositoryRequest is a request struct for ModifyRepository endpoint.
+type ModifyRepositoryRequest struct {
 	OrganizationID uint
 	Repository     helm.Repository
 }
 
-// PatchRepositoryResponse is a response struct for PatchRepository endpoint.
-type PatchRepositoryResponse struct {
+// ModifyRepositoryResponse is a response struct for ModifyRepository endpoint.
+type ModifyRepositoryResponse struct {
 	Err error
 }
 
-func (r PatchRepositoryResponse) Failed() error {
+func (r ModifyRepositoryResponse) Failed() error {
 	return r.Err
 }
 
-// MakePatchRepositoryEndpoint returns an endpoint for the matching method of the underlying service.
-func MakePatchRepositoryEndpoint(service helm.Service) endpoint.Endpoint {
+// MakeModifyRepositoryEndpoint returns an endpoint for the matching method of the underlying service.
+func MakeModifyRepositoryEndpoint(service helm.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(PatchRepositoryRequest)
+		req := request.(ModifyRepositoryRequest)
 
-		err := service.PatchRepository(ctx, req.OrganizationID, req.Repository)
+		err := service.ModifyRepository(ctx, req.OrganizationID, req.Repository)
 
 		if err != nil {
 			if serviceErr := serviceError(nil); errors.As(err, &serviceErr) && serviceErr.ServiceError() {
-				return PatchRepositoryResponse{Err: err}, nil
+				return ModifyRepositoryResponse{Err: err}, nil
 			}
 
-			return PatchRepositoryResponse{Err: err}, err
+			return ModifyRepositoryResponse{Err: err}, err
 		}
 
-		return PatchRepositoryResponse{}, nil
+		return ModifyRepositoryResponse{}, nil
 	}
 }
 

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -297,7 +297,7 @@ func (s service) ListRepositories(ctx context.Context, organizationID uint) (rep
 }
 
 func (s service) DeleteRepository(ctx context.Context, organizationID uint, repoName string) error {
-	for defaultRepoName, _ := range s.config.Repositories {
+	for defaultRepoName := range s.config.Repositories {
 		if defaultRepoName == repoName {
 			return NewValidationError("default repositories cannot be deleted", nil)
 		}
@@ -331,7 +331,7 @@ func (s service) DeleteRepository(ctx context.Context, organizationID uint, repo
 }
 
 func (s service) ModifyRepository(ctx context.Context, organizationID uint, repository Repository) error {
-	for repoName, _ := range s.config.Repositories {
+	for repoName := range s.config.Repositories {
 		if repoName == repository.Name {
 			return NewValidationError("default repositories cannot be modified", nil)
 		}
@@ -588,13 +588,4 @@ func (s service) repoExists(ctx context.Context, repository Repository, helmEnv 
 	}
 
 	return false, nil
-}
-
-func contains(repoName string, repos []Repository) bool {
-	for _, repo := range repos {
-		if repo.Name == repoName {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/helm/service_test.go
+++ b/internal/helm/service_test.go
@@ -255,58 +255,6 @@ func Test_service_ListRepositories(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "merge default repos with user added repos",
-			fields: fields{
-				store:         &MockStore{},
-				secretStore:   &MockSecretStore{},
-				repoValidator: NewHelmRepoValidator(),
-				envResolver:   &MockEnvResolver{},
-				envService:    &MockEnvService{},
-				logger:        common.NoopLogger{},
-			},
-			args: args{
-				ctx:            context.Background(),
-				organizationID: 2,
-			},
-			wantRepos: []Repository{
-				{
-					Name: "user-repo",
-					URL:  "https://userdomain.io/userrepo/charts",
-				},
-				{
-					Name: "stable",
-					URL:  "https://kubernetes-charts.storage.googleapis.com",
-				},
-			},
-			setupMocks: func(store *Store, secretStore *SecretStore, envResolver *EnvResolver, envService *EnvService, arguments args) {
-				storeMock := (*store).(*MockStore)
-				storeMock.On("List", arguments.ctx, arguments.organizationID).Return(
-					[]Repository{
-						{
-							Name: "user-repo",
-							URL:  "https://userdomain.io/userrepo/charts",
-						},
-					},
-					nil,
-				)
-
-				envResolverMock := (*envResolver).(*MockEnvResolver)
-				envResolverMock.On("ResolveHelmEnv", arguments.ctx, arguments.organizationID).Return(HelmEnv{home: "/test"}, nil)
-
-				envServiceMock := (*envService).(*MockEnvService)
-				envServiceMock.On("ListRepositories", arguments.ctx, HelmEnv{home: "/test"}).Return(
-					[]Repository{
-						{
-							Name: "stable",
-							URL:  "https://kubernetes-charts.storage.googleapis.com",
-						},
-					},
-					nil,
-				)
-			},
-			wantErr: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/helm/service_test.go
+++ b/internal/helm/service_test.go
@@ -118,8 +118,13 @@ func Test_service_AddRepository(t *testing.T) {
 				secretStoreMock := (*secretStore).(*MockSecretStore)
 				secretStoreMock.On("CheckPasswordSecret", arguments.ctx, arguments.repository.PasswordSecretID).Return(nil)
 
-				storeMock := (*store).(*MockStore)
-				storeMock.On("Get", arguments.ctx, arguments.organizationID, arguments.repository).Return(Repository{}, nil)
+				envResolverMock := (*envResolver).(*MockEnvResolver)
+				envResolverMock.On("ResolveHelmEnv", arguments.ctx, arguments.organizationID).Return(HelmEnv{home: "/test"}, nil)
+
+				envServiceMock := (*envService).(*MockEnvService)
+				envServiceMock.On("ListRepositories", arguments.ctx, HelmEnv{home: "/test"}).Return([]Repository{
+					{Name: "test-repo"},
+				}, nil)
 			},
 			wantErr: true,
 		},
@@ -154,6 +159,7 @@ func Test_service_AddRepository(t *testing.T) {
 				envResolverMock.On("ResolveHelmEnv", arguments.ctx, arguments.organizationID).Return(HelmEnv{home: "/test"}, nil)
 
 				envServiceMock := (*envService).(*MockEnvService)
+				envServiceMock.On("ListRepositories", arguments.ctx, HelmEnv{home: "/test"}).Return([]Repository{}, nil)
 				envServiceMock.On("AddRepository", arguments.ctx, HelmEnv{home: "/test"}, arguments.repository).Return(nil)
 			},
 			wantErr: false,

--- a/internal/helm/zz_generated.mock_test.go
+++ b/internal/helm/zz_generated.mock_test.go
@@ -300,8 +300,8 @@ func (_m *MockService) ListRepositories(ctx context.Context, organizationID uint
 	return r0, r1
 }
 
-// PatchRepository provides a mock function.
-func (_m *MockService) PatchRepository(ctx context.Context, organizationID uint, repository Repository) error {
+// ModifyRepository provides a mock function.
+func (_m *MockService) ModifyRepository(ctx context.Context, organizationID uint, repository Repository) error {
 	ret := _m.Called(ctx, organizationID, repository)
 
 	var r0 error
@@ -568,20 +568,6 @@ func (_m *MockStore) List(ctx context.Context, organizationID uint) ([]Repositor
 	}
 
 	return r0, r1
-}
-
-// Patch provides a mock function.
-func (_m *MockStore) Patch(ctx context.Context, organizationID uint, repository Repository) error {
-	ret := _m.Called(ctx, organizationID, repository)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint, Repository) error); ok {
-		r0 = rf(ctx, organizationID, repository)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // Update provides a mock function.


### PR DESCRIPTION
 - Make the helm2 envservice get an ensuringEnvResolver as well and backport the legacy functionality into it
 - Make helm2's ListRepositories work by returning what is in the repo file instead of returning the defaults.
 - Make a separate ModifyRepository handler to distinguish modifications from repo updates. 
 - PatchRepository is removed until a use case comes up to implement it properly