### PR TITLE
Change Helm home directory layout

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -798,7 +798,7 @@ traefik:
 
 	// Helm configuration
 	v.SetDefault("helm::tiller::version", "v2.16.3")
-	v.SetDefault("helm::home", "./var/cache")
+	v.SetDefault("helm::home", "./var/cache/helm")
 	v.SetDefault("helm::v3", false)
 	v.SetDefault("helm::repositories::stable", "https://kubernetes-charts.storage.googleapis.com")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -798,7 +798,7 @@ traefik:
 
 	// Helm configuration
 	v.SetDefault("helm::tiller::version", "v2.16.3")
-	v.SetDefault("helm::home", "./var/cache/helm")
+	v.SetDefault("helm::home", "./var/cache")
 	v.SetDefault("helm::v3", false)
 	v.SetDefault("helm::repositories::stable", "https://kubernetes-charts.storage.googleapis.com")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -15,7 +15,6 @@
 package global
 
 import (
-	"path/filepath"
 	"time"
 )
 
@@ -173,9 +172,4 @@ var Config struct {
 	Telemetry struct {
 		Debug bool
 	}
-}
-
-// GetHelmPath returns local helm path
-func GetHelmPath(organizationName string) string {
-	return filepath.Join(Config.Helm.Home, organizationName)
 }

--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -26,6 +26,7 @@ const (
 	cacheDir         = "cache"
 	noOrg            = 0 // signals that no organization id is provided
 
+	helmBaseDir = "helm"
 	orgsHomeDir = "orgs"
 )
 
@@ -98,16 +99,16 @@ func (er envResolver) ResolveHelmEnv(ctx context.Context, organizationID uint) (
 	}
 
 	return HelmEnv{
-		home:     path.Join(er.helmHomesDir, orgsHomeDir, orgName),
-		cacheDir: path.Join(er.helmHomesDir, orgsHomeDir, orgName, cacheDir),
+		home:     path.Join(er.helmHomesDir, helmBaseDir, orgsHomeDir, orgName),
+		cacheDir: path.Join(er.helmHomesDir, helmBaseDir, orgsHomeDir, orgName, cacheDir),
 		platform: false,
 	}, nil
 }
 
 func (er envResolver) ResolvePlatformEnv(ctx context.Context) (HelmEnv, error) {
 	return HelmEnv{
-		home:     path.Join(er.helmHomesDir, PlatformHelmHome),
-		cacheDir: path.Join(er.helmHomesDir, PlatformHelmHome, cacheDir),
+		home:     path.Join(er.helmHomesDir, helmBaseDir, PlatformHelmHome),
+		cacheDir: path.Join(er.helmHomesDir, helmBaseDir, PlatformHelmHome, cacheDir),
 		platform: true,
 	}, nil
 }

--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -16,17 +16,17 @@ package helm
 
 import (
 	"context"
-	"fmt"
 	"path"
 
 	"emperror.dev/errors"
 )
 
 const (
-	PlatformHelmHome = "pipeline"
-	helmPostFix      = "helm"
+	PlatformHelmHome = "platform"
 	cacheDir         = "cache"
 	noOrg            = 0 // signals that no organization id is provided
+
+	orgsHomeDir = "orgs"
 )
 
 // +testify:mock:testOnly=true
@@ -98,16 +98,16 @@ func (er envResolver) ResolveHelmEnv(ctx context.Context, organizationID uint) (
 	}
 
 	return HelmEnv{
-		home:     path.Join(er.helmHomesDir, orgName, helmPostFix),
-		cacheDir: path.Join(er.helmHomesDir, orgName, cacheDir),
+		home:     path.Join(er.helmHomesDir, orgsHomeDir, orgName),
+		cacheDir: path.Join(er.helmHomesDir, orgsHomeDir, orgName, cacheDir),
 		platform: false,
 	}, nil
 }
 
 func (er envResolver) ResolvePlatformEnv(ctx context.Context) (HelmEnv, error) {
 	return HelmEnv{
-		home:     path.Join(fmt.Sprintf("%s-%s", er.helmHomesDir, PlatformHelmHome), helmPostFix),
-		cacheDir: path.Join(fmt.Sprintf("%s-%s", er.helmHomesDir, PlatformHelmHome), cacheDir),
+		home:     path.Join(er.helmHomesDir, PlatformHelmHome),
+		cacheDir: path.Join(er.helmHomesDir, PlatformHelmHome, cacheDir),
 		platform: true,
 	}, nil
 }

--- a/internal/helm/envresolver_test.go
+++ b/internal/helm/envresolver_test.go
@@ -52,9 +52,9 @@ func Test_helm2EnvResolver_ResolveHelmEnv(t *testing.T) {
 				organizationID: 1,
 			},
 			want: HelmEnv{
-				home:         "testHomesDir/testOrg/helm",
+				home:         "testHomesDir/helm/orgs/testOrg",
 				platform:     false,
-				cacheDir:     "testHomesDir/testOrg/cache",
+				cacheDir:     "testHomesDir/helm/orgs/testOrg/cache",
 				repoCacheDir: "",
 			},
 			wantErr: false,
@@ -119,10 +119,10 @@ func Test_helm3EnvResolver_ResolveHelmEnv(t *testing.T) {
 				organizationID: 1,
 			},
 			want: HelmEnv{
-				home:         "testHomesDir/testOrg/helm/repository/repositories.yaml",
-				repoCacheDir: "testHomesDir/testOrg/helm/repository/cache",
+				home:         "testHomesDir/helm/orgs/testOrg/repository/repositories.yaml",
+				repoCacheDir: "testHomesDir/helm/orgs/testOrg/repository/cache",
 				platform:     false,
-				cacheDir:     "testHomesDir/testOrg/cache",
+				cacheDir:     "testHomesDir/helm/orgs/testOrg/cache",
 			},
 			wantErr: false,
 			setupMocks: func(orgService *OrgService, arguments args) {
@@ -182,9 +182,9 @@ func Test_envResolver_ResolvePlatformEnv(t *testing.T) {
 				ctx: context.Background(),
 			},
 			want: HelmEnv{
-				home:     "testHomesDir-pipeline/helm",
+				home:     "testHomesDir/helm/platform",
 				platform: true,
-				cacheDir: "testHomesDir-pipeline/cache",
+				cacheDir: "testHomesDir/helm/platform/cache",
 			},
 			wantErr: false,
 		},

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -26,7 +26,6 @@ const (
 	StableRepository = "stable"
 	BanzaiRepository = "banzaicloud-stable"
 	LokiRepository   = "loki"
-	HelmPostFix      = "helm"
 )
 
 const releaseNameMaxLen = 53

--- a/src/helm/install.go
+++ b/src/helm/install.go
@@ -15,8 +15,8 @@
 package helm
 
 import (
-	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -31,16 +31,10 @@ import (
 	phelm "github.com/banzaicloud/pipeline/pkg/helm"
 )
 
-// CreateEnvSettings Create env settings on a given path
-func CreateEnvSettings(helmRepoHome string) helmEnv.EnvSettings {
-	var settings helmEnv.EnvSettings
-	settings.Home = helmpath.Home(helmRepoHome)
-	return settings
-}
-
 // GenerateHelmRepoEnv Generate helm path based on orgName
 func GenerateHelmRepoEnv(orgName string) helmEnv.EnvSettings {
-	env, _, err := GenerateHelmRepoEnvOnPath(global.GetHelmPath(fmt.Sprintf("%s/%s", orgName, phelm.HelmPostFix)))
+	// new layout of the local helm env!
+	env, _, err := GenerateHelmRepoEnvOnPath(path.Join(global.Config.Helm.Home, "helm", "orgs", orgName))
 	if err != nil {
 		log.Errorf("local helm env setup failed err: %+v env: %+v", err, env)
 	}
@@ -49,7 +43,9 @@ func GenerateHelmRepoEnv(orgName string) helmEnv.EnvSettings {
 
 // GenerateHelmRepoEnv Generate helm to the given path
 func GenerateHelmRepoEnvOnPath(path string) (helmEnv.EnvSettings, bool, error) {
-	env := CreateEnvSettings(path)
+	var env helmEnv.EnvSettings
+	env.Home = helmpath.Home(path)
+
 	isNewEnv := false
 	// check local helm
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -64,7 +60,7 @@ func GenerateHelmRepoEnvOnPath(path string) (helmEnv.EnvSettings, bool, error) {
 }
 
 func GeneratePlatformHelmRepoEnv() helmEnv.EnvSettings {
-	env, _, err := GenerateHelmRepoEnvOnPath(fmt.Sprintf("%s-%s/%s", global.Config.Helm.Home, helm.PlatformHelmHome, phelm.HelmPostFix))
+	env, _, err := GenerateHelmRepoEnvOnPath(path.Join(global.Config.Helm.Home, "helm", helm.PlatformHelmHome))
 	if err != nil {
 		log.Errorf("platform helm env setup failed err: %+v env: %+v", err, env)
 	}

--- a/src/helm/install_test.go
+++ b/src/helm/install_test.go
@@ -30,7 +30,7 @@ func TestIntegration(t *testing.T) {
 	t.Run("platform helm home", func(t *testing.T) {
 		global.Config.Helm.Home = "var/cache/test"
 
-		expected := "var/cache/test-pipeline/helm"
+		expected := "var/cache/test/helm/platform"
 
 		env := GeneratePlatformHelmRepoEnv()
 		if env.Home.String() != expected {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Made Helm home directory layout cleaner:

```
var/cache/
└── helm
    ├── orgs
    │   └── myorg
    │       ├── cache
    │       │   ├── discovery-cache
    │       │   └── http-cache
    │       └── repository
    │           └── cache
    └── platform
        └── repository
            └── cache
```
Update: the old (helm2) implementation had also been moved to the new layout for consistency reasons.
 
### Why?
The new structure is cleaner
