### PR TITLE
Made cluster group deployments aware of the organizationID

### DIFF
--- a/internal/clustergroup/deployment/helm.go
+++ b/internal/clustergroup/deployment/helm.go
@@ -32,6 +32,7 @@ type ChartMeta struct {
 type HelmService interface {
 	GetChartMeta(orgId uint, name, version string) (ChartMeta, error)
 	InstallOrUpgrade(
+		orgID uint,
 		c helm.ClusterDataProvider,
 		release helm.Release,
 		opts helm.Options,
@@ -40,31 +41,31 @@ type HelmService interface {
 	DeleteRelease(c helm.ClusterDataProvider, releaseName, namespace string) error
 }
 
-type Helm3Service struct {
+type helm3Service struct {
 	facade   helm.Service
 	releaser helm.UnifiedReleaser
 }
 
-func (h *Helm3Service) GetRelease(c helm.ClusterDataProvider, releaseName, namespace string) (helm.Release, error) {
+func (h *helm3Service) GetRelease(c helm.ClusterDataProvider, releaseName, namespace string) (helm.Release, error) {
 	return h.releaser.GetRelease(c, releaseName, namespace)
 }
 
 func NewHelmService(facade helm.Service, releaser helm.UnifiedReleaser) HelmService {
-	return &Helm3Service{
+	return &helm3Service{
 		facade:   facade,
 		releaser: releaser,
 	}
 }
 
-func (h *Helm3Service) DeleteRelease(c helm.ClusterDataProvider, releaseName, namespace string) error {
+func (h *helm3Service) DeleteRelease(c helm.ClusterDataProvider, releaseName, namespace string) error {
 	return h.releaser.Delete(c, releaseName, namespace)
 }
 
-func (h *Helm3Service) InstallOrUpgrade(c helm.ClusterDataProvider, release helm.Release, opts helm.Options) error {
-	return h.releaser.InstallOrUpgrade(c, release, opts)
+func (h *helm3Service) InstallOrUpgrade(orgID uint, c helm.ClusterDataProvider, release helm.Release, opts helm.Options) error {
+	return h.releaser.InstallOrUpgrade(orgID, c, release, opts)
 }
 
-func (h *Helm3Service) GetChartMeta(orgId uint, name, version string) (ChartMeta, error) {
+func (h *helm3Service) GetChartMeta(orgId uint, name, version string) (ChartMeta, error) {
 	repoAndChart := strings.Split(name, "/")
 	if len(repoAndChart) != 2 {
 		return ChartMeta{}, errors.Errorf("missing repo ref from chart name %s", name)

--- a/internal/clustergroup/deployment/manager.go
+++ b/internal/clustergroup/deployment/manager.go
@@ -81,15 +81,19 @@ func (m *CGDeploymentManager) ReconcileState(featureState api.Feature) error {
 	if err != nil {
 		err = errors.WrapIfWithDetails(err, "failed to list deployment for cluster group",
 			"clusterGroupID", clusterGroup.Id)
-		m.logger.Error(err.Error())
+		m.errorHandler.Handle(err)
 	}
 	for _, deployment := range deploymentModels {
 		if !featureState.Enabled {
 			// if feature is disabled delete all deployments belonging to the cluster group
-			m.DeleteDeployment(&featureState.ClusterGroup, deployment.DeploymentReleaseName, true) // nolint: errcheck
+			if _, err := m.DeleteDeployment(&featureState.ClusterGroup, deployment.DeploymentReleaseName, true); err != nil {
+				m.errorHandler.Handle(err)
+			}
 		} else {
 			// delete deployment from clusters not belonging to the group anymore
-			m.deleteDeploymentFromTargetClusters(&featureState.ClusterGroup, deployment.DeploymentReleaseName, deployment, false, true) // nolint: errcheck
+			if _, err := m.deleteDeploymentFromTargetClusters(&featureState.ClusterGroup, deployment.DeploymentReleaseName, deployment, false, true); err != nil {
+				m.errorHandler.Handle(err)
+			}
 		}
 	}
 
@@ -109,8 +113,8 @@ func (m *CGDeploymentManager) GetMembersStatus(featureState api.Feature) (map[ui
 	return statusMap, nil
 }
 
-func (m CGDeploymentManager) installDeploymentOnCluster(log *logrus.Entry, apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
-	log.Info("install cluster group deployment")
+func (m CGDeploymentManager) installDeploymentOnCluster(orgID uint, apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
+	m.logger.Info("install cluster group deployment")
 
 	values, err := depInfo.GetValuesForCluster(apiCluster.GetName())
 	if err != nil {
@@ -122,7 +126,7 @@ func (m CGDeploymentManager) installDeploymentOnCluster(log *logrus.Entry, apiCl
 		return errors.WrapIff(err, "invalid values for chart %s in cluster %s", requestedChart.Name, apiCluster.GetName())
 	}
 
-	err = m.helmService.InstallOrUpgrade(apiCluster, internalhelm.Release{
+	err = m.helmService.InstallOrUpgrade(orgID, apiCluster, internalhelm.Release{
 		ReleaseName: depInfo.ReleaseName,
 		ChartName:   depInfo.Chart,
 		Namespace:   depInfo.Namespace,
@@ -137,12 +141,12 @@ func (m CGDeploymentManager) installDeploymentOnCluster(log *logrus.Entry, apiCl
 		return fmt.Errorf("error deploying chart: %v", err)
 	}
 
-	log.Info("installing cluster group deployment succeeded")
+	m.logger.Info("installing cluster group deployment succeeded")
 	return nil
 }
 
-func (m CGDeploymentManager) upgradeDeploymentOnCluster(log *logrus.Entry, apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
-	log.Info("upgrade cluster group deployment")
+func (m CGDeploymentManager) upgradeDeploymentOnCluster(orgID uint, apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
+	m.logger.Info("upgrade cluster group deployment")
 
 	values, err := depInfo.GetValuesForCluster(apiCluster.GetName())
 	if err != nil {
@@ -154,7 +158,7 @@ func (m CGDeploymentManager) upgradeDeploymentOnCluster(log *logrus.Entry, apiCl
 		return errors.WrapIff(err, "invalid values for chart %s in cluster %s", requestedChart.Name, apiCluster.GetName())
 	}
 
-	err = m.helmService.InstallOrUpgrade(apiCluster, internalhelm.Release{
+	err = m.helmService.InstallOrUpgrade(orgID, apiCluster, internalhelm.Release{
 		ReleaseName: depInfo.ReleaseName,
 		ChartName:   depInfo.Chart,
 		Namespace:   depInfo.Namespace,
@@ -173,7 +177,7 @@ func (m CGDeploymentManager) upgradeDeploymentOnCluster(log *logrus.Entry, apiCl
 	return nil
 }
 
-func (m CGDeploymentManager) upgradeOrInstallDeploymentOnCluster(apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
+func (m CGDeploymentManager) upgradeOrInstallDeploymentOnCluster(orgID uint, apiCluster api.Cluster, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) error {
 	log := m.logger.WithFields(logrus.Fields{"deploymentName": depInfo.Chart, "releaseName": depInfo.ReleaseName, "clusterName": apiCluster.GetName(), "clusterId": apiCluster.GetID()})
 
 	status, err := m.getClusterDeploymentStatus(apiCluster, depInfo.ReleaseName, depInfo)
@@ -181,14 +185,14 @@ func (m CGDeploymentManager) upgradeOrInstallDeploymentOnCluster(apiCluster api.
 		return err
 	}
 	if status.Status == NotInstalledStatus {
-		err := m.installDeploymentOnCluster(log, apiCluster, depInfo, requestedChart, dryRun)
+		err := m.installDeploymentOnCluster(orgID, apiCluster, depInfo, requestedChart, dryRun)
 		if err != nil {
 			return err
 		}
 	}
 
 	if status.Stale {
-		err := m.upgradeDeploymentOnCluster(log, apiCluster, depInfo, requestedChart, dryRun)
+		err := m.upgradeDeploymentOnCluster(orgID, apiCluster, depInfo, requestedChart, dryRun)
 		if err != nil {
 			return err
 		}
@@ -566,7 +570,7 @@ func (m CGDeploymentManager) SyncDeployment(clusterGroup *api.ClusterGroup, orgI
 	if err != nil {
 		return nil, errors.WrapIf(err, "error getting chart description")
 	}
-	targetClustersStatus := m.upgradeOrInstallDeploymentToTargetClusters(clusterGroup, depInfo, requestedChart, false)
+	targetClustersStatus := m.upgradeOrInstallDeploymentToTargetClusters(orgId, clusterGroup, depInfo, requestedChart, false)
 	response = append(response, targetClustersStatus...)
 
 	targetClustersStatus, err = m.deleteDeploymentFromTargetClusters(clusterGroup, releaseName, deploymentModel, false, false)
@@ -634,7 +638,7 @@ func (m CGDeploymentManager) deleteDeploymentFromTargetClusters(clusterGroup *ap
 	return targetClustersStatus, nil
 }
 
-func (m CGDeploymentManager) upgradeOrInstallDeploymentToTargetClusters(clusterGroup *api.ClusterGroup, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) []TargetClusterStatus {
+func (m CGDeploymentManager) upgradeOrInstallDeploymentToTargetClusters(orgID uint, clusterGroup *api.ClusterGroup, depInfo *DeploymentInfo, requestedChart ChartMeta, dryRun bool) []TargetClusterStatus {
 	targetClusterStatus := make([]TargetClusterStatus, 0)
 	deploymentCount := 0
 	statusChan := make(chan TargetClusterStatus)
@@ -653,7 +657,7 @@ func (m CGDeploymentManager) upgradeOrInstallDeploymentToTargetClusters(clusterG
 					Distribution: apiCluster.GetDistribution(),
 					Status:       OperationSucceededStatus,
 				}
-				clerr := m.upgradeOrInstallDeploymentOnCluster(apiCluster, depInfo, requestedChart, dryRun)
+				clerr := m.upgradeOrInstallDeploymentOnCluster(orgID, apiCluster, depInfo, requestedChart, dryRun)
 				if clerr != nil {
 					opStatus.Status = OperationFailedStatus
 					opStatus.Error = clerr.Error()
@@ -718,7 +722,7 @@ func (m CGDeploymentManager) CreateDeployment(clusterGroup *api.ClusterGroup, or
 		return nil, err
 	}
 
-	targetClusterStatus := m.upgradeOrInstallDeploymentToTargetClusters(clusterGroup, depInfo, requestedChart, cgDeployment.DryRun)
+	targetClusterStatus := m.upgradeOrInstallDeploymentToTargetClusters(orgId, clusterGroup, depInfo, requestedChart, cgDeployment.DryRun)
 	return targetClusterStatus, nil
 }
 
@@ -758,7 +762,7 @@ func (m CGDeploymentManager) UpdateDeployment(clusterGroup *api.ClusterGroup, or
 		return nil, err
 	}
 
-	targetClusterStatus := m.upgradeOrInstallDeploymentToTargetClusters(clusterGroup, depInfo, requestedChart, cgDeployment.DryRun)
+	targetClusterStatus := m.upgradeOrInstallDeploymentToTargetClusters(orgId, clusterGroup, depInfo, requestedChart, cgDeployment.DryRun)
 	return targetClusterStatus, nil
 }
 

--- a/internal/federation/deployment.go
+++ b/internal/federation/deployment.go
@@ -20,6 +20,7 @@ import (
 
 type HelmService interface {
 	InstallOrUpgrade(
+		orgID uint,
 		c internalHelm.ClusterDataProvider,
 		release internalHelm.Release,
 		opts internalHelm.Options,

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -40,6 +40,10 @@ type OperatorImage struct {
 	Tag        string `json:"tag,omitempty"`
 }
 
+const (
+	noOrgID = 0 //represents the platform org
+)
+
 func (m *FederationReconciler) ReconcileController(desiredState DesiredState) error {
 	m.logger.Debug("start reconciling Federation controller")
 	defer m.logger.Debug("finished reconciling Federation controller")
@@ -305,6 +309,7 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 	}
 
 	err := m.helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		internalHelm.Release{
 			ReleaseName: federationReleaseName,

--- a/internal/federation/reconcile_ext_dns.go
+++ b/internal/federation/reconcile_ext_dns.go
@@ -113,6 +113,7 @@ func EnsureCRDSourceForExtDNS(
 	}
 
 	err = helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		internalhelm.Release{
 			ReleaseName: releaseName,

--- a/internal/federation/reconcile_ext_dns_test.go
+++ b/internal/federation/reconcile_ext_dns_test.go
@@ -75,7 +75,7 @@ func testEnsureCRDSourceForExtDNS(v3 bool, testNamespace string) func(t *testing
 		if err := unifiedReleaser.Delete(&clusterConfig, releaseName, testNamespace); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		err = unifiedReleaser.InstallOrUpgrade(&clusterConfig, helm.Release{
+		err = unifiedReleaser.InstallOrUpgrade(0, &clusterConfig, helm.Release{
 			ReleaseName: releaseName,
 			ChartName:   chartName,
 			Namespace:   testNamespace,

--- a/internal/helm/helmadapter/helm_service.go
+++ b/internal/helm/helmadapter/helm_service.go
@@ -169,6 +169,7 @@ func (h *helm3UnifiedReleaser) GetDeployment(ctx context.Context, clusterID uint
 }
 
 func (h *helm3UnifiedReleaser) InstallOrUpgrade(
+	orgID uint,
 	c helm.ClusterDataProvider,
 	release helm.Release,
 	opts helm.Options,
@@ -176,29 +177,29 @@ func (h *helm3UnifiedReleaser) InstallOrUpgrade(
 	ctx := context.Background()
 	retrievedRelease, err := h.helmService.GetRelease(
 		ctx,
-		0,
+		orgID,
 		c.GetID(),
 		release.ReleaseName,
 		opts,
 	)
 	if err != nil {
 		if helm.ErrReleaseNotFound(err) {
-			_, err := h.helmService.InstallRelease(ctx, 0, c.GetID(), release, opts)
+			_, err := h.helmService.InstallRelease(ctx, orgID, c.GetID(), release, opts)
 			return err
 		}
 		return errors.WrapIf(err, "failed to retrieve release")
 	}
 	if retrievedRelease.ReleaseInfo.Status == release2.StatusDeployed.String() {
-		_, err := h.helmService.UpgradeRelease(ctx, 0, c.GetID(), release, opts)
+		_, err := h.helmService.UpgradeRelease(ctx, orgID, c.GetID(), release, opts)
 		return err
 	}
 	if retrievedRelease.ReleaseInfo.Status == release2.StatusFailed.String() {
-		if err := h.helmService.DeleteRelease(ctx, 0, c.GetID(), release.ReleaseName, opts); err != nil {
+		if err := h.helmService.DeleteRelease(ctx, orgID, c.GetID(), release.ReleaseName, opts); err != nil {
 			if !helm.ErrReleaseNotFound(err) {
 				return errors.WrapIf(err, "unable to delete release")
 			}
 		}
-		_, err := h.helmService.InstallRelease(ctx, 0, c.GetID(), release, opts)
+		_, err := h.helmService.InstallRelease(ctx, orgID, c.GetID(), release, opts)
 		return err
 	}
 	return errors.Errorf("Release is in invalid state unable to upgrade: %s", retrievedRelease.ReleaseInfo.Status)

--- a/internal/helm/integration_test.go
+++ b/internal/helm/integration_test.go
@@ -41,8 +41,9 @@ type Values struct {
 }
 
 const (
-	v2 = false
-	v3 = true
+	v2      = false
+	v3      = true
+	noOrgID = 0 // implicitly means platform helm env
 )
 
 var clusterId = uint(123) //nolint:gochecknoglobals
@@ -180,6 +181,7 @@ func testDeleteChart(helmService helm.UnifiedReleaser, kubeConfig []byte, testNa
 func testCreateChart(helmService helm.UnifiedReleaser, kubeConfig []byte, testNamespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		err := helmService.InstallOrUpgrade(
+			noOrgID,
 			&internaltesting.ClusterData{K8sConfig: kubeConfig, ID: clusterId},
 			helm.Release{
 				ReleaseName: "chartmuseum",
@@ -215,6 +217,7 @@ func testUpgradeChart(helmService helm.UnifiedReleaser, kubeConfig []byte, testN
 		}
 
 		err = helmService.InstallOrUpgrade(
+			noOrgID,
 			&internaltesting.ClusterData{K8sConfig: kubeConfig, ID: clusterId},
 			helm.Release{
 				ReleaseName: "chartmuseum",
@@ -251,6 +254,7 @@ func testUpgradeFailedChart(helmService helm.UnifiedReleaser, kubeConfig []byte,
 		}
 
 		err = helmService.InstallOrUpgrade(
+			noOrgID,
 			&internaltesting.ClusterData{K8sConfig: kubeConfig, ID: clusterId},
 			helm.Release{
 				ReleaseName: "chartmuseum",
@@ -271,6 +275,7 @@ func testUpgradeFailedChart(helmService helm.UnifiedReleaser, kubeConfig []byte,
 
 		// restore with original values
 		err = helmService.InstallOrUpgrade(
+			noOrgID,
 			&internaltesting.ClusterData{K8sConfig: kubeConfig, ID: clusterId},
 			helm.Release{
 				ReleaseName: "chartmuseum",

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -114,6 +114,7 @@ type UnifiedReleaser interface {
 
 	// Covers Federation and Backyards style implementation
 	InstallOrUpgrade(
+		orgID uint,
 		c ClusterDataProvider,
 		release Release,
 		opts Options,

--- a/internal/helm2/service.go
+++ b/internal/helm2/service.go
@@ -351,6 +351,7 @@ func findRelease(releaseName string, k8sConfig []byte) (*release.Release, error)
 }
 
 func (s *LegacyHelmService) InstallOrUpgrade(
+	orgID uint,
 	c internalhelm.ClusterDataProvider,
 	release internalhelm.Release,
 	opts internalhelm.Options,

--- a/internal/istio/istiofeature/helm.go
+++ b/internal/istio/istiofeature/helm.go
@@ -18,8 +18,11 @@ import (
 	internalHelm "github.com/banzaicloud/pipeline/internal/helm"
 )
 
+const noOrgID = 0 // represents the platform org
+
 type HelmService interface {
 	InstallOrUpgrade(
+		orgID uint,
 		c internalHelm.ClusterDataProvider,
 		release internalHelm.Release,
 		opts internalHelm.Options,

--- a/internal/istio/istiofeature/reconcile_backyards.go
+++ b/internal/istio/istiofeature/reconcile_backyards.go
@@ -295,6 +295,7 @@ func (m *MeshReconciler) installBackyards(c cluster.CommonCluster, monitoring mo
 	}
 
 	err = m.helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		internalHelm.Release{
 			ReleaseName: backyardsReleaseName,

--- a/internal/istio/istiofeature/reconcile_canary_operator.go
+++ b/internal/istio/istiofeature/reconcile_canary_operator.go
@@ -86,6 +86,7 @@ func (m *MeshReconciler) installCanaryOperator(c cluster.CommonCluster, promethe
 	}
 
 	err = m.helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		helm.Release{
 			ReleaseName: canaryOperatorReleaseName,

--- a/internal/istio/istiofeature/reconcile_istio_operator.go
+++ b/internal/istio/istiofeature/reconcile_istio_operator.go
@@ -88,6 +88,7 @@ func (m *MeshReconciler) installIstioOperator(c cluster.CommonCluster) error {
 	}
 
 	err = m.helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		helm.Release{
 			ReleaseName: istioOperatorReleaseName,

--- a/internal/istio/istiofeature/reconcile_node_exporter.go
+++ b/internal/istio/istiofeature/reconcile_node_exporter.go
@@ -66,6 +66,7 @@ func (m *MeshReconciler) installNodeExporter(c cluster.CommonCluster) error {
 	nodeExporterConfig := m.Configuration.internalConfig.Charts.NodeExporter
 
 	err = m.helmService.InstallOrUpgrade(
+		noOrgID,
 		c,
 		helm.Release{
 			ReleaseName: nodeExporterReleaseName,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Cluster group deployments made aware of the organisation which' member is performing operations. Relevant interface operations are provided with the orgID in order to use the proper repositories where appropriate. (These generic interface modifications propagated to the using modules as well)

### Why?
Cluster group deployments only could be made from the builtin helm repositories


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)