### PR TITLE
ClusterSetup workflow enhanced not to install Tiller in case helm v3 is switched on 

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -406,7 +406,7 @@ func main() {
 		errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 	}
 
-	releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, commonLogger)
+	releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, db, commonSecretStore, commonLogger)
 
 	clusterManager := cluster.NewManager(clusters, secretValidator, clusterEvents, statusChangeDurationMetric, clusterTotalMetric, workflowClient, logrusLogger, errorHandler, clusteradapter.NewStore(db, clusters), releaseDeleter)
 	commonClusterGetter := common.NewClusterGetter(clusterManager, logrusLogger, errorHandler)

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -406,7 +406,9 @@ func main() {
 		errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 	}
 
-	clusterManager := cluster.NewManager(clusters, secretValidator, clusterEvents, statusChangeDurationMetric, clusterTotalMetric, workflowClient, logrusLogger, errorHandler, clusteradapter.NewStore(db, clusters))
+	releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, commonLogger)
+
+	clusterManager := cluster.NewManager(clusters, secretValidator, clusterEvents, statusChangeDurationMetric, clusterTotalMetric, workflowClient, logrusLogger, errorHandler, clusteradapter.NewStore(db, clusters), releaseDeleter)
 	commonClusterGetter := common.NewClusterGetter(clusterManager, logrusLogger, errorHandler)
 
 	var group run.Group

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -324,14 +324,16 @@ func main() {
 				config.Helm.Tiller.Version,
 				kubernetes.NewClientFactory(configFactory),
 			)
-			activity.RegisterWithOptions(installTillerActivity.Execute, activity.RegisterOptions{Name: clustersetup.InstallTillerActivityName})
 
-			installTillerWaitActivity := clustersetup.NewInstallTillerWaitActivity(
-				config.Helm.Tiller.Version,
-				kubernetes.NewHelmClientFactory(configFactory, commonadapter.NewLogger(logger)),
-			)
-			activity.RegisterWithOptions(installTillerWaitActivity.Execute, activity.RegisterOptions{Name: clustersetup.InstallTillerWaitActivityName})
+			if !config.Helm.V3 {
+				activity.RegisterWithOptions(installTillerActivity.Execute, activity.RegisterOptions{Name: clustersetup.InstallTillerActivityName})
 
+				installTillerWaitActivity := clustersetup.NewInstallTillerWaitActivity(
+					config.Helm.Tiller.Version,
+					kubernetes.NewHelmClientFactory(configFactory, commonadapter.NewLogger(logger)),
+				)
+				activity.RegisterWithOptions(installTillerWaitActivity.Execute, activity.RegisterOptions{Name: clustersetup.InstallTillerWaitActivityName})
+			}
 			installNodePoolLabelSetOperatorActivity := clustersetup.NewInstallNodePoolLabelSetOperatorActivity(
 				config.Cluster.Labels,
 				unifiedHelmReleaser,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -236,6 +236,7 @@ func main() {
 			errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 		}
 
+		releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, logger)
 		clusterRepo := clusteradapter.NewClusters(db)
 		clusterManager := cluster.NewManager(
 			clusterRepo,
@@ -247,6 +248,7 @@ func main() {
 			logrusLogger,
 			errorHandler,
 			clusteradapter.NewStore(db, clusterRepo),
+			releaseDeleter,
 		)
 		tokenStore := bauth.NewVaultTokenStore("pipeline")
 		tokenManager := pkgAuth.NewTokenManager(

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -236,7 +236,9 @@ func main() {
 			errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 		}
 
-		releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, commonLogger)
+		commonSecretStore := commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))
+
+		releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, db, commonSecretStore, commonLogger)
 		clusterRepo := clusteradapter.NewClusters(db)
 		clusterManager := cluster.NewManager(
 			clusterRepo,
@@ -260,8 +262,6 @@ func main() {
 			tokenStore,
 		)
 		tokenGenerator := auth.NewClusterTokenGenerator(tokenManager, tokenStore)
-
-		commonSecretStore := commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))
 
 		unifiedHelmReleaser, helmFacade := cmd.CreateUnifiedHelmReleaser(
 			config.Helm,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -236,7 +236,7 @@ func main() {
 			errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
 		}
 
-		releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, logger)
+		releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, commonLogger)
 		clusterRepo := clusteradapter.NewClusters(db)
 		clusterManager := cluster.NewManager(
 			clusterRepo,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -294,6 +294,7 @@ func main() {
 		{
 			wf := clustersetup.Workflow{
 				InstallInitManifest: config.Cluster.Manifest != "",
+				HelmV3:              config.Helm.V3,
 			}
 			workflow.RegisterWithOptions(wf.Execute, workflow.RegisterOptions{Name: clustersetup.WorkflowName})
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -549,7 +549,7 @@ func main() {
 
 		workflow.RegisterWithOptions(intClusterWorkflow.DeleteK8sResourcesWorkflow, workflow.RegisterOptions{Name: intClusterWorkflow.DeleteK8sResourcesWorkflowName})
 
-		deleteHelmDeploymentsActivity := intClusterWorkflow.MakeDeleteHelmDeploymentsActivity(k8sConfigGetter, logrusLogger)
+		deleteHelmDeploymentsActivity := intClusterWorkflow.MakeDeleteHelmDeploymentsActivity(k8sConfigGetter, releaseDeleter, logrusLogger)
 		activity.RegisterWithOptions(deleteHelmDeploymentsActivity.Execute, activity.RegisterOptions{Name: intClusterWorkflow.DeleteHelmDeploymentsActivityName})
 
 		deleteUserNamespacesActivity := intClusterWorkflow.MakeDeleteUserNamespacesActivity(intClusterK8s.MakeUserNamespaceDeleter(logrusLogger), k8sConfigGetter)

--- a/internal/cluster/clustersetup/workflow_test.go
+++ b/internal/cluster/clustersetup/workflow_test.go
@@ -182,3 +182,56 @@ func (s *WorkflowTestSuite) Test_Success_InstallInitManifest() {
 	s.True(s.env.IsWorkflowCompleted())
 	s.NoError(s.env.GetWorkflowError())
 }
+
+func (s *WorkflowTestSuite) Test_Success_HelmV3() {
+	wf := Workflow{
+		InstallInitManifest: true,
+		HelmV3:              true,
+	}
+	workflow.RegisterWithOptions(wf.Execute, workflow.RegisterOptions{Name: s.T().Name()})
+
+	s.env.OnActivity(
+		InitManifestActivityName,
+		mock.Anything,
+		InitManifestActivityInput{ConfigSecretID: "secret", Cluster: testCluster, Organization: testOrganization},
+	).Return(nil)
+
+	s.env.OnActivity(
+		CreatePipelineNamespaceActivityName,
+		mock.Anything,
+		CreatePipelineNamespaceActivityInput{ConfigSecretID: "secret"},
+	).Return(nil)
+
+	s.env.OnActivity(
+		LabelKubeSystemNamespaceActivityName,
+		mock.Anything,
+		LabelKubeSystemNamespaceActivityInput{ConfigSecretID: "secret"},
+	).Return(nil)
+
+	s.env.OnActivity(
+		InstallNodePoolLabelSetOperatorActivityName,
+		mock.Anything,
+		InstallNodePoolLabelSetOperatorActivityInput{ClusterID: 1},
+	).Return(nil)
+
+	s.env.OnActivity(
+		ConfigureNodePoolLabelsActivityName,
+		mock.Anything,
+		ConfigureNodePoolLabelsActivityInput{
+			ConfigSecretID: "secret",
+			Labels:         testNodePoolLabels,
+		},
+	).Return(nil)
+
+	workflowInput := WorkflowInput{
+		ConfigSecretID: "secret",
+		Cluster:        testCluster,
+		Organization:   testOrganization,
+		NodePoolLabels: testNodePoolLabels,
+	}
+
+	s.env.ExecuteWorkflow(s.T().Name(), workflowInput)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -88,3 +88,15 @@ func CreateUnifiedHelmReleaser(
 
 	return helmadapter.NewUnifiedHelm3Releaser(service, logger), service
 }
+
+// CreateReleaseDeleter creates a new (helm2 or helm3 specific) deleter instance based on the provided argunments
+func CreateReleaseDeleter(helmConfig helm.Config, logger helm.Logger) helm.ReleaseDeleter {
+	orgService := helmadapter.NewOrgService(logger)
+	if helmConfig.V3 {
+		releaser := helmadapter.NewReleaser(logger)
+		helm3EnvResolver := helm.NewHelm3EnvResolver(helmConfig.Home, orgService, logger)
+		return helm.NewReleaseDeleter(helm3EnvResolver, releaser, logger)
+	}
+
+	return helmadapter.NewHelm2ReleaseDeleter()
+}

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -94,6 +94,7 @@ func CreateReleaseDeleter(helmConfig helm.Config, logger helm.Logger) helm.Relea
 	orgService := helmadapter.NewOrgService(logger)
 	if helmConfig.V3 {
 		releaser := helmadapter.NewReleaser(logger)
+		// TODO ensuring envresolver
 		helm3EnvResolver := helm.NewHelm3EnvResolver(helmConfig.Home, orgService, logger)
 		return helmadapter.NewReleaseDeleter(helm3EnvResolver, releaser, logger)
 	}

--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -95,7 +95,7 @@ func CreateReleaseDeleter(helmConfig helm.Config, logger helm.Logger) helm.Relea
 	if helmConfig.V3 {
 		releaser := helmadapter.NewReleaser(logger)
 		helm3EnvResolver := helm.NewHelm3EnvResolver(helmConfig.Home, orgService, logger)
-		return helm.NewReleaseDeleter(helm3EnvResolver, releaser, logger)
+		return helmadapter.NewReleaseDeleter(helm3EnvResolver, releaser, logger)
 	}
 
 	return helmadapter.NewHelm2ReleaseDeleter()

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -200,13 +200,9 @@ func (r releaser) Uninstall(ctx context.Context, helmEnv helm.HelmEnv, kubeConfi
 }
 
 func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, options helm.Options) ([]helm.Release, error) {
-	ns := "default"
-	if options.Namespace != "" {
-		ns = options.Namespace
-	}
 
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
+	restClientGetter := NewCustomGetter(options.Namespace, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
 	actionConfig, err := r.getActionConfiguration(restClientGetter, options.Namespace)
 	if err != nil {
@@ -459,6 +455,10 @@ func (r releaser) processOptions(listAction *action.List, options helm.Options) 
 	action := listAction
 	if options.Filter != nil {
 		action.Filter = *options.Filter
+	}
+
+	if options.Namespace == "" {
+		action.AllNamespaces = true
 	}
 	// apply other options here
 	return action

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -568,7 +568,7 @@ func (r releaseDeleter) DeleteReleases(ctx context.Context, orgID uint, kubeConf
 
 	var uninstallErrs error
 	for _, release := range filteredReleases {
-		err := r.releaser.Uninstall(ctx, helmEnv, kubeConfig, release.ReleaseName, helm.Options{})
+		err := r.releaser.Uninstall(ctx, helmEnv, kubeConfig, release.ReleaseName, helm.Options{Namespace: release.Namespace})
 		if err != nil {
 			r.logger.Debug("failed to uninstall release", map[string]interface{}{"release": release.ReleaseName})
 			uninstallErrs = errors.Combine(err, uninstallErrs)

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -245,7 +245,7 @@ func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.
 }
 
 func (r releaser) Get(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseInput helm.Release, options helm.Options) (helm.Release, error) {
-	ns := "default"
+	ns := ""
 	if options.Namespace != "" {
 		ns = options.Namespace
 	}

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -202,7 +202,6 @@ func (r releaser) Uninstall(ctx context.Context, helmEnv helm.HelmEnv, kubeConfi
 }
 
 func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, options helm.Options) ([]helm.Release, error) {
-
 	// component processing the kubeconfig
 	restClientGetter := NewCustomGetter(options.Namespace, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 

--- a/internal/helm/releaser.go
+++ b/internal/helm/releaser.go
@@ -111,3 +111,14 @@ type Releaser interface {
 func ErrReleaseNotFound(err error) bool {
 	return strings.Contains(errors.Cause(err).Error(), "not found")
 }
+
+// ReleaseDeleter abstraction of the operations
+type ReleaseDeleter interface {
+	// DeleteReleases deletes all releases in the provided namespaces; all namespaces are considered when no namespaces provided
+	DeleteReleases(ctx context.Context, orgID uint, kubeConfig []byte, namespaces []string) error
+}
+
+type ListerUninstaller interface {
+	Uninstall(ctx context.Context, helmEnv HelmEnv, kubeConfig KubeConfigBytes, releaseName string, options Options) error
+	List(ctx context.Context, helmEnv HelmEnv, kubeConfig KubeConfigBytes, options Options) ([]Release, error)
+}

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -125,7 +125,7 @@ func getClusterFromRequest(c *gin.Context) (cluster.CommonCluster, bool) {
 	clusters := clusteradapter.NewClusters(global.DB())
 	secretValidator := providers.NewSecretValidator(secret.Store)
 	clusterStore := clusteradapter.NewStore(global.DB(), clusters)
-	clusterManager := cluster.NewManager(clusters, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore)
+	clusterManager := cluster.NewManager(clusters, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore, nil)
 	clusterGetter := common.NewClusterGetter(clusterManager, log, errorHandler)
 
 	return clusterGetter.GetClusterFromRequest(c)

--- a/src/api/secrets.go
+++ b/src/api/secrets.go
@@ -470,7 +470,7 @@ func checkClustersBeforeDelete(orgId uint, secretId string) error {
 	secretValidator := providers.NewSecretValidator(secret.Store)
 	clusterRepo := clusteradapter.NewClusters(global.DB())
 	clusterStore := clusteradapter.NewStore(global.DB(), clusterRepo)
-	clusterManager := cluster.NewManager(clusterRepo, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore)
+	clusterManager := cluster.NewManager(clusterRepo, secretValidator, cluster.NewNopClusterEvents(), nil, nil, nil, log, errorHandler, clusterStore, nil)
 
 	clusters, err := clusterManager.GetClustersBySecretID(context.Background(), orgId, secretId)
 	if err != nil {

--- a/src/cluster/manager.go
+++ b/src/cluster/manager.go
@@ -85,11 +85,11 @@ func NewManager(
 	logger logrus.FieldLogger,
 	errorHandler emperror.Handler,
 	clusterStore interface {
-	SetStatus(ctx context.Context, id uint, status, message string) error
-},
+		SetStatus(ctx context.Context, id uint, status, message string) error
+	},
 	releaseDeleter interface {
-	DeleteReleases(ctx context.Context, orgID uint, kubeConfig []byte, namespaces []string) error
-},
+		DeleteReleases(ctx context.Context, orgID uint, kubeConfig []byte, namespaces []string) error
+	},
 ) *Manager {
 	return &Manager{
 		clusters:                   clusters,

--- a/src/cluster/manager.go
+++ b/src/cluster/manager.go
@@ -70,6 +70,9 @@ type Manager struct {
 	clusterStore               interface {
 		SetStatus(ctx context.Context, id uint, status, message string) error
 	}
+	releaseDeleter interface {
+		DeleteReleases(ctx context.Context, orgID uint, kubeConfig []byte, namespaces []string) error
+	}
 }
 
 func NewManager(
@@ -82,8 +85,11 @@ func NewManager(
 	logger logrus.FieldLogger,
 	errorHandler emperror.Handler,
 	clusterStore interface {
-		SetStatus(ctx context.Context, id uint, status, message string) error
-	},
+	SetStatus(ctx context.Context, id uint, status, message string) error
+},
+	releaseDeleter interface {
+	DeleteReleases(ctx context.Context, orgID uint, kubeConfig []byte, namespaces []string) error
+},
 ) *Manager {
 	return &Manager{
 		clusters:                   clusters,
@@ -96,6 +102,7 @@ func NewManager(
 		logger:                     logger,
 		errorHandler:               errorHandler,
 		clusterStore:               clusterStore,
+		releaseDeleter:             releaseDeleter,
 	}
 }
 

--- a/src/cluster/manager_delete.go
+++ b/src/cluster/manager_delete.go
@@ -215,12 +215,14 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 			}
 		}
 
-		namespaceFilter := make([]string, len(namespaceList.Items))
-		for _, ns := range namespaceList.Items {
-			namespaceFilter = append(namespaceFilter, ns.Name)
+		var namespaceFilter []string
+		if namespaceList != nil {
+			namespaceFilter = make([]string, 0, len(namespaceList.Items))
+			for _, ns := range namespaceList.Items {
+				namespaceFilter = append(namespaceFilter, ns.Name)
+			}
 		}
 
-		//err = helm.DeleteAllDeployment(logger, config, namespaceList)
 		err := m.releaseDeleter.DeleteReleases(ctx, cluster.GetOrganizationId(), config, namespaceFilter)
 		if err != nil {
 			err = errors.WrapIf(err, "failed to delete deployments")

--- a/src/cluster/manager_delete.go
+++ b/src/cluster/manager_delete.go
@@ -30,7 +30,6 @@ import (
 	intClusterK8s "github.com/banzaicloud/pipeline/internal/cluster/kubernetes"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	"github.com/banzaicloud/pipeline/pkg/k8sclient"
-	"github.com/banzaicloud/pipeline/src/helm"
 	"github.com/banzaicloud/pipeline/src/secret"
 )
 
@@ -216,7 +215,13 @@ func (m *Manager) deleteCluster(ctx context.Context, cluster CommonCluster, forc
 			}
 		}
 
-		err = helm.DeleteAllDeployment(logger, config, namespaceList)
+		namespaceFilter := make([]string, len(namespaceList.Items))
+		for _, ns := range namespaceList.Items {
+			namespaceFilter = append(namespaceFilter, ns.Name)
+		}
+
+		//err = helm.DeleteAllDeployment(logger, config, namespaceList)
+		err := m.releaseDeleter.DeleteReleases(ctx, cluster.GetOrganizationId(), config, namespaceFilter)
 		if err != nil {
 			err = errors.WrapIf(err, "failed to delete deployments")
 

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -177,7 +177,7 @@ func GetChartFile(file []byte, fileName string) (string, error) {
 
 // DeleteAllDeployment deletes all Helm deployment
 // namespaces - if provided than delete all helm deployments only from the provided namespaces
-func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte, namespaces *v1.NamespaceList) error {
+func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte, namespaces []string) error {
 	log.Info("getting deployments....")
 	filter := ""
 	releaseResp, err := ListDeployments(&filter, "", kubeconfig)
@@ -188,10 +188,10 @@ func DeleteAllDeployment(log logrus.FieldLogger, kubeconfig []byte, namespaces *
 	if releaseResp != nil {
 		var nsFilter map[string]bool
 		if namespaces != nil {
-			nsFilter = make(map[string]bool, len(namespaces.Items))
+			nsFilter = make(map[string]bool, len(namespaces))
 
-			for _, ns := range namespaces.Items {
-				nsFilter[ns.Name] = true
+			for _, ns := range namespaces {
+				nsFilter[ns] = true
 			}
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
* Remove tiller related activities from the cluster setup workflow
* Amendments to the Releaser implementation to handle all namespaces
* Decoupled delete all releases call from the helm version (affects cluster deletion)


### Why?
No tiller is needed for helm 3
