### PR TITLE
fix(EKS): removed node pool create failure residue

### DIFF
--- a/internal/cluster/clusterworkflow/workflow_create_node_pool.go
+++ b/internal/cluster/clusterworkflow/workflow_create_node_pool.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/cadence/workflow"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
-	_cadence "github.com/banzaicloud/pipeline/pkg/cadence"
+	pkgCadence "github.com/banzaicloud/pipeline/pkg/cadence"
 )
 
 const CreateNodePoolWorkflowName = "create-node-pool"
@@ -41,7 +41,7 @@ func CreateNodePoolWorkflow(ctx workflow.Context, input CreateNodePoolWorkflowIn
 			InitialInterval:          15 * time.Second,
 			BackoffCoefficient:       1.0,
 			MaximumAttempts:          30,
-			NonRetriableErrorReasons: []string{_cadence.ClientErrorReason, "cadenceInternal:Panic"},
+			NonRetriableErrorReasons: []string{pkgCadence.ClientErrorReason, "cadenceInternal:Panic"},
 		},
 	}
 	_ctx := ctx
@@ -55,7 +55,7 @@ func CreateNodePoolWorkflow(ctx workflow.Context, input CreateNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, CreateNodePoolLabelSetActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}
@@ -70,7 +70,7 @@ func CreateNodePoolWorkflow(ctx workflow.Context, input CreateNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, CreateNodePoolActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}
@@ -85,7 +85,7 @@ func CreateNodePoolWorkflow(ctx workflow.Context, input CreateNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, SetClusterStatusActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}

--- a/internal/cluster/clusterworkflow/workflow_delete_node_pool.go
+++ b/internal/cluster/clusterworkflow/workflow_delete_node_pool.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/cadence/workflow"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
-	_cadence "github.com/banzaicloud/pipeline/pkg/cadence"
+	pkgCadence "github.com/banzaicloud/pipeline/pkg/cadence"
 )
 
 const DeleteNodePoolWorkflowName = "delete-node-pool"
@@ -40,7 +40,7 @@ func DeleteNodePoolWorkflow(ctx workflow.Context, input DeleteNodePoolWorkflowIn
 			InitialInterval:          15 * time.Second,
 			BackoffCoefficient:       1.0,
 			MaximumAttempts:          30,
-			NonRetriableErrorReasons: []string{_cadence.ClientErrorReason, "cadenceInternal:Panic"},
+			NonRetriableErrorReasons: []string{pkgCadence.ClientErrorReason, "cadenceInternal:Panic"},
 		},
 	}
 	_ctx := ctx
@@ -54,7 +54,7 @@ func DeleteNodePoolWorkflow(ctx workflow.Context, input DeleteNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, DeleteNodePoolActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}
@@ -68,7 +68,7 @@ func DeleteNodePoolWorkflow(ctx workflow.Context, input DeleteNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, DeleteNodePoolLabelSetActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}
@@ -83,7 +83,7 @@ func DeleteNodePoolWorkflow(ctx workflow.Context, input DeleteNodePoolWorkflowIn
 
 		err := workflow.ExecuteActivity(ctx, SetClusterStatusActivityName, input).Get(ctx, nil)
 		if err != nil {
-			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, err.Error())
+			_ = setClusterStatus(_ctx, input.ClusterID, cluster.Warning, pkgCadence.UnwrapError(err).Error())
 
 			return err
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3031
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
1. Unwrapped Cadence errors at cluster node pool creation/deletion.
2. Removed all residue resources when an AWS/EKS node pool creation fails, including deleting failed-to-create CloudFormation stacks.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
There were a couple minor issues such as 

- error details not being displayed and 

and one major issue namely 

- when the CF node pool / ASG stack creation failed, a non-describable (but list-able) failed stack was left behind which couldn't be deleted on the pipeline API due to shortcutting the request response due to no node pool entry in the database and also couldn't be recreated because the stack was already existing.

Solution to the minor problems were trivial.
3 different solutions were considered for the major issue: (in the order of consideration)
1. **Recording the failed-to-create node pools in the database as "known" node pool in order to execute deletion on delete request.**
This proved to be unfeasible as the database modification is part of the activity, but the workflow retry logic would try to rerun the activity which would cause a clash when trying to write the node pool to the DB for the second time. 
- I considered checking whether the DB and activity objects are identical and skipping the DB write in that case, but it would have been tedious and difficult to maintain because of two similarly structured but different types which are used directly, not through an interface.
- Also considered using the workflow ID - which remains the same throughout same workflow's activity retries - to identify retries, but didn't find any good ways to persist it throughout activity retries - for example as part of a pool description in the database it felt forced/out-of-place workaround and not a real fix. **After a discussion there is supposed to be an available activity attempt indicator, so I'm trying to pursue this solution.**
- Also considered moving the database mutation out of the node pool creation activity in order to prevent workflow retry issues while writing failed-to-create node pools to the DB on workflow level, but I didn't like that approach from a high level perspective, the DB write should be part of the current create node pool activity and refactoring that single activity into smaller steps felt like a bigger refactor which seemed out of scope for the current bug.

2. **Checking failed-to-create stack existence from AWS instead of the database and executing a delete on such stacks.**
This option would have been feasible, but it would have meant coupling node pool creation and deletion steps together loosely by requiring a list+delete action for all resources mutated during creation which I consider harder to maintain compared to option 3. Also this basically would have relegated failure cleanup to a manual request.

3. **Making the node pool create activity atomic and restoring the pre-node-pool-creation state of the cluster in case of a failure including the CloudFormation stacks.**
This proved to be the easiest to implement solution right now because only the node pool / ASG stack creation step mutates any resources which meant a single deletion step in the error handling branch resolved the issue and eliminated all failure residue. From what I understood (CMIIW) this is also the long-term goal we are working towards - making infrastructure resource mutation atomic seems a good approach to me. This solution also requires the least amount of manual intervention in case of a node pool creation issue while preserves and conveys all failure information as a cluster status warning.

See the referenced issue for more details.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
All 2 solutions, but especially the 1 minor ones (error unwrapping) **SHOULD** be considered to be utilized for all other use-cases in the code-base where similar issues may arise.
I decided not to include these changes into this PR because they are not part of the strict scope, but I'm planning to implement those changes after finishing this PR.

The following PRs implemented those minor fixes/improvements:
Error detail propagation: https://github.com/banzaicloud/pipeline/pull/3106
Unique AWS client request token: https://github.com/banzaicloud/pipeline/pull/3107

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider) [AWS]
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- ~Write unit tests for the node pool creation/deletion workflows.~ Note: out of scope for the current PR due to time constraints and some obstacles to be solved for activity unit testing.
- [X] Annotate the stack delete errors returned with the intention (like wrap with "deleting failed stack")
- [X] Reimplement this way: https://github.com/banzaicloud/pipeline/issues/3031#issuecomment-669140908
