### PR TITLE
Pass namespace information when installing, retrieving and deleting releases

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -761,13 +761,14 @@ func main() {
 							kitxhttp.ServerOptions(httpServerOptions),
 						)
 
-						cRouter.POST("/deployments", gin.WrapH(router))
-						cRouter.GET("/deployments", gin.WrapH(router))
-						cRouter.GET("/deployments/:name", gin.WrapH(router))
-						cRouter.PUT("/deployments/:name", gin.WrapH(router))
-						cRouter.HEAD("/deployments/:name", gin.WrapH(router))
-						cRouter.DELETE("/deployments/:name", gin.WrapH(router))
-						cRouter.GET("/deployments/:name/resources", gin.WrapH(router))
+						deploymentsRouter := cRouter.Group("/deployments")
+						deploymentsRouter.POST("", gin.WrapH(router))
+						deploymentsRouter.GET("", gin.WrapH(router))
+						deploymentsRouter.GET(":name", gin.WrapH(router))
+						deploymentsRouter.PUT(":name", gin.WrapH(router))
+						deploymentsRouter.HEAD(":name", gin.WrapH(router))
+						deploymentsRouter.DELETE(":name", gin.WrapH(router))
+						deploymentsRouter.GET(":name/resources", gin.WrapH(router))
 
 						// other version dependant operations
 						cRouter.GET("/endpoints", api.MakeEndpointLister(cs, helmFacade, logger).ListEndpoints)

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -176,6 +176,7 @@ func decodeInstallReleaseHTTPRequest(_ context.Context, r *http.Request) (interf
 			DryRun:       request.DryRun,
 			GenerateName: request.ReleaseName == "",
 			Wait:         request.Wait,
+			Namespace:    request.Namespace,
 		},
 	}, nil
 }

--- a/internal/helm/helmdriver/transport_http.go
+++ b/internal/helm/helmdriver/transport_http.go
@@ -400,10 +400,16 @@ func decodeDeleteReleaseHTTPRequest(_ context.Context, r *http.Request) (interfa
 		return nil, errors.WrapIf(err, "failed to decode delete release request")
 	}
 
+	// namespace is passed as query parameter - quickfix, revisit this and decide on a final solution (eg introduce the namespace rest resource)
+	namespace := r.URL.Query().Get("namespace")
+
 	return DeleteReleaseRequest{
 		OrganizationID: orgID,
 		ClusterID:      clusterID,
 		ReleaseName:    releaseName,
+		Options: helm.Options{
+			Namespace: namespace,
+		},
 	}, nil
 }
 
@@ -478,10 +484,16 @@ func decodeGetReleaseHTTPRequest(_ context.Context, r *http.Request) (interface{
 		return nil, errors.WrapIf(err, "failed to decode get release request")
 	}
 
+	// namespace is passed as query parameter - quickfix, revisit this and decide on a final solution (eg introduce the namespace rest resource)
+	namespace := r.URL.Query().Get("namespace")
+
 	return GetReleaseRequest{
 		OrganizationID: orgID,
 		ClusterID:      clusterID,
 		ReleaseName:    releaseName,
+		Options: helm.Options{
+			Namespace: namespace,
+		},
 	}, nil
 }
 func decodeGetReleaseResourcesHTTPRequest(_ context.Context, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Namespace information is passed to the backend when operating releases

### Why?
Releases were always deployed to the default namespace regardless the selected one. Deletion failed on releases other than the default namespace.

### Additional context
The PR aligns the implementation to the helm 3 namespace handling

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)