### PR TITLE
decouple the helm version / implementation from security scan apis

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -765,9 +765,16 @@ func main() {
 				}
 
 				cRouter.GET("/images", api.ListImages)
-				cRouter.GET("/images/:imageDigest/deployments", api.GetImageDeployments)
-				cRouter.GET("/deployments/:name/images", api.GetDeploymentImages)
 
+				if config.Helm.V3 {
+					imageDeploymentHandler := api.NewImageDeploymentsHandler(helmFacade, cs, logger)
+					cRouter.GET("/images/:imageDigest/deployments", imageDeploymentHandler.GetImageDeployments)
+				} else {
+					imageDeploymentHandler := api.NewImageDeploymentsHandler(api.NewHelm2ReleaseLister(cs), cs, logger)
+					cRouter.GET("/images/:imageDigest/deployments", imageDeploymentHandler.GetImageDeployments)
+				}
+
+				cRouter.GET("/deployments/:name/images", api.GetDeploymentImages)
 				{
 					clusterStore := clusteradapter.NewStore(db, clusters)
 

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -484,18 +484,23 @@ func encodeGetReleaseHTTPResponse(ctx context.Context, w http.ResponseWriter, re
 func decodeListReleasesHTTPRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	orgID, err := extractUintParamFromRequest("orgId", r)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to decode delete release request")
+		return nil, errors.WrapIf(err, "failed to decode list release request")
 	}
 
 	clusterID, err := extractUintParamFromRequest("clusterId", r)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to decode delete release request")
+		return nil, errors.WrapIf(err, "failed to decode list release request")
+	}
+
+	var releaseFilter helm.ReleaseFilter
+	if err := mapstructure.Decode(mux.Vars(r), &releaseFilter); err != nil {
+		return nil, errors.WrapIf(err, "failed to decode list release request")
 	}
 
 	return ListReleasesRequest{
 		OrganizationID: orgID,
 		ClusterID:      clusterID,
-		Filters:        nil,
+		Filters:        releaseFilter,
 	}, nil
 }
 

--- a/internal/helm/helmdriver/zz_generated.endpoint.go
+++ b/internal/helm/helmdriver/zz_generated.endpoint.go
@@ -422,7 +422,7 @@ func MakeListChartsEndpoint(service helm.Service) endpoint.Endpoint {
 type ListReleasesRequest struct {
 	OrganizationID uint
 	ClusterID      uint
-	Filters        interface{}
+	Filters        helm.ReleaseFilter
 	Options        helm.Options
 }
 

--- a/internal/helm/releaser.go
+++ b/internal/helm/releaser.go
@@ -43,15 +43,22 @@ type ReleaseResource struct {
 //  Release represents information related to a helm chart release
 type Release struct {
 	// ReleaseInput struct encapsulating information about the release to be created
-	ReleaseName string
-	ChartName   string
-	Namespace   string
-	Values      map[string]interface{} //json representation
-	Version     string
-	ReleaseInfo ReleaseInfo
+	ReleaseName    string
+	ChartName      string
+	Namespace      string
+	Values         map[string]interface{} //json representation
+	Version        string
+	ReleaseInfo    ReleaseInfo
+	ReleaseVersion int32
 }
 
 type KubeConfigBytes = []byte
+
+// ReleaseFilter struct for release filter data
+type ReleaseFilter struct {
+	TagFilter string  `json:"tag" mapstructure:"tag"`
+	Filter    *string `json:"filter,omitempty" mapstructure:"filter"`
+}
 
 // releaser collects and groups helm release related operations
 // it's intended to be embedded in the "Helm Facade"
@@ -62,7 +69,7 @@ type releaser interface {
 	// Delete deletes the  specified release
 	DeleteRelease(ctx context.Context, organizationID uint, clusterID uint, releaseName string, options Options) error
 	// List retrieves  releases in a given namespace, eventually applies the passed in filters
-	ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters interface{}, options Options) ([]Release, error)
+	ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters ReleaseFilter, options Options) ([]Release, error)
 	// Get retrieves the release details for the given  release
 	GetRelease(ctx context.Context, organizationID uint, clusterID uint, releaseName string, options Options) (Release, error)
 	// Upgrade upgrades the given release

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -452,7 +452,7 @@ func (s service) DeleteRelease(ctx context.Context, organizationID uint, cluster
 	return nil
 }
 
-func (s service) ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters interface{}, options Options) ([]Release, error) {
+func (s service) ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters ReleaseFilter, options Options) ([]Release, error) {
 	helmEnv, err := s.envResolver.ResolveHelmEnv(ctx, organizationID)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to set up helm repository environment")

--- a/internal/helm/zz_generated.mock_test.go
+++ b/internal/helm/zz_generated.mock_test.go
@@ -255,11 +255,11 @@ func (_m *MockService) ListCharts(ctx context.Context, organizationID uint, filt
 }
 
 // ListReleases provides a mock function.
-func (_m *MockService) ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters interface{}, options Options) ([]Release, error) {
+func (_m *MockService) ListReleases(ctx context.Context, organizationID uint, clusterID uint, filters ReleaseFilter, options Options) ([]Release, error) {
 	ret := _m.Called(ctx, organizationID, clusterID, filters, options)
 
 	var r0 []Release
-	if rf, ok := ret.Get(0).(func(context.Context, uint, uint, interface{}, Options) []Release); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint, uint, ReleaseFilter, Options) []Release); ok {
 		r0 = rf(ctx, organizationID, clusterID, filters, options)
 	} else {
 		if ret.Get(0) != nil {
@@ -268,7 +268,7 @@ func (_m *MockService) ListReleases(ctx context.Context, organizationID uint, cl
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uint, uint, interface{}, Options) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, uint, uint, ReleaseFilter, Options) error); ok {
 		r1 = rf(ctx, organizationID, clusterID, filters, options)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This PR decouples the helm version dependencies from the get image deployments operation (part of the security scan api)

### Why?
This is required in order to support helm3 libraries too.
