### PR TITLE
Fix Amazon PKE cluster update workflow

### DIFF
--- a/src/api/cluster_update.go
+++ b/src/api/cluster_update.go
@@ -42,8 +42,9 @@ func (a *ClusterAPI) UpdateCluster(c *gin.Context) {
 	}
 
 	var err error
-	if commonCluster.GetDistribution() == pkgCluster.PKE {
-		switch commonCluster.GetCloud() {
+	var cloud = commonCluster.GetCloud()
+	if cloud != pkgCluster.Amazon && commonCluster.GetDistribution() == pkgCluster.PKE {
+		switch cloud {
 		case pkgCluster.Azure:
 			var updateRequest *apicluster.UpdatePKEOnAzureClusterRequest
 			if err := c.BindJSON(&updateRequest); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix condition before JSON bind in case of cluster update


### Why?
The cluster update flow not started in case of `Amazon PKE`


### Additional context
Tested with
- Amazon PKE
- Amazon EKS
- vSphere PKE

### Checklist

- [x] Implementation tested (with at least one cloud provider)
