### PR TITLE
Fix helm3 uninstall for deleted crds using private fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,9 @@ require (
 )
 
 replace (
+        // helm 3.1.3 + fix uninstall for missing types
+	helm.sh/helm/v3 => github.com/pepov/helm/v3 v3.0.0-20200516203950-a5c4e1dd7628
+
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.0.0+incompatible
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
 	github.com/apache/thrift => github.com/apache/thrift v0.0.0-20151001171628-53dd39833a08

--- a/go.sum
+++ b/go.sum
@@ -992,6 +992,8 @@ github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/pepov/helm/v3 v3.0.0-20200516203950-a5c4e1dd7628 h1:ZTrqBuLAFETff7nOXQXkofYf68tkoDSoyJ1UbuLAWes=
+github.com/pepov/helm/v3 v3.0.0-20200516203950-a5c4e1dd7628/go.mod h1:WYsFJuMASa/4XUqLyv54s0U/f3mlAaRErGmyy4z921g=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Uses a custom helm3 fork to avoid failures when uninstall tries to remove CRs whose kind is already gone.


### Why?
Because those resources are technically gone and cannot be deleted anyways, but the release cannot be easily removed, and there's no force flag either.


### Additional context
We are waiting what the upstream developers has to say about the patch:
https://github.com/helm/helm/pull/8151