### PR TITLE
EKS: update node pool CF template to latest EKS node group template

### DIFF
--- a/templates/eks/amazon-eks-iam-cf.yaml
+++ b/templates/eks/amazon-eks-iam-cf.yaml
@@ -36,6 +36,19 @@ Parameters:
     Description: The path of the provided role to set for the EKS nodes.
     Default: "/"
 
+Mappings:
+    PartitionMap:
+        aws:
+            EC2ServicePrincipal: "ec2.amazonaws.com"
+        aws-us-gov:
+            EC2ServicePrincipal: "ec2.amazonaws.com"
+        aws-cn:
+            EC2ServicePrincipal: "ec2.amazonaws.com.cn"
+        aws-iso:
+            EC2ServicePrincipal: "ec2.c2s.ic.gov"
+        aws-iso-b:
+            EC2ServicePrincipal: "ec2.sc2s.sgov.gov"
+
 Conditions:
   CreateUser: !Equals [ !Ref UserId, "" ]
   CreateClusterRole: !Equals [ !Ref ClusterRoleId, "" ]
@@ -77,14 +90,14 @@ Resources:
         - Effect: Allow
           Principal:
             Service:
-            - ec2.amazonaws.com
+                - !FindInMap [PartitionMap, !Ref "AWS::Partition", EC2ServicePrincipal]
           Action:
           - sts:AssumeRole
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
       Policies:
         -
           PolicyName: NodePolicy

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -2,173 +2,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Amazon EKS - Node Group'
 
-Parameters:
-
-  KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instances
-    Type: String
-
-  NodeImageId:
-    Type: AWS::EC2::Image::Id
-    Description: AMI id for the node instances.
-
-  NodeInstanceType:
-    Description: EC2 instance type for the node instances
-    Type: String
-    Default: t2.medium
-    AllowedValues:
-    - t2.small
-    - t2.medium
-    - t2.large
-    - t2.xlarge
-    - t2.2xlarge
-    - t3.nano
-    - t3.micro
-    - t3.small
-    - t3.medium
-    - t3.large
-    - t3.xlarge
-    - t3.2xlarge
-    - m3.medium
-    - m3.large
-    - m3.xlarge
-    - m3.2xlarge
-    - m4.large
-    - m4.xlarge
-    - m4.2xlarge
-    - m4.4xlarge
-    - m4.10xlarge
-    - m5.large
-    - m5.xlarge
-    - m5.2xlarge
-    - m5.4xlarge
-    - m5.12xlarge
-    - m5.24xlarge
-    - c4.large
-    - c4.xlarge
-    - c4.2xlarge
-    - c4.4xlarge
-    - c4.8xlarge
-    - c5.large
-    - c5.xlarge
-    - c5.2xlarge
-    - c5.4xlarge
-    - c5.9xlarge
-    - c5.18xlarge
-    - i3.large
-    - i3.xlarge
-    - i3.2xlarge
-    - i3.4xlarge
-    - i3.8xlarge
-    - i3.16xlarge
-    - r3.xlarge
-    - r3.2xlarge
-    - r3.4xlarge
-    - r3.8xlarge
-    - r4.large
-    - r4.xlarge
-    - r4.2xlarge
-    - r4.4xlarge
-    - r4.8xlarge
-    - r4.16xlarge
-    - x1.16xlarge
-    - x1.32xlarge
-    - p2.xlarge
-    - p2.8xlarge
-    - p2.16xlarge
-    - p3.2xlarge
-    - p3.8xlarge
-    - p3.16xlarge
-    - r5.large
-    - r5.xlarge
-    - r5.2xlarge
-    - r5.4xlarge
-    - r5.12xlarge
-    - r5.24xlarge
-    - r5d.large
-    - r5d.xlarge
-    - r5d.2xlarge
-    - r5d.4xlarge
-    - r5d.12xlarge
-    - r5d.24xlarge
-    - z1d.large
-    - z1d.xlarge
-    - z1d.2xlarge
-    - z1d.3xlarge
-    - z1d.6xlarge
-    - z1d.12xlarge
-    ConstraintDescription: must be a valid EC2 instance type
-
-  NodeAutoScalingGroupMinSize:
-    Type: Number
-    Description: Minimum size of Node Group ASG.
-    Default: 1
-
-  NodeAutoScalingGroupMaxSize:
-    Type: Number
-    Description: Maximum size of Node Group ASG.
-    Default: 3
-
-  NodeAutoScalingInitSize:
-    Type: Number
-    Description: The initial size of Node Group ASG.
-    Default: 1
-
-  NodeAutoScalingGroupMaxBatchSize:
-    Type: Number
-    Description: Minimum size of Node Group ASG.
-    Default: 2
-
-  NodeVolumeSize:
-    Type: Number
-    Description: Node volume size
-    Default: 20
-
-  NodeSpotPrice:
-    Type: String
-    Description: The spot price for this ASG
-
-  ClusterName:
-    Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
-    Type: String
-
-  BootstrapArguments:
-    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
-    Default: ""
-    Type: String
-
-  NodeGroupName:
-    Description: Unique identifier for the Node Group.
-    Type: String
-
-  ClusterControlPlaneSecurityGroup:
-    Description: The security group of the cluster control plane.
-    Type: AWS::EC2::SecurityGroup::Id
-
-  NodeSecurityGroup:
-    Description: Security group for all nodes in the cluster.
-    Type: AWS::EC2::SecurityGroup::Id
-
-  VpcId:
-    Description: The VPC of the worker instances
-    Type: AWS::EC2::VPC::Id
-
-  Subnets:
-    Description: The subnets where workers can be created.
-    Type: List<AWS::EC2::Subnet::Id>
-
-  NodeInstanceRoleId:
-    Description: The role for node IAM profile
-    Type: String
-
-  ClusterAutoscalerEnabled:
-    Description: Enable Cluster Autoscaler (true/false)
-    Type: String
-
-  TerminationDetachEnabled:
-    Description: Enable detachment from ASG at instance termination (true/false)
-    Type: String
-
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -187,10 +20,10 @@ Metadata:
           - NodeAutoScalingGroupMinSize
           - NodeAutoScalingGroupMaxSize
           - NodeAutoScalingInitSize
-          - NodeAutoScalingGroupMaxBatchSize
           - NodeVolumeSize
           - NodeSpotPrice
           - NodeInstanceType
+          - NodeImageIdSSMParam
           - NodeImageId
           - KeyName
           - BootstrapArguments
@@ -200,10 +33,369 @@ Metadata:
         Parameters:
           - VpcId
           - Subnets
+
+Parameters:
+
+  BootstrapArguments:
+    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
+    Default: ""
+    Type: String
+
+  ClusterControlPlaneSecurityGroup:
+      Description: The security group of the cluster control plane.
+      Type: AWS::EC2::SecurityGroup::Id
+
+  ClusterName:
+      Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
+      Type: String
+
+  KeyName:
+    Description: The EC2 Key Pair to allow SSH access to the instances
+    Type: String
+
+  NodeAutoScalingInitSize:
+      Type: Number
+      Description: The initial size of Node Group ASG.
+      Default: 1
+
+  NodeAutoScalingGroupMaxBatchSize:
+      Type: Number
+      Description: Minimum size of Node Group ASG.
+      Default: 2
+
+  NodeAutoScalingGroupMinSize:
+      Type: Number
+      Description: Minimum size of Node Group ASG.
+      Default: 1
+
+  NodeAutoScalingGroupMaxSize:
+      Type: Number
+      Description: Maximum size of Node Group ASG.
+      Default: 3
+
+  NodeGroupName:
+      Description: Unique identifier for the Node Group.
+      Type: String
+
+  NodeImageId:
+      Type: String
+      Default: ""
+      Description: (Optional) Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+
+  NodeImageIdSSMParam:
+      Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+      Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
+      Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
+
+  NodeInstanceType:
+    Description: EC2 instance type for the node instances
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+        - a1.medium
+        - a1.large
+        - a1.xlarge
+        - a1.2xlarge
+        - a1.4xlarge
+        - c1.medium
+        - c1.xlarge
+        - c3.large
+        - c3.xlarge
+        - c3.2xlarge
+        - c3.4xlarge
+        - c3.8xlarge
+        - c4.large
+        - c4.xlarge
+        - c4.2xlarge
+        - c4.4xlarge
+        - c4.8xlarge
+        - c5.large
+        - c5.xlarge
+        - c5.2xlarge
+        - c5.4xlarge
+        - c5.9xlarge
+        - c5.12xlarge
+        - c5.18xlarge
+        - c5.24xlarge
+        - c5.metal
+        - c5d.large
+        - c5d.xlarge
+        - c5d.2xlarge
+        - c5d.4xlarge
+        - c5d.9xlarge
+        - c5d.12xlarge
+        - c5d.18xlarge
+        - c5d.24xlarge
+        - c5d.metal
+        - c5n.large
+        - c5n.xlarge
+        - c5n.2xlarge
+        - c5n.4xlarge
+        - c5n.9xlarge
+        - c5n.18xlarge
+        - cc2.8xlarge
+        - cr1.8xlarge
+        - d2.xlarge
+        - d2.2xlarge
+        - d2.4xlarge
+        - d2.8xlarge
+        - f1.2xlarge
+        - f1.4xlarge
+        - f1.16xlarge
+        - g2.2xlarge
+        - g2.8xlarge
+        - g3s.xlarge
+        - g3.4xlarge
+        - g3.8xlarge
+        - g3.16xlarge
+        - h1.2xlarge
+        - h1.4xlarge
+        - h1.8xlarge
+        - h1.16xlarge
+        - hs1.8xlarge
+        - i2.xlarge
+        - i2.2xlarge
+        - i2.4xlarge
+        - i2.8xlarge
+        - i3.large
+        - i3.xlarge
+        - i3.2xlarge
+        - i3.4xlarge
+        - i3.8xlarge
+        - i3.16xlarge
+        - i3.metal
+        - i3en.large
+        - i3en.xlarge
+        - i3en.2xlarge
+        - i3en.3xlarge
+        - i3en.6xlarge
+        - i3en.12xlarge
+        - i3en.24xlarge
+        - inf1.xlarge
+        - inf1.2xlarge
+        - inf1.6xlarge
+        - inf1.24xlarge
+        - m1.small
+        - m1.medium
+        - m1.large
+        - m1.xlarge
+        - m2.xlarge
+        - m2.2xlarge
+        - m2.4xlarge
+        - m3.medium
+        - m3.large
+        - m3.xlarge
+        - m3.2xlarge
+        - m4.large
+        - m4.xlarge
+        - m4.2xlarge
+        - m4.4xlarge
+        - m4.10xlarge
+        - m4.16xlarge
+        - m5.large
+        - m5.xlarge
+        - m5.2xlarge
+        - m5.4xlarge
+        - m5.8xlarge
+        - m5.12xlarge
+        - m5.16xlarge
+        - m5.24xlarge
+        - m5.metal
+        - m5a.large
+        - m5a.xlarge
+        - m5a.2xlarge
+        - m5a.4xlarge
+        - m5a.8xlarge
+        - m5a.12xlarge
+        - m5a.16xlarge
+        - m5a.24xlarge
+        - m5ad.large
+        - m5ad.xlarge
+        - m5ad.2xlarge
+        - m5ad.4xlarge
+        - m5ad.12xlarge
+        - m5ad.24xlarge
+        - m5d.large
+        - m5d.xlarge
+        - m5d.2xlarge
+        - m5d.4xlarge
+        - m5d.8xlarge
+        - m5d.12xlarge
+        - m5d.16xlarge
+        - m5d.24xlarge
+        - m5d.metal
+        - m5dn.large
+        - m5dn.xlarge
+        - m5dn.2xlarge
+        - m5dn.4xlarge
+        - m5dn.8xlarge
+        - m5dn.12xlarge
+        - m5dn.16xlarge
+        - m5dn.24xlarge
+        - m5n.large
+        - m5n.xlarge
+        - m5n.2xlarge
+        - m5n.4xlarge
+        - m5n.8xlarge
+        - m5n.12xlarge
+        - m5n.16xlarge
+        - m5n.24xlarge
+        - p2.xlarge
+        - p2.8xlarge
+        - p2.16xlarge
+        - p3.2xlarge
+        - p3.8xlarge
+        - p3.16xlarge
+        - p3dn.24xlarge
+        - g4dn.xlarge
+        - g4dn.2xlarge
+        - g4dn.4xlarge
+        - g4dn.8xlarge
+        - g4dn.12xlarge
+        - g4dn.16xlarge
+        - g4dn.metal
+        - r3.large
+        - r3.xlarge
+        - r3.2xlarge
+        - r3.4xlarge
+        - r3.8xlarge
+        - r4.large
+        - r4.xlarge
+        - r4.2xlarge
+        - r4.4xlarge
+        - r4.8xlarge
+        - r4.16xlarge
+        - r5.large
+        - r5.xlarge
+        - r5.2xlarge
+        - r5.4xlarge
+        - r5.8xlarge
+        - r5.12xlarge
+        - r5.16xlarge
+        - r5.24xlarge
+        - r5.metal
+        - r5a.large
+        - r5a.xlarge
+        - r5a.2xlarge
+        - r5a.4xlarge
+        - r5a.8xlarge
+        - r5a.12xlarge
+        - r5a.16xlarge
+        - r5a.24xlarge
+        - r5ad.large
+        - r5ad.xlarge
+        - r5ad.2xlarge
+        - r5ad.4xlarge
+        - r5ad.12xlarge
+        - r5ad.24xlarge
+        - r5d.large
+        - r5d.xlarge
+        - r5d.2xlarge
+        - r5d.4xlarge
+        - r5d.8xlarge
+        - r5d.12xlarge
+        - r5d.16xlarge
+        - r5d.24xlarge
+        - r5d.metal
+        - r5dn.large
+        - r5dn.xlarge
+        - r5dn.2xlarge
+        - r5dn.4xlarge
+        - r5dn.8xlarge
+        - r5dn.12xlarge
+        - r5dn.16xlarge
+        - r5dn.24xlarge
+        - r5n.large
+        - r5n.xlarge
+        - r5n.2xlarge
+        - r5n.4xlarge
+        - r5n.8xlarge
+        - r5n.12xlarge
+        - r5n.16xlarge
+        - r5n.24xlarge
+        - t1.micro
+        - t2.nano
+        - t2.micro
+        - t2.small
+        - t2.medium
+        - t2.large
+        - t2.xlarge
+        - t2.2xlarge
+        - t3.nano
+        - t3.micro
+        - t3.small
+        - t3.medium
+        - t3.large
+        - t3.xlarge
+        - t3.2xlarge
+        - t3a.nano
+        - t3a.micro
+        - t3a.small
+        - t3a.medium
+        - t3a.large
+        - t3a.xlarge
+        - t3a.2xlarge
+        - u-6tb1.metal
+        - u-9tb1.metal
+        - u-12tb1.metal
+        - x1.16xlarge
+        - x1.32xlarge
+        - x1e.xlarge
+        - x1e.2xlarge
+        - x1e.4xlarge
+        - x1e.8xlarge
+        - x1e.16xlarge
+        - x1e.32xlarge
+        - z1d.large
+        - z1d.xlarge
+        - z1d.2xlarge
+        - z1d.3xlarge
+        - z1d.6xlarge
+        - z1d.12xlarge
+        - z1d.metal
+    ConstraintDescription: must be a valid EC2 instance type
+
+  NodeVolumeSize:
+    Type: Number
+    Description: Node volume size
+    Default: 20
+
+  Subnets:
+    Description: The subnets where workers can be created.
+    Type: List<AWS::EC2::Subnet::Id>
+
+  VpcId:
+      Description: The VPC of the worker instances
+      Type: AWS::EC2::VPC::Id
+
+  ClusterAutoscalerEnabled:
+      Description: Enable Cluster Autoscaler (true/false)
+      Type: String
+
+  NodeInstanceRoleId:
+      Description: The role for node IAM profile
+      Type: String
+
+  NodeSecurityGroup:
+      Description: Security group for all nodes in the cluster.
+      Type: AWS::EC2::SecurityGroup::Id
+
+  NodeSpotPrice:
+      Type: String
+      Description: The spot price for this ASG
+
+  TerminationDetachEnabled:
+      Description: Enable detachment from ASG at instance termination (true/false)
+      Type: String
+
 Conditions:
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
+  HasNodeImageId: !Not
+      - "Fn::Equals":
+            - Ref: NodeImageId
+            - ""
 
 Resources:
   NodeInstanceProfile:
@@ -263,59 +455,71 @@ Resources:
       ToPort: 22
       FromPort: 22
 
+  NodeLaunchTemplate:
+      Type: "AWS::EC2::LaunchTemplate"
+      Properties:
+          LaunchTemplateData:
+              BlockDeviceMappings:
+                  - DeviceName: /dev/xvda
+                    Ebs:
+                        DeleteOnTermination: true
+                        VolumeSize: !Ref NodeVolumeSize
+                        VolumeType: gp2
+              IamInstanceProfile:
+                  Arn: !GetAtt NodeInstanceProfile.Arn
+              InstanceMarketOptions:
+                  MarketType: spot
+                  SpotOptions:
+                      MaxPrice: !If [ IsSpotInstance, !Ref NodeSpotPrice, !Ref "AWS::NoValue" ]
+                      SpotInstanceType: one-time
+              ImageId: !If
+                  - HasNodeImageId
+                  - Ref: NodeImageId
+                  - Ref: NodeImageIdSSMParam
+              InstanceType: !Ref NodeInstanceType
+              KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
+              SecurityGroupIds:
+                  - Ref: NodeSecurityGroup
+              UserData: !Base64
+                  "Fn::Sub": |
+                      #!/bin/bash
+                      set -o xtrace
+                      /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
+                      /opt/aws/bin/cfn-signal --exit-code $? \
+                               --stack  ${AWS::StackName} \
+                               --resource NodeGroup  \
+                               --region ${AWS::Region}
+              MetadataOptions:
+                  "HttpPutResponseHopLimit" : 2
+
   NodeGroup:
-    Type: AWS::AutoScaling::AutoScalingGroup
-    Properties:
-      DesiredCapacity: !Ref NodeAutoScalingInitSize
-      LaunchConfigurationName: !Ref NodeLaunchConfig
-      MinSize: !Ref NodeAutoScalingGroupMinSize
-      MaxSize: !Ref NodeAutoScalingGroupMaxSize
-      VPCZoneIdentifier:
-        !Ref Subnets
-      Tags:
-      - Key: Name
-        Value: !Sub "${ClusterName}-${NodeGroupName}"
-        PropagateAtLaunch: 'true'
-      - Key: !Sub 'kubernetes.io/cluster/${ClusterName}'
-        Value: 'owned'
-        PropagateAtLaunch: 'true'
-      - Key: !If [ AutoscalerEnabled, 'k8s.io/cluster-autoscaler/enabled', 'k8s.io/cluster-autoscaler/disabled' ]
-        Value: 'true'
-        PropagateAtLaunch: 'false'
-      - Key: 'bzc:detach-asg-instance-on-termination'
-        Value: !Sub "${TerminationDetachEnabled}"
-        PropagateAtLaunch: 'false'
+      Type: AWS::AutoScaling::AutoScalingGroup
+      Properties:
+          DesiredCapacity: !Ref NodeAutoScalingInitSize
+          LaunchTemplate:
+              LaunchTemplateId: !Ref NodeLaunchTemplate
+              Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
+          MinSize: !Ref NodeAutoScalingGroupMinSize
+          MaxSize: !Ref NodeAutoScalingGroupMaxSize
+          VPCZoneIdentifier:
+              !Ref Subnets
+          Tags:
+              - Key: Name
+                Value: !Sub "${ClusterName}-${NodeGroupName}-Node"
+                PropagateAtLaunch: 'true'
+              - Key: !Sub 'kubernetes.io/cluster/${ClusterName}'
+                Value: 'owned'
+                PropagateAtLaunch: 'true'
+              - Key: !If [ AutoscalerEnabled, 'k8s.io/cluster-autoscaler/enabled', 'k8s.io/cluster-autoscaler/disabled' ]
+                Value: 'true'
+                PropagateAtLaunch: 'false'
+              - Key: 'bzc:detach-asg-instance-on-termination'
+                Value: !Sub "${TerminationDetachEnabled}"
+                PropagateAtLaunch: 'false'
 
-    {{- if .UpdatePolicyEnabled }}
-    UpdatePolicy:
-      AutoScalingRollingUpdate:
-        MaxBatchSize: !Ref NodeAutoScalingGroupMaxBatchSize
-        PauseTime: PT5M
-    {{- end}}
-
-  NodeLaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
-    Properties:
-      IamInstanceProfile: !Ref NodeInstanceProfile
-      ImageId: !Ref NodeImageId
-      InstanceType: !Ref NodeInstanceType
-      SpotPrice: !If [ IsSpotInstance, !Ref NodeSpotPrice, !Ref "AWS::NoValue" ]
-      KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
-      SecurityGroups:
-      - !Ref NodeSecurityGroup
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref NodeVolumeSize
-            VolumeType: gp2
-            DeleteOnTermination: true
-      UserData:
-        Fn::Base64:
-          !Sub |
-            #!/bin/bash
-            set -o xtrace
-            /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
-            /opt/aws/bin/cfn-signal --exit-code $? \
-                     --stack  ${AWS::StackName} \
-                     --resource NodeGroup  \
-                     --region ${AWS::Region}
+      {{- if .UpdatePolicyEnabled }}
+      UpdatePolicy:
+          AutoScalingRollingUpdate:
+              MaxBatchSize: !Ref NodeAutoScalingGroupMaxBatchSize
+              PauseTime: PT5M
+      {{- end}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2948 
| License         | Apache 2.0


### What's in this PR?
Update EKS CloudFormation templates to align with latest EKS node group template: https://amazon-eks.s3.us-west-2.amazonaws.com/cloudformation/2020-05-08/amazon-eks-nodegroup.yaml

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
