### PR TITLE
docs(developer): fix EKS doc issues (AWS IAM auth binary install, EKS ami image query script)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -156,7 +156,7 @@ vault kv put secret/banzaicloud/aws \
 Creating and using EKS clusters requires to you to have the [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) installed on your machine:
 
 ```bash
-go get github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator
+go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 ```
 
 #### EKS ami image query script

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -171,7 +171,7 @@ K8S_VERSIONS=(
 
 for version in ${K8S_VERSIONS[@]}; do
 	echo "K8S Version:" $version
-	for region in `aws ec2 describe-regions --output text | cut -f3 | sort -V`; do
+	for region in `aws ec2 describe-regions --output text | cut -f4 | sort -V`; do
 	    aws ssm get-parameter --name /aws/service/eks/optimized-ami/${version}/amazon-linux-2/recommended/image_id --region ${region} --query Parameter.Value --output text | xargs -I "{}" echo \"$region\": \"{}\",
 	done
 done

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -163,10 +163,9 @@ go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 
 ```
 K8S_VERSIONS=(
-  "1.11"
-  "1.12"
-  "1.13"
   "1.14"
+  "1.15"
+  "1.16"
 )
 
 for version in ${K8S_VERSIONS[@]}; do


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the AWS IAM Authenticator binary install command, the EKS ami image query script and updates the same script's Kubernetes versions.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because the original AWS IAM Authenticator command yielded an error, the image query script failed/didn't run properly with the incorrect region field and the Kubernetes versions lacked the current ones while included years-old deprecated versions.
See the individual commit messages for more details.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
