### PR TITLE
Do not retry failed stack errors

### DIFF
--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -83,7 +83,7 @@ func UpdateNodePoolWorkflow(ctx workflow.Context, input UpdateNodePoolWorkflowIn
 			InitialInterval:          20 * time.Second,
 			BackoffCoefficient:       1.1,
 			MaximumAttempts:          10,
-			NonRetriableErrorReasons: []string{"cadenceInternal:Panic"},
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", ErrReasonStackFailed},
 		}
 
 		processEvent := process.NewProcessEvent(workflow.WithStartToCloseTimeout(ctx, 10*time.Minute), UpdateNodeGroupActivityName)

--- a/pkg/providers/amazon/cloudformation/cloudformation.go
+++ b/pkg/providers/amazon/cloudformation/cloudformation.go
@@ -104,7 +104,11 @@ func NewAwsStackFailure(awsStackError error, stackName, clientRequestToken strin
 	isFinalErr := false
 
 	switch aws.StringValue(stacksOutput.Stacks[0].StackStatus) {
-	case cloudformation.StackStatusCreateFailed, cloudformation.StackStatusDeleteFailed, cloudformation.StackStatusRollbackFailed, cloudformation.StackStatusUpdateRollbackFailed:
+	case cloudformation.StackStatusCreateFailed,
+		cloudformation.StackStatusDeleteFailed,
+		cloudformation.StackStatusRollbackFailed,
+		cloudformation.StackStatusUpdateRollbackFailed,
+		cloudformation.StackStatusUpdateRollbackComplete:
 		isFinalErr = true
 	}
 

--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -75,7 +75,7 @@ func EKSUpdateClusterWorkflow(ctx workflow.Context, input EKSUpdateClusterstruct
 			BackoffCoefficient:       1.5,
 			MaximumInterval:          30 * time.Second,
 			MaximumAttempts:          5,
-			NonRetriableErrorReasons: []string{"cadenceInternal:Panic"},
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", eksWorkflow.ErrReasonStackFailed},
 		},
 	}
 
@@ -89,7 +89,7 @@ func EKSUpdateClusterWorkflow(ctx workflow.Context, input EKSUpdateClusterstruct
 			BackoffCoefficient:       1.5,
 			MaximumInterval:          30 * time.Second,
 			MaximumAttempts:          5,
-			NonRetriableErrorReasons: []string{"cadenceInternal:Panic"},
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", eksWorkflow.ErrReasonStackFailed},
 		},
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Fixes stack update waiting to not retry final state errors.


### Why?
Stacks in final state, completing with an error won't change, so retrying the wait operation does not make much sense.
