### PR TITLE
Repos name filter handled properly when listing charts

### DIFF
--- a/internal/helm/charter.go
+++ b/internal/helm/charter.go
@@ -96,6 +96,11 @@ func exactMatchRegexp(value string) string {
 	if value == "" {
 		return value
 	}
+
+	// the value gets cleaned (aggressively) before applying the exact match regexp boundaries
+	value = strings.TrimSuffix(value, "$")
+	value = strings.TrimPrefix(value, "^")
+
 	return fmt.Sprintf("%s%s%s", "^", value, "$")
 }
 

--- a/internal/helm/helmadapter/helm2_env_service.go
+++ b/internal/helm/helmadapter/helm2_env_service.go
@@ -54,7 +54,7 @@ func NewHelmEnvService(config Config, secretStore helm.SecretStore, logger Logge
 func (h helmEnvService) ListCharts(_ context.Context, helmEnv helm.HelmEnv, filter helm.ChartFilter) (helm.ChartList, error) {
 	envSettings := environment.EnvSettings{Home: helmpath.Home(helmEnv.GetHome())}
 
-	legacyChartSlice, err := legacyHelm.ChartsGet(envSettings, filter.StrictNameFilter(), filter.RepoFilter(), filter.VersionFilter(), filter.KeywordFilter())
+	legacyChartSlice, err := legacyHelm.ChartsGet(envSettings, filter.StrictNameFilter(), filter.StrictRepoFilter(), filter.VersionFilter(), filter.KeywordFilter())
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to get chart list")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
Fixes a bug: when listing charts for a given helm repo the backend ignored the sent in regexp boundaries (so no exact match was applied on repo name)

### Why?
Charts were returned for all helm repos that matched the sent in repo name (eg: stable, banzai-stable)
