### PR TITLE
Add helm version to capabilities API

### DIFF
--- a/cmd/pipeline/capabilities.go
+++ b/cmd/pipeline/capabilities.go
@@ -48,5 +48,8 @@ func mapCapabilities(config configuration) cap.Capabilities {
 				"controllers": config.Cluster.Ingress.Controllers,
 			},
 		},
+		"helm": cap.Cap{
+			"version": "3.1.2", // TODO: determine based on go.mod build time
+		},
 	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Add helm version to capabilities API


### Why?
CLI should be able to query the currently used Helm version.
