### PR TITLE
List helm charts operation made backwards compatible

### DIFF
--- a/internal/helm/helmadapter/helm3_env_service.go
+++ b/internal/helm/helmadapter/helm3_env_service.go
@@ -224,10 +224,12 @@ func (h helm3EnvService) ListCharts(ctx context.Context, helmEnv helm.HelmEnv, f
 			Name:   filter.RepoFilter(),
 			Charts: make([]interface{}, 0, 0),
 		}
+
+		versions := make([]interface{}, 0, len(chartVersions))
 		for _, chartVersion := range chartVersions {
-			// omg!
-			chartEntry.Charts = append(chartEntry.Charts, []interface{}{chartVersion})
+			chartEntry.Charts = append(versions, chartVersion)
 		}
+		chartEntry.Charts = append(chartEntry.Charts, versions)
 	}
 
 	if len(chartEntry.Charts) > 0 {
@@ -351,7 +353,7 @@ func (h helm3EnvService) listCharts(_ context.Context, helmEnv helm.HelmEnv, fil
 	}
 
 	for _, repoEntry := range repoFile.Repositories {
-		if !matchesFilter(fmt.Sprintf("%s%s%s", "^", filter.RepoFilter(), "$"), repoEntry.Name) {
+		if !matchesFilter(filter.StrictRepoFilter(), repoEntry.Name) {
 			h.logger.Debug("repository name doesn't match the filter",
 				map[string]interface{}{"filter": filter.RepoFilter(), "repoEntry": repoEntry.Name})
 			// skip further processing

--- a/internal/helm/helmadapter/helm3_env_service.go
+++ b/internal/helm/helmadapter/helm3_env_service.go
@@ -227,7 +227,7 @@ func (h helm3EnvService) ListCharts(ctx context.Context, helmEnv helm.HelmEnv, f
 
 		versions := make([]interface{}, 0, len(chartVersions))
 		for _, chartVersion := range chartVersions {
-			chartEntry.Charts = append(versions, chartVersion)
+			versions = append(versions, chartVersion)
 		}
 		chartEntry.Charts = append(chartEntry.Charts, versions)
 	}
@@ -404,6 +404,7 @@ func (h helm3EnvService) listCharts(_ context.Context, helmEnv helm.HelmEnv, fil
 		}
 	}
 
+	// slice of slices (elements of the slice are slices of charts, one slice per repo)
 	return chartListSlice, nil
 }
 

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -247,15 +247,10 @@ func (r releaser) List(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.
 }
 
 func (r releaser) Get(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.KubeConfigBytes, releaseInput helm.Release, options helm.Options) (helm.Release, error) {
-	ns := ""
-	if options.Namespace != "" {
-		ns = options.Namespace
-	}
-
 	// component processing the kubeconfig
-	restClientGetter := NewCustomGetter(ns, kubeConfig, helmEnv.GetCacheDir(), r.logger)
+	restClientGetter := NewCustomGetter(options.Namespace, kubeConfig, helmEnv.GetCacheDir(), r.logger)
 
-	actionConfig, err := r.getActionConfiguration(restClientGetter, ns)
+	actionConfig, err := r.getActionConfiguration(restClientGetter, options.Namespace)
 	if err != nil {
 		return helm.Release{}, errors.WrapIf(err, "failed to get action configuration")
 	}

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -906,42 +906,42 @@ func ChartsGet(env helm_env.EnvSettings, queryName, queryRepo, queryVersion, que
 	if len(f.Repositories) == 0 {
 		return nil, nil
 	}
-	cl := make([]ChartList, 0)
+	retChartList := make([]ChartList, 0)
 
 	for _, r := range f.Repositories {
 		log.Debugf("Repository: %s", r.Name)
-		i, errIndx := repo.LoadIndexFile(r.Cache)
+		repoIndex, errIndx := repo.LoadIndexFile(r.Cache)
 		if errIndx != nil {
 			return nil, errIndx
 		}
 		repoMatched, _ := regexp.MatchString(queryRepo, strings.ToLower(r.Name))
 		if repoMatched || queryRepo == "" {
 			log.Debugf("Repository: %s Matched", r.Name)
-			c := ChartList{
+			chartList := ChartList{
 				Name:   r.Name,
 				Charts: make([]repo.ChartVersions, 0),
 			}
-			for n := range i.Entries {
-				log.Debugf("Chart: %s", n)
-				chartMatched, _ := regexp.MatchString("^"+queryName+"$", strings.ToLower(n))
+			for chartName := range repoIndex.Entries {
+				log.Debugf("Chart: %s", chartName)
+				chartMatched, _ := regexp.MatchString("^"+queryName+"$", strings.ToLower(chartName))
 
-				kwString := strings.ToLower(strings.Join(i.Entries[n][0].Keywords, " "))
+				kwString := strings.ToLower(strings.Join(repoIndex.Entries[chartName][0].Keywords, " "))
 				log.Debugf("kwString: %s", kwString)
 
 				kwMatched, _ := regexp.MatchString(queryKeyword, kwString)
 				if (chartMatched || queryName == "") && (kwMatched || queryKeyword == "") {
-					log.Debugf("Chart: %s Matched", n)
+					log.Debugf("Chart: %s Matched", chartName)
 					if queryVersion == "latest" {
-						c.Charts = append(c.Charts, repo.ChartVersions{i.Entries[n][0]})
+						chartList.Charts = append(chartList.Charts, repo.ChartVersions{repoIndex.Entries[chartName][0]})
 					} else {
-						c.Charts = append(c.Charts, i.Entries[n])
+						chartList.Charts = append(chartList.Charts, repoIndex.Entries[chartName])
 					}
 				}
 			}
-			cl = append(cl, c)
+			retChartList = append(retChartList, chartList)
 		}
 	}
-	return cl, nil
+	return retChartList, nil
 }
 
 // ChartDetails describes a chart details


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
The helm chartlist response is made similar to the legacy (helm2)

### Why?
Each helm chart version was displayed on the UI (broken backwards compatibility)
