### PR TITLE
Update traefik chart version

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -623,7 +623,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::ingress::namespace", "")
 	v.SetDefault("cluster::ingress::releaseName", "ingress")
 	v.SetDefault("cluster::ingress::charts::traefik::chart", "stable/traefik")
-	v.SetDefault("cluster::ingress::charts::traefik::version", "1.86.1")
+	v.SetDefault("cluster::ingress::charts::traefik::version", "1.86.2")
 	v.SetDefault("cluster::ingress::charts::traefik::values", `
 ssl:
   enabled: true
@@ -699,7 +699,7 @@ ssl:
 	// ingress controller config
 	v.SetDefault("cluster::posthook::ingress::enabled", true)
 	v.SetDefault("cluster::posthook::ingress::chart", "banzaicloud-stable/pipeline-cluster-ingress")
-	v.SetDefault("cluster::posthook::ingress::version", "0.0.8")
+	v.SetDefault("cluster::posthook::ingress::version", "0.0.10")
 	v.SetDefault("cluster::posthook::ingress::values", `
 traefik:
   ssl:

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -78,7 +78,7 @@ func TestConfigure_DefaultValueBinding(t *testing.T) {
 					Charts: ingress.ChartsConfig{
 						Traefik: ingress.TraefikChartConfig{
 							Chart:   "stable/traefik",
-							Version: "1.86.1",
+							Version: "1.86.2",
 							Values: values.Config(map[string]interface{}{
 								"ssl": map[string]interface{}{
 									"enabled":     true,


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/banzai-charts/pull/1090
| License         | Apache 2.0


### What's in this PR?
The old traefik version (1.7.9) doesn't work properly with K8s version 1.18.
