### PR TITLE
Make audit log sensitive patterns more strict

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -607,9 +607,9 @@ func main() {
 			driver,
 			auditlog.WithUserIDExtractor(auth.GetCurrentUserID),
 			auditlog.WithSensitivePaths([]*regexp.Regexp{
-				regexp.MustCompile("/auth/dex(?:/.*)?"),
-				regexp.MustCompile("/.*/api/v1/orgs/.*/secrets(?:/.*)?"),
-				regexp.MustCompile("/.*/api/v1/orgs/.*/clusters/.*/pke/ready"),
+				regexp.MustCompile("^/auth/dex(?:/[^/]+)*"),
+				regexp.MustCompile("^/(?:[^/]+/)*api/v1/orgs/[0-9]+/secrets(?:/[^/]+)*"),
+				regexp.MustCompile("^/(?:[^/]+/)*api/v1/orgs/[0-9]+/clusters/[^/]+/pke/ready"),
 			}),
 			auditlog.WithErrorHandler(errorHandler),
 		))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Make audit log sensitive URL path filters more strict
