### PR TITLE
migra: use python3 explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,8 +181,8 @@ jobs:
                 run:
                     name: Install migra for PostgreSQL database diffs
                     command: |
-                        apt-get install -y python-pip
-                        pip install migra[pg]
+                        apt-get install -y python3-pip
+                        pip3 install migra[pg]
 
             -
                 run:


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Using Python 3 for `migra` (testing Postgres schema diffs).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise `migra` fails with (migra needs Python 3 now):
```bash
#!/bin/bash -eo pipefail
migra postgresql://postgres:postgres@localhost/pipeline_migrations postgresql://postgres:postgres@localhost/pipeline_automigrate --unsafe
Traceback (most recent call last):
  File "/usr/local/bin/migra", line 7, in <module>
    from migra import do_command
  File "/usr/local/lib/python2.7/dist-packages/migra/__init__.py", line 4, in <module>
    from .command import do_command
  File "/usr/local/lib/python2.7/dist-packages/migra/command.py", line 9, in <module>
    from .migra import Migration
  File "/usr/local/lib/python2.7/dist-packages/migra/migra.py", line 3, in <module>
    from schemainspect import DBInspector, get_inspector
  File "/usr/local/lib/python2.7/dist-packages/schemainspect/__init__.py", line 4, in <module>
    from .command import do_command
  File "/usr/local/lib/python2.7/dist-packages/schemainspect/command.py", line 34
    thing=f"{dep.kind_dependent_on}: {thing}",
                                            ^
SyntaxError: invalid syntax

Exited with code exit status 1
CircleCI received exit code 1
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
