### PR TITLE
Fix logging integrated service helm3 upgrade issue

### DIFF
--- a/cmd/pipeline/capabilities.go
+++ b/cmd/pipeline/capabilities.go
@@ -20,7 +20,7 @@ import (
 
 // mapCapabilities maps configuration to capabilities.
 func mapCapabilities(config configuration) cap.Capabilities {
-	return cap.Capabilities{
+	caps := cap.Capabilities{
 		"features": cap.Cap{
 			"vault": cap.Cap{
 				"enabled": config.Cluster.Vault.Enabled,
@@ -48,8 +48,13 @@ func mapCapabilities(config configuration) cap.Capabilities {
 				"controllers": config.Cluster.Ingress.Controllers,
 			},
 		},
-		"helm": cap.Cap{
-			"version": "3.1.3", // TODO: determine based on go.mod build time
-		},
 	}
+
+	if config.Helm.V3 {
+		caps["helm"] = cap.Cap{
+			"version": "3.1.3", // TODO: determine based on go.mod build time
+		}
+	}
+
+	return caps
 }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Do not return helm capabilities if v3 is not enabled for backwards compatibility.


### Why?
Latest banzai-cli uses the capabilities API to setup helm shims and it mistakenly sets up helm3 as the default even if it's not enabled on the pipeline instance yet.


