### PR TITLE
Fix uninstall order for backyards components

### DIFF
--- a/internal/istio/istiofeature/reconcile.go
+++ b/internal/istio/istiofeature/reconcile.go
@@ -45,14 +45,14 @@ func (m *MeshReconciler) Reconcile() error {
 		}
 	case DesiredStateAbsent:
 		reconcilers = []ReconcilerWithCluster{
-			m.ReconcileRemoteIstios,
-			m.ReconcileIstio,
-			m.ReconcileIstioOperator,
-			m.ReconcileCanaryOperator,
+			m.ReconcileNodeExporter,
 			func(desiredState DesiredState, c cluster.CommonCluster) error {
 				return m.ReconcileBackyards(desiredState, c, false)
 			},
-			m.ReconcileNodeExporter,
+			m.ReconcileCanaryOperator,
+			m.ReconcileRemoteIstios,
+			m.ReconcileIstio,
+			m.ReconcileIstioOperator,
 			m.ReconcileCanaryOperatorNamespace,
 			m.ReconcileBackyardsNamespace,
 			m.ReconcileIstioOperatorNamespace,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix backyards uninstall order


### Why?
Helm3 is sensitive on missing CRDs when trying to delete an object, therefore the removal of CRDs should be last