### PR TITLE
Clustergroup deployment fix

### DIFF
--- a/internal/clustergroup/deployment/helm.go
+++ b/internal/clustergroup/deployment/helm.go
@@ -30,7 +30,7 @@ type ChartMeta struct {
 }
 
 type HelmService interface {
-	GetChartMeta(name, version string) (ChartMeta, error)
+	GetChartMeta(orgId uint, name, version string) (ChartMeta, error)
 	InstallOrUpgrade(
 		c helm.ClusterDataProvider,
 		release helm.Release,
@@ -64,12 +64,12 @@ func (h *Helm3Service) InstallOrUpgrade(c helm.ClusterDataProvider, release helm
 	return h.releaser.InstallOrUpgrade(c, release, opts)
 }
 
-func (h *Helm3Service) GetChartMeta(name, version string) (ChartMeta, error) {
+func (h *Helm3Service) GetChartMeta(orgId uint, name, version string) (ChartMeta, error) {
 	repoAndChart := strings.Split(name, "/")
 	if len(repoAndChart) != 2 {
 		return ChartMeta{}, errors.Errorf("missing repo ref from chart name %s", name)
 	}
-	chart, err := h.facade.GetChart(context.TODO(), 0, helm.ChartFilter{
+	chart, err := h.facade.GetChart(context.TODO(), orgId, helm.ChartFilter{
 		Repo:    []string{repoAndChart[0]},
 		Name:    []string{repoAndChart[1]},
 		Version: []string{version},

--- a/internal/clustergroup/deployment/integration_test.go
+++ b/internal/clustergroup/deployment/integration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/banzaicloud/pipeline/internal/common"
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/internal/helm"
-	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	helmtesting "github.com/banzaicloud/pipeline/internal/helm/testing"
 )
 
@@ -69,6 +68,9 @@ func testGetChartDesc(home string, v3 bool) func(*testing.T) {
 		secretStore := helmtesting.SetupSecretStore()
 		_, clusterService := helmtesting.ClusterKubeConfig(t, clusterId)
 
+		fakeOrgId := uint(123)
+		fakeOrgName := "asd"
+
 		global.Config.Helm.Home = home
 		config := helm.Config{
 			Home: home,
@@ -79,11 +81,14 @@ func testGetChartDesc(home string, v3 bool) func(*testing.T) {
 		}
 
 		logger := common.NoopLogger{}
-		releaser, facade := cmd.CreateUnifiedHelmReleaser(config, db, secretStore, clusterService, helmadapter.NewOrgService(logger), logger)
+		releaser, facade := cmd.CreateUnifiedHelmReleaser(config, db, secretStore, clusterService, helmtesting.FakeOrg{
+			OrgId:   fakeOrgId,
+			OrgName: fakeOrgName,
+		}, logger)
 
 		helmService := deployment.NewHelmService(facade, releaser)
 
-		chartMeta, err := helmService.GetChartMeta("stable/mysql", "1.6.3")
+		chartMeta, err := helmService.GetChartMeta(fakeOrgId, "stable/mysql", "1.6.3")
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/internal/clustergroup/deployment/manager.go
+++ b/internal/clustergroup/deployment/manager.go
@@ -548,7 +548,7 @@ func (m CGDeploymentManager) DeleteDeployment(clusterGroup *api.ClusterGroup, re
 }
 
 // SyncDeployment deletes deployments from target clusters not belonging to the group anymore, installs or upgrades to member clusters
-func (m CGDeploymentManager) SyncDeployment(clusterGroup *api.ClusterGroup, orgName string, releaseName string) ([]TargetClusterStatus, error) {
+func (m CGDeploymentManager) SyncDeployment(clusterGroup *api.ClusterGroup, orgId uint, releaseName string) ([]TargetClusterStatus, error) {
 	deploymentModel, err := m.repository.FindByName(clusterGroup.Id, releaseName)
 	if err != nil {
 		return nil, err
@@ -562,7 +562,7 @@ func (m CGDeploymentManager) SyncDeployment(clusterGroup *api.ClusterGroup, orgN
 	// get deployment status for each cluster group member
 	response := make([]TargetClusterStatus, 0)
 
-	requestedChart, err := m.helmService.GetChartMeta(depInfo.Chart, depInfo.ChartVersion)
+	requestedChart, err := m.helmService.GetChartMeta(orgId, depInfo.Chart, depInfo.ChartVersion)
 	if err != nil {
 		return nil, errors.WrapIf(err, "error getting chart description")
 	}
@@ -672,7 +672,7 @@ func (m CGDeploymentManager) upgradeOrInstallDeploymentToTargetClusters(clusterG
 	return targetClusterStatus
 }
 
-func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, orgName string, cgDeployment *ClusterGroupDeployment) ([]TargetClusterStatus, error) {
+func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, orgId uint, orgName string, cgDeployment *ClusterGroupDeployment) ([]TargetClusterStatus, error) {
 	if len(cgDeployment.ReleaseName) == 0 {
 		return nil, errors.Errorf("release name is mandatory")
 	}
@@ -691,7 +691,7 @@ func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, or
 		}
 	}
 
-	requestedChart, err := m.helmService.GetChartMeta(cgDeployment.Name, cgDeployment.Version)
+	requestedChart, err := m.helmService.GetChartMeta(orgId, cgDeployment.Name, cgDeployment.Version)
 	if err != nil {
 		return nil, errors.WrapIf(err, "error getting chart description")
 	}
@@ -724,8 +724,8 @@ func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, or
 
 // UpdateDeployment upgrades deployment using provided values or using already provided values if ReUseValues = true.
 // The deployment is installed on a member cluster in case it's was not installed previously.
-func (m CGDeploymentManager) UpdateDeployment(clusterGroup *api.ClusterGroup, cgDeployment *ClusterGroupDeployment) ([]TargetClusterStatus, error) {
-	requestedChart, err := m.helmService.GetChartMeta(cgDeployment.Name, cgDeployment.Version)
+func (m CGDeploymentManager) UpdateDeployment(clusterGroup *api.ClusterGroup, orgId uint, cgDeployment *ClusterGroupDeployment) ([]TargetClusterStatus, error) {
+	requestedChart, err := m.helmService.GetChartMeta(orgId, cgDeployment.Name, cgDeployment.Version)
 	if err != nil {
 		return nil, errors.WrapIf(err, "error getting chart description")
 	}

--- a/src/api/clustergroup/deployment/create.go
+++ b/src/api/clustergroup/deployment/create.go
@@ -90,7 +90,7 @@ func (n *API) Create(c *gin.Context) {
 		return
 	}
 
-	targetClusterStatus, err := n.deploymentManager.CreateDeployment(clusterGroup, organization.Name, deployment)
+	targetClusterStatus, err := n.deploymentManager.CreateDeployment(clusterGroup, organization.ID, organization.Name, deployment)
 	if err != nil {
 		n.errorHandler.Handle(c, err)
 		return

--- a/src/api/clustergroup/deployment/sync.go
+++ b/src/api/clustergroup/deployment/sync.go
@@ -68,7 +68,7 @@ func (n *API) Sync(c *gin.Context) {
 		return
 	}
 
-	response, err := n.deploymentManager.SyncDeployment(clusterGroup, organization.Name, name)
+	response, err := n.deploymentManager.SyncDeployment(clusterGroup, organization.ID, name)
 	if err != nil {
 		n.errorHandler.Handle(c, err)
 		return

--- a/src/api/clustergroup/deployment/upgrade.go
+++ b/src/api/clustergroup/deployment/upgrade.go
@@ -71,7 +71,7 @@ func (n *API) Upgrade(c *gin.Context) {
 
 	deployment.ReleaseName = name
 
-	targetClusterStatus, err := n.deploymentManager.UpdateDeployment(clusterGroup, deployment)
+	targetClusterStatus, err := n.deploymentManager.UpdateDeployment(clusterGroup, orgID, deployment)
 	if err != nil {
 		n.errorHandler.Handle(c, err)
 		return


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Adds missing orgId from the chart description retreiver method of the clustergroup helm service. Without it the multicluster deployment feature will not be able to find a chart to deploy.

