### PR TITLE
Helm3 support for the Backyards integrated service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ commands:
                     name: Run integration tests
                     command: |
                         make config/config.yaml
-                        KUBECONFIG=$PWD/build/kubeconfig PIPELINE_CONFIG_DIR=$PWD/config make GOARGS="-p=2" test-integration
+                        KUBECONFIG=$PWD/build/kubeconfig PIPELINE_CONFIG_DIR=$PWD/config make GOARGS="-p=1" test-integration
                     environment:
                         VAULT_ADDR: http://localhost:8200
                         VAULT_TOKEN: 227e1cce-6bf7-30bb-2d2a-acc854318caf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ commands:
                     name: Run integration tests
                     command: |
                         make config/config.yaml
-                        KUBECONFIG=$PWD/build/kubeconfig PIPELINE_CONFIG_DIR=$PWD/config make GOARGS="-p=1" test-integration
+                        KUBECONFIG=$PWD/build/kubeconfig PIPELINE_CONFIG_DIR=$PWD/config make GOARGS="-p=2" test-integration
                     environment:
                         VAULT_ADDR: http://localhost:8200
                         VAULT_TOKEN: 227e1cce-6bf7-30bb-2d2a-acc854318caf

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -481,7 +481,14 @@ func main() {
 	clusterGroupManager := clustergroup.NewManager(cgroupAdapter, clustergroup.NewClusterGroupRepository(db, logrusLogger), logrusLogger, errorHandler)
 	federationHandler := federation.NewFederationHandler(cgroupAdapter, config.Cluster.Namespace, logrusLogger, errorHandler, config.Cluster.Federation, config.Cluster.DNS.Config)
 	deploymentManager := deployment.NewCGDeploymentManager(db, cgroupAdapter, logrusLogger, errorHandler)
-	serviceMeshFeatureHandler := cgFeatureIstio.NewServiceMeshFeatureHandler(cgroupAdapter, logrusLogger, errorHandler, config.Cluster.Backyards)
+
+	var helmService cgFeatureIstio.HelmService
+	if config.Helm.V3 {
+		panic("helm service not implemented for v3")
+	} else {
+		helmService = &cgFeatureIstio.LegacyV2HelmService{}
+	}
+	serviceMeshFeatureHandler := cgFeatureIstio.NewServiceMeshFeatureHandler(cgroupAdapter, logrusLogger, errorHandler, config.Cluster.Backyards, helmService)
 	clusterGroupManager.RegisterFeatureHandler(federation.FeatureName, federationHandler)
 	clusterGroupManager.RegisterFeatureHandler(deployment.FeatureName, deploymentManager)
 	clusterGroupManager.RegisterFeatureHandler(cgFeatureIstio.FeatureName, serviceMeshFeatureHandler)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -398,7 +398,13 @@ func main() {
 
 			federationHandler := federation.NewFederationHandler(cgroupAdapter, config.Cluster.Namespace, logrusLogger, errorHandler, config.Cluster.Federation, config.Cluster.DNS.Config)
 			deploymentManager := deployment.NewCGDeploymentManager(db, cgroupAdapter, logrusLogger, errorHandler)
-			serviceMeshFeatureHandler := cgFeatureIstio.NewServiceMeshFeatureHandler(cgroupAdapter, logrusLogger, errorHandler, config.Cluster.Backyards)
+			var helmService cgFeatureIstio.HelmService
+			if config.Helm.V3 {
+				panic("helm service not implemented for v3")
+			} else {
+				helmService = &cgFeatureIstio.LegacyV2HelmService{}
+			}
+			serviceMeshFeatureHandler := cgFeatureIstio.NewServiceMeshFeatureHandler(cgroupAdapter, logrusLogger, errorHandler, config.Cluster.Backyards, helmService)
 			clusterGroupManager.RegisterFeatureHandler(federation.FeatureName, federationHandler)
 			clusterGroupManager.RegisterFeatureHandler(deployment.FeatureName, deploymentManager)
 			clusterGroupManager.RegisterFeatureHandler(cgFeatureIstio.FeatureName, serviceMeshFeatureHandler)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -261,7 +261,7 @@ func main() {
 
 		commonSecretStore := commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))
 
-		unifiedHelmReleaser, _ := cmd.CreateUnifiedHelmReleaser(
+		unifiedHelmReleaser, helmFacade := cmd.CreateUnifiedHelmReleaser(
 			config.Helm,
 			db,
 			commonSecretStore,
@@ -400,7 +400,7 @@ func main() {
 			deploymentManager := deployment.NewCGDeploymentManager(db, cgroupAdapter, logrusLogger, errorHandler)
 			var helmService cgFeatureIstio.HelmService
 			if config.Helm.V3 {
-				panic("helm service not implemented for v3")
+				helmService = cgFeatureIstio.NewHelmV3Service(helmFacade)
 			} else {
 				helmService = &cgFeatureIstio.LegacyV2HelmService{}
 			}

--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -25,6 +25,7 @@ import (
 const (
 	PlatformHelmHome = "pipeline"
 	helmPostFix      = "helm"
+	cacheDir         = "cache"
 	noOrg            = 0 // signals that no organization id is provided
 )
 
@@ -45,10 +46,16 @@ type HelmEnv struct {
 	platform bool
 
 	repoCacheDir string
+
+	cacheDir string
 }
 
 func (e HelmEnv) GetHome() string {
 	return e.home
+}
+
+func (e HelmEnv) GetCacheDir() string {
+	return e.cacheDir
 }
 
 func (e HelmEnv) IsPlatform() bool {
@@ -88,6 +95,7 @@ func (er envResolver) ResolveHelmEnv(ctx context.Context, organizationID uint) (
 
 	return HelmEnv{
 		home:     path.Join(er.helmHomesDir, orgName, helmPostFix),
+		cacheDir: path.Join(er.helmHomesDir, orgName, cacheDir),
 		platform: false,
 	}, nil
 }
@@ -95,6 +103,7 @@ func (er envResolver) ResolveHelmEnv(ctx context.Context, organizationID uint) (
 func (er envResolver) ResolvePlatformEnv(ctx context.Context) (HelmEnv, error) {
 	return HelmEnv{
 		home:     path.Join(fmt.Sprintf("%s-%s", er.helmHomesDir, PlatformHelmHome), helmPostFix),
+		cacheDir: path.Join(fmt.Sprintf("%s-%s", er.helmHomesDir, PlatformHelmHome), cacheDir),
 		platform: true,
 	}, nil
 }

--- a/internal/helm/envresolver_test.go
+++ b/internal/helm/envresolver_test.go
@@ -54,6 +54,7 @@ func Test_helm2EnvResolver_ResolveHelmEnv(t *testing.T) {
 			want: HelmEnv{
 				home:         "testHomesDir/testOrg/helm",
 				platform:     false,
+				cacheDir:     "testHomesDir/testOrg/cache",
 				repoCacheDir: "",
 			},
 			wantErr: false,
@@ -121,6 +122,7 @@ func Test_helm3EnvResolver_ResolveHelmEnv(t *testing.T) {
 				home:         "testHomesDir/testOrg/helm/repository/repositories.yaml",
 				repoCacheDir: "testHomesDir/testOrg/helm/repository/cache",
 				platform:     false,
+				cacheDir:     "testHomesDir/testOrg/cache",
 			},
 			wantErr: false,
 			setupMocks: func(orgService *OrgService, arguments args) {
@@ -182,6 +184,7 @@ func Test_envResolver_ResolvePlatformEnv(t *testing.T) {
 			want: HelmEnv{
 				home:     "testHomesDir-pipeline/helm",
 				platform: true,
+				cacheDir: "testHomesDir-pipeline/cache",
 			},
 			wantErr: false,
 		},

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -16,8 +16,10 @@ package helmadapter
 
 import (
 	"context"
+	"crypto/sha1"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -37,8 +39,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/banzaicloud/pipeline/internal/helm"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
@@ -59,13 +64,13 @@ func (r releaser) Install(_ context.Context, helmEnv helm.HelmEnv, kubeConfig he
 	// customize the settings passed forward
 	envSettings := r.processEnvSettings(helmEnv)
 
-	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
-
 	ns := "default"
 	if options.Namespace != "" {
 		ns = options.Namespace
 	}
+
+	// component processing the kubeconfig
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
 	actionConfig, err := r.getActionConfiguration(restClientGetter, ns)
 	if err != nil {
@@ -165,16 +170,14 @@ func (r releaser) Install(_ context.Context, helmEnv helm.HelmEnv, kubeConfig he
 }
 
 func (r releaser) Uninstall(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseName string, options helm.Options) error {
-	// customize the settings passed forward
-	envSettings := r.processEnvSettings(helmEnv)
-
-	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
-
 	ns := "default"
 	if options.Namespace != "" {
 		ns = options.Namespace
 	}
+
+	// component processing the kubeconfig
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
+
 	actionConfig, err := r.getActionConfiguration(restClientGetter, ns)
 	if err != nil {
 		return errors.WrapIf(err, "failed to get action configuration")
@@ -197,11 +200,13 @@ func (r releaser) Uninstall(ctx context.Context, helmEnv helm.HelmEnv, kubeConfi
 }
 
 func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, options helm.Options) ([]helm.Release, error) {
-	// customize the settings passed forward
-	envSettings := r.processEnvSettings(helmEnv)
+	ns := "default"
+	if options.Namespace != "" {
+		ns = options.Namespace
+	}
 
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
 	actionConfig, err := r.getActionConfiguration(restClientGetter, options.Namespace)
 	if err != nil {
@@ -239,13 +244,15 @@ func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.
 }
 
 func (r releaser) Get(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseInput helm.Release, options helm.Options) (helm.Release, error) {
-	// customize the settings passed forward
-	envSettings := r.processEnvSettings(helmEnv)
+	ns := "default"
+	if options.Namespace != "" {
+		ns = options.Namespace
+	}
 
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
-	actionConfig, err := r.getActionConfiguration(restClientGetter, options.Namespace)
+	actionConfig, err := r.getActionConfiguration(restClientGetter, ns)
 	if err != nil {
 		return helm.Release{}, errors.WrapIf(err, "failed to get action configuration")
 	}
@@ -275,16 +282,13 @@ func (r releaser) Get(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.K
 }
 
 func (r releaser) Upgrade(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseInput helm.Release, options helm.Options) (string, error) {
-	// customize the settings passed forward
-	envSettings := r.processEnvSettings(helmEnv)
+	ns := "default"
+	if options.Namespace != "" {
+		ns = options.Namespace
+	}
 
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
-
-	ns := "default"
-	if releaseInput.Namespace != "" {
-		ns = releaseInput.Namespace
-	}
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
 	actionConfig, err := r.getActionConfiguration(restClientGetter, ns)
 	if err != nil {
@@ -292,7 +296,7 @@ func (r releaser) Upgrade(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig 
 	}
 
 	upgradeAction := action.NewUpgrade(actionConfig)
-	upgradeAction.Namespace = options.Namespace
+	upgradeAction.Namespace = ns
 	upgradeAction.Install = options.Install
 	upgradeAction.Wait = options.Wait
 	upgradeAction.Timeout = time.Minute * 5
@@ -302,7 +306,7 @@ func (r releaser) Upgrade(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig 
 		upgradeAction.Version = ">0.0.0-0"
 	}
 
-	chartPath, err := upgradeAction.ChartPathOptions.LocateChart(releaseInput.ChartName, envSettings)
+	chartPath, err := upgradeAction.ChartPathOptions.LocateChart(releaseInput.ChartName, r.processEnvSettings(helmEnv))
 	if err != nil {
 		return "", errors.WrapIf(err, "failed to locate chart")
 	}
@@ -351,11 +355,13 @@ func (r releaser) Upgrade(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig 
 }
 
 func (r releaser) Resources(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseInput helm.Release, options helm.Options) ([]helm.ReleaseResource, error) {
-	// customize the settings passed forward
-	envSettings := r.processEnvSettings(helmEnv)
+	ns := "default"
+	if releaseInput.Namespace != "" {
+		ns = releaseInput.Namespace
+	}
 
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(envSettings.RESTClientGetter(), kubeConfig, r.logger)
+	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
 	actionConfig, err := r.getActionConfiguration(restClientGetter, options.Namespace)
 	if err != nil {
@@ -456,30 +462,61 @@ func isChartInstallable(ch *chart.Chart) (bool, error) {
 }
 
 type customGetter struct {
-	delegate        genericclioptions.RESTClientGetter
 	kubeConfigBytes []byte
 	logger          Logger
+	namespace       string
+	cacheDir        string
 }
 
-func NewCustomGetter(delegate genericclioptions.RESTClientGetter, kubeconfig []byte, logger Logger) genericclioptions.RESTClientGetter {
+func NewCustomGetter(namespace string, kubeconfig []byte, cacheDir string, logger Logger) genericclioptions.RESTClientGetter {
 	return customGetter{
-		delegate:        delegate,
 		kubeConfigBytes: kubeconfig,
 		logger:          logger,
+		namespace:       namespace,
+		cacheDir:        cacheDir,
 	}
 }
 
 func (c customGetter) ToRESTConfig() (*rest.Config, error) {
-	return k8sclient.NewClientConfig(c.kubeConfigBytes)
+	return c.ToRawKubeConfigLoader().ClientConfig()
 }
+
 func (c customGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	return c.delegate.ToDiscoveryClient()
+	config, err := c.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// The more groups you have, the more discovery requests you need to make.
+	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
+	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	config.Burst = 100
+
+	return disk.NewCachedDiscoveryClientForConfig(
+		config,
+		filepath.Join(c.cacheDir, "discovery-cache", fmt.Sprintf("%x", sha1.Sum([]byte(config.Host)))),
+		filepath.Join(c.cacheDir, "http-cache"),
+		time.Minute*10,
+	)
 }
 
 func (c customGetter) ToRESTMapper() (meta.RESTMapper, error) {
-	return c.delegate.ToRESTMapper()
+	discoveryClient, err := c.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+	return expander, nil
 }
 
 func (c customGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
-	return c.delegate.ToRawKubeConfigLoader()
+	loader, err := k8sclient.NewRawKubeConfigLoader(c.kubeConfigBytes, &clientcmd.ConfigOverrides{Context: clientcmdapi.Context{
+		Namespace: c.namespace,
+	}})
+	if err != nil {
+		c.logger.Error("error constructing the kubeconfig loader", map[string]interface{}{"err": err})
+	}
+	return loader
 }

--- a/internal/helm/releaser.go
+++ b/internal/helm/releaser.go
@@ -16,7 +16,10 @@ package helm
 
 import (
 	"context"
+	"strings"
 	"time"
+
+	"emperror.dev/errors"
 )
 
 // ReleaseInfo copy of the struct form the helm library
@@ -103,4 +106,8 @@ type Releaser interface {
 	Upgrade(ctx context.Context, helmEnv HelmEnv, kubeConfig KubeConfigBytes, releaseInput Release, options Options) (string, error)
 	// Resources retrieves the kubernetes resources belonging to the release
 	Resources(ctx context.Context, helmEnv HelmEnv, kubeConfig KubeConfigBytes, releaseInput Release, options Options) ([]ReleaseResource, error)
+}
+
+func ErrReleaseNotFound(err error) bool {
+	return strings.Contains(errors.Cause(err).Error(), "not found")
 }

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -58,7 +58,6 @@ type Options struct {
 	OdPcts       map[string]interface{} `json:"odPcts,omitempty"`
 	ReuseValues  bool                   `json:"reuseValues,omitempty"`
 	Install      bool                   `json:"install,omitempty"`
-	Optionals    map[string]interface{}
 }
 
 // +kit:endpoint:errorStrategy=service

--- a/internal/istio/istiofeature/api.go
+++ b/internal/istio/istiofeature/api.go
@@ -79,6 +79,7 @@ type MeshReconciler struct {
 	Master        cluster.CommonCluster
 	Remotes       []cluster.CommonCluster
 
+	helmService   HelmService
 	clusterGetter api.ClusterGetter
 	logger        logrus.FieldLogger
 	errorHandler  emperror.Handler

--- a/internal/istio/istiofeature/handler.go
+++ b/internal/istio/istiofeature/handler.go
@@ -30,6 +30,7 @@ type ServiceMeshFeatureHandler struct {
 	logger        logrus.FieldLogger
 	errorHandler  emperror.Handler
 	staticConfig  StaticConfig
+	helmService   HelmService
 }
 
 // NewServiceMeshFeatureHandler returns a new ServiceMeshFeatureHandler instance.
@@ -38,12 +39,14 @@ func NewServiceMeshFeatureHandler(
 	logger logrus.FieldLogger,
 	errorHandler emperror.Handler,
 	staticConfig StaticConfig,
+	helmService HelmService,
 ) *ServiceMeshFeatureHandler {
 	return &ServiceMeshFeatureHandler{
 		clusterGetter: clusterGetter,
 		logger:        logger,
 		errorHandler:  errorHandler,
 		staticConfig:  staticConfig,
+		helmService:   helmService,
 	}
 }
 
@@ -67,7 +70,7 @@ func (h *ServiceMeshFeatureHandler) ReconcileState(featureState api.Feature) err
 		return errors.WithStack(err)
 	}
 
-	mesh := NewMeshReconciler(*config, h.clusterGetter, logger, h.errorHandler)
+	mesh := NewMeshReconciler(*config, h.clusterGetter, logger, h.errorHandler, h.helmService)
 	err = mesh.Reconcile()
 	if err != nil {
 		h.errorHandler.Handle(err)
@@ -142,7 +145,7 @@ func (h *ServiceMeshFeatureHandler) GetMembersStatus(featureState api.Feature) (
 		return nil, errors.WithStack(err)
 	}
 
-	mesh := NewMeshReconciler(*config, h.clusterGetter, h.logger, h.errorHandler)
+	mesh := NewMeshReconciler(*config, h.clusterGetter, h.logger, h.errorHandler, h.helmService)
 	statusMap, err = mesh.GetClusterStatus()
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not get clusters status")

--- a/internal/istio/istiofeature/helm_test.go
+++ b/internal/istio/istiofeature/helm_test.go
@@ -66,7 +66,7 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	// t.Run("helmV2", testIntegrationV2(kubeConfig, "istiofeature-helm"))
+	t.Run("helmV2", testIntegrationV2(kubeConfig, "istiofeature-helm"))
 	t.Run("helmV3", testIntegrationV3(kubeConfig, global.Config.Helm.Home, "istiofeature-helm-v3"))
 }
 

--- a/internal/istio/istiofeature/helm_test.go
+++ b/internal/istio/istiofeature/helm_test.go
@@ -43,11 +43,6 @@ type Values struct {
 	Service struct {
 		ExternalPort int `json:"externalPort,omitempty"`
 	} `json:"service,omitempty"`
-	UpdateStrategy struct {
-		RollingUpdate struct {
-			MaxUnavailable int `json:"maxUnavailable,omitempty"`
-		} `json:"rollingUpdate,omitempty"`
-	} `json:"updateStrategy,omitempty"`
 }
 
 func TestIntegration(t *testing.T) {
@@ -71,7 +66,7 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	t.Run("helmV2", testIntegrationV2(kubeConfig, "istiofeature-helm"))
+	// t.Run("helmV2", testIntegrationV2(kubeConfig, "istiofeature-helm"))
 	t.Run("helmV3", testIntegrationV3(kubeConfig, global.Config.Helm.Home, "istiofeature-helm-v3"))
 }
 

--- a/internal/istio/istiofeature/helm_test.go
+++ b/internal/istio/istiofeature/helm_test.go
@@ -12,22 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package istiofeature
+package istiofeature_test
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
+	"github.com/banzaicloud/pipeline/internal/cmd"
+	"github.com/banzaicloud/pipeline/internal/common"
+	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/internal/helm"
+	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
+	"github.com/banzaicloud/pipeline/internal/istio/istiofeature"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	"github.com/banzaicloud/pipeline/src/secret"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+type Values struct {
+	Service struct {
+		ExternalPort int `json:"externalPort,omitempty"`
+	} `json:"service,omitempty"`
+	UpdateStrategy struct {
+		RollingUpdate struct {
+			MaxUnavailable int `json:"maxUnavailable,omitempty"`
+		} `json:"rollingUpdate,omitempty"`
+	} `json:"updateStrategy,omitempty"`
+}
 
 func TestIntegration(t *testing.T) {
 	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
@@ -50,41 +71,72 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	testNamespace := "istiofeature-helm"
-
-	helmService := &LegacyV2HelmService{}
-
-	t.Run("testCreateNodeExporter", testCreateNodeExporter(helmService, kubeConfig, testNamespace))
-	t.Run("testUpgradeNodeExporter", testUpgradeNodeExporter(helmService, kubeConfig, testNamespace))
-	t.Run("testHandleFailedDeployment", testUpgradeFailedNodeExporter(helmService, kubeConfig, testNamespace))
-	t.Run("testDeleteNodeExporterAfterSuite", testDeleteNodeExporter(helmService, kubeConfig, testNamespace))
+	t.Run("helmV2", testIntegrationV2(kubeConfig, "istiofeature-helm"))
+	t.Run("helmV3", testIntegrationV3(kubeConfig, global.Config.Helm.Home, "istiofeature-helm-v3"))
 }
 
-func testDeleteNodeExporter(helmService HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
+func testIntegrationV2(kubeConfig []byte, testNamespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		helmService := &istiofeature.LegacyV2HelmService{}
+		t.Run("testDeleteChartmuseumBeforeSuite", testDeleteChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testCreateChartmuseum", testCreateChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testUpgradeChartmuseum", testUpgradeChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testHandleFailedDeployment", testUpgradeFailedChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testDeleteChartmuseumAfterSuite", testDeleteChartmuseum(helmService, kubeConfig, testNamespace))
+	}
+}
+
+func testIntegrationV3(kubeConfig []byte, home, testNamespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		db := setupDatabase(t)
+		secretStore := setupSecretStore()
+		clusterService := clusterKubeConfig(t, kubeConfig)
+
+		config := helm.Config{
+			Home: home,
+			V3:   true,
+			Repositories: map[string]string{
+				"stable": "https://kubernetes-charts.storage.googleapis.com",
+			},
+		}
+
+		_, helmFacade := cmd.CreateUnifiedHelmReleaser(config, db, secretStore, clusterService, common.NoopLogger{})
+
+		helmService := istiofeature.NewHelmV3Service(helmFacade)
+
+		t.Run("testDeleteChartmuseumBeforeSuite", testDeleteChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testCreateChartmuseum", testCreateChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testUpgradeChartmuseum", testUpgradeChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testHandleFailedDeployment", testUpgradeFailedChartmuseum(helmService, kubeConfig, testNamespace))
+		t.Run("testDeleteChartmuseumAfterSuite", testDeleteChartmuseum(helmService, kubeConfig, testNamespace))
+	}
+}
+
+func testDeleteChartmuseum(helmService istiofeature.HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		err := helmService.Delete(
-			&clusterProviderData{k8sConfig: kubeConfig},
-			"node-exporter",
+			&istiofeature.ClusterProviderData{K8sConfig: kubeConfig, ID: 1},
+			"chartmuseum",
 			testNamespace,
 		)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 
-		assertNodeExporterRemoved(t, kubeConfig, testNamespace)
+		assertChartmuseumRemoved(t, kubeConfig, testNamespace)
 	}
 }
 
-func testCreateNodeExporter(helmService HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
+func testCreateChartmuseum(helmService istiofeature.HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		err := helmService.InstallOrUpgrade(
-			&clusterProviderData{k8sConfig: kubeConfig},
+			&istiofeature.ClusterProviderData{K8sConfig: kubeConfig, ID: 1},
 			helm.Release{
-				ReleaseName: "node-exporter",
-				ChartName:   "stable/prometheus-node-exporter",
+				ReleaseName: "chartmuseum",
+				ChartName:   "stable/chartmuseum",
 				Namespace:   testNamespace,
 				Values:      nil,
-				Version:     "1.8.1",
+				Version:     "2.12.0",
 			},
 			helm.Options{
 				Namespace: testNamespace,
@@ -96,40 +148,30 @@ func testCreateNodeExporter(helmService HelmService, kubeConfig []byte, testName
 			t.Fatalf("%+v", err)
 		}
 
-		assertNodeExporter(t, kubeConfig, testNamespace, 9100)
+		assertChartmuseum(t, kubeConfig, testNamespace, 8080)
 	}
 }
 
-func testUpgradeNodeExporter(helmService HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
+func testUpgradeChartmuseum(helmService istiofeature.HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		var expectPort int32 = 19191
 
-		type Values struct {
-			Service struct {
-				Type        string            `json:"type,omitempty"`
-				Port        int               `json:"port,omitempty"`
-				TargetPort  int               `json:"targetPort,omitempty"`
-				NodePort    int               `json:"nodePort,omitempty"`
-				Annotations map[string]string `json:"annotations,omitempty"`
-			} `json:"service,omitempty"`
-		}
-
 		values := Values{}
-		values.Service.Port = int(expectPort)
+		values.Service.ExternalPort = int(expectPort)
 
-		serializedValues, err := convertStructure(values)
+		serializedValues, err := istiofeature.ConvertStructure(values)
 		if err != nil {
 			t.Fatalf("%+v", serializedValues)
 		}
 
 		err = helmService.InstallOrUpgrade(
-			&clusterProviderData{k8sConfig: kubeConfig},
+			&istiofeature.ClusterProviderData{K8sConfig: kubeConfig, ID: 1},
 			helm.Release{
-				ReleaseName: "node-exporter",
-				ChartName:   "stable/prometheus-node-exporter",
+				ReleaseName: "chartmuseum",
+				ChartName:   "stable/chartmuseum",
 				Namespace:   testNamespace,
 				Values:      serializedValues,
-				Version:     "1.8.1",
+				Version:     "2.12.0",
 			},
 			helm.Options{
 				Namespace: testNamespace,
@@ -141,41 +183,31 @@ func testUpgradeNodeExporter(helmService HelmService, kubeConfig []byte, testNam
 			t.Fatalf("%+v", err)
 		}
 
-		assertNodeExporter(t, kubeConfig, testNamespace, expectPort)
+		assertChartmuseum(t, kubeConfig, testNamespace, expectPort)
 	}
 }
 
-func testUpgradeFailedNodeExporter(helmService HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
+func testUpgradeFailedChartmuseum(helmService istiofeature.HelmService, kubeConfig []byte, testNamespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		// invalid port will fail the release
 		var expectPort int32 = 1111111
 
-		type Values struct {
-			Service struct {
-				Type        string            `json:"type,omitempty"`
-				Port        int               `json:"port,omitempty"`
-				TargetPort  int               `json:"targetPort,omitempty"`
-				NodePort    int               `json:"nodePort,omitempty"`
-				Annotations map[string]string `json:"annotations,omitempty"`
-			} `json:"service,omitempty"`
-		}
-
 		values := Values{}
-		values.Service.Port = int(expectPort)
+		values.Service.ExternalPort = int(expectPort)
 
-		serializedValues, err := convertStructure(values)
+		serializedValues, err := istiofeature.ConvertStructure(values)
 		if err != nil {
 			t.Fatalf("%+v", serializedValues)
 		}
 
 		err = helmService.InstallOrUpgrade(
-			&clusterProviderData{k8sConfig: kubeConfig},
+			&istiofeature.ClusterProviderData{K8sConfig: kubeConfig, ID: 1},
 			helm.Release{
-				ReleaseName: "node-exporter",
-				ChartName:   "stable/prometheus-node-exporter",
+				ReleaseName: "chartmuseum",
+				ChartName:   "stable/chartmuseum",
 				Namespace:   testNamespace,
 				Values:      serializedValues,
-				Version:     "1.8.1",
+				Version:     "2.12.0",
 			},
 			helm.Options{
 				Namespace: testNamespace,
@@ -188,23 +220,30 @@ func testUpgradeFailedNodeExporter(helmService HelmService, kubeConfig []byte, t
 		}
 
 		// restore with original values
-		err = installOrUpgradeDeployment(
-			&clusterProviderData{k8sConfig: kubeConfig},
-			testNamespace,
-			"stable/prometheus-node-exporter",
-			"node-exporter",
-			nil,
-			"1.8.1",
-			true, true)
+		err = helmService.InstallOrUpgrade(
+			&istiofeature.ClusterProviderData{K8sConfig: kubeConfig, ID: 1},
+			helm.Release{
+				ReleaseName: "chartmuseum",
+				ChartName:   "stable/chartmuseum",
+				Namespace:   testNamespace,
+				Values:      nil,
+				Version:     "2.12.0",
+			},
+			helm.Options{
+				Namespace: testNamespace,
+				Wait:      true,
+				Install:   true,
+			},
+		)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 
-		assertNodeExporter(t, kubeConfig, testNamespace, 9100)
+		assertChartmuseum(t, kubeConfig, testNamespace, 8080)
 	}
 }
 
-func assertNodeExporter(t *testing.T, kubeConfig []byte, testNamespace string, expectedPort int32) {
+func assertChartmuseum(t *testing.T, kubeConfig []byte, testNamespace string, expectedPort int32) {
 	restConfig, err := k8sclient.NewClientConfig(kubeConfig)
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -215,30 +254,30 @@ func assertNodeExporter(t *testing.T, kubeConfig []byte, testNamespace string, e
 		t.Fatalf("%+v", err)
 	}
 
-	ds, err := clientSet.AppsV1().DaemonSets(testNamespace).Get("node-exporter-prometheus-node-exporter", metav1.GetOptions{})
+	ds, err := clientSet.AppsV1().Deployments(testNamespace).Get("chartmuseum-chartmuseum", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
-		t.Fatalf("Node exporters are not running")
+	if ds.Status.ReadyReplicas != ds.Status.Replicas || ds.Status.ReadyReplicas < 1 {
+		t.Fatalf("chartmuseum is not running")
 	}
 
-	svc, err := clientSet.CoreV1().Services(testNamespace).Get("node-exporter-prometheus-node-exporter", metav1.GetOptions{})
+	svc, err := clientSet.CoreV1().Services(testNamespace).Get("chartmuseum-chartmuseum", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
 	if len(svc.Spec.Ports) < 1 {
-		t.Fatalf("Missing node exporter service ports")
+		t.Fatalf("Missing chartmuseum service ports")
 	}
 
 	if svc.Spec.Ports[0].Port != expectedPort {
-		t.Fatalf("Node exporter service port mismatch, expected %d vs %d", expectedPort, svc.Spec.Ports[0].Port)
+		t.Fatalf("chartmuseum service port mismatch, expected %d vs %d", expectedPort, svc.Spec.Ports[0].Port)
 	}
 }
 
-func assertNodeExporterRemoved(t *testing.T, kubeConfig []byte, testNamespace string) {
+func assertChartmuseumRemoved(t *testing.T, kubeConfig []byte, testNamespace string) {
 	restConfig, err := k8sclient.NewClientConfig(kubeConfig)
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -249,12 +288,34 @@ func assertNodeExporterRemoved(t *testing.T, kubeConfig []byte, testNamespace st
 		t.Fatalf("%+v", err)
 	}
 
-	dsList, err := clientSet.AppsV1().DaemonSets(testNamespace).List(metav1.ListOptions{})
+	dsList, err := clientSet.AppsV1().Deployments(testNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
 	if len(dsList.Items) > 0 {
-		t.Fatalf("no daemonsets expected, node exporter should be removed")
+		t.Fatalf("no deployments expected, chartmuseum should be removed")
 	}
+}
+
+func setupDatabase(t *testing.T) *gorm.DB {
+	db, err := gorm.Open("sqlite3", "file::memory:")
+	require.NoError(t, err)
+
+	err = helmadapter.Migrate(db, common.NoopLogger{})
+	require.NoError(t, err)
+
+	return db
+}
+
+func setupSecretStore() common.SecretStore {
+	return commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(func(ctx context.Context) (uint, bool) {
+		return 0, false
+	}))
+}
+
+func clusterKubeConfig(t *testing.T, kubeConfigBytes []byte) helm.ClusterService {
+	return helm.ClusterKubeConfigFunc(func(ctx context.Context, clusterID uint) ([]byte, error) {
+		return kubeConfigBytes, nil
+	})
 }

--- a/internal/istio/istiofeature/helm_test.go
+++ b/internal/istio/istiofeature/helm_test.go
@@ -1,0 +1,237 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiofeature
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/banzaicloud/pipeline/internal/global"
+	"github.com/banzaicloud/pipeline/pkg/k8sclient"
+	"github.com/ghodss/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestIntegration(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("skipping as execution was not requested explicitly using go test -run")
+	}
+
+	var err error
+	global.Config.Helm.Home, err = ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	kubeConfigFile := os.Getenv("KUBECONFIG")
+	if kubeConfigFile == "" {
+		t.Skip("skipping as Kubernetes config was not provided")
+	}
+
+	kubeConfig, err := ioutil.ReadFile(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	testNamespace := "istiofeature-helm"
+
+	t.Run("testDeleteNodeExporter", testDeleteNodeExporter(kubeConfig, testNamespace))
+	t.Run("testCreateNodeExporter", testCreateNodeExporter(kubeConfig, testNamespace))
+	t.Run("testUpgradeNodeExporter", testUpgradeNodeExporter(kubeConfig, testNamespace))
+	t.Run("testHandleFailedDeployment", testUpgradeFailedNodeExporter(kubeConfig, testNamespace))
+	t.Run("testDeleteNodeExporterAfterSuite", testDeleteNodeExporter(kubeConfig, testNamespace))
+
+}
+
+func testDeleteNodeExporter(kubeConfig []byte, testNamespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		err := deleteDeployment(
+			&clusterProviderData{k8sConfig: kubeConfig},
+			"node-exporter",
+		)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		assertNodeExporterRemoved(t, kubeConfig, testNamespace)
+	}
+}
+
+func testCreateNodeExporter(kubeConfig []byte, testNamespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		err := installOrUpgradeDeployment(
+			&clusterProviderData{k8sConfig: kubeConfig},
+			testNamespace,
+			"stable/prometheus-node-exporter",
+			"node-exporter",
+			nil,
+			"1.8.1",
+			true, true)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		assertNodeExporter(t, kubeConfig, testNamespace, 9100)
+	}
+}
+
+func testUpgradeNodeExporter(kubeConfig []byte, testNamespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		var expectPort int32 = 19191
+
+		type Values struct {
+			Service struct {
+				Type        string            `json:"type,omitempty"`
+				Port        int               `json:"port,omitempty"`
+				TargetPort  int               `json:"targetPort,omitempty"`
+				NodePort    int               `json:"nodePort,omitempty"`
+				Annotations map[string]string `json:"annotations,omitempty"`
+			} `json:"service,omitempty"`
+		}
+
+		values := Values{}
+		values.Service.Port = int(expectPort)
+
+		serializedValues, err := yaml.Marshal(values)
+		if err != nil {
+			t.Fatalf("%+v", serializedValues)
+		}
+
+		err = installOrUpgradeDeployment(
+			&clusterProviderData{k8sConfig: kubeConfig},
+			testNamespace,
+			"stable/prometheus-node-exporter",
+			"node-exporter",
+			serializedValues,
+			"1.8.1",
+			true, true)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		assertNodeExporter(t, kubeConfig, testNamespace, expectPort)
+	}
+}
+
+func testUpgradeFailedNodeExporter(kubeConfig []byte, testNamespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		// invalid port will fail the release
+		var expectPort int32 = 1111111
+
+		type Values struct {
+			Service struct {
+				Type        string            `json:"type,omitempty"`
+				Port        int               `json:"port,omitempty"`
+				TargetPort  int               `json:"targetPort,omitempty"`
+				NodePort    int               `json:"nodePort,omitempty"`
+				Annotations map[string]string `json:"annotations,omitempty"`
+			} `json:"service,omitempty"`
+		}
+
+		values := Values{}
+		values.Service.Port = int(expectPort)
+
+		serializedValues, err := yaml.Marshal(values)
+		if err != nil {
+			t.Fatalf("%+v", serializedValues)
+		}
+
+		err = installOrUpgradeDeployment(
+			&clusterProviderData{k8sConfig: kubeConfig},
+			testNamespace,
+			"stable/prometheus-node-exporter",
+			"node-exporter",
+			serializedValues,
+			"1.8.1",
+			true, true)
+		if err == nil {
+			t.Fatalf("this upgrade should fail because of the invalid port")
+		}
+
+		// restore with original values
+		err = installOrUpgradeDeployment(
+			&clusterProviderData{k8sConfig: kubeConfig},
+			testNamespace,
+			"stable/prometheus-node-exporter",
+			"node-exporter",
+			nil,
+			"1.8.1",
+			true, true)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		assertNodeExporter(t, kubeConfig, testNamespace, 9100)
+	}
+}
+
+func assertNodeExporter(t *testing.T, kubeConfig []byte, testNamespace string, expectedPort int32) {
+	restConfig, err := k8sclient.NewClientConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	clientSet, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	ds, err := clientSet.AppsV1().DaemonSets(testNamespace).Get("node-exporter-prometheus-node-exporter", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
+		t.Fatalf("Node exporters are not running")
+	}
+
+	svc, err := clientSet.CoreV1().Services(testNamespace).Get("node-exporter-prometheus-node-exporter", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if len(svc.Spec.Ports) < 1 {
+		t.Fatalf("Missing node exporter service ports")
+	}
+
+	if svc.Spec.Ports[0].Port != expectedPort {
+		t.Fatalf("Node exporter service port mismatch, expected %d vs %d", expectedPort, svc.Spec.Ports[0].Port)
+	}
+}
+
+func assertNodeExporterRemoved(t *testing.T, kubeConfig []byte, testNamespace string) {
+	restConfig, err := k8sclient.NewClientConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	clientSet, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	dsList, err := clientSet.AppsV1().DaemonSets(testNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if len(dsList.Items) > 0 {
+		t.Fatalf("no daemonsets expected, node exporter should be removed")
+	}
+}

--- a/internal/istio/istiofeature/helm_values_test.go
+++ b/internal/istio/istiofeature/helm_values_test.go
@@ -49,7 +49,7 @@ func TestFromValues(t *testing.T) {
 		},
 	}
 
-	mapStringValues, err := convertStructure(values)
+	mapStringValues, err := ConvertStructure(values)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/internal/istio/istiofeature/helm_values_test.go
+++ b/internal/istio/istiofeature/helm_values_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiofeature
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromValues(t *testing.T) {
+	expectedD := 123
+	expectedE := true
+
+	type A struct {
+		B struct {
+			C struct {
+				D int  `json:"d,omitempty"`
+				E bool `json:"e,omitempty"`
+			} `json:"c,omitempty"`
+		} `json:"b,omitempty"`
+	}
+
+	values := A{
+		B: struct {
+			C struct {
+				D int  `json:"d,omitempty"`
+				E bool `json:"e,omitempty"`
+			} `json:"c,omitempty"`
+		}{
+			C: struct {
+				D int  `json:"d,omitempty"`
+				E bool `json:"e,omitempty"`
+			}{
+				D: expectedD,
+				E: expectedE,
+			},
+		},
+	}
+
+	mapStringValues, err := convertStructure(values)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if b, ok := mapStringValues["b"].(map[string]interface{}); !ok {
+		t.Fatalf("expected map[string]interface{} for field b")
+	} else {
+		if c, ok := b["c"].(map[string]interface{}); !ok {
+			t.Fatalf("expected map[string]interface{} for field c")
+		} else {
+			if d, ok := c["d"]; !ok {
+				t.Fatalf("missing field d")
+			} else {
+				if d != float64(expectedD) {
+					t.Fatalf("invalid value for d %d type: %+v", d, reflect.TypeOf(d))
+				}
+			}
+			if e, ok := c["e"]; !ok {
+				t.Fatalf("missing field e")
+			} else {
+				if e != expectedE {
+					t.Fatalf("invalid value for e %+v type: %+v", e, reflect.TypeOf(e))
+				}
+			}
+		}
+	}
+}

--- a/internal/istio/istiofeature/mesh.go
+++ b/internal/istio/istiofeature/mesh.go
@@ -35,10 +35,16 @@ func init() {
 }
 
 // NewMeshReconciler crates a new mesh feature reconciler
-func NewMeshReconciler(config Config, clusterGetter api.ClusterGetter, logger logrus.FieldLogger, errorHandler emperror.Handler) *MeshReconciler {
+func NewMeshReconciler(
+	config Config,
+	clusterGetter api.ClusterGetter,
+	logger logrus.FieldLogger,
+	errorHandler emperror.Handler,
+	helmService HelmService) *MeshReconciler {
 	reconciler := &MeshReconciler{
 		Configuration: config,
 
+		helmService:   helmService,
 		clusterGetter: clusterGetter,
 		logger:        logger,
 		errorHandler:  errorHandler,

--- a/internal/istio/istiofeature/reconcile_backyards.go
+++ b/internal/istio/istiofeature/reconcile_backyards.go
@@ -289,7 +289,7 @@ func (m *MeshReconciler) installBackyards(c cluster.CommonCluster, monitoring mo
 		values.UseIstioResources = false
 	}
 
-	mapStringValues, err := convertStructure(values)
+	mapStringValues, err := ConvertStructure(values)
 	if err != nil {
 		return errors.WrapIf(err, "failed to convert backyards chart values")
 	}

--- a/internal/istio/istiofeature/reconcile_canary_operator.go
+++ b/internal/istio/istiofeature/reconcile_canary_operator.go
@@ -80,7 +80,7 @@ func (m *MeshReconciler) installCanaryOperator(c cluster.CommonCluster, promethe
 		values.Operator.Image.Tag = canaryChart.Values.Operator.Image.Tag
 	}
 
-	valuesOverride, err := convertStructure(values)
+	valuesOverride, err := ConvertStructure(values)
 	if err != nil {
 		return errors.WrapIf(err, "could not marshal chart value overrides")
 	}

--- a/internal/istio/istiofeature/reconcile_istio_operator.go
+++ b/internal/istio/istiofeature/reconcile_istio_operator.go
@@ -82,7 +82,7 @@ func (m *MeshReconciler) installIstioOperator(c cluster.CommonCluster) error {
 		values.Operator.Image.Tag = istioChart.Values.Operator.Image.Tag
 	}
 
-	valuesOverride, err := convertStructure(values)
+	valuesOverride, err := ConvertStructure(values)
 	if err != nil {
 		return errors.WrapIf(err, "could not marshal chart value overrides")
 	}

--- a/internal/istio/istiofeature/reconcile_node_exporter.go
+++ b/internal/istio/istiofeature/reconcile_node_exporter.go
@@ -58,7 +58,7 @@ func (m *MeshReconciler) installNodeExporter(c cluster.CommonCluster) error {
 	values.Service.Port = 19100
 	values.Service.TargetPort = 19100
 
-	valuesOverride, err := convertStructure(values)
+	valuesOverride, err := ConvertStructure(values)
 	if err != nil {
 		return errors.WrapIf(err, "could not marshal chart value overrides")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0

### What's in this PR?
Helm3 support for the Backyards integration by replacing existing helm2 calls with the generic implementation.
Fixes for the helm3 implementation:
- add wait if configured
- explicit timeouts for release operations
- create namespace if it does not exist

### Why?
To be able to switch to helm3,  and still support helm2 in the meantime.
