### PR TITLE
Add support to override AWS auth config from cluster create request i…

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -23146,6 +23146,8 @@ components:
           $ref: '#/components/schemas/BaseUpdateNodePoolOptions'
     CreateEKSProperties_eks:
       properties:
+        authConfigMap:
+          type: string
         version:
           example: "1.10"
           type: string

--- a/.gen/pipeline/pipeline/model_create_eks_properties_eks.go
+++ b/.gen/pipeline/pipeline/model_create_eks_properties_eks.go
@@ -12,6 +12,8 @@ package pipeline
 
 type CreateEksPropertiesEks struct {
 
+	AuthConfigMap string `json:"authConfigMap,omitempty"`
+
 	Version string `json:"version,omitempty"`
 
 	LogTypes []string `json:"logTypes,omitempty"`

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4664,6 +4664,8 @@ components:
                     required:
                         - nodePools
                     properties:
+                        authConfigMap:
+                            type: string
                         version:
                             type: string
                             example: "1.10"

--- a/database/migrations/mysql/1595244196_add_eks_auth_configmap_column.down.sql
+++ b/database/migrations/mysql/1595244196_add_eks_auth_configmap_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `amazon_eks_clusters` DROP COLUMN `auth_config_map`;

--- a/database/migrations/mysql/1595244196_add_eks_auth_configmap_column.up.sql
+++ b/database/migrations/mysql/1595244196_add_eks_auth_configmap_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `amazon_eks_clusters` ADD COLUMN `auth_config_map` text COLLATE utf8mb4_unicode_ci;

--- a/database/migrations/postgres/1595244196_add_eks_auth_configmap_column.down.sql
+++ b/database/migrations/postgres/1595244196_add_eks_auth_configmap_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "amazon_eks_clusters" DROP COLUMN "auth_config_map";

--- a/database/migrations/postgres/1595244196_add_eks_auth_configmap_column.up.sql
+++ b/database/migrations/postgres/1595244196_add_eks_auth_configmap_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "amazon_eks_clusters" ADD COLUMN "auth_config_map" TEXT;

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -42,6 +42,7 @@ type CreateClusterEKS struct {
 	// Default: ["public"]
 	APIServerAccessPoints []string          `json:"apiServerAccessPoints,omitempty" yaml:"apiServerAccessPoints,omitempty"`
 	Tags                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	AuthConfigMap         string            `json:"authConfigMap,omitempty" yaml:"authConfigMap,omitempty"`
 }
 
 // UpdateClusterAmazonEKS describes Amazon EKS's node fields of an UpdateCluster request

--- a/internal/cluster/distribution/eks/eksmodel/eks.go
+++ b/internal/cluster/distribution/eks/eksmodel/eks.go
@@ -54,7 +54,7 @@ type EKSClusterModel struct {
 
 	SSHGenerated bool `gorm:"default:true"`
 
-	AuthConfigMap string
+	AuthConfigMap string `gorm:"type:text"`
 }
 
 // TableName sets EKSClusterModel's table name

--- a/internal/cluster/distribution/eks/eksmodel/eks.go
+++ b/internal/cluster/distribution/eks/eksmodel/eks.go
@@ -53,6 +53,8 @@ type EKSClusterModel struct {
 	CurrentWorkflowID string
 
 	SSHGenerated bool `gorm:"default:true"`
+
+	AuthConfigMap string
 }
 
 // TableName sets EKSClusterModel's table name

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
@@ -151,6 +151,7 @@ func (c *EksClusterCreator) create(ctx context.Context, logger logrus.FieldLogge
 			LogTypes:           modelCluster.LogTypes,
 			UseGeneratedSSHKey: modelCluster.SSHGenerated,
 			Tags:               modelCluster.Cluster.Tags,
+			AuthConfigMap:      modelCluster.AuthConfigMap,
 		},
 		PostHooks:        createRequest.PostHooks,
 		OrganizationName: org.Name,

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
@@ -55,6 +55,8 @@ type CreateInfrastructureWorkflowInput struct {
 	AsgList  []AutoscaleGroup
 
 	UseGeneratedSSHKey bool
+
+	AuthConfigMap string
 }
 
 type CreateInfrastructureWorkflowOutput struct {
@@ -296,6 +298,7 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 			KubernetesVersion:   input.KubernetesVersion,
 			NodeInstanceRoleArn: iamRolesActivityOutput.NodeInstanceRoleArn,
 			ClusterUserArn:      iamRolesActivityOutput.ClusterUserArn,
+			AuthConfigMap:       input.AuthConfigMap,
 		}
 		bootstrapActivityFeature = workflow.ExecuteActivity(ctx, BootstrapActivityName, activityInput)
 	}

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -82,6 +82,7 @@ func CreateEKSClusterFromRequest(request *pkgCluster.CreateClusterRequest, orgId
 		ClusterRoleId:         request.Properties.CreateClusterEKS.IAM.ClusterRoleID,
 		NodeInstanceRoleId:    request.Properties.CreateClusterEKS.IAM.NodeInstanceRoleID,
 		APIServerAccessPoints: createAPIServerAccessPointsFromRequest(request),
+		AuthConfigMap:         request.Properties.CreateClusterEKS.AuthConfigMap,
 	}
 
 	if request.Properties.CreateClusterEKS.Tags != nil {

--- a/src/cluster/eks_create_cluster.go
+++ b/src/cluster/eks_create_cluster.go
@@ -74,6 +74,7 @@ func EKSCreateClusterWorkflow(ctx workflow.Context, input EKSCreateClusterWorkfl
 		EndpointPrivateAccess: input.EndpointPublicAccess,
 		UseGeneratedSSHKey:    input.UseGeneratedSSHKey,
 		Tags:                  input.Tags,
+		AuthConfigMap:         input.AuthConfigMap,
 	}
 
 	infraOutput := eksWorkflow.CreateInfrastructureWorkflowOutput{}


### PR DESCRIPTION
…n case of Amazon EKS

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add support to override AWS auth config from cluster create request in case of Amazon EKS


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
