### PR TITLE
Reconcile helm repos / Password credential resolution for helm repositories

### DIFF
--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -66,7 +66,7 @@ func CreateUnifiedHelmReleaser(
 	envResolver := helm.NewHelm3EnvResolver(helmConfig.Home, orgService, logger)
 	envService := helmadapter.NewHelm3EnvService(logger)
 	// wrap the envresolver
-	ensuringEnvResolver := helm.NewEnsuringEnvResolver(envResolver, envService, helmConfig.Repositories, logger)
+	ensuringEnvResolver := helm.NewEnsuringEnvResolver(envResolver, envService, repoStore, helmConfig.Repositories, logger)
 
 	// set up platform helm env
 	platformHelmEnv, _ := envResolver.ResolvePlatformEnv(context.Background())

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -55,7 +55,7 @@ func CreateUnifiedHelmReleaser(
 			repoStore,
 			secretStore,
 			validator,
-			helm.NewEnsuringEnvResolver(helm2EnvResolver, envService, helmConfig.Repositories, logger),
+			helm.NewEnsuringEnvResolver(helm2EnvResolver, envService, repoStore, helmConfig.Repositories, logger),
 			envService,
 			releaser,
 			clusterService,

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -49,7 +49,7 @@ func CreateUnifiedHelmReleaser(
 	helm2EnvResolver := helm.NewHelm2EnvResolver(helmConfig.Home, orgService, logger)
 
 	if !helmConfig.V3 {
-		envService := helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), logger)
+		envService := helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), secretStore, logger)
 		service := helm.NewService(
 			helmConfig,
 			repoStore,
@@ -64,7 +64,7 @@ func CreateUnifiedHelmReleaser(
 	}
 
 	envResolver := helm.NewHelm3EnvResolver(helmConfig.Home, orgService, logger)
-	envService := helmadapter.NewHelm3EnvService(logger)
+	envService := helmadapter.NewHelm3EnvService(secretStore, logger)
 	// wrap the envresolver
 	ensuringEnvResolver := helm.NewEnsuringEnvResolver(envResolver, envService, repoStore, helmConfig.Repositories, logger)
 

--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -203,10 +203,11 @@ type ensuringEnvResolver struct {
 	// envresolver instance that gets decorated with the new functionality
 	envResolver EnvResolver
 	envService  EnvService
+	store       Store
 	logger      Logger
 }
 
-func NewEnsuringEnvResolver(envResolver EnvResolver, envService EnvService, defaultRepos map[string]string, logger Logger) EnvResolver {
+func NewEnsuringEnvResolver(envResolver EnvResolver, envService EnvService, store Store, defaultRepos map[string]string, logger Logger) EnvResolver {
 	repos := make([]Repository, 0, len(defaultRepos))
 	for repo, url := range defaultRepos {
 		repos = append(repos, Repository{Name: repo, URL: url})
@@ -215,6 +216,7 @@ func NewEnsuringEnvResolver(envResolver EnvResolver, envService EnvService, defa
 		defaultRepos: repos,
 		envResolver:  envResolver,
 		envService:   envService,
+		store:        store,
 		logger:       logger,
 	}
 }
@@ -227,13 +229,18 @@ func (e ensuringEnvResolver) ResolveHelmEnv(ctx context.Context, organizationID 
 	}
 
 	// make sure the env is created on the filesystem
-	env, err := e.envService.EnsureEnv(ctx, helmEnv, e.defaultRepos)
+	env, isNewEnv, err := e.envService.EnsureEnv(ctx, helmEnv, e.defaultRepos)
 	if err != nil {
 		return HelmEnv{}, errors.WrapIf(err, "failed to ensure helm environment")
 	}
-	e.logger.Debug("successfully resolved helm environment", map[string]interface{}{"orgID": organizationID, "helmEnv": helmEnv})
 
-	//add defaults
+	if isNewEnv {
+		if err := newOrgEnvReconciler(organizationID, e.envService, e.store, e.logger).Reconcile(ctx, helmEnv); err != nil {
+			return HelmEnv{}, errors.WrapIfWithDetails(err, "failed to reconcile persisted repositories")
+		}
+	}
+
+	e.logger.Debug("successfully resolved helm environment", map[string]interface{}{"orgID": organizationID, "helmEnv": helmEnv})
 	return env, nil
 }
 
@@ -243,11 +250,71 @@ func (e ensuringEnvResolver) ResolvePlatformEnv(ctx context.Context) (HelmEnv, e
 		return HelmEnv{}, errors.WrapIf(err, "failed to resolve platform helm env")
 	}
 
-	env, err := e.envService.EnsureEnv(ctx, helmEnv, e.defaultRepos)
+	env, _, err := e.envService.EnsureEnv(ctx, helmEnv, e.defaultRepos)
 	if err != nil {
 		return HelmEnv{}, errors.WrapIf(err, "failed to ensure platform helm environment")
 	}
 
 	e.logger.Debug("successfully resolved platform helm environment")
 	return env, nil
+}
+
+// component for synchronizing persisted repositories with the helm repos
+type orgEnvReconciler struct {
+	orgID      uint
+	envService EnvService
+	repoStore  Store
+
+	logger Logger
+}
+
+func newOrgEnvReconciler(orgID uint, envService EnvService, repoStore Store, logger Logger) EnvReconciler {
+	return orgEnvReconciler{
+		orgID:      orgID,
+		envService: envService,
+		repoStore:  repoStore,
+		logger:     logger,
+	}
+}
+
+// Reconcile checks the database for persisted repos and adds them to the org's helm repo if required
+func (o orgEnvReconciler) Reconcile(ctx context.Context, helmEnv HelmEnv) error {
+	persistedRepos, err := o.repoStore.List(ctx, o.orgID)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to get persisted repositories during repo reconciliation", "orgID", o.orgID, "helmEnv", helmEnv)
+	}
+	if len(persistedRepos) == 0 {
+		o.logger.Debug("no reconcile needed, no persisted repos found")
+		return nil
+	}
+
+	envRepos, err := o.envService.ListRepositories(ctx, helmEnv)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to get persisted repositories", "orgID", o.orgID, "helmEnv", helmEnv)
+	}
+
+	missingRepos := make([]Repository, 0, len(persistedRepos))
+	for _, persistedRepo := range persistedRepos {
+		for _, envRepo := range envRepos {
+			if persistedRepo == envRepo {
+				o.logger.Debug("repo already added")
+				continue
+			}
+		}
+		missingRepos = append(missingRepos, persistedRepo)
+	}
+
+	if len(missingRepos) == 0 {
+		o.logger.Debug("reconciliation succeeded - no repos to reconcile")
+		return nil
+	}
+
+	for _, missingRepo := range missingRepos {
+		if err := o.envService.AddRepository(ctx, helmEnv, missingRepo); err != nil {
+			return errors.WrapIfWithDetails(err, "failed to reconcile persisted repositorys")
+		}
+	}
+
+	o.logger.Debug("helm repo reconciliation succeeded")
+	return nil
 }

--- a/internal/helm/helmadapter/helm2_env_service.go
+++ b/internal/helm/helmadapter/helm2_env_service.go
@@ -191,6 +191,6 @@ func (h helmEnvService) repositoryToEntry(ctx context.Context, repository helm.R
 }
 
 func (h helmEnvService) EnsureEnv(_ context.Context, helmEnv helm.HelmEnv, defaultRepos []helm.Repository) (helm.HelmEnv, bool, error) {
-	_, err := legacyHelm.GenerateHelmRepoEnvOnPath(helmEnv.GetHome())
-	return helmEnv, true, err
+	_, isNew, err := legacyHelm.GenerateHelmRepoEnvOnPath(helmEnv.GetHome())
+	return helmEnv, isNew, err
 }

--- a/internal/helm/helmadapter/helm2_env_service.go
+++ b/internal/helm/helmadapter/helm2_env_service.go
@@ -178,7 +178,7 @@ func (h helmEnvService) repositoryToEntry(repository helm.Repository) (repo.Entr
 	return entry, nil
 }
 
-func (h helmEnvService) EnsureEnv(_ context.Context, helmEnv helm.HelmEnv, defaultRepos []helm.Repository) (helm.HelmEnv, error) {
+func (h helmEnvService) EnsureEnv(_ context.Context, helmEnv helm.HelmEnv, defaultRepos []helm.Repository) (helm.HelmEnv, bool, error) {
 	_, err := legacyHelm.GenerateHelmRepoEnvOnPath(helmEnv.GetHome())
-	return helmEnv, err
+	return helmEnv, false, err
 }

--- a/internal/helm/helmadapter/helm3_env_service.go
+++ b/internal/helm/helmadapter/helm3_env_service.go
@@ -94,15 +94,18 @@ func (h helm3EnvService) AddRepository(ctx context.Context, helmEnv helm.HelmEnv
 		return errors.Errorf("repository name (%s) already exists, please specify a different name", repository.Name)
 	}
 
-	passwordSecret, err := h.secretStore.ResolvePasswordSecrets(ctx, repository.PasswordSecretID)
-	if err != nil {
-		return errors.WrapIf(err, "failed to resolve repo credentials")
-	}
 	c := repo.Entry{
-		Name:     repository.Name,
-		URL:      repository.URL,
-		Username: passwordSecret.UserName,
-		Password: passwordSecret.Password,
+		Name: repository.Name,
+		URL:  repository.URL,
+	}
+	if repository.PasswordSecretID != "" {
+		passwordSecret, err := h.secretStore.ResolvePasswordSecrets(ctx, repository.PasswordSecretID)
+		if err != nil {
+			return errors.WrapIf(err, "failed to resolve repo credentials")
+		}
+
+		c.Username = passwordSecret.UserName
+		c.Password = passwordSecret.Password
 	}
 
 	envSettings := h.processEnvSettings(helmEnv)

--- a/internal/helm/helmadapter/helm3_env_service.go
+++ b/internal/helm/helmadapter/helm3_env_service.go
@@ -137,6 +137,7 @@ func (h helm3EnvService) ListRepositories(_ context.Context, helmEnv helm.HelmEn
 		repos = append(repos, helm.Repository{
 			Name: entry.Name,
 			URL:  entry.URL,
+			// TODO warning! do not propagate sensitive data!
 		})
 	}
 

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -144,7 +144,7 @@ type EnvService interface {
 
 	// EnsureEnv ensures the helm environment represented by the input.
 	// If theh environment exists (on the filesystem) it does nothing
-	EnsureEnv(ctx context.Context, helmEnv HelmEnv, defaultRepos []Repository) (HelmEnv, error)
+	EnsureEnv(ctx context.Context, helmEnv HelmEnv, defaultRepos []Repository) (HelmEnv, bool, error)
 }
 
 // +testify:mock:testOnly=true

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -293,7 +293,7 @@ func (s service) ListRepositories(ctx context.Context, organizationID uint) (rep
 		return nil, errors.WrapIf(err, "failed to retrieve default repositories")
 	}
 
-	return envRepos, nil
+	return s.decorateRepos(ctx, organizationID, envRepos), nil
 }
 
 func (s service) DeleteRepository(ctx context.Context, organizationID uint, repoName string) error {
@@ -588,4 +588,30 @@ func (s service) repoExists(ctx context.Context, repository Repository, helmEnv 
 	}
 
 	return false, nil
+}
+
+// decorateRepos retrieves secretReferences for the repo
+func (s service) decorateRepos(ctx context.Context, orgID uint, repos []Repository) []Repository {
+	persistedRepos, err := s.store.List(ctx, orgID)
+	if err != nil {
+		s.logger.Warn("failed to decorate repositories with secret references")
+		return repos
+	}
+
+	if len(persistedRepos) == 0 {
+		s.logger.Debug("no persisted repos found, no secret references to add to the repo list")
+		return repos
+	}
+
+	decorated := make([]Repository, 0, len(repos))
+	for _, repo := range repos {
+		for _, persistedRepo := range persistedRepos {
+			if repo.Name == persistedRepo.Name {
+				repo.PasswordSecretID = persistedRepo.PasswordSecretID
+			}
+		}
+		decorated = append(decorated, repo)
+	}
+
+	return decorated
 }

--- a/internal/helm/zz_generated.mock_test.go
+++ b/internal/helm/zz_generated.mock_test.go
@@ -376,7 +376,7 @@ func (_m *MockEnvService) DeleteRepository(ctx context.Context, helmEnv HelmEnv,
 }
 
 // EnsureEnv provides a mock function.
-func (_m *MockEnvService) EnsureEnv(ctx context.Context, helmEnv HelmEnv, defaultRepos []Repository) (HelmEnv, error) {
+func (_m *MockEnvService) EnsureEnv(ctx context.Context, helmEnv HelmEnv, defaultRepos []Repository) (HelmEnv, bool, error) {
 	ret := _m.Called(ctx, helmEnv, defaultRepos)
 
 	var r0 HelmEnv
@@ -386,14 +386,21 @@ func (_m *MockEnvService) EnsureEnv(ctx context.Context, helmEnv HelmEnv, defaul
 		r0 = ret.Get(0).(HelmEnv)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, HelmEnv, []Repository) error); ok {
+	var r1 bool
+	if rf, ok := ret.Get(1).(func(context.Context, HelmEnv, []Repository) bool); ok {
 		r1 = rf(ctx, helmEnv, defaultRepos)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(bool)
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, HelmEnv, []Repository) error); ok {
+		r2 = rf(ctx, helmEnv, defaultRepos)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetChart provides a mock function.

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -763,10 +763,13 @@ func ReposAdd(env helm_env.EnvSettings, Hrepo *repo.Entry) (bool, error) {
 	}
 
 	c := repo.Entry{
-		Name:  Hrepo.Name,
-		URL:   Hrepo.URL,
-		Cache: env.Home.CacheIndex(Hrepo.Name),
+		Name:     Hrepo.Name,
+		Cache:    env.Home.CacheIndex(Hrepo.Name),
+		URL:      Hrepo.URL,
+		Username: Hrepo.Username,
+		Password: Hrepo.Password,
 	}
+
 	r, err := repo.NewChartRepository(&c, getter.All(env))
 	if err != nil {
 		return false, errors.Wrap(err, "Cannot create a new ChartRepo")

--- a/src/helm/install.go
+++ b/src/helm/install.go
@@ -40,7 +40,7 @@ func CreateEnvSettings(helmRepoHome string) helmEnv.EnvSettings {
 
 // GenerateHelmRepoEnv Generate helm path based on orgName
 func GenerateHelmRepoEnv(orgName string) helmEnv.EnvSettings {
-	env, err := GenerateHelmRepoEnvOnPath(global.GetHelmPath(fmt.Sprintf("%s/%s", orgName, phelm.HelmPostFix)))
+	env, _, err := GenerateHelmRepoEnvOnPath(global.GetHelmPath(fmt.Sprintf("%s/%s", orgName, phelm.HelmPostFix)))
 	if err != nil {
 		log.Errorf("local helm env setup failed err: %+v env: %+v", err, env)
 	}
@@ -48,22 +48,23 @@ func GenerateHelmRepoEnv(orgName string) helmEnv.EnvSettings {
 }
 
 // GenerateHelmRepoEnv Generate helm to the given path
-func GenerateHelmRepoEnvOnPath(path string) (helmEnv.EnvSettings, error) {
+func GenerateHelmRepoEnvOnPath(path string) (helmEnv.EnvSettings, bool, error) {
 	env := CreateEnvSettings(path)
-
+	isNewEnv := false
 	// check local helm
 	if _, err := os.Stat(path); os.IsNotExist(err) {
+		isNewEnv = true
 		log.Infof("Helm directories [%s] not exists", path)
 		if err := InstallLocalHelm(env); err != nil {
-			return helmEnv.EnvSettings{}, errors.Wrap(err, "unable to install local helm env")
+			return helmEnv.EnvSettings{}, isNewEnv, errors.Wrap(err, "unable to install local helm env")
 		}
 	}
 
-	return env, nil
+	return env, isNewEnv, nil
 }
 
 func GeneratePlatformHelmRepoEnv() helmEnv.EnvSettings {
-	env, err := GenerateHelmRepoEnvOnPath(fmt.Sprintf("%s-%s/%s", global.Config.Helm.Home, helm.PlatformHelmHome, phelm.HelmPostFix))
+	env, _, err := GenerateHelmRepoEnvOnPath(fmt.Sprintf("%s-%s/%s", global.Config.Helm.Home, helm.PlatformHelmHome, phelm.HelmPostFix))
 	if err != nil {
 		log.Errorf("platform helm env setup failed err: %+v env: %+v", err, env)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
* org level helm repositories (added by users) are restored when the helm environment is (re)created (eg.: pipeline-restart)
* password secrets for repositories are resolved during repository addition

### Why?
* previously on pipeline application restart user added repositories were lost
* password secrets were not resolved when adding repositories
