### PR TITLE
add support for eks 1.17

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -166,6 +166,7 @@ K8S_VERSIONS=(
   "1.14"
   "1.15"
   "1.16"
+  "1.17"
 )
 
 for version in ${K8S_VERSIONS[@]}; do

--- a/internal/cluster/distribution/eks/defaults.go
+++ b/internal/cluster/distribution/eks/defaults.go
@@ -113,6 +113,30 @@ var defaultImageMap = []struct {
 			"us-west-2":      "ami-0809659d79ce80260", // US West (Oregon).
 		},
 	},
+	{
+		constraintForVersion("1.17"),
+		map[string]string{
+			// Kubernetes Version 1.17.7
+			"ap-east-1":      "ami-0bb3febb3142599d2", // Asia Pacific (Hong Kong).
+			"ap-northeast-1": "ami-06c747ba66b41a7ba", // Asia Pacific (Tokyo).
+			"ap-northeast-2": "ami-05ec1709521de4ece", // Asia Pacific (Seoul).
+			"ap-southeast-1": "ami-0d536714e5639f906", // Asia Pacific (Mumbai).
+			"ap-southeast-2": "ami-04e1f56b76edf1adb", // Asia Pacific (Singapore).
+			"ap-south-1":     "ami-0b9b4038f1f04c8d3", // Asia Pacific (Sydney).
+			"ca-central-1":   "ami-00ca7c831ef613b49", // Canada (Central).
+			"eu-central-1":   "ami-0f0a5a541ea7e37e6", // EU (Frankfurt).
+			"eu-north-1":     "ami-07bfdb27ea538e70e", // EU (Stockholm).
+			"eu-west-1":      "ami-036a0d0e0582ceb89", // EU (Ireland).
+			"eu-west-2":      "ami-0d556f731d5b55154", // EU (London).
+			"eu-west-3":      "ami-07592d8accea4be97", // EU (Paris).
+			"me-south-1":     "ami-0ae84a39f0799dcd7", // Middle East (Bahrain).
+			"sa-east-1":      "ami-080e2d0ed87f73d34", // South America (Sao Paulo).
+			"us-east-1":      "ami-07fb69750f0a547e7", // US East (N. Virginia).
+			"us-east-2":      "ami-0f56d1834ab6cf42e", // US East (Ohio).
+			"us-west-1":      "ami-083bfcb4c129eb7a7", // US West (N. California).
+			"us-west-2":      "ami-085fc3ebd8fc486ff", // US West (Oregon).
+		},
+	},
 }
 
 // GetDefaultImageID returns the EKS optimized AMI for given Kubernetes version and region.

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -289,7 +289,7 @@ func (eks *UpdateClusterAmazonEKS) Validate() error {
 
 // isValidVersion validates the given K8S version
 func isValidVersion(version string) (bool, error) {
-	constraint, err := semver.NewConstraint(">= 1.14, <= 1.16")
+	constraint, err := semver.NewConstraint(">= 1.14, <= 1.17")
 	if err != nil {
 		return false, errors.WrapIf(err, "couldn't create semver Kubernetes version check constraint")
 	}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Enable Kubernetes version 1.17 on EKS and add default AMI ids for 1.17.



### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
