### PR TITLE
Coalesce values while retrieving release details

### DIFF
--- a/internal/helm/helmadapter/releaser_service.go
+++ b/internal/helm/helmadapter/releaser_service.go
@@ -83,6 +83,9 @@ func (r releaser) Install(ctx context.Context, helmEnv helm.HelmEnv, kubeConfig 
 
 	installAction := action.NewInstall(actionConfig)
 	installAction.Namespace = ns
+	if releaseInput.ReleaseName == "" {
+		installAction.GenerateName = true
+	}
 
 	name, chartRef, err := installAction.NameAndChart(releaseInput.NameAndChartSlice())
 	if err != nil {

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -170,6 +170,7 @@ func decodeInstallReleaseHTTPRequest(_ context.Context, r *http.Request) (interf
 			ChartName:   request.Name,
 			Namespace:   request.Namespace,
 			Values:      request.Values,
+			Version:     request.Version,
 		},
 		Options: helm.Options{
 			DryRun:       request.DryRun,

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mitchellh/mapstructure"
 	kitxhttp "github.com/sagikazarmark/kitx/transport/http"
+	"helm.sh/helm/v3/pkg/chartutil"
 
 	"github.com/banzaicloud/pipeline/.gen/pipeline/pipeline"
 	"github.com/banzaicloud/pipeline/internal/helm"
@@ -515,6 +516,8 @@ func encodeGetReleaseHTTPResponse(ctx context.Context, w http.ResponseWriter, re
 		return errors.WrapIf(release.Err, "failed to retrieve releases")
 	}
 
+	mergedValues := chartutil.CoalesceTables(release.R0.Values, release.R0.ReleaseInfo.Values)
+
 	resp := pipeline.GetDeploymentResponse{
 		ReleaseName:  release.R0.ReleaseName,
 		Chart:        release.R0.ChartName, // TODO what's this
@@ -526,7 +529,7 @@ func encodeGetReleaseHTTPResponse(ctx context.Context, w http.ResponseWriter, re
 		Status:       release.R0.ReleaseInfo.Status,
 		CreatedAt:    release.R0.ReleaseInfo.FirstDeployed.String(),
 		Notes:        release.R0.ReleaseInfo.Notes,
-		Values:       release.R0.Values,
+		Values:       mergedValues,
 	}
 
 	return kitxhttp.JSONResponseEncoder(ctx, w, resp)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
* Release values are coalesced during release details retrieval (backwards compatibility reasons)
* Release name is generated when not explicitly sent in (release install failed)
* Release Version is passed to the backend (was omitted)

### Why?
Overrides were not presented on the UI

