### PR TITLE
Pin Alpine version to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.14
 ARG FROM_IMAGE=scratch
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.14
-ARG FROM_IMAGE=alpine:3.11
+ARG FROM_IMAGE=alpine:3.12
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.14
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.14
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457


### PR DESCRIPTION
Until bzr is available in 3.12 or an alternative installation method is provided
