### PR TITLE
audit: fix sensitive path regexps for prefix with //

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -608,8 +608,8 @@ func main() {
 			auditlog.WithUserIDExtractor(auth.GetCurrentUserID),
 			auditlog.WithSensitivePaths([]*regexp.Regexp{
 				regexp.MustCompile("^/auth/dex(?:/[^/]+)*"),
-				regexp.MustCompile("^/(?:[^/]+/)*api/v1/orgs/[0-9]+/secrets(?:/[^/]+)*"),
-				regexp.MustCompile("^/(?:[^/]+/)*api/v1/orgs/[0-9]+/clusters/[^/]+/pke/ready"),
+				regexp.MustCompile("^/(?:[^/]*/)*api/v1/orgs/[0-9]+/secrets(?:/[^/]+)*"),
+				regexp.MustCompile("^/(?:[^/]*/)*api/v1/orgs/[0-9]+/clusters/[^/]+/pke/ready"),
 			}),
 			auditlog.WithErrorHandler(errorHandler),
 		))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

If the basepath is configured incorrectly (with a trailing slash), the sensitive paths are not detected, so secrets can appear in the audit log. This is fixed with this PR.

```
{"application":"pipeline","channel":"audit","correlationID":"70b50df1-0d65-4dc1-a4a5-1b7d272e7a4c","http.clientIP":"3.133.90.137","http.method":"POST","http.path":"/pipeline//api/v1/orgs/1/clusters/59/pke/ready","http.requestBody":"{\"config\":\"YXBpVmV
```