### PR TITLE
Fix amazon secret default region

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -274,6 +274,7 @@ func main() {
 	secretStore := secretadapter.NewVaultStore(vaultClient, "secret")
 	pkeSecreter := pkesecret.NewPkeSecreter(vaultClient, commonLogger)
 	secretTypes := types.NewDefaultTypeList(types.DefaultTypeListConfig{
+		AmazonRegion:       config.Cloud.Amazon.DefaultRegion,
 		TLSDefaultValidity: config.Secret.TLS.DefaultValidity,
 		PkeSecreter:        pkeSecreter,
 	})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -213,6 +213,7 @@ func main() {
 	secretStore := secretadapter.NewVaultStore(vaultClient, "secret")
 	pkeSecreter := pkesecret.NewPkeSecreter(vaultClient, commonLogger)
 	secretTypes := types.NewDefaultTypeList(types.DefaultTypeListConfig{
+		AmazonRegion:       config.Cloud.Amazon.DefaultRegion,
 		TLSDefaultValidity: config.Secret.TLS.DefaultValidity,
 		PkeSecreter:        pkeSecreter,
 	})

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -44,15 +44,7 @@ type Config struct {
 	// Cadence configuration
 	Cadence cadence.Config
 
-	Cloud struct {
-		Amazon struct {
-			DefaultRegion string
-		}
-
-		Alibaba struct {
-			DefaultRegion string
-		}
-	}
+	Cloud CloudConfig
 
 	Cloudinfo CloudinfoConfig
 
@@ -142,6 +134,36 @@ func (c *Config) Process() error {
 	err = errors.Append(err, c.Cluster.Process())
 
 	return err
+}
+
+type CloudConfig struct {
+	Amazon AmazonCloudConfig
+
+	Alibaba struct {
+		DefaultRegion string
+	}
+}
+
+func (c CloudConfig) Validate() error {
+	var errs error
+
+	errs = errors.Append(errs, c.Amazon.Validate())
+
+	return errs
+}
+
+type AmazonCloudConfig struct {
+	DefaultRegion string
+}
+
+func (c AmazonCloudConfig) Validate() error {
+	var errs error
+
+	if c.DefaultRegion == "" {
+		errs = errors.Append(errs, errors.New("amazon default region is required"))
+	}
+
+	return errs
 }
 
 type CloudinfoConfig struct {

--- a/internal/secret/types/type_amazon.go
+++ b/internal/secret/types/type_amazon.go
@@ -31,7 +31,10 @@ const (
 	FieldAmazonSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 )
 
-type AmazonType struct{}
+type AmazonType struct {
+	// Region is used for secret verification.
+	Region string
+}
 
 func (AmazonType) Name() string {
 	return Amazon
@@ -51,10 +54,8 @@ func (t AmazonType) Validate(data map[string]string) error {
 	return validateDefinition(data, t.Definition())
 }
 
-const defaultAmazonRegion = "us-west-2"
-
 // TODO: rewrite this function!
-func (AmazonType) Verify(data map[string]string) error {
+func (t AmazonType) Verify(data map[string]string) error {
 	creds := credentials.NewStaticCredentials(
 		data[FieldAmazonAccessKeyId],
 		data[FieldAmazonSecretAccessKey],
@@ -63,7 +64,7 @@ func (AmazonType) Verify(data map[string]string) error {
 
 	sess, err := session.NewSession(&aws.Config{
 		Credentials: creds,
-		Region:      aws.String(defaultAmazonRegion),
+		Region:      aws.String(t.Region),
 	})
 	if err != nil {
 		return err

--- a/internal/secret/types/types.go
+++ b/internal/secret/types/types.go
@@ -22,6 +22,7 @@ import (
 
 // DefaultTypeListConfig contains the required configuration for the default type list.
 type DefaultTypeListConfig struct {
+	AmazonRegion       string
 	TLSDefaultValidity time.Duration
 	PkeSecreter        PkeSecreter
 }
@@ -30,7 +31,7 @@ type DefaultTypeListConfig struct {
 func NewDefaultTypeList(config DefaultTypeListConfig) secret.TypeList {
 	return secret.NewTypeList([]secret.Type{
 		AlibabaType{},
-		AmazonType{},
+		AmazonType{Region: config.AmazonRegion},
 		AzureType{},
 		AzureStorageAccountType{},
 		CloudflareType{},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Use the configured default region for amazon secret verification


### Why?
Depending on the account, the hard-coded default region might not be available everywhere.
