### PR TITLE
Make the logging integrated service helm3 aware

### DIFF
--- a/internal/integratedservices/services/dns/common_test.go
+++ b/internal/integratedservices/services/dns/common_test.go
@@ -149,3 +149,7 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 		ReleaseName: releaseName,
 	}, nil
 }
+
+func (d dummyHelmService) IsV3() bool {
+	return false
+}

--- a/internal/integratedservices/services/helm.go
+++ b/internal/integratedservices/services/helm.go
@@ -39,4 +39,6 @@ type HelmService interface {
 
 	// GetDeployment gets a deployment by release name from a specific cluster.
 	GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error)
+
+	IsV3() bool
 }

--- a/internal/integratedservices/services/logging/common_test.go
+++ b/internal/integratedservices/services/logging/common_test.go
@@ -168,6 +168,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 

--- a/internal/integratedservices/services/logging/operator.go
+++ b/internal/integratedservices/services/logging/operator.go
@@ -404,6 +404,7 @@ func (op IntegratedServiceOperator) installLoggingOperator(ctx context.Context, 
 			Repository: op.config.Images.Operator.Repository,
 			Tag:        op.config.Images.Operator.Tag,
 		},
+		CreateCustomResource: !op.helmService.IsV3(),
 	}
 
 	operatorConfigValues, err := copystructure.Copy(op.config.Charts.Operator.Values)

--- a/internal/integratedservices/services/logging/values.go
+++ b/internal/integratedservices/services/logging/values.go
@@ -15,7 +15,8 @@
 package logging
 
 type loggingOperatorValues struct {
-	Image imageValues `json:"image" mapstructure:"image"`
+	Image                imageValues `json:"image" mapstructure:"image"`
+	CreateCustomResource bool        `json:"createCustomResource" mapstructure:"createCustomResource"`
 }
 
 type imageValues struct {

--- a/internal/integratedservices/services/monitoring/common_test.go
+++ b/internal/integratedservices/services/monitoring/common_test.go
@@ -173,6 +173,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 

--- a/internal/integratedservices/services/vault/common_test.go
+++ b/internal/integratedservices/services/vault/common_test.go
@@ -138,6 +138,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Make the logging integrated service aware whether it's running on helm3 or helm2 and set the appropriate `createCustomResource` flag accordingly

