### PR TITLE
Set template name in cluster create and update flows

### DIFF
--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -163,12 +163,14 @@ func (cc VspherePKEClusterCreator) Create(ctx context.Context, params VspherePKE
 	nodePools := make([]pke.NodePool, len(params.NodePools))
 	for i, np := range params.NodePools {
 		nodePools[i] = pke.NodePool{
-			CreatedBy: np.CreatedBy,
-			Name:      np.Name,
-			Roles:     np.Roles,
-			Size:      np.Size,
-			VCPU:      np.VCPU,
-			RAM:       np.RAM,
+			CreatedBy:    np.CreatedBy,
+			Name:         np.Name,
+			Roles:        np.Roles,
+			Size:         np.Size,
+			VCPU:         np.VCPU,
+			RAM:          np.RAM,
+			TemplateName: np.TemplateName,
+		}
 		}
 	}
 	createParams := pke.CreateParams{

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -149,10 +149,13 @@ type VspherePKEClusterCreationParams struct {
 
 // Create
 func (cc VspherePKEClusterCreator) Create(ctx context.Context, params VspherePKEClusterCreationParams) (cl pke.PKEOnVsphereCluster, err error) {
-	_, err = cc.secrets.Get(params.OrganizationID, params.SecretID)
+	var vsphereSecret *secret.SecretItemResponse
+	vsphereSecret, err = cc.secrets.Get(params.OrganizationID, params.SecretID)
 	if err = errors.WrapIf(err, "failed to get secret"); err != nil {
 		return
 	}
+
+	var defaultNodeTemplate = vsphereSecret.Values[secrettype.VsphereDefaultNodeTemplate]
 
 	// TODO maybe check the connection here, OR don't fetch the secret at all
 
@@ -171,6 +174,8 @@ func (cc VspherePKEClusterCreator) Create(ctx context.Context, params VspherePKE
 			RAM:          np.RAM,
 			TemplateName: np.TemplateName,
 		}
+		if nodePools[i].TemplateName == "" {
+			nodePools[i].TemplateName = defaultNodeTemplate
 		}
 	}
 	createParams := pke.CreateParams{

--- a/internal/providers/vsphere/pke/driver/cluster_updater.go
+++ b/internal/providers/vsphere/pke/driver/cluster_updater.go
@@ -123,12 +123,13 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 
 		for _, np := range nodePoolsToCreate {
 			nodePool := pke.NodePool{
-				CreatedBy: np.CreatedBy,
-				Name:      np.Name,
-				Roles:     np.Roles,
-				Size:      np.Size,
-				VCPU:      np.VCPU,
-				RAM:       np.RAM,
+				CreatedBy:    np.CreatedBy,
+				Name:         np.Name,
+				Roles:        np.Roles,
+				Size:         np.Size,
+				VCPU:         np.VCPU,
+				RAM:          np.RAM,
+				TemplateName: np.TemplateName,
 			}
 			for i := 1; i <= np.Size; i++ {
 				nodesToCreate = append(nodesToCreate, tf.getNode(nodePool, i))
@@ -169,12 +170,13 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 				// check existing nodes are fine, create new vm otherwise
 				for i := 1; i <= np.Size; i++ {
 					nodesToCreate = append(nodesToCreate, tf.getNode(pke.NodePool{
-						CreatedBy: np.CreatedBy,
-						Name:      np.Name,
-						Roles:     np.Roles,
-						Size:      np.Size,
-						VCPU:      np.VCPU,
-						RAM:       np.RAM,
+						CreatedBy:    np.CreatedBy,
+						Name:         np.Name,
+						Roles:        np.Roles,
+						Size:         np.Size,
+						VCPU:         np.VCPU,
+						RAM:          np.RAM,
+						TemplateName: np.TemplateName,
 					}, i))
 				}
 

--- a/internal/providers/vsphere/pke/driver/cluster_updater.go
+++ b/internal/providers/vsphere/pke/driver/cluster_updater.go
@@ -21,6 +21,7 @@ import (
 
 	"emperror.dev/errors"
 
+	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	"github.com/banzaicloud/pipeline/src/utils"
 
 	"go.uber.org/cadence/client"
@@ -101,6 +102,12 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 		return errors.WrapIf(err, "failed to get or create SSH key pair")
 	}
 
+	vsphereSecret, err := cu.secrets.Get(cluster.OrganizationID, cluster.SecretID)
+	if err != nil {
+		return errors.WrapIf(err, "failed to get cluster's secret")
+	}
+	var defaultNodeTemplate = vsphereSecret.Values[secrettype.VsphereDefaultNodeTemplate]
+
 	tf := nodeTemplateFactory{
 		ClusterID:                   cluster.ID,
 		ClusterName:                 cluster.Name,
@@ -131,6 +138,10 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 				RAM:          np.RAM,
 				TemplateName: np.TemplateName,
 			}
+			if nodePool.TemplateName == "" {
+				nodePool.TemplateName = defaultNodeTemplate
+			}
+
 			for i := 1; i <= np.Size; i++ {
 				nodesToCreate = append(nodesToCreate, tf.getNode(nodePool, i))
 			}
@@ -169,6 +180,10 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 			if np.Size != existingNodePool.Size {
 				// check existing nodes are fine, create new vm otherwise
 				for i := 1; i <= np.Size; i++ {
+					var templateName = np.TemplateName
+					if templateName == "" {
+						templateName = defaultNodeTemplate
+					}
 					nodesToCreate = append(nodesToCreate, tf.getNode(pke.NodePool{
 						CreatedBy:    np.CreatedBy,
 						Name:         np.Name,
@@ -176,7 +191,7 @@ func (cu ClusterUpdater) Update(ctx context.Context, params VspherePKEClusterUpd
 						Size:         np.Size,
 						VCPU:         np.VCPU,
 						RAM:          np.RAM,
-						TemplateName: np.TemplateName,
+						TemplateName: templateName,
 					}, i))
 				}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Set node template name in cluster create and update flows
- Override template name from secret if it isn't present in the request

### Why?
- Allow the user override node template in the request(s)
- Store node template name in DB to help UI cluster update flow to show the right node template name for the user


### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
