### PR TITLE
traefik: rbac should be enabled

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -630,6 +630,8 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 ssl:
   enabled: true
   generateTLS: true
+rbac:
+  enabled: true
 `)
 
 	v.SetDefault("cluster::autoscale::namespace", "")

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -80,6 +80,9 @@ func TestConfigure_DefaultValueBinding(t *testing.T) {
 							Chart:   "stable/traefik",
 							Version: "1.86.2",
 							Values: values.Config(map[string]interface{}{
+								"rbac": map[string]interface{}{
+									"enabled": true,
+								},
 								"ssl": map[string]interface{}{
 									"enabled":     true,
 									"generateTLS": true,


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Enable RBAC in traefik integrated service chart installation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
```
E0723 12:57:51.764291       1 reflector.go:205] github.com/containous/traefik/vendor/k8s.io/client-go/informers/factory.go:86: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "system:serviceaccount:pipeline-system:default" cannot list resource "ingresses" in API group "extensions" at the cluster scope
E0723 12:57:51.771417       1 reflector.go:205] github.com/containous/traefik/vendor/k8s.io/client-go/informers/factory.go:86: Failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:pipeline-system:default" cannot list resource "endpoints" in API group "" at the cluster scope
E0723 12:57:51.772718       1 reflector.go:205] github.com/containous/traefik/vendor/k8s.io/client-go/informers/factory.go:86: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:pipeline-system:default" cannot list resource "services" in API group "" at the cluster scope
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
