### PR TITLE
Use preinstalled PKE binary

### DIFF
--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -612,9 +612,12 @@ const masterUserDataScriptTemplate = `#!/bin/sh
 export HTTP_PROXY="{{ .HttpProxy }}"
 export HTTPS_PROXY="{{ .HttpsProxy }}"
 export NO_PROXY="{{ .NoProxy }}"
-until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
-chmod +x /usr/local/bin/pke
-export PATH=$PATH:/usr/local/bin/
+
+if ! command -v pke > /dev/null 2>&1; then
+	until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
+	chmod +x /usr/local/bin/pke
+	export PATH=$PATH:/usr/local/bin/
+fi
 
 PRIVATE_IP=$(hostname -I | cut -d" " -f 1)
 

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -613,10 +613,10 @@ export HTTP_PROXY="{{ .HttpProxy }}"
 export HTTPS_PROXY="{{ .HttpsProxy }}"
 export NO_PROXY="{{ .NoProxy }}"
 
+export PATH=$PATH:/usr/local/bin/
 if ! command -v pke > /dev/null 2>&1; then
 	until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
 	chmod +x /usr/local/bin/pke
-	export PATH=$PATH:/usr/local/bin/
 fi
 
 PRIVATE_IP=$(hostname -I | cut -d" " -f 1)

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -402,9 +402,11 @@ export NO_PROXY="{{ .NoProxy }}"
 PRIVATE_IP=$(hostname -I | cut -d" " -f 1)
 PUBLIC_ADDRESS="{{ if .PublicAddress }}{{ .PublicAddress }}{{ else }}$PRIVATE_IP{{ end }}"
 
-until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
-chmod +x /usr/local/bin/pke
-export PATH=$PATH:/usr/local/bin/
+if ! command -v pke > /dev/null 2>&1; then
+	until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
+	chmod +x /usr/local/bin/pke
+	export PATH=$PATH:/usr/local/bin/
+fi
 
 pke install master --pipeline-url="{{ .PipelineURL }}" \
 --pipeline-insecure="{{ .PipelineURLInsecure }}" \

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -402,10 +402,10 @@ export NO_PROXY="{{ .NoProxy }}"
 PRIVATE_IP=$(hostname -I | cut -d" " -f 1)
 PUBLIC_ADDRESS="{{ if .PublicAddress }}{{ .PublicAddress }}{{ else }}$PRIVATE_IP{{ end }}"
 
+export PATH=$PATH:/usr/local/bin/
 if ! command -v pke > /dev/null 2>&1; then
 	until curl -v https://banzaicloud.com/downloads/pke/pke-{{ .PKEVersion }} -o /usr/local/bin/pke; do sleep 10; done
 	chmod +x /usr/local/bin/pke
-	export PATH=$PATH:/usr/local/bin/
 fi
 
 pke install master --pipeline-url="{{ .PipelineURL }}" \

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -64,9 +64,11 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
-            curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
-            chmod +x /usr/local/bin/pke
-            export PATH=$PATH:/usr/local/bin/
+            if ! command -v pke > /dev/null 2>&1; then
+                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                chmod +x /usr/local/bin/pke
+                export PATH=$PATH:/usr/local/bin/
+            fi
 
             ${PkeCommand}
           - {

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -64,10 +64,10 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
+            export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
                 curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
                 chmod +x /usr/local/bin/pke
-                export PATH=$PATH:/usr/local/bin/
             fi
 
             ${PkeCommand}

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -66,7 +66,7 @@ Resources:
 
             export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
-                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                until curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke; do sleep 10; done
                 chmod +x /usr/local/bin/pke
             fi
 

--- a/templates/pke/masters.cf.yaml
+++ b/templates/pke/masters.cf.yaml
@@ -115,7 +115,7 @@ Resources:
 
             export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
-                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                until curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke; do sleep 10; done
                 chmod +x /usr/local/bin/pke
             fi
 

--- a/templates/pke/masters.cf.yaml
+++ b/templates/pke/masters.cf.yaml
@@ -113,9 +113,11 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
-            curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
-            chmod +x /usr/local/bin/pke
-            export PATH=$PATH:/usr/local/bin/
+            if ! command -v pke > /dev/null 2>&1; then
+                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                chmod +x /usr/local/bin/pke
+                export PATH=$PATH:/usr/local/bin/
+            fi
 
             ${PkeCommand}
 

--- a/templates/pke/masters.cf.yaml
+++ b/templates/pke/masters.cf.yaml
@@ -113,10 +113,10 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
+            export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
                 curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
                 chmod +x /usr/local/bin/pke
-                export PATH=$PATH:/usr/local/bin/
             fi
 
             ${PkeCommand}

--- a/templates/pke/worker.cf.yaml
+++ b/templates/pke/worker.cf.yaml
@@ -93,7 +93,7 @@ Resources:
 
             export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
-                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                until curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke; do sleep 10; done
                 chmod +x /usr/local/bin/pke
             fi
 

--- a/templates/pke/worker.cf.yaml
+++ b/templates/pke/worker.cf.yaml
@@ -91,10 +91,10 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
+            export PATH=$PATH:/usr/local/bin/
             if ! command -v pke > /dev/null 2>&1; then
                 curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
                 chmod +x /usr/local/bin/pke
-                export PATH=$PATH:/usr/local/bin/
             fi
 
             ${PkeCommand}

--- a/templates/pke/worker.cf.yaml
+++ b/templates/pke/worker.cf.yaml
@@ -91,9 +91,11 @@ Resources:
 
             hostnamectl set-hostname $(curl http://169.254.169.254/latest/meta-data/hostname)
 
-            curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
-            chmod +x /usr/local/bin/pke
-            export PATH=$PATH:/usr/local/bin/
+            if ! command -v pke > /dev/null 2>&1; then
+                curl -v https://banzaicloud.com/downloads/pke/pke-${PkeVersion} -o /usr/local/bin/pke
+                chmod +x /usr/local/bin/pke
+                export PATH=$PATH:/usr/local/bin/
+            fi
 
             ${PkeCommand}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2938
| License         | Apache 2.0


### What's in this PR?
Use preinstalled PKE binary in the user data script.


### Additional context
It might make sense to also validate if the binary is executable. In this case the condition would look like:

```bash
if ! [ -x "$(command -v pke)" ]; then
    # ...
fi
```

