### PR TITLE
Update amis in case of EKS 1.14 and 1.15

### DIFF
--- a/internal/cluster/distribution/eks/defaults.go
+++ b/internal/cluster/distribution/eks/defaults.go
@@ -68,25 +68,25 @@ var defaultImageMap = []struct {
 	{
 		constraintForVersion("1.14"),
 		map[string]string{
-			// Kubernetes Version 1.14.7
-			"ap-east-1":      "ami-0af3a70f827304d17", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-0b60cbd90564dfe00", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-0cf70ba01dfd0f782", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-0d275f57a60281ccc", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-0159ec8365aea1724", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-07e2a96e251e970bd", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-0ef56ecc6435d1f65", // Canada (Central).
-			"eu-central-1":   "ami-03fbd442f4f3aa689", // EU (Frankfurt).
-			"eu-north-1":     "ami-01feb408eb7fc7e23", // EU (Stockholm).
-			"eu-west-1":      "ami-02dca57ad67c7bf57", // EU (Ireland).
-			"eu-west-2":      "ami-0a69fbeff04e330e9", // EU (London).
-			"eu-west-3":      "ami-074b0da576fa9f5c9", // EU (Paris).
-			"me-south-1":     "ami-0fc6f1ff5cd458c95", // Middle East (Bahrain).
-			"sa-east-1":      "ami-010ffc66e06c843b2", // South America (Sao Paulo).
-			"us-east-1":      "ami-07d6c8e62ce328a10", // US East (N. Virginia).
-			"us-east-2":      "ami-053250833d1030033", // US East (Ohio).
-			"us-west-1":      "ami-062d2cddf8747e025", // US West (N. California).
-			"us-west-2":      "ami-07be7092831897fd6", // US West (Oregon).
+			// Kubernetes Version 1.14.9
+			"ap-east-1":      "ami-03d6ba9854832e1af", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-0472f72a6affbe2cc", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-01b6316fe22d918a9", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-069fad55139bcb636", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-0fbfeefbb99c1783d", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-09edbbb02478906e3", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-064fd810d76e41b31", // Canada (Central).
+			"eu-central-1":   "ami-03d9393d97f5959fe", // EU (Frankfurt).
+			"eu-north-1":     "ami-00aa667bc61a020ac", // EU (Stockholm).
+			"eu-west-1":      "ami-048d37e92ce89022e", // EU (Ireland).
+			"eu-west-2":      "ami-0a907f63b13a38029", // EU (London).
+			"eu-west-3":      "ami-043b0c38ebd8435f9", // EU (Paris).
+			"me-south-1":     "ami-0e337e92214d0764d", // Middle East (Bahrain).
+			"sa-east-1":      "ami-0fb60915ec12aac26", // South America (Sao Paulo).
+			"us-east-1":      "ami-05e621d4ba5b28dcc", // US East (N. Virginia).
+			"us-east-2":      "ami-0b89776dcfa5f2dee", // US East (Ohio).
+			"us-west-1":      "ami-0be2b482206616dc2", // US West (N. California).
+			"us-west-2":      "ami-0a907f63b13a38029", // US West (Oregon).
 		},
 	},
 	{

--- a/internal/cluster/distribution/eks/defaults.go
+++ b/internal/cluster/distribution/eks/defaults.go
@@ -68,25 +68,25 @@ var defaultImageMap = []struct {
 	{
 		constraintForVersion("1.15"),
 		map[string]string{
-			// Kubernetes Version 1.15.10
-			"ap-east-1":      "ami-0d591ec9aab8976dc", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-06abd5347585f6519", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-065649f5fee9f227a", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-08805da128ddc2ee1", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-01b5910473e0a2d61", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-0b0bc41a50e8cd33e", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-032ef9dea6ae46809", // Canada (Central).
-			"eu-central-1":   "ami-0c9af00bc060dfa76", // EU (Frankfurt).
-			"eu-north-1":     "ami-07739287a5dbb16d0", // EU (Stockholm).
-			"eu-west-1":      "ami-04bf3ca704bd6b643", // EU (Ireland).
-			"eu-west-2":      "ami-0162c7f5400c6ec02", // EU (London).
-			"eu-west-3":      "ami-026d2ac4b345304dc", // EU (Paris).
-			"me-south-1":     "ami-078805035ccb0040b", // Middle East (Bahrain).
-			"sa-east-1":      "ami-0fee705e85dc3ac2c", // South America (Sao Paulo).
-			"us-east-1":      "ami-0582e4c984a1e848a", // US East (N. Virginia).
-			"us-east-2":      "ami-08880278b3cac5832", // US East (Ohio).
-			"us-west-1":      "ami-0b65bc2de276c7db7", // US West (N. California).
-			"us-west-2":      "ami-000a48e69e7695a4a", // US West (Oregon).
+			// Kubernetes Version 1.15.11
+			"ap-east-1":      "ami-0ae1b0aad4d6fb508", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-026e39e61d44ff507", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-0e1e660d5e393d5f1", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-0d32de2029a9f56fd", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-07aee5ce871a45bcf", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-040e5afd1b110a399", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-0286b3b75d600924d", // Canada (Central).
+			"eu-central-1":   "ami-02497bca9c9dbc206", // EU (Frankfurt).
+			"eu-north-1":     "ami-0efc0441f778f5826", // EU (Stockholm).
+			"eu-west-1":      "ami-023736532608ff45e", // EU (Ireland).
+			"eu-west-2":      "ami-0a79663bf395ae44d", // EU (London).
+			"eu-west-3":      "ami-0de67e5d090c0eef0", // EU (Paris).
+			"me-south-1":     "ami-075a74dc065b91bf6", // Middle East (Bahrain).
+			"sa-east-1":      "ami-07b176b7f55c9df7c", // South America (Sao Paulo).
+			"us-east-1":      "ami-06d4f570358b1b626", // US East (N. Virginia).
+			"us-east-2":      "ami-0c1bd9eca9c869a0d", // US East (Ohio).
+			"us-west-1":      "ami-03ac9a33b2d6c61f7", // US West (N. California).
+			"us-west-2":      "ami-065418523a44331e5", // US West (Oregon).
 		},
 	},
 }

--- a/internal/cluster/distribution/eks/defaults.go
+++ b/internal/cluster/distribution/eks/defaults.go
@@ -42,30 +42,6 @@ var defaultImageMap = []struct {
 	images     map[string]string
 }{
 	{
-		constraintForVersion("1.13"),
-		map[string]string{
-			// Kubernetes Version 1.13.11
-			"ap-east-1":      "ami-061c919d6ecc3fdb4", // Asia Pacific (Hong Kong).
-			"ap-northeast-1": "ami-01fd7f32ab8a9e032", // Asia Pacific (Tokyo).
-			"ap-northeast-2": "ami-053959c7a4a9cb654", // Asia Pacific (Seoul).
-			"ap-southeast-1": "ami-0baa81231c278c1ac", // Asia Pacific (Mumbai).
-			"ap-southeast-2": "ami-091a252b3e9cabcc2", // Asia Pacific (Singapore).
-			"ap-south-1":     "ami-0b667ccbbae9214e3", // Asia Pacific (Sydney).
-			"ca-central-1":   "ami-0808a5ff743eb2806", // Canada (Central).
-			"eu-central-1":   "ami-0a9ad7a4ae50e8e77", // EU (Frankfurt).
-			"eu-north-1":     "ami-0b9403c917e4f92b5", // EU (Stockholm).
-			"eu-west-1":      "ami-08684dce117829aa8", // EU (Ireland).
-			"eu-west-2":      "ami-07bf4afe6ca486eeb", // EU (London).
-			"eu-west-3":      "ami-095de5b6bd8b1acf0", // EU (Paris).
-			"me-south-1":     "ami-02ec1b153ae90c2c3", // Middle East (Bahrain).
-			"sa-east-1":      "ami-035e63ad35c591df8", // South America (Sao Paulo).
-			"us-east-1":      "ami-0795ae6584e7f8070", // US East (N. Virginia).
-			"us-east-2":      "ami-01505c630227fa3f8", // US East (Ohio).
-			"us-west-1":      "ami-02f3579ca4683a2ed", // US West (N. California).
-			"us-west-2":      "ami-04e247c4613de71fa", // US West (Oregon).
-		},
-	},
-	{
 		constraintForVersion("1.14"),
 		map[string]string{
 			// Kubernetes Version 1.14.9

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -288,7 +288,7 @@ func (eks *UpdateClusterAmazonEKS) Validate() error {
 
 // isValidVersion validates the given K8S version
 func isValidVersion(version string) (bool, error) {
-	constraint, err := semver.NewConstraint(">= 1.13, < 1.16")
+	constraint, err := semver.NewConstraint(">= 1.14, < 1.16")
 	if err != nil {
 		return false, errors.WrapIf(err, "couldn't create semver Kubernetes version check constraint")
 	}


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/cloudinfo/pull/323
| License         | Apache 2.0


### What's in this PR?
Update amis in case of EKS 1.14 and 1.15