### PR TITLE
Make json the default log format

### DIFF
--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -3,6 +3,7 @@
 # Pipeline logging configuration
 log:
     level: "debug"
+    format: "logfmt"
 
 pipeline:
     uuid: ""

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -3,7 +3,7 @@
 # Pipeline logging configuration
 #log:
 #    level: "info"
-#    format: "logfmt"
+#    format: "json"
 
 # Pipeline error handling configuration
 #errors:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -487,7 +487,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("auth::token::issuer", "")
 	v.SetDefault("auth::token::audience", "")
 
-	v.SetDefault("log::format", "logfmt")
+	v.SetDefault("log::format", "json")
 	v.SetDefault("log::level", "info")
 	v.RegisterAlias("log::noColor", "no_color")
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Makes json the default log format in configuration


### Why?
In production environments, we should log everything in json


### Additional context
Certain underlying libraries (looking at you client-go) thinks it's a good idea to define a global, non-overrideable logger,
so some log lines might not be encoded as JSON. AFAIK that's not a problem though, Fluentbit/D can convert those log entries to JSON (cc @tarokkk to confirm)
