### PR TITLE
Release api related amendments

### DIFF
--- a/internal/helm/api_service.go
+++ b/internal/helm/api_service.go
@@ -1,0 +1,31 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"context"
+)
+
+// HelmAPI interface intended to gather all the helm operations exposed as rest services
+type RestAPI interface {
+	// Gets releases and decorates the re
+	GetReleases(ctx context.Context, organizationID uint, clusterID uint, filters ReleaseFilter, options Options) (releaseList []DetailedRelease, err error)
+}
+
+// DetailedRelease wraps a release and adds additional information to it
+type DetailedRelease struct {
+	Release
+	Supported bool `json:"supported"`
+}

--- a/internal/helm/helmadapter/helm2_env_service.go
+++ b/internal/helm/helmadapter/helm2_env_service.go
@@ -172,7 +172,6 @@ func (h helmEnvService) UpdateRepository(_ context.Context, helmEnv helm.HelmEnv
 }
 
 func (h helmEnvService) CheckReleaseCharts(ctx context.Context, helmEnv helm.HelmEnv, releases []helm.Release) (map[string]bool, error) {
-
 	// noop in case of helm 2
 	return nil, nil
 }

--- a/internal/helm/helmadapter/helm2_env_service.go
+++ b/internal/helm/helmadapter/helm2_env_service.go
@@ -171,6 +171,12 @@ func (h helmEnvService) UpdateRepository(_ context.Context, helmEnv helm.HelmEnv
 	return nil
 }
 
+func (h helmEnvService) CheckReleaseCharts(ctx context.Context, helmEnv helm.HelmEnv, releases []helm.Release) (map[string]bool, error) {
+
+	// noop in case of helm 2
+	return nil, nil
+}
+
 func (h helmEnvService) repositoryToEntry(ctx context.Context, repository helm.Repository) (repo.Entry, error) {
 	entry := repo.Entry{
 		Name: repository.Name,

--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -17,6 +17,7 @@ package helmadapter
 import (
 	"context"
 	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -275,7 +276,7 @@ func (r releaser) Get(_ context.Context, helmEnv helm.HelmEnv, kubeConfig helm.K
 			Deleted:       rawRelease.Info.Deleted.Time,
 			Description:   rawRelease.Info.Description,
 			Status:        rawRelease.Info.Status.String(),
-			Notes:         rawRelease.Info.Notes,
+			Notes:         base64.StdEncoding.EncodeToString([]byte(rawRelease.Info.Notes)),
 			Values:        rawRelease.Config,
 		},
 	}, nil

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -92,7 +92,7 @@ func RegisterReleaserHTTPHandlers(endpoints Endpoints, router *mux.Router, optio
 	router.Methods(http.MethodPost).Path("").Handler(kithttp.NewServer(
 		endpoints.InstallRelease,
 		decodeInstallReleaseHTTPRequest,
-		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusCreated), errorEncoder),
+		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusAccepted), errorEncoder),
 		options...,
 	))
 

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -524,17 +524,21 @@ func encodeListReleasesHTTPResponse(ctx context.Context, w http.ResponseWriter, 
 		return errors.WrapIf(releases.Err, "failed to retrieve releases")
 	}
 
-	resp := make([]deployment.ListDeploymentResponse, 0, len(releases.R0))
+	resp := make([]helm2.ListDeploymentResponse, 0, len(releases.R0))
 	for _, release := range releases.R0 {
-		resp = append(resp, deployment.ListDeploymentResponse{
+		resp = append(resp, helm2.ListDeploymentResponse{
 			Name:         release.ReleaseName,
 			Chart:        release.ChartName,
 			ChartName:    release.ChartName,
 			ChartVersion: release.Version,
 			Version:      release.ReleaseVersion,
 			UpdatedAt:    release.ReleaseInfo.LastDeployed,
+			Status:       release.ReleaseInfo.Status,
 			Namespace:    release.Namespace,
 			CreatedAt:    release.ReleaseInfo.FirstDeployed,
+			Supported:    true,
+			//WhiteListed:  false,
+			//Rejected:     false,
 		})
 	}
 

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -27,7 +27,6 @@ import (
 	kitxhttp "github.com/sagikazarmark/kitx/transport/http"
 
 	"github.com/banzaicloud/pipeline/.gen/pipeline/pipeline"
-	"github.com/banzaicloud/pipeline/internal/clustergroup/deployment"
 	"github.com/banzaicloud/pipeline/internal/helm"
 	apphttp "github.com/banzaicloud/pipeline/internal/platform/appkit/transport/http"
 	helm2 "github.com/banzaicloud/pipeline/pkg/helm"
@@ -470,12 +469,12 @@ func encodeGetReleaseHTTPResponse(ctx context.Context, w http.ResponseWriter, re
 		ChartName:    release.R0.ChartName,
 		ChartVersion: release.R0.Version,
 		Namespace:    release.R0.Namespace,
-		Version:      0, // TODO populate it
+		Version:      release.R0.ReleaseVersion,
 		UpdatedAt:    release.R0.ReleaseInfo.LastDeployed.String(),
 		Status:       release.R0.ReleaseInfo.Status,
 		CreatedAt:    release.R0.ReleaseInfo.FirstDeployed.String(),
 		Notes:        release.R0.ReleaseInfo.Notes,
-		Values:       nil, // TODO populate this
+		Values:       release.R0.Values,
 	}
 
 	return kitxhttp.JSONResponseEncoder(ctx, w, resp)

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -93,7 +93,7 @@ func RegisterReleaserHTTPHandlers(endpoints Endpoints, router *mux.Router, optio
 	router.Methods(http.MethodPost).Path("").Handler(kithttp.NewServer(
 		endpoints.InstallRelease,
 		decodeInstallReleaseHTTPRequest,
-		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusAccepted), errorEncoder),
+		kitxhttp.ErrorResponseEncoder(kitxhttp.StatusCodeResponseEncoder(http.StatusCreated), errorEncoder),
 		options...,
 	))
 

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -607,7 +607,12 @@ func (s service) GetReleases(ctx context.Context, organizationID uint, clusterID
 	}
 
 	ret := make([]DetailedRelease, 0, len(releases))
-	supportedChartMap, err := s.envService.CheckReleaseCharts(ctx, HelmEnv{}, releases)
+	helmEnv, err := s.envResolver.ResolveHelmEnv(ctx, organizationID)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to resolve helm env releases")
+	}
+
+	supportedChartMap, err := s.envService.CheckReleaseCharts(ctx, helmEnv, releases)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to retrieve charts")
 	}

--- a/internal/helm/zz_generated.mock_test.go
+++ b/internal/helm/zz_generated.mock_test.go
@@ -217,6 +217,29 @@ func (_m *MockService) GetReleaseResources(ctx context.Context, organizationID u
 	return r0, r1
 }
 
+// GetReleases provides a mock function.
+func (_m *MockService) GetReleases(ctx context.Context, organizationID uint, clusterID uint, filters ReleaseFilter, options Options) (releaseList []DetailedRelease, err error) {
+	ret := _m.Called(ctx, organizationID, clusterID, filters, options)
+
+	var r0 []DetailedRelease
+	if rf, ok := ret.Get(0).(func(context.Context, uint, uint, ReleaseFilter, Options) []DetailedRelease); ok {
+		r0 = rf(ctx, organizationID, clusterID, filters, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]DetailedRelease)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uint, uint, ReleaseFilter, Options) error); ok {
+		r1 = rf(ctx, organizationID, clusterID, filters, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // InstallRelease provides a mock function.
 func (_m *MockService) InstallRelease(ctx context.Context, organizationID uint, clusterID uint, release Release, options Options) error {
 	ret := _m.Called(ctx, organizationID, clusterID, release, options)
@@ -359,6 +382,29 @@ func (_m *MockEnvService) AddRepository(ctx context.Context, helmEnv HelmEnv, re
 	}
 
 	return r0
+}
+
+// CheckReleaseCharts provides a mock function.
+func (_m *MockEnvService) CheckReleaseCharts(ctx context.Context, helmEnv HelmEnv, releases []Release) (map[string]bool, error) {
+	ret := _m.Called(ctx, helmEnv, releases)
+
+	var r0 map[string]bool
+	if rf, ok := ret.Get(0).(func(context.Context, HelmEnv, []Release) map[string]bool); ok {
+		r0 = rf(ctx, helmEnv, releases)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]bool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, HelmEnv, []Release) error); ok {
+		r1 = rf(ctx, helmEnv, releases)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // DeleteRepository provides a mock function.

--- a/internal/integratedservices/services/zz_generated.mock.go
+++ b/internal/integratedservices/services/zz_generated.mock.go
@@ -65,3 +65,17 @@ func (_m *MockHelmService) GetDeployment(ctx context.Context, clusterID uint, re
 
 	return r0, r1
 }
+
+// IsV3 provides a mock function.
+func (_m *MockHelmService) IsV3() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     |no
| License         | Apache 2.0


### What's in this PR?
The PR has a series of amendments to the release api:
* releases in the response are decorated with the supported flag
* added new abstraction layer for high level service logic required by the rest API (to be refined / refactored later)
* other fixes related to the releases API (base64 encode fields, add missing information to the response)

### Why?
H3 implementation in pipeline tries to remain backwards compatible with previous versions. Testing is underway, risen issues are being continuously fixed
