### PR TITLE
Fix monitoring integrated service for helm3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_PACKAGE = ${PACKAGE}/cmd/pipeline
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
-HELM_VERSION = $(shell cat go.mod | grep helm.sh/helm/v3 | cut -d" " -f2 | sed s/^v//)
+HELM_VERSION = $(shell cat go.mod | grep helm.sh/helm/v3 | grep -v "=>" | cut -d" " -f2 | sed s/^v//)
 LDFLAGS += -X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${BUILD_DATE} -X main.helmVersion=${HELM_VERSION}
 export CGO_ENABLED ?= 0
 ifeq ($(VERBOSE), 1)

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ debug: GOTAGS += dev
 debug: builddebug-pipeline
 	PIPELINE_CONFIG_DIR=$${PWD}/config VAULT_ADDR="http://127.0.0.1:8200" dlv --listen=:40000 --log --headless=true --api-version=2 exec build/debug/pipeline -- $(ARGS)
 
+.PHONY: debug-worker
+debug-worker: GOTAGS += dev
+debug-worker: builddebug-worker
+	PIPELINE_CONFIG_DIR=$${PWD}/config VAULT_ADDR="http://127.0.0.1:8200" dlv --listen=:40000 --log --headless=true --api-version=2 exec build/debug/worker -- $(ARGS)
+
 .PHONY: run-worker
 run-worker: GOTAGS += dev
 run-worker: build-worker ## Build and execute a binary

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -670,6 +670,7 @@ func main() {
 					config.Cluster.Monitoring.Config,
 					logger,
 					commonSecretStore,
+					integratedServiceMonitoring.Migrate,
 				),
 				integratedServiceLogging.MakeIntegratedServicesOperator(
 					clusterGetter,

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/gofrs/flock v0.7.1
 	github.com/gofrs/uuid v3.2.0+incompatible
-	github.com/golang/protobuf v1.3.4
+	github.com/golang/protobuf v1.3.5
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
 	github.com/gosimple/slug v1.9.0 // indirect
@@ -145,6 +145,9 @@ replace (
 	github.com/qor/auth => github.com/banzaicloud/auth v0.1.3
 
 	gopkg.in/yaml.v2 => github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182
+
+    // release-3.1
+	helm.sh/helm/v3 => github.com/pepov/helm/v3 v3.0.0-20200519142412-df65965032e2
 
 	// Kubernetes
 	k8s.io/api => k8s.io/api v0.17.5

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ replace (
 
 	gopkg.in/yaml.v2 => github.com/banzaicloud/go-yaml v0.0.0-20190116151056-02e17e901182
 
-    // release-3.1
+    // https://github.com/helm/helm/compare/release-3.1...pepov:release-3.1
 	helm.sh/helm/v3 => github.com/pepov/helm/v3 v3.0.0-20200519142412-df65965032e2
 
 	// Kubernetes

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manb
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -181,6 +182,8 @@ github.com/banzaicloud/helm v2.7.1-0.20200228123321-c4355aab74fc+incompatible h1
 github.com/banzaicloud/helm v2.7.1-0.20200228123321-c4355aab74fc+incompatible/go.mod h1:jr3AOoMmWJs0qi4BM4OrTCIOwNyQu7/K9hA6B1SxD1s=
 github.com/banzaicloud/istio-operator v0.0.0-20200330114955-d15bdd228ae4 h1:nz020decQ0q8AkYzrnc/NZTbcuzw9B8N+s7LW5DA+3E=
 github.com/banzaicloud/istio-operator v0.0.0-20200330114955-d15bdd228ae4/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
+github.com/banzaicloud/k8s-objectmatcher v1.3.2 h1:HhXkOWg4xmAW203p3G4Av9ylUfkUJF1+8MK90XQAaJw=
+github.com/banzaicloud/k8s-objectmatcher v1.3.2/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
 github.com/banzaicloud/logging-operator/pkg/sdk v0.1.1 h1:qXmP4D3hbW0GT+rMLDqAnAJY0NcqqDhE2UmQxPieRfQ=
 github.com/banzaicloud/logging-operator/pkg/sdk v0.1.1/go.mod h1:1pRU2dbp3jA+d6Ha6l/8+K+5g6Gfs8zZoC9xQgo9+VQ=
 github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f h1:WeGZeO6I+lI1IG2vm1iXTeMrHLcMUjfoYm+rubBM5c4=
@@ -214,10 +217,14 @@ github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
+github.com/bugsnag/bugsnag-go v1.4.0 h1:CLCt5wO6/P0GelBEMRrlF52XveQMnnXHoCoxGZ+8a5g=
+github.com/bugsnag/bugsnag-go v1.4.0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABFQA=
+github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
@@ -227,6 +234,7 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -384,6 +392,7 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -564,8 +573,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.3-0.20190920234318-1680a479a2cf/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
-github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
+github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -625,6 +634,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/goph/emperror v0.17.2 h1:yLapQcmEsO0ipe9p5TaN22djm3OFV/TfM/fcYP0/J18=
+github.com/goph/emperror v0.17.2/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH4LNHic=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -769,6 +780,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kisielk/errcheck v1.1.0 h1:ZqfnKyx9KGpRcW04j5nnPDgRgoXUeLh2YFBeFzphcA0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -992,6 +1005,10 @@ github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/pepov/helm/v3 v3.0.0-20200519134727-a7dd1b1ba6a5 h1:ozIfn2QlxHTmqVSidtSAaK0tir3X560/hTuUNjLWalQ=
+github.com/pepov/helm/v3 v3.0.0-20200519134727-a7dd1b1ba6a5/go.mod h1:wuSD1s2SAwS0qc4XHTkRfpKuoMZgtd6KbPDhIsZSrOg=
+github.com/pepov/helm/v3 v3.0.0-20200519142412-df65965032e2 h1:ml+rfMcwaH83F3euH3TyL7AJIM6Xi24Y3mWawODmtH8=
+github.com/pepov/helm/v3 v3.0.0-20200519142412-df65965032e2/go.mod h1:wuSD1s2SAwS0qc4XHTkRfpKuoMZgtd6KbPDhIsZSrOg=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1085,6 +1102,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.4.0 h1:LUa41nrWTQNGhzdsZ5lTnkwbNjj6rXTdazA1cSdjkOY=
 github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3 h1:xkBtI5JktwbW/vf4vopBbhYsRFTGfQWHYXzC0/qYwxI=
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
@@ -1623,8 +1641,6 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v0.3.5/go.mod h1:Mnf3e5FUzXbkCfynWBGOwLssY7gTQgCHObK9tMpAriY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
-helm.sh/helm/v3 v3.1.3 h1:5ZGCmJ/KkAxELcDFnBPOjmD3skpRkyqwo7aAxjfN0IU=
-helm.sh/helm/v3 v3.1.3/go.mod h1:WYsFJuMASa/4XUqLyv54s0U/f3mlAaRErGmyy4z921g=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -535,7 +535,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::monitoring::namespace", "")
 	v.SetDefault("cluster::monitoring::grafana::adminUser", "admin")
 	v.SetDefault("cluster::monitoring::charts::operator::chart", "stable/prometheus-operator")
-	v.SetDefault("cluster::monitoring::charts::operator::version", "8.5.14")
+	v.SetDefault("cluster::monitoring::charts::operator::version", "8.13.8")
 	v.SetDefault("cluster::monitoring::charts::operator::values", map[string]interface{}{
 		"prometheus": map[string]interface{}{
 			"ingress": map[string]interface{}{

--- a/internal/integratedservices/services/dns/common_test.go
+++ b/internal/integratedservices/services/dns/common_test.go
@@ -149,3 +149,7 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 		ReleaseName: releaseName,
 	}, nil
 }
+
+func (d dummyHelmService) IsV3() bool {
+	return false
+}

--- a/internal/integratedservices/services/helm.go
+++ b/internal/integratedservices/services/helm.go
@@ -39,4 +39,6 @@ type HelmService interface {
 
 	// GetDeployment gets a deployment by release name from a specific cluster.
 	GetDeployment(ctx context.Context, clusterID uint, releaseName, namespace string) (*pkgHelm.GetDeploymentResponse, error)
+
+	IsV3() bool
 }

--- a/internal/integratedservices/services/logging/common_test.go
+++ b/internal/integratedservices/services/logging/common_test.go
@@ -168,6 +168,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 

--- a/internal/integratedservices/services/monitoring/common_test.go
+++ b/internal/integratedservices/services/monitoring/common_test.go
@@ -173,6 +173,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 

--- a/internal/integratedservices/services/monitoring/migrator.go
+++ b/internal/integratedservices/services/monitoring/migrator.go
@@ -1,0 +1,77 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"fmt"
+
+	"emperror.dev/errors"
+	"github.com/Masterminds/semver/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+type K8sClientFactory func() (kubernetes.Interface, error)
+type Migrator func(configFactory K8sClientFactory, namespace, oldChartVersion, newChartVersion string) error
+
+func Migrate(clientFactory K8sClientFactory, namespace, oldChartVersion, newChartVersion string) error {
+	referenceVersion, err := semver.NewVersion("8.13.0")
+	if err != nil {
+		return errors.WrapIf(err, "invalid reference version")
+	}
+
+	oldSemVer, err := semver.NewVersion(oldChartVersion)
+	if err != nil {
+		return errors.WrapIf(err, "invalid old chart version")
+	}
+
+	newSemVer, err := semver.NewVersion(newChartVersion)
+	if err != nil {
+		return errors.WrapIf(err, "invalid new chart version")
+	}
+
+	if oldSemVer.LessThan(referenceVersion) && newSemVer.GreaterThan(referenceVersion) {
+		clientset, err := clientFactory()
+		if err != nil {
+			return errors.WrapIf(err, "unable to creates kubernetes config for migration")
+		}
+
+		ingresses, err := clientset.ExtensionsV1beta1().Ingresses(namespace).List(
+			v1.ListOptions{
+				LabelSelector: labels.SelectorFromSet(map[string]string{"release": prometheusOperatorReleaseName}).String(),
+			})
+		if err != nil {
+			return errors.WrapIf(err, "unable to remove legacy ingresses")
+		}
+		for _, i := range ingresses.Items {
+			err = clientset.ExtensionsV1beta1().Ingresses(namespace).Delete(i.Name, &v1.DeleteOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return errors.WrapIf(err, "unable to remove ingress")
+			}
+		}
+		err = clientset.AppsV1().Deployments(namespace).Delete(fmt.Sprintf("%s-grafana", prometheusOperatorReleaseName), &v1.DeleteOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return errors.WrapIf(err, "unable to remove grafana deployment")
+			}
+		}
+	}
+	return nil
+}

--- a/internal/integratedservices/services/monitoring/migrator_test.go
+++ b/internal/integratedservices/services/monitoring/migrator_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"testing"
+
+	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMigrateIngress(t *testing.T) {
+	releaseNamespace := "asd"
+	ingressNameToRemove := "aaa"
+	oldVersion := "8.5.14"
+	newVersion := "8.13.8"
+
+	allIngresses := []runtime.Object{
+		&v1beta1.Ingress{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      ingressNameToRemove,
+				Namespace: releaseNamespace,
+				Labels: map[string]string{
+					"release": prometheusOperatorReleaseName,
+				},
+			},
+		},
+		&v1beta1.Ingress{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "bbb",
+				Namespace: releaseNamespace,
+				Labels: map[string]string{
+					"does": "notmatch",
+				},
+			},
+		},
+	}
+
+	t.Run("migrate", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(allIngresses...)
+
+		clientsetFactory := func() (kubernetes.Interface, error) {
+			return clientset, nil
+		}
+
+		err := Migrate(clientsetFactory, releaseNamespace, oldVersion, newVersion)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		ingresses, err := clientset.ExtensionsV1beta1().Ingresses(releaseNamespace).List(v1.ListOptions{})
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if len(ingresses.Items) != len(allIngresses)-1 {
+			t.Fatalf("invalid number of ingresses left, expected %d, got %d: %+v", len(allIngresses)-1, len(ingresses.Items), ingresses.Items)
+		}
+
+		for _, i := range ingresses.Items {
+			if i.Name == ingressNameToRemove && i.Namespace == releaseNamespace {
+				t.Fatal("failed to remove the single ingress expected")
+			}
+		}
+	})
+
+	t.Run("nomigrate", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(allIngresses...)
+
+		clientsetFactory := func() (kubernetes.Interface, error) {
+			return clientset, nil
+		}
+
+		err := Migrate(clientsetFactory, releaseNamespace, oldVersion, oldVersion)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		ingresses, err := clientset.ExtensionsV1beta1().Ingresses(releaseNamespace).List(v1.ListOptions{})
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if len(ingresses.Items) != len(allIngresses) {
+			t.Fatalf("expected that nobody get harmed")
+		}
+	})
+}

--- a/internal/integratedservices/services/monitoring/operator.go
+++ b/internal/integratedservices/services/monitoring/operator.go
@@ -23,6 +23,9 @@ import (
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/mapstructure"
 	"k8s.io/api/storage/v1beta1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/banzaicloud/pipeline/pkg/k8sclient"
 
 	"github.com/banzaicloud/pipeline/internal/common"
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
@@ -45,6 +48,7 @@ type IntegratedServiceOperator struct {
 	config            Config
 	logger            common.Logger
 	secretStore       services.SecretStore
+	migrator          Migrator
 }
 
 type chartValuesManager struct {
@@ -61,6 +65,7 @@ func MakeIntegratedServiceOperator(
 	config Config,
 	logger common.Logger,
 	secretStore services.SecretStore,
+	migrator Migrator,
 ) IntegratedServiceOperator {
 	return IntegratedServiceOperator{
 		clusterGetter:     clusterGetter,
@@ -70,6 +75,7 @@ func MakeIntegratedServiceOperator(
 		config:            config,
 		logger:            logger,
 		secretStore:       secretStore,
+		migrator:          migrator,
 	}
 }
 
@@ -286,10 +292,17 @@ func (op IntegratedServiceOperator) installPrometheusOperator(
 				Tag:        op.config.Images.Operator.Tag,
 			},
 			CleanupCustomResource: true,
+			CreateCustomResource:  true,
 		},
 		Grafana:      valuesManager.generateGrafanaChartValues(spec.Grafana, grafanaUser, grafanaPass, op.config.Images.Grafana),
 		Alertmanager: alertmanagerValues,
 		Prometheus:   valuesManager.generatePrometheusChartValues(ctx, spec.Prometheus, prometheusSecretName, op.config.Images.Prometheus),
+	}
+
+	if op.helmService.IsV3() {
+		// todo consider disabling cleanup in favor of installing crds from the chart's crds folder, but will need to take care of upgrades in that case
+		//chartValues.PrometheusOperator.CleanupCustomResource = false
+		chartValues.PrometheusOperator.CreateCustomResource = false
 	}
 
 	if spec.Exporters.Enabled {
@@ -317,6 +330,30 @@ func (op IntegratedServiceOperator) installPrometheusOperator(
 	valuesBytes, err := mergeOperatorValuesWithConfig(*chartValues, operatorConfigValues)
 	if err != nil {
 		return errors.WrapIf(err, "failed to merge operator values with config")
+	}
+
+	if op.migrator != nil {
+		release, err := op.helmService.GetDeployment(ctx, cluster.GetID(), prometheusOperatorReleaseName, op.config.Namespace)
+		if err != nil {
+			return err
+		}
+
+		k8sClientFactory := func() (kubernetes.Interface, error) {
+			kubeConfig, err := cluster.GetK8sConfig()
+			if err != nil {
+				return nil, err
+			}
+			client, err := k8sclient.NewClientFromKubeConfig(kubeConfig)
+			if err != nil {
+				return nil, err
+			}
+			return client, nil
+		}
+
+		err = op.migrator(k8sClientFactory, op.config.Namespace, release.ChartVersion, op.config.Charts.Operator.Version)
+		if err != nil {
+			return err
+		}
 	}
 
 	return op.helmService.ApplyDeployment(

--- a/internal/integratedservices/services/monitoring/operator_test.go
+++ b/internal/integratedservices/services/monitoring/operator_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestIntegratedServiceOperator_Name(t *testing.T) {
-	op := MakeIntegratedServiceOperator(nil, nil, nil, nil, Config{}, nil, nil)
+	op := MakeIntegratedServiceOperator(nil, nil, nil, nil, Config{}, nil, nil, nil)
 
 	assert.Equal(t, "monitoring", op.Name())
 }
@@ -81,7 +81,7 @@ func TestIntegratedServiceOperator_Apply(t *testing.T) {
 				Values: map[string]interface{}{},
 			},
 		},
-	}, logger, secretStore)
+	}, logger, secretStore, nil)
 
 	cases := map[string]struct {
 		Spec    integratedservices.IntegratedServiceSpec
@@ -166,7 +166,7 @@ func TestIntegratedServiceOperator_Deactivate(t *testing.T) {
 	secretStore := commonadapter.NewSecretStore(orgSecretStore, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))
 	logger := services.NoopLogger{}
 	kubernetesService := dummyKubernetesService{}
-	op := MakeIntegratedServiceOperator(clusterGetter, clusterService, helmService, &kubernetesService, Config{}, logger, secretStore)
+	op := MakeIntegratedServiceOperator(clusterGetter, clusterService, helmService, &kubernetesService, Config{}, logger, secretStore, nil)
 
 	ctx := context.Background()
 

--- a/internal/integratedservices/services/monitoring/values.go
+++ b/internal/integratedservices/services/monitoring/values.go
@@ -28,6 +28,7 @@ type prometheusOperatorValues struct {
 type operatorSpecValues struct {
 	Image                 imageValues `json:"image"`
 	CleanupCustomResource bool        `json:"cleanupCustomResource"`
+	CreateCustomResource  bool        `json:"createCustomResource"`
 }
 
 type imageValues struct {

--- a/internal/integratedservices/services/vault/common_test.go
+++ b/internal/integratedservices/services/vault/common_test.go
@@ -138,6 +138,10 @@ func (d dummyHelmService) GetDeployment(ctx context.Context, clusterID uint, rel
 	}, nil
 }
 
+func (d dummyHelmService) IsV3() bool {
+	return false
+}
+
 type dummyKubernetesService struct {
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fixes a typical CRD handling issue to support the helm v3 path, and upgrade the prometheus operator chart to avoid an upgrade issue that has been fixed in the grafana chart: https://github.com/helm/charts/commit/a63e6819b8acc4617cd480acd0d5094e482de2b5

Also add a migration step to avoid helm upgrade failures due to changed label selectors and api groups.

### Upgrade instructions
The integrated service should be upgraded as usual with the "save all changes" or cli `cluster service monitoring update` commands.