### PR TITLE
EKS: enable K8s version 1.16

### DIFF
--- a/internal/cluster/distribution/eks/defaults.go
+++ b/internal/cluster/distribution/eks/defaults.go
@@ -113,6 +113,30 @@ var defaultImageMap = []struct {
 			"us-west-2":      "ami-000a48e69e7695a4a", // US West (Oregon).
 		},
 	},
+	{
+		constraintForVersion("1.16"),
+		map[string]string{
+			// Kubernetes Version 1.16.8
+			"ap-east-1":      "ami-024ec7439d902ac50", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-0ca8e5c318b118092", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-0da70348effa9af72", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-093fffbd1480f8c72", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-0ed6c012b2bd57b73", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-00725375bc29d9601", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-0139a5bcca4fd37a9", // Canada (Central).
+			"eu-central-1":   "ami-0bf7306240d09dcdd", // EU (Frankfurt).
+			"eu-north-1":     "ami-030f9071e0d32b989", // EU (Stockholm).
+			"eu-west-1":      "ami-03c5e686287fd90e9", // EU (Ireland).
+			"eu-west-2":      "ami-02e571568d897dcab", // EU (London).
+			"eu-west-3":      "ami-0170bd57fa0c260da", // EU (Paris).
+			"me-south-1":     "ami-08bf7870510670f47", // Middle East (Bahrain).
+			"sa-east-1":      "ami-0ed2cc7e74c7bc2e2", // South America (Sao Paulo).
+			"us-east-1":      "ami-05ac566a7ec2378db", // US East (N. Virginia).
+			"us-east-2":      "ami-0edc51bc2f03c9dc2", // US East (Ohio).
+			"us-west-1":      "ami-015fd1269b5bc0c23", // US West (N. California).
+			"us-west-2":      "ami-0809659d79ce80260", // US West (Oregon).
+		},
+	},
 }
 
 // GetDefaultImageID returns the EKS optimized AMI for given Kubernetes version and region.

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -288,7 +288,7 @@ func (eks *UpdateClusterAmazonEKS) Validate() error {
 
 // isValidVersion validates the given K8S version
 func isValidVersion(version string) (bool, error) {
-	constraint, err := semver.NewConstraint(">= 1.13, < 1.16")
+	constraint, err := semver.NewConstraint(">= 1.13, <= 1.16")
 	if err != nil {
 		return false, errors.WrapIf(err, "couldn't create semver Kubernetes version check constraint")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Enable Kubernetes version 1.16 on EKS and add default ami image id for 1.16.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

