### PR TITLE
Fix vault address in vault service tests

### DIFF
--- a/internal/integratedservices/services/vault/manager_test.go
+++ b/internal/integratedservices/services/vault/manager_test.go
@@ -17,6 +17,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -110,7 +111,7 @@ func testIntegratedServiceManagerGetOutput(t *testing.T) {
 			spec: obj{
 				"customVault": obj{
 					"enabled": true,
-					"address": "http://localhost:8200/",
+					"address": os.Getenv("VAULT_ADDR"),
 					"policy":  getDefaultPolicy(orgID),
 				},
 				"settings": obj{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Fixes the vault address used in vault integrated service functional tests


### Why?
In some cases Vault might not listen on a standard port, so hard-coding it in tests is a bad idea.
