### PR TITLE
EKS: remove default image param from node pool CF

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -79,13 +79,7 @@ Parameters:
 
   NodeImageId:
       Type: String
-      Default: ""
       Description: (Optional) Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
-
-  NodeImageIdSSMParam:
-      Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-      Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
-      Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances
@@ -392,10 +386,6 @@ Conditions:
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
-  HasNodeImageId: !Not
-      - "Fn::Equals":
-            - Ref: NodeImageId
-            - ""
 
 Resources:
   NodeInstanceProfile:
@@ -472,10 +462,7 @@ Resources:
                   SpotOptions:
                       MaxPrice: !If [ IsSpotInstance, !Ref NodeSpotPrice, !Ref "AWS::NoValue" ]
                       SpotInstanceType: one-time
-              ImageId: !If
-                  - HasNodeImageId
-                  - Ref: NodeImageId
-                  - Ref: NodeImageIdSSMParam
+              ImageId: !Ref NodeImageId
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #2968 
| License         | Apache 2.0


### What's in this PR?
Remove default image param from node pool CloudFormation template since it's unnecessary because Pipeline always sets default image in case it's not provided while it requires additional access rights for user.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)

