### PR TITLE
Bump chart version with latest pipeline version included

### DIFF
--- a/charts/pipeline/Chart.yaml
+++ b/charts/pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pipeline
 home: https://banzaicloud.com
-version: 1.0.1
+version: 1.1.0
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline
@@ -9,7 +9,7 @@ keywords:
   - banzaicloud
   - cloud
 
-appVersion: 0.40.0
+appVersion: 0.45.0
 
 maintainers:
 - name: Banzai Cloud

--- a/charts/pipeline/values.yaml
+++ b/charts/pipeline/values.yaml
@@ -19,7 +19,7 @@ hostAliases: []
 
 image:
   repository: banzaicloud/pipeline
-  tag: 0.40.0
+  tag: 0.45.0
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Updates the chart version to release latest changes and upgrade to latest pipeline version

### Why?
The pipelinectl drain command is broken in the previous chart version, thus we need at least a patch release, but since the pipeline version got outdated I decided to add it into this bump as well and make it a minor release instead.

