### PR TITLE
fix: decoded CloudFormation error detail for logging purposes

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
@@ -152,7 +152,8 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 
 	// wait for IAM roles to created before starting user access key creation
 	iamRolesActivityOutput := &CreateIamRolesActivityOutput{}
-	if err := iamRolesCreateActivityFuture.Get(ctx, &iamRolesActivityOutput); err != nil {
+	err := decodeCloudFormationError(iamRolesCreateActivityFuture.Get(ctx, &iamRolesActivityOutput))
+	if err != nil {
 		return nil, err
 	}
 
@@ -211,7 +212,7 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 		for i, future := range createSubnetFutures {
 			var activityOutput CreateSubnetActivityOutput
 
-			errs[i] = future.Get(ctx, &activityOutput)
+			errs[i] = decodeCloudFormationError(future.Get(ctx, &activityOutput))
 			if errs[i] == nil {
 				existingAndNewSubnets = append(existingAndNewSubnets, Subnet{
 					SubnetID:         activityOutput.SubnetID,
@@ -350,7 +351,7 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 	errs := make([]error, len(asgFutures))
 	for i, future := range asgFutures {
 		var activityOutput CreateAsgActivityOutput
-		errs[i] = future.Get(ctx, &activityOutput)
+		errs[i] = decodeCloudFormationError(future.Get(ctx, &activityOutput))
 	}
 	if err := errors.Combine(errs...); err != nil {
 		return nil, err

--- a/internal/cluster/distribution/eks/eksprovider/workflow/error.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/error.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Banzai Cloud
+// Copyright © 2020 Banzai Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,41 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cluster
+package workflow
 
 import (
-	"errors"
 	"fmt"
 
-	emperrors "emperror.dev/errors"
+	"emperror.dev/errors"
 	"go.uber.org/cadence"
-
-	eksWorkflow "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 )
-
-var ErrInvalidClusterInstance = errors.New("invalid cluster instance")
-
-type invalidError struct {
-	err error
-}
-
-func (e *invalidError) Error() string {
-	return e.err.Error()
-}
-
-func (invalidError) IsInvalid() bool {
-	return true
-}
 
 // decodeCloudFormationError decodes a Cloud Formation cadence.CustomError into
 // a simplified object which returns a detailed error message on its Error()
 // (message string) function implementation.
 func decodeCloudFormationError(err error) error {
-	if customError, ok := err.(*cadence.CustomError); ok && customError.Reason() == eksWorkflow.ErrReasonStackFailed {
+	if customError, ok := err.(*cadence.CustomError); ok && customError.Reason() == ErrReasonStackFailed {
 		var details string
 		_ = customError.Details(&details)
 
-		return emperrors.NewPlain(fmt.Sprintf("%s: %s", customError.Reason(), details))
+		return errors.NewPlain(fmt.Sprintf("%s: %s", customError.Reason(), details))
 	}
 
 	return err

--- a/internal/cluster/distribution/eks/eksworkflow/error.go
+++ b/internal/cluster/distribution/eks/eksworkflow/error.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Banzai Cloud
+// Copyright © 2020 Banzai Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,41 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cluster
+package eksworkflow
 
 import (
-	"errors"
 	"fmt"
 
-	emperrors "emperror.dev/errors"
+	"emperror.dev/errors"
 	"go.uber.org/cadence"
-
-	eksWorkflow "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 )
-
-var ErrInvalidClusterInstance = errors.New("invalid cluster instance")
-
-type invalidError struct {
-	err error
-}
-
-func (e *invalidError) Error() string {
-	return e.err.Error()
-}
-
-func (invalidError) IsInvalid() bool {
-	return true
-}
 
 // decodeCloudFormationError decodes a Cloud Formation cadence.CustomError into
 // a simplified object which returns a detailed error message on its Error()
 // (message string) function implementation.
 func decodeCloudFormationError(err error) error {
-	if customError, ok := err.(*cadence.CustomError); ok && customError.Reason() == eksWorkflow.ErrReasonStackFailed {
+	if customError, ok := err.(*cadence.CustomError); ok && customError.Reason() == ErrReasonStackFailed {
 		var details string
 		_ = customError.Details(&details)
 
-		return emperrors.NewPlain(fmt.Sprintf("%s: %s", customError.Reason(), details))
+		return errors.NewPlain(fmt.Sprintf("%s: %s", customError.Reason(), details))
 	}
 
 	return err

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -175,11 +175,11 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 		}
 
 		processActivity := process.StartActivity(ctx, WaitCloudFormationStackUpdateActivityName)
-		err = workflow.ExecuteActivity(
+		err = decodeCloudFormationError(workflow.ExecuteActivity(
 			workflow.WithActivityOptions(ctx, activityOptions),
 			WaitCloudFormationStackUpdateActivityName,
 			activityInput,
-		).Get(ctx, nil)
+		).Get(ctx, nil))
 		processActivity.Finish(ctx, err)
 		if err != nil {
 			return err

--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -56,7 +56,7 @@ func waitForActivities(asgFutures []workflow.Future, ctx workflow.Context, clust
 	errs := make([]error, len(asgFutures))
 	for i, future := range asgFutures {
 		var activityOutput eksWorkflow.CreateAsgActivityOutput
-		errs[i] = future.Get(ctx, &activityOutput)
+		errs[i] = decodeCloudFormationError(future.Get(ctx, &activityOutput))
 	}
 	if err := errors.Combine(errs...); err != nil {
 		_ = eksWorkflow.SetClusterStatus(ctx, clusterID, pkgCluster.Warning, err.Error())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
I introduced a `decodeCloudFormationError()` function to all 3
packages where cadence activities are used which would employ the
`packageCFError()` function to pack their returned
error in order to decode it before sending upwards.

Unfortunately there are 3 different "states" of the AWS/EKS distribution workflows with multiple instances of code duplication which made me implement the above mentioned functionality at 3 different places.
If anyone sees a good location for the single definition of this functionality, let me know and I will migrate these instances there.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In case of CloudFormation errors the received stack error was
packaged with https://github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksworkflow.common.go `packageCFError()`
into a `cadence.CustomError` using the `ErrReasonStackFailed` and the
original error message as detail.

When this error was returned to the workflow (for example
`UpdateNodePoolWorkflow`) and sent upstream, the details were never
extracted and thus valuable information was lost.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
