### PR TITLE
Fix create nodepool validation

### DIFF
--- a/internal/cluster/distribution/eks/node_pool.go
+++ b/internal/cluster/distribution/eks/node_pool.go
@@ -52,6 +52,14 @@ func (n NewNodePool) Validate() error {
 		if n.Autoscaling.MaxSize <= n.Autoscaling.MinSize {
 			violations = append(violations, "maximum autoscaling size cannot be lower than the minimum")
 		}
+
+		if n.Size < n.Autoscaling.MinSize {
+			violations = append(violations, "desired size cannot be lower than the autoscaling minimum")
+		}
+
+		if n.Size > n.Autoscaling.MaxSize {
+			violations = append(violations, "desired size cannot be higher than the autoscaling maximum")
+		}
 	} else if n.Size < 1 {
 		violations = append(violations, "size cannot be lower than one")
 	}

--- a/internal/cluster/distribution/eks/node_pool.go
+++ b/internal/cluster/distribution/eks/node_pool.go
@@ -45,8 +45,8 @@ func (n NewNodePool) Validate() error {
 	var violations []string
 
 	if n.Autoscaling.Enabled {
-		if n.Autoscaling.MinSize < 1 {
-			violations = append(violations, "minimum autoscaling size cannot be lower than one")
+		if n.Autoscaling.MinSize < 0 {
+			violations = append(violations, "minimum autoscaling size cannot be lower than zero")
 		}
 
 		if n.Autoscaling.MaxSize <= n.Autoscaling.MinSize {
@@ -54,11 +54,11 @@ func (n NewNodePool) Validate() error {
 		}
 
 		if n.Size < n.Autoscaling.MinSize {
-			violations = append(violations, "desired size cannot be lower than the autoscaling minimum")
+			violations = append(violations, "node pool size cannot be lower than the autoscaling minimum size")
 		}
 
 		if n.Size > n.Autoscaling.MaxSize {
-			violations = append(violations, "desired size cannot be higher than the autoscaling maximum")
+			violations = append(violations, "node pool size cannot be higher than the autoscaling maximum size")
 		}
 	} else if n.Size < 1 {
 		violations = append(violations, "size cannot be lower than one")

--- a/internal/cluster/distribution/eks/node_pool_test.go
+++ b/internal/cluster/distribution/eks/node_pool_test.go
@@ -39,6 +39,17 @@ func TestNodePoolSizeValidation(t *testing.T) {
 		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
 	})
 
+	t.Run("PoolMinSizeNegative", func(t *testing.T) {
+		pool := base
+		pool.Size = 1
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = -1
+		pool.Autoscaling.MaxSize = 2
+
+		err := pool.Validate()
+		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
+	})
+
 	t.Run("PoolSizeUnderMin", func(t *testing.T) {
 		pool := base
 		pool.Size = 0
@@ -83,7 +94,18 @@ func TestNodePoolSizeValidation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("PoolValidNoAS", func(t *testing.T) {
+	t.Run("PoolZeroAutoscaling", func(t *testing.T) {
+		pool := base
+		pool.Size = 0
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = 0
+		pool.Autoscaling.MaxSize = 2
+
+		err := pool.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("PoolValidNoAutoscaling", func(t *testing.T) {
 		pool := base
 		pool.Size = 1
 		pool.Autoscaling.Enabled = false

--- a/internal/cluster/distribution/eks/node_pool_test.go
+++ b/internal/cluster/distribution/eks/node_pool_test.go
@@ -1,0 +1,94 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eks
+
+import (
+	"testing"
+
+	"emperror.dev/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/banzaicloud/pipeline/internal/cluster"
+)
+
+func TestNodePoolSizeValidation(t *testing.T) {
+	base := NewNodePool{
+		Name:         "pool",
+		InstanceType: "c5.large",
+		Image:        "ami",
+	}
+
+	t.Run("PoolZeroSize", func(t *testing.T) {
+		pool := base
+		pool.Size = 0
+		pool.Autoscaling.Enabled = false
+
+		err := pool.Validate()
+		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
+	})
+
+	t.Run("PoolSizeUnderMin", func(t *testing.T) {
+		pool := base
+		pool.Size = 0
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = 1
+		pool.Autoscaling.MaxSize = 2
+
+		err := pool.Validate()
+		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
+	})
+
+	t.Run("PoolSizeOverMax", func(t *testing.T) {
+		pool := base
+		pool.Size = 3
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = 1
+		pool.Autoscaling.MaxSize = 2
+
+		err := pool.Validate()
+		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
+	})
+
+	t.Run("PoolReverseRange", func(t *testing.T) {
+		pool := base
+		pool.Size = 1
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = 2
+		pool.Autoscaling.MaxSize = 1
+
+		err := pool.Validate()
+		assert.IsType(t, cluster.ValidationError{}, errors.Cause(err))
+	})
+
+	t.Run("PoolValidRange", func(t *testing.T) {
+		pool := base
+		pool.Size = 1
+		pool.Autoscaling.Enabled = true
+		pool.Autoscaling.MinSize = 1
+		pool.Autoscaling.MaxSize = 2
+
+		err := pool.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("PoolValidNoAS", func(t *testing.T) {
+		pool := base
+		pool.Size = 1
+		pool.Autoscaling.Enabled = false
+
+		err := pool.Validate()
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3017 
| License         | Apache 2.0


### What's in this PR?
* Allow zero-sized autoscaled node pools (like at the time of cluster creation)
* Check if desired count is between the min and max size

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)