### PR TITLE
Automatically add go.mod to plz-out

### DIFF
--- a/BUILD.plz
+++ b/BUILD.plz
@@ -5,6 +5,22 @@ github_repo(
 )
 
 genrule(
+    name = "go.mod",
+    outs = ["go.mod"],
+    cmd = [
+        """cat > $OUTS << EOF
+module plz-out
+
+go 1.14
+EOF
+      """
+    ],
+    labels = [
+        "link:plz-out/"
+    ]
+)
+
+genrule(
     name = "docker-compose.override.yml",
     srcs = ["docker-compose.override.yml.dist"],
     outs = ["docker-compose.override.yml"],

--- a/BUILD.plz
+++ b/BUILD.plz
@@ -6,12 +6,13 @@ github_repo(
 
 genrule(
     name = "go.mod",
+    srcs = ["go.mod"],
     outs = ["go.mod"],
     cmd = [
-        """cat > $OUTS << EOF
+        """export GO=$(cat "$SRC" | grep '^go .*$') && cat > $OUT << EOF
 module plz-out
 
-go 1.14
+$GO
 EOF
       """
     ],


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Regular go tools look for go files in all directories.
This causes issues in case of please, because it actually stores
Go files in its plz-out directory.

The solution is to make it a dummy module,
because Go's package filtering (eg. ./...) ignores submodules.