### PR TITLE
Fix request body when using logfmt log format

### DIFF
--- a/internal/platform/gin/auditlog/auditlogdriver/log.go
+++ b/internal/platform/gin/auditlog/auditlogdriver/log.go
@@ -99,7 +99,12 @@ func appendFields(data map[string]interface{}, entry auditlog.Entry, fields []st
 		case "http.responseSize":
 			data[field] = entry.HTTP.ResponseSize
 		case "http.requestBody":
-			data[field] = entry.HTTP.RequestBody
+			var body string
+			if entry.HTTP.RequestBody != nil {
+				body = *entry.HTTP.RequestBody
+			}
+
+			data[field] = body
 		case "http.errors":
 			if len(entry.HTTP.Errors) > 0 {
 				data[field] = entry.HTTP.Errors

--- a/internal/platform/gin/auditlog/auditlogdriver/log_test.go
+++ b/internal/platform/gin/auditlog/auditlogdriver/log_test.go
@@ -66,7 +66,7 @@ func TestLogDriver(t *testing.T) {
 				"http.statusCode":   entry.HTTP.StatusCode,
 				"http.responseTime": entry.HTTP.ResponseTime,
 				"http.responseSize": entry.HTTP.ResponseSize,
-				"http.requestBody":  entry.HTTP.RequestBody,
+				"http.requestBody":  "",
 			},
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related #3003
| License         | Apache 2.0


### What's in this PR?
Fix request body when using logfmt log format


### Why?
The logfmt formatter printed the memory address of the pointer


### Additional context
Not even sure why the request body is a pointer. We should take a look at this
