### PR TITLE
Add middleware for ensuring helm environment reconciliation

### DIFF
--- a/internal/cmd/helm.go
+++ b/internal/cmd/helm.go
@@ -108,3 +108,14 @@ func CreateReleaseDeleter(helmConfig helm.Config, db *gorm.DB, secretStore helma
 	logger.Debug("assembled helm 2 release deleter")
 	return helmadapter.NewHelm2ReleaseDeleter()
 }
+
+func NewEnsuringEnvResolver(helmConfig helm.Config, db *gorm.DB, secretStore helmadapter.SecretStore, logger helm.Logger) helm.EnvResolver {
+	repoStore := helmadapter.NewHelmRepoStore(db, logger)
+	secret := helmadapter.NewSecretStore(secretStore, logger)
+	envService := helmadapter.NewHelmEnvService(helmadapter.NewConfig(helmConfig.Repositories), secret, logger)
+	orgService := helmadapter.NewOrgService(logger)
+
+	helm2EnvResolver := helm.NewHelm2EnvResolver(helmConfig.Home, orgService, logger)
+
+	return helm.NewEnsuringEnvResolver(helm2EnvResolver, envService, repoStore, helmConfig.Repositories, logger)
+}

--- a/internal/helm/helmadapter/middleware.go
+++ b/internal/helm/helmadapter/middleware.go
@@ -1,0 +1,55 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helmadapter
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/banzaicloud/pipeline/internal/helm"
+)
+
+// envEnsurerMiddleware component providing middleware logic for reconciling persisted customer helm repositories
+type envEnsurerMiddleware struct {
+	envEnsurer helm.EnvResolver // must be an ensuring envresolver
+	logger     Logger
+}
+
+// NewHelmEnvEnsurerMiddleware
+func NewHelmEnvEnsurerMiddleware(envResolver helm.EnvResolver, logger Logger) envEnsurerMiddleware {
+	return envEnsurerMiddleware{
+		envEnsurer: envResolver,
+		logger:     logger,
+	}
+}
+
+func (e envEnsurerMiddleware) Middleware(c *gin.Context) {
+	orgIDStr := c.Param("orgid")
+	orgID, err := strconv.ParseInt(orgIDStr, 10, 32)
+	if err != nil {
+		return
+	}
+
+	if orgID < 1 {
+		// there's no org id found in the URL, do nothing
+		return
+	}
+
+	// make sure the helm env is created and persisted repos are restored
+	if _, err := e.envEnsurer.ResolveHelmEnv(c.Request.Context(), uint(orgID)); err != nil {
+		e.logger.Warn("failed to ensure helm env", map[string]interface{}{"orgID": orgID})
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Deployment api routes have been added a middleware for ensuring helm2 environments are properly reconciled.


### Why?
The deployment api routes (legacy implementation) didn't ensure that persisted customer repositories are restored.
