### PR TITLE
add processlog and MaximumAttempts to CalculateNodePoolVersionActivity

### DIFF
--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -98,16 +98,19 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 		activityOptions.RetryPolicy = &cadence.RetryPolicy{
 			InitialInterval:    10 * time.Second,
 			BackoffCoefficient: 1.01,
+			MaximumAttempts:    10,
 			MaximumInterval:    10 * time.Minute,
 		}
 
 		var output CalculateNodePoolVersionActivityOutput
 
+		processActivity := process.StartActivity(ctx, CalculateNodePoolVersionActivityName)
 		err = workflow.ExecuteActivity(
 			workflow.WithActivityOptions(ctx, activityOptions),
 			CalculateNodePoolVersionActivityName,
 			activityInput,
 		).Get(ctx, &output)
+		processActivity.Finish(ctx, err)
 		if err != nil {
 			return
 		}

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -104,13 +104,11 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 
 		var output CalculateNodePoolVersionActivityOutput
 
-		processActivity := process.StartActivity(ctx, CalculateNodePoolVersionActivityName)
 		err = workflow.ExecuteActivity(
 			workflow.WithActivityOptions(ctx, activityOptions),
 			CalculateNodePoolVersionActivityName,
 			activityInput,
 		).Get(ctx, &output)
-		processActivity.Finish(ctx, err)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adding MaximumAttempts to the activity retryPolicy otherwise it fails with for the open-source version:
```
Id  Name           Distribution  Location   CreatorName  CreatedAt                  Status   StatusMessage                                                                                                                                 
1   nandi-options  eks           eu-west-1  bonifaido    2020-05-22T16:03:58+02:00  WARNING  failed to update node pool: both MaximumAttempts and ExpirationIntervalInSeconds on retry policy are not set, at least one of them must be set
```

Also adding processlog for this activity as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
