### PR TITLE
Use go_library compat rules

### DIFF
--- a/.gen/anchore/BUILD
+++ b/.gen/anchore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "anchore",
     srcs = glob(
         ["*.go"],

--- a/.gen/cloudinfo/BUILD
+++ b/.gen/cloudinfo/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cloudinfo",
     srcs = glob(
         ["*.go"],

--- a/.gen/pipeline/pipeline/BUILD
+++ b/.gen/pipeline/pipeline/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pipeline",
     srcs = glob(
         ["*.go"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           path: |
             .plz-cache
-          key: ${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*') }}
+          key: ${{ runner.os }}-plz-v2-${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*', '**/go.mod', '**/go.sum', '**/*.go') }}
           restore-keys: |
             ${{ runner.os }}-plz-v2-
 
@@ -74,7 +74,7 @@ jobs:
         with:
           path: |
             .plz-cache
-          key: ${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*') }}
+          key: ${{ runner.os }}-plz-v2-${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*', '**/go.mod', '**/go.sum', '**/*.go') }}
           restore-keys: |
             ${{ runner.os }}-plz-v2-
 
@@ -111,7 +111,7 @@ jobs:
         with:
           path: |
             .plz-cache
-          key: ${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*') }}
+          key: ${{ runner.os }}-plz-v2-${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*', '**/go.mod', '**/go.sum', '**/*.go') }}
           restore-keys: |
             ${{ runner.os }}-plz-v2-
 
@@ -156,7 +156,7 @@ jobs:
         with:
           path: |
             .plz-cache
-          key: ${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*') }}
+          key: ${{ runner.os }}-plz-v2-${{ runner.os }}-plz-v2-${{ hashFiles('**/BUILD', '**/BUILD.plz', '**/.plzconfig*', '**/go.mod', '**/go.sum', '**/*.go') }}
           restore-keys: |
             ${{ runner.os }}-plz-v2-
 

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,3 +1,6 @@
+[Go]
+GoPath = ""
+
 [buildconfig]
 go-home = "$(eval echo ~$(whoami))"
 helm-tool = "///pleasings2//tools/k8s:helm"

--- a/BUILD.plz
+++ b/BUILD.plz
@@ -1,7 +1,7 @@
 github_repo(
     name = "pleasings2",
     repo = "sagikazarmark/mypleasings",
-    revision = "446eaa1ff5ce24a45abbdb9aab0403a889b86f30",
+    revision = "648831adaf53fc5a8d7b72278a4be060667afb14",
 )
 
 genrule(

--- a/internal/anchore/BUILD
+++ b/internal/anchore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "anchore",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":anchore"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":anchore"],
 )

--- a/internal/app/frontend/BUILD
+++ b/internal/app/frontend/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "frontend",
     srcs = glob(
         ["*.go"],

--- a/internal/app/frontend/notification/BUILD
+++ b/internal/app/frontend/notification/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "notification",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":notification"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":notification"],
 )

--- a/internal/app/frontend/notification/notificationadapter/BUILD
+++ b/internal/app/frontend/notification/notificationadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "notificationadapter",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,20 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":notificationadapter"],
-    deps = ["//internal/app/frontend/notification"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":notificationadapter",
+        "//internal/app/frontend/notification",
+    ],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":notificationadapter"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = ["//internal/app/frontend/notification"],
+    deps = [
+        ":notificationadapter",
+        "//internal/app/frontend/notification",
+    ],
 )

--- a/internal/app/frontend/notification/notificationdriver/BUILD
+++ b/internal/app/frontend/notification/notificationdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "notificationdriver",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":notificationdriver"],
-    deps = ["//internal/app/frontend/notification"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":notificationdriver",
+        "//internal/app/frontend/notification",
+    ],
 )

--- a/internal/app/pipeline/auth/token/BUILD
+++ b/internal/app/pipeline/auth/token/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "token",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":token"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":token"],
 )

--- a/internal/app/pipeline/auth/token/tokenadapter/BUILD
+++ b/internal/app/pipeline/auth/token/tokenadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "tokenadapter",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":tokenadapter"],
-    deps = ["//internal/app/pipeline/auth/token"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":tokenadapter",
+        "//internal/app/pipeline/auth/token",
+    ],
 )

--- a/internal/app/pipeline/auth/token/tokendriver/BUILD
+++ b/internal/app/pipeline/auth/token/tokendriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "tokendriver",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":tokendriver"],
-    deps = ["//internal/app/pipeline/auth/token"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":tokendriver",
+        "//internal/app/pipeline/auth/token",
+    ],
 )

--- a/internal/app/pipeline/cap/BUILD
+++ b/internal/app/pipeline/cap/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cap",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/cap/capdriver/BUILD
+++ b/internal/app/pipeline/cap/capdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "capdriver",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/cloud/google/project/BUILD
+++ b/internal/app/pipeline/cloud/google/project/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "project",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/cloud/google/project/projectdriver/BUILD
+++ b/internal/app/pipeline/cloud/google/project/projectdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "projectdriver",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":projectdriver"],
-    deps = ["//internal/app/pipeline/cloud/google/project"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":projectdriver",
+        "//internal/app/pipeline/cloud/google/project",
+    ],
 )

--- a/internal/app/pipeline/process/BUILD
+++ b/internal/app/pipeline/process/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "process",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/process/app/BUILD
+++ b/internal/app/pipeline/process/app/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "app",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/process/processadapter/BUILD
+++ b/internal/app/pipeline/process/processadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "processadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/process/processdriver/BUILD
+++ b/internal/app/pipeline/process/processdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "processdriver",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipeline/secrettype/BUILD
+++ b/internal/app/pipeline/secrettype/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secrettype",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":secrettype"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":secrettype"],
 )

--- a/internal/app/pipeline/secrettype/secrettypedriver/BUILD
+++ b/internal/app/pipeline/secrettype/secrettypedriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secrettypedriver",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipelinectl/cli/commands/BUILD
+++ b/internal/app/pipelinectl/cli/commands/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "commands",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipelinectl/cli/commands/drain/BUILD
+++ b/internal/app/pipelinectl/cli/commands/drain/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "drain",
     srcs = glob(
         ["*.go"],

--- a/internal/app/pipelinectl/cli/commands/telemetry/BUILD
+++ b/internal/app/pipelinectl/cli/commands/telemetry/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "telemetry",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":telemetry"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":telemetry"],
 )

--- a/internal/ark/BUILD
+++ b/internal/ark/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ark",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/api/BUILD
+++ b/internal/ark/api/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "api",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/client/BUILD
+++ b/internal/ark/client/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "client",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/clustermanager/BUILD
+++ b/internal/ark/clustermanager/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustermanager",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/events/BUILD
+++ b/internal/ark/events/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "events",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":events"],
-    deps = ["//src/cluster"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":events",
+        "//src/cluster",
+    ],
 )

--- a/internal/ark/posthook/BUILD
+++ b/internal/ark/posthook/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "posthook",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/providers/amazon/BUILD
+++ b/internal/ark/providers/amazon/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "amazon",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/providers/azure/BUILD
+++ b/internal/ark/providers/azure/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "azure",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/providers/google/BUILD
+++ b/internal/ark/providers/google/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "google",
     srcs = glob(
         ["*.go"],

--- a/internal/ark/sync/BUILD
+++ b/internal/ark/sync/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "sync",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/BUILD
+++ b/internal/cluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cluster",
     srcs = glob(
         ["*.go"],
@@ -15,8 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":cluster"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":cluster",
         "//pkg/brn",
         "//pkg/cloud",
     ],

--- a/internal/cluster/auth/BUILD
+++ b/internal/cluster/auth/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "auth",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/clusteradapter/BUILD
+++ b/internal/cluster/clusteradapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusteradapter",
     srcs = glob(
         ["*.go"],
@@ -22,8 +22,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":clusteradapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":clusteradapter",
         "//internal/cluster",
         "//internal/cluster/clusterworkflow",
         "//internal/cluster/distribution/eks",

--- a/internal/cluster/clusteradapter/clustermodel/BUILD
+++ b/internal/cluster/clusteradapter/clustermodel/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustermodel",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/clusterbase/BUILD
+++ b/internal/cluster/clusterbase/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusterbase",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/clusterconfig/BUILD
+++ b/internal/cluster/clusterconfig/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusterconfig",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/clusterdriver/BUILD
+++ b/internal/cluster/clusterdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusterdriver",
     srcs = glob(
         ["*.go"],
@@ -16,6 +16,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":clusterdriver"],
-    deps = ["//internal/cluster"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":clusterdriver",
+        "//internal/cluster",
+    ],
 )

--- a/internal/cluster/clustersecret/BUILD
+++ b/internal/cluster/clustersecret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustersecret",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":clustersecret"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":clustersecret"],
 )

--- a/internal/cluster/clustersecret/clustersecretadapter/BUILD
+++ b/internal/cluster/clustersecret/clustersecretadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustersecretadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/clustersetup/BUILD
+++ b/internal/cluster/clustersetup/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustersetup",
     srcs = glob(
         ["*.go"],
@@ -17,8 +17,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":clustersetup"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":clustersetup",
         "//pkg/k8sclient",
         "//pkg/kubernetes",
     ],
@@ -26,10 +27,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":clustersetup"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":clustersetup",
         "//pkg/k8sclient",
         "//pkg/kubernetes",
     ],

--- a/internal/cluster/clusterworkflow/BUILD
+++ b/internal/cluster/clusterworkflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusterworkflow",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/BUILD
+++ b/internal/cluster/distribution/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "distribution",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/eks/BUILD
+++ b/internal/cluster/distribution/eks/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "eks",
     srcs = glob(
         ["*.go"],
@@ -12,8 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":eks"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":eks",
         "//internal/cluster",
         "//pkg/brn",
     ],

--- a/internal/cluster/distribution/eks/eksadapter/BUILD
+++ b/internal/cluster/distribution/eks/eksadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "eksadapter",
     srcs = glob(
         ["*.go"],
@@ -19,8 +19,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":eksadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":eksadapter",
         "//internal/cluster",
         "//internal/cluster/distribution/eks",
         "//internal/cluster/distribution/eks/eksmodel",

--- a/internal/cluster/distribution/eks/ekscluster/BUILD
+++ b/internal/cluster/distribution/eks/ekscluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ekscluster",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/eks/ekscluster/nodepools/BUILD
+++ b/internal/cluster/distribution/eks/ekscluster/nodepools/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "nodepools",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/eks/eksmodel/BUILD
+++ b/internal/cluster/distribution/eks/eksmodel/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "eksmodel",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/eks/eksprovider/adapter/BUILD
+++ b/internal/cluster/distribution/eks/eksprovider/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/distribution/eks/eksprovider/driver/BUILD
+++ b/internal/cluster/distribution/eks/eksprovider/driver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "driver",
     srcs = glob(
         ["*.go"],
@@ -29,8 +29,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":driver"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":driver",
         "//internal/cluster/distribution/eks/ekscluster",
         "//internal/cluster/distribution/eks/eksprovider/workflow",
     ],

--- a/internal/cluster/distribution/eks/eksprovider/workflow/BUILD
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],
@@ -31,6 +31,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":workflow"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":workflow"],
 )

--- a/internal/cluster/distribution/eks/eksworkflow/BUILD
+++ b/internal/cluster/distribution/eks/eksworkflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "eksworkflow",
     srcs = glob(
         ["*.go"],
@@ -20,6 +20,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":eksworkflow"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":eksworkflow"],
 )

--- a/internal/cluster/distribution/pke/pkeaws/BUILD
+++ b/internal/cluster/distribution/pke/pkeaws/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pkeaws",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":pkeaws"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":pkeaws"],
 )

--- a/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/BUILD
+++ b/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pkeawsadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/dns/BUILD
+++ b/internal/cluster/dns/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "dns",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/endpoints/BUILD
+++ b/internal/cluster/endpoints/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "endpoints",
     srcs = glob(
         ["*.go"],
@@ -16,8 +16,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":endpoints"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":endpoints",
         "//internal/common",
         "//pkg/helm",
     ],

--- a/internal/cluster/kubernetes/BUILD
+++ b/internal/cluster/kubernetes/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetes",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/metrics/BUILD
+++ b/internal/cluster/metrics/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "metrics",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/metrics/adapters/prometheus/BUILD
+++ b/internal/cluster/metrics/adapters/prometheus/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "prometheus",
     srcs = glob(
         ["*.go"],

--- a/internal/cluster/oidc/BUILD
+++ b/internal/cluster/oidc/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "oidc",
     srcs = glob(
         ["*.go"],
@@ -15,8 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":oidc"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":oidc",
         "//internal/cluster/auth",
         "//src/auth",
     ],

--- a/internal/cluster/resourcesummary/BUILD
+++ b/internal/cluster/resourcesummary/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "resourcesummary",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":resourcesummary"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":resourcesummary"],
 )

--- a/internal/cluster/workflow/BUILD
+++ b/internal/cluster/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],

--- a/internal/clustergroup/BUILD
+++ b/internal/clustergroup/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustergroup",
     srcs = glob(
         ["*.go"],

--- a/internal/clustergroup/adapter/BUILD
+++ b/internal/clustergroup/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],

--- a/internal/clustergroup/api/BUILD
+++ b/internal/clustergroup/api/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "api",
     srcs = glob(
         ["*.go"],

--- a/internal/clustergroup/deployment/BUILD
+++ b/internal/clustergroup/deployment/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "deployment",
     srcs = glob(
         ["*.go"],
@@ -18,8 +18,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":deployment"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":deployment",
         "//internal/cmd",
         "//internal/common",
         "//internal/global",
@@ -30,10 +31,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":deployment"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":deployment",
         "//internal/cmd",
         "//internal/common",
         "//internal/global",

--- a/internal/cmd/BUILD
+++ b/internal/cmd/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cmd",
     srcs = glob(
         ["*.go"],
@@ -31,8 +31,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":cmd"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":cmd",
         "//internal/integratedservices/services/dns",
         "//internal/integratedservices/services/ingress",
         "//pkg/hook",

--- a/internal/common/BUILD
+++ b/internal/common/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "common",
     srcs = glob(
         ["*.go"],

--- a/internal/common/commonadapter/BUILD
+++ b/internal/common/commonadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "commonadapter",
     srcs = glob(
         ["*.go"],
@@ -16,8 +16,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":commonadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":commonadapter",
         "//internal/common",
         "//internal/secret/secrettype",
         "//src/secret",

--- a/internal/dashboard/BUILD
+++ b/internal/dashboard/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "dashboard",
     srcs = glob(
         ["*.go"],

--- a/internal/database/sql/json/BUILD
+++ b/internal/database/sql/json/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "json",
     srcs = glob(
         ["*.go"],

--- a/internal/federation/BUILD
+++ b/internal/federation/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "federation",
     srcs = glob(
         ["*.go"],
@@ -19,8 +19,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":federation"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":federation",
         "//internal/cmd",
         "//internal/helm",
         "//internal/helm/testing",
@@ -31,10 +32,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":federation"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":federation",
         "//internal/cmd",
         "//internal/helm",
         "//internal/helm/testing",

--- a/internal/global/BUILD
+++ b/internal/global/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "global",
     srcs = glob(
         ["*.go"],

--- a/internal/global/globalcluster/BUILD
+++ b/internal/global/globalcluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "globalcluster",
     srcs = glob(
         ["*.go"],

--- a/internal/global/globaleks/BUILD
+++ b/internal/global/globaleks/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "globaleks",
     srcs = glob(
         ["*.go"],

--- a/internal/global/nplabels/BUILD
+++ b/internal/global/nplabels/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "nplabels",
     srcs = glob(
         ["*.go"],

--- a/internal/helm/BUILD
+++ b/internal/helm/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "helm",
     srcs = glob(
         ["*.go"],
@@ -15,8 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":helm"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":helm",
         "//internal/cmd",
         "//internal/common",
         "//internal/helm/helmadapter",
@@ -28,10 +29,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":helm"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":helm",
         "//internal/cmd",
         "//internal/common",
         "//internal/helm/helmadapter",

--- a/internal/helm/helmadapter/BUILD
+++ b/internal/helm/helmadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "helmadapter",
     srcs = glob(
         ["*.go"],
@@ -20,8 +20,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":helmadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":helmadapter",
         "//internal/common",
         "//internal/helm",
     ],

--- a/internal/helm/helmdriver/BUILD
+++ b/internal/helm/helmdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "helmdriver",
     srcs = glob(
         ["*.go"],
@@ -17,6 +17,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":helmdriver"],
-    deps = ["//internal/helm"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":helmdriver",
+        "//internal/helm",
+    ],
 )

--- a/internal/helm/testing/BUILD
+++ b/internal/helm/testing/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "testing",
     srcs = glob(
         ["*.go"],

--- a/internal/hollowtrees/BUILD
+++ b/internal/hollowtrees/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "hollowtrees",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/BUILD
+++ b/internal/integratedservices/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "integratedservices",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":integratedservices"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":integratedservices"],
 )

--- a/internal/integratedservices/integratedserviceadapter/BUILD
+++ b/internal/integratedservices/integratedserviceadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "integratedserviceadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/integratedserviceadapter/workflow/BUILD
+++ b/internal/integratedservices/integratedserviceadapter/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/integratedservicesdriver/BUILD
+++ b/internal/integratedservices/integratedservicesdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "integratedservicesdriver",
     srcs = glob(
         ["*.go"],
@@ -16,8 +16,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":integratedservicesdriver"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":integratedservicesdriver",
         "//.gen/pipeline/pipeline",
         "//internal/integratedservices",
     ],

--- a/internal/integratedservices/services/BUILD
+++ b/internal/integratedservices/services/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "services",
     srcs = glob(
         ["*.go"],
@@ -17,8 +17,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":services"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":services",
         "//internal/integratedservices",
         "//internal/integratedservices/services/expiry",
     ],

--- a/internal/integratedservices/services/dns/BUILD
+++ b/internal/integratedservices/services/dns/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "dns",
     srcs = glob(
         ["*.go"],
@@ -25,8 +25,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":dns"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":dns",
         "//internal/common/commonadapter",
         "//internal/helm",
         "//internal/integratedservices",

--- a/internal/integratedservices/services/dns/dnsadapter/BUILD
+++ b/internal/integratedservices/services/dns/dnsadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "dnsadapter",
     srcs = glob(
         ["*.go"],
@@ -16,8 +16,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":dnsadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":dnsadapter",
         "//internal/integratedservices/services",
         "//src/auth",
     ],

--- a/internal/integratedservices/services/dns/externaldns/BUILD
+++ b/internal/integratedservices/services/dns/externaldns/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "externaldns",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/services/expiry/BUILD
+++ b/internal/integratedservices/services/expiry/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "expiry",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":expiry"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":expiry"],
 )

--- a/internal/integratedservices/services/expiry/adapter/BUILD
+++ b/internal/integratedservices/services/expiry/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/services/expiry/adapter/workflow/BUILD
+++ b/internal/integratedservices/services/expiry/adapter/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/services/ingress/BUILD
+++ b/internal/integratedservices/services/ingress/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ingress",
     srcs = glob(
         ["*.go"],
@@ -21,8 +21,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":ingress"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":ingress",
         "//internal/integratedservices",
         "//internal/integratedservices/services",
         "//pkg/jsonstructure",

--- a/internal/integratedservices/services/ingress/ingressadapter/BUILD
+++ b/internal/integratedservices/services/ingress/ingressadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ingressadapter",
     srcs = glob(
         ["*.go"],
@@ -17,8 +17,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":ingressadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":ingressadapter",
         "//internal/integratedservices/services/ingress",
         "//src/auth",
     ],

--- a/internal/integratedservices/services/logging/BUILD
+++ b/internal/integratedservices/services/logging/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "logging",
     srcs = glob(
         ["*.go"],
@@ -31,8 +31,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":logging"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":logging",
         "//internal/common/commonadapter",
         "//internal/helm",
         "//internal/integratedservices",

--- a/internal/integratedservices/services/monitoring/BUILD
+++ b/internal/integratedservices/services/monitoring/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "monitoring",
     srcs = glob(
         ["*.go"],
@@ -28,8 +28,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":monitoring"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":monitoring",
         "//internal/common/commonadapter",
         "//internal/helm",
         "//internal/integratedservices",

--- a/internal/integratedservices/services/securityscan/BUILD
+++ b/internal/integratedservices/services/securityscan/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "securityscan",
     srcs = glob(
         ["*.go"],
@@ -25,8 +25,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":securityscan"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":securityscan",
         "//internal/anchore",
         "//internal/integratedservices",
         "//internal/integratedservices/services",

--- a/internal/integratedservices/services/securityscan/securityscanadapter/BUILD
+++ b/internal/integratedservices/services/securityscan/securityscanadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "securityscanadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/integratedservices/services/vault/BUILD
+++ b/internal/integratedservices/services/vault/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "vault",
     srcs = glob(
         ["*.go"],
@@ -19,8 +19,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":vault"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":vault",
         "//internal/common/commonadapter",
         "//internal/helm",
         "//internal/integratedservices",
@@ -36,10 +37,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":vault"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":vault",
         "//internal/common/commonadapter",
         "//internal/helm",
         "//internal/integratedservices",

--- a/internal/istio/BUILD
+++ b/internal/istio/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "istio",
     srcs = glob(
         ["*.go"],

--- a/internal/istio/istiofeature/BUILD
+++ b/internal/istio/istiofeature/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "istiofeature",
     srcs = glob(
         ["*.go"],

--- a/internal/kubernetes/BUILD
+++ b/internal/kubernetes/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetes",
     srcs = glob(
         ["*.go"],

--- a/internal/kubernetes/kubernetesadapter/BUILD
+++ b/internal/kubernetes/kubernetesadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetesadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/monitor/BUILD
+++ b/internal/monitor/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "monitor",
     srcs = glob(
         ["*.go"],

--- a/internal/network/BUILD
+++ b/internal/network/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "network",
     srcs = glob(
         ["*.go"],

--- a/internal/objectstore/BUILD
+++ b/internal/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],

--- a/internal/pke/BUILD
+++ b/internal/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],

--- a/internal/pke/workflow/BUILD
+++ b/internal/pke/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":workflow"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":workflow"],
 )

--- a/internal/pke/workflow/adapter/BUILD
+++ b/internal/pke/workflow/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/appkit/BUILD
+++ b/internal/platform/appkit/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "appkit",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/appkit/transport/http/BUILD
+++ b/internal/platform/appkit/transport/http/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "http",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":http"],
-    deps = ["//pkg/problems"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":http",
+        "//pkg/problems",
+    ],
 )

--- a/internal/platform/buildinfo/BUILD
+++ b/internal/platform/buildinfo/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "buildinfo",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/cadence/BUILD
+++ b/internal/platform/cadence/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cadence",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/context/BUILD
+++ b/internal/platform/context/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "context",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/database/BUILD
+++ b/internal/platform/database/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "database",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":database"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":database"],
 )

--- a/internal/platform/errorhandler/BUILD
+++ b/internal/platform/errorhandler/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "errorhandler",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/gin/BUILD
+++ b/internal/platform/gin/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "gin",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/gin/auditlog/BUILD
+++ b/internal/platform/gin/auditlog/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "auditlog",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":auditlog"],
-    deps = ["//internal/platform/gin/correlationid"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":auditlog",
+        "//internal/platform/gin/correlationid",
+    ],
 )

--- a/internal/platform/gin/auditlog/auditlogdriver/BUILD
+++ b/internal/platform/gin/auditlog/auditlogdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "auditlogdriver",
     srcs = glob(
         ["*.go"],
@@ -15,8 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":auditlogdriver"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":auditlogdriver",
         "//internal/common",
         "//internal/platform/gin/auditlog",
     ],

--- a/internal/platform/gin/correlationid/BUILD
+++ b/internal/platform/gin/correlationid/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "correlationid",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/gin/ginauth/BUILD
+++ b/internal/platform/gin/ginauth/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ginauth",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":ginauth"],
-    deps = ["//src/auth"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":ginauth",
+        "//src/auth",
+    ],
 )

--- a/internal/platform/gin/log/BUILD
+++ b/internal/platform/gin/log/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "log",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/gin/utils/BUILD
+++ b/internal/platform/gin/utils/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "utils",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/log/BUILD
+++ b/internal/platform/log/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "log",
     srcs = glob(
         ["*.go"],

--- a/internal/platform/watermill/BUILD
+++ b/internal/platform/watermill/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "watermill",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/BUILD
+++ b/internal/providers/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "providers",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/alibaba/BUILD
+++ b/internal/providers/alibaba/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "alibaba",
     srcs = glob(
         ["*.go"],
@@ -22,6 +22,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":alibaba"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":alibaba"],
 )

--- a/internal/providers/alibaba/alibabaadapter/BUILD
+++ b/internal/providers/alibaba/alibabaadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "alibabaadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/amazon/BUILD
+++ b/internal/providers/amazon/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "amazon",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/BUILD
+++ b/internal/providers/azure/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "azure",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/azureadapter/BUILD
+++ b/internal/providers/azure/azureadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "azureadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/pke/BUILD
+++ b/internal/providers/azure/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/pke/adapter/BUILD
+++ b/internal/providers/azure/pke/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],
@@ -19,6 +19,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":adapter"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":adapter"],
 )

--- a/internal/providers/azure/pke/driver/BUILD
+++ b/internal/providers/azure/pke/driver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "driver",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/pke/driver/commoncluster/BUILD
+++ b/internal/providers/azure/pke/driver/commoncluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "commoncluster",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/azure/pke/workflow/BUILD
+++ b/internal/providers/azure/pke/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],
@@ -26,6 +26,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":workflow"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":workflow"],
 )

--- a/internal/providers/google/BUILD
+++ b/internal/providers/google/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "google",
     srcs = glob(
         ["*.go"],
@@ -24,6 +24,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":google"],
-    deps = ["//internal/cluster/clusteradapter/clustermodel"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":google",
+        "//internal/cluster/clusteradapter/clustermodel",
+    ],
 )

--- a/internal/providers/google/googleadapter/BUILD
+++ b/internal/providers/google/googleadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "googleadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/kubernetes/kubernetesadapter/BUILD
+++ b/internal/providers/kubernetes/kubernetesadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetesadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/oracle/BUILD
+++ b/internal/providers/oracle/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "oracle",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/pke/BUILD
+++ b/internal/providers/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],
@@ -16,6 +16,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":pke"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":pke"],
 )

--- a/internal/providers/pke/pkeworkflow/BUILD
+++ b/internal/providers/pke/pkeworkflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pkeworkflow",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/pke/pkeworkflow/pkeworkflowadapter/BUILD
+++ b/internal/providers/pke/pkeworkflow/pkeworkflowadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pkeworkflowadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/vsphere/pke/BUILD
+++ b/internal/providers/vsphere/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/vsphere/pke/adapter/BUILD
+++ b/internal/providers/vsphere/pke/adapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "adapter",
     srcs = glob(
         ["*.go"],
@@ -18,8 +18,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":adapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":adapter",
         "//internal/cluster/clusteradapter/clustermodel",
         "//internal/providers/vsphere/pke",
     ],

--- a/internal/providers/vsphere/pke/driver/BUILD
+++ b/internal/providers/vsphere/pke/driver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "driver",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/vsphere/pke/driver/commoncluster/BUILD
+++ b/internal/providers/vsphere/pke/driver/commoncluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "commoncluster",
     srcs = glob(
         ["*.go"],

--- a/internal/providers/vsphere/pke/workflow/BUILD
+++ b/internal/providers/vsphere/pke/workflow/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "workflow",
     srcs = glob(
         ["*.go"],
@@ -25,6 +25,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":workflow"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":workflow"],
 )

--- a/internal/secret/BUILD
+++ b/internal/secret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secret",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/kubesecret/BUILD
+++ b/internal/secret/kubesecret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubesecret",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":kubesecret"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":kubesecret"],
 )

--- a/internal/secret/pkesecret/BUILD
+++ b/internal/secret/pkesecret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pkesecret",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/restricted/BUILD
+++ b/internal/secret/restricted/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "restricted",
     srcs = glob(
         ["*.go"],
@@ -12,8 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":restricted"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":restricted",
         "//internal/secret/secrettype",
         "//src/secret",
     ],

--- a/internal/secret/secretadapter/BUILD
+++ b/internal/secret/secretadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secretadapter",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,20 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":secretadapter"],
-    deps = ["//internal/secret"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":secretadapter",
+        "//internal/secret",
+    ],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":secretadapter"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = ["//internal/secret"],
+    deps = [
+        ":secretadapter",
+        "//internal/secret",
+    ],
 )

--- a/internal/secret/secrettype/BUILD
+++ b/internal/secret/secrettype/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secrettype",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/ssh/BUILD
+++ b/internal/secret/ssh/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ssh",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/ssh/sshadapter/BUILD
+++ b/internal/secret/ssh/sshadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "sshadapter",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/ssh/sshdriver/BUILD
+++ b/internal/secret/ssh/sshdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "sshdriver",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/sshsecret/BUILD
+++ b/internal/secret/sshsecret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "sshsecret",
     srcs = glob(
         ["*.go"],

--- a/internal/secret/types/BUILD
+++ b/internal/secret/types/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "types",
     srcs = glob(
         ["*.go"],
@@ -18,6 +18,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":types"],
-    deps = ["//internal/secret"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":types",
+        "//internal/secret",
+    ],
 )

--- a/internal/security/BUILD
+++ b/internal/security/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "security",
     srcs = glob(
         ["*.go"],

--- a/internal/testing/BUILD
+++ b/internal/testing/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "testing",
     srcs = glob(
         ["*.go"],

--- a/pkg/any/BUILD
+++ b/pkg/any/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "any",
     srcs = glob(
         ["*.go"],

--- a/pkg/auth/BUILD
+++ b/pkg/auth/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "auth",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":auth"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":auth"],
 )

--- a/pkg/backoff/BUILD
+++ b/pkg/backoff/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "backoff",
     srcs = glob(
         ["*.go"],

--- a/pkg/brn/BUILD
+++ b/pkg/brn/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "brn",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":brn"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":brn"],
 )

--- a/pkg/cadence/BUILD
+++ b/pkg/cadence/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cadence",
     srcs = glob(
         ["*.go"],

--- a/pkg/cloud/BUILD
+++ b/pkg/cloud/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cloud",
     srcs = glob(
         ["*.go"],

--- a/pkg/cloudinfo/BUILD
+++ b/pkg/cloudinfo/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cloudinfo",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/BUILD
+++ b/pkg/cluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cluster",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/ack/BUILD
+++ b/pkg/cluster/ack/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ack",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/ack/action/BUILD
+++ b/pkg/cluster/ack/action/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "action",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/aks/BUILD
+++ b/pkg/cluster/aks/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "aks",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/gke/BUILD
+++ b/pkg/cluster/gke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "gke",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/kubernetes/BUILD
+++ b/pkg/cluster/kubernetes/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetes",
     srcs = glob(
         ["*.go"],

--- a/pkg/cluster/pke/BUILD
+++ b/pkg/cluster/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],

--- a/pkg/common/BUILD
+++ b/pkg/common/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "common",
     srcs = glob(
         ["*.go"],

--- a/pkg/ctxutil/BUILD
+++ b/pkg/ctxutil/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ctxutil",
     srcs = glob(
         ["*.go"],

--- a/pkg/errors/BUILD
+++ b/pkg/errors/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "errors",
     srcs = glob(
         ["*.go"],

--- a/pkg/gormhelper/BUILD
+++ b/pkg/gormhelper/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "gormhelper",
     srcs = glob(
         ["*.go"],

--- a/pkg/helm/BUILD
+++ b/pkg/helm/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "helm",
     srcs = glob(
         ["*.go"],

--- a/pkg/helm/kube/BUILD
+++ b/pkg/helm/kube/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kube",
     srcs = glob(
         ["*.go"],

--- a/pkg/hook/BUILD
+++ b/pkg/hook/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "hook",
     srcs = glob(
         ["*.go"],

--- a/pkg/hpa/BUILD
+++ b/pkg/hpa/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "hpa",
     srcs = glob(
         ["*.go"],

--- a/pkg/jsonstructure/BUILD
+++ b/pkg/jsonstructure/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "jsonstructure",
     srcs = glob(
         ["*.go"],
@@ -15,6 +15,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":jsonstructure"],
-    deps = ["//pkg/any"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":jsonstructure",
+        "//pkg/any",
+    ],
 )

--- a/pkg/k8sclient/BUILD
+++ b/pkg/k8sclient/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "k8sclient",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,14 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":k8sclient"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":k8sclient"],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":k8sclient"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = [],
+    deps = [":k8sclient"],
 )

--- a/pkg/k8sutil/BUILD
+++ b/pkg/k8sutil/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "k8sutil",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":k8sutil"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":k8sutil"],
 )

--- a/pkg/kubernetes/BUILD
+++ b/pkg/kubernetes/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "kubernetes",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":kubernetes"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":kubernetes"],
 )

--- a/pkg/kubernetes/custom/npls/BUILD
+++ b/pkg/kubernetes/custom/npls/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "npls",
     srcs = glob(
         ["*.go"],

--- a/pkg/mirror/BUILD
+++ b/pkg/mirror/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "mirror",
     srcs = glob(
         ["*.go"],

--- a/pkg/objectstore/BUILD
+++ b/pkg/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],

--- a/pkg/problems/BUILD
+++ b/pkg/problems/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "problems",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":problems"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":problems"],
 )

--- a/pkg/providers/BUILD
+++ b/pkg/providers/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "providers",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/alibaba/BUILD
+++ b/pkg/providers/alibaba/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "alibaba",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/alibaba/objectstore/BUILD
+++ b/pkg/providers/alibaba/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,14 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":objectstore"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":objectstore"],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":objectstore"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = [],
+    deps = [":objectstore"],
 )

--- a/pkg/providers/amazon/BUILD
+++ b/pkg/providers/amazon/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "amazon",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/amazon/autoscaling/BUILD
+++ b/pkg/providers/amazon/autoscaling/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "autoscaling",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/amazon/cloudformation/BUILD
+++ b/pkg/providers/amazon/cloudformation/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cloudformation",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/amazon/ec2/BUILD
+++ b/pkg/providers/amazon/ec2/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "ec2",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/amazon/objectstore/BUILD
+++ b/pkg/providers/amazon/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,14 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":objectstore"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":objectstore"],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":objectstore"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = [],
+    deps = [":objectstore"],
 )

--- a/pkg/providers/azure/BUILD
+++ b/pkg/providers/azure/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "azure",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/azure/objectstore/BUILD
+++ b/pkg/providers/azure/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],
@@ -15,14 +15,20 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":objectstore"],
-    deps = ["//pkg/providers/azure"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":objectstore",
+        "//pkg/providers/azure",
+    ],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":objectstore"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = ["//pkg/providers/azure"],
+    deps = [
+        ":objectstore",
+        "//pkg/providers/azure",
+    ],
 )

--- a/pkg/providers/google/BUILD
+++ b/pkg/providers/google/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "google",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/google/objectstore/BUILD
+++ b/pkg/providers/google/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],
@@ -12,14 +12,14 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":objectstore"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":objectstore"],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":objectstore"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = [],
+    deps = [":objectstore"],
 )

--- a/pkg/providers/oracle/BUILD
+++ b/pkg/providers/oracle/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "oracle",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/cluster/BUILD
+++ b/pkg/providers/oracle/cluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cluster",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/cluster/manager/BUILD
+++ b/pkg/providers/oracle/cluster/manager/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "manager",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/model/BUILD
+++ b/pkg/providers/oracle/model/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "model",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/network/BUILD
+++ b/pkg/providers/oracle/network/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "network",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/objectstore/BUILD
+++ b/pkg/providers/oracle/objectstore/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "objectstore",
     srcs = glob(
         ["*.go"],
@@ -15,14 +15,14 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":objectstore"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":objectstore"],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":objectstore"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = [],
+    deps = [":objectstore"],
 )

--- a/pkg/providers/oracle/oci/BUILD
+++ b/pkg/providers/oracle/oci/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "oci",
     srcs = glob(
         ["*.go"],

--- a/pkg/providers/oracle/secret/BUILD
+++ b/pkg/providers/oracle/secret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secret",
     srcs = glob(
         ["*.go"],

--- a/pkg/sdk/brn/BUILD
+++ b/pkg/sdk/brn/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "brn",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":brn"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":brn"],
 )

--- a/pkg/sdk/cadence/lib/pipeline/processlog/BUILD
+++ b/pkg/sdk/cadence/lib/pipeline/processlog/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "processlog",
     srcs = glob(
         ["*.go"],

--- a/pkg/sdk/process/BUILD
+++ b/pkg/sdk/process/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "process",
     srcs = glob(
         ["*.go"],

--- a/pkg/secret/BUILD
+++ b/pkg/secret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secret",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":secret"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":secret"],
 )

--- a/pkg/security/BUILD
+++ b/pkg/security/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "security",
     srcs = glob(
         ["*.go"],

--- a/pkg/validation/BUILD
+++ b/pkg/validation/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "validation",
     srcs = glob(
         ["*.go"],

--- a/pkg/values/BUILD
+++ b/pkg/values/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "values",
     srcs = glob(
         ["*.go"],

--- a/src/api/BUILD
+++ b/src/api/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "api",
     srcs = glob(
         ["*.go"],
@@ -51,8 +51,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":api"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":api",
         "//internal/common",
         "//internal/global",
         "//internal/secret/pkesecret",
@@ -68,10 +69,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":api"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":api",
         "//internal/common",
         "//internal/global",
         "//internal/secret/pkesecret",

--- a/src/api/ark/backups/BUILD
+++ b/src/api/ark/backups/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "backups",
     srcs = glob(
         ["*.go"],

--- a/src/api/ark/backupservice/BUILD
+++ b/src/api/ark/backupservice/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "backupservice",
     srcs = glob(
         ["*.go"],

--- a/src/api/ark/buckets/BUILD
+++ b/src/api/ark/buckets/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "buckets",
     srcs = glob(
         ["*.go"],

--- a/src/api/ark/common/BUILD
+++ b/src/api/ark/common/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "common",
     srcs = glob(
         ["*.go"],

--- a/src/api/ark/restores/BUILD
+++ b/src/api/ark/restores/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "restores",
     srcs = glob(
         ["*.go"],

--- a/src/api/ark/schedules/BUILD
+++ b/src/api/ark/schedules/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "schedules",
     srcs = glob(
         ["*.go"],

--- a/src/api/cluster/BUILD
+++ b/src/api/cluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cluster",
     srcs = glob(
         ["*.go"],
@@ -21,8 +21,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":cluster"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":cluster",
         "//.gen/pipeline/pipeline",
         "//internal/pke",
         "//internal/providers/azure/pke",

--- a/src/api/cluster/namespace/BUILD
+++ b/src/api/cluster/namespace/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "namespace",
     srcs = glob(
         ["*.go"],

--- a/src/api/cluster/pke/BUILD
+++ b/src/api/cluster/pke/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "pke",
     srcs = glob(
         ["*.go"],

--- a/src/api/clustergroup/BUILD
+++ b/src/api/clustergroup/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clustergroup",
     srcs = glob(
         ["*.go"],

--- a/src/api/clustergroup/common/BUILD
+++ b/src/api/clustergroup/common/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "common",
     srcs = glob(
         ["*.go"],

--- a/src/api/clustergroup/deployment/BUILD
+++ b/src/api/clustergroup/deployment/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "deployment",
     srcs = glob(
         ["*.go"],

--- a/src/api/clustergroup/feature/BUILD
+++ b/src/api/clustergroup/feature/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "feature",
     srcs = glob(
         ["*.go"],

--- a/src/api/common/BUILD
+++ b/src/api/common/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "common",
     srcs = glob(
         ["*.go"],

--- a/src/auth/BUILD
+++ b/src/auth/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "auth",
     srcs = glob(
         ["*.go"],
@@ -17,14 +17,20 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":auth"],
-    deps = ["//internal/common"],
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":auth",
+        "//internal/common",
+    ],
 )
 
 go_test(
     name = "integration_test",
-    srcs = [":auth"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
-    deps = ["//internal/common"],
+    deps = [
+        ":auth",
+        "//internal/common",
+    ],
 )

--- a/src/auth/authadapter/BUILD
+++ b/src/auth/authadapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "authadapter",
     srcs = glob(
         ["*.go"],
@@ -12,8 +12,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":authadapter"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":authadapter",
         "//internal/common",
         "//src/auth",
     ],

--- a/src/auth/authdriver/BUILD
+++ b/src/auth/authdriver/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "authdriver",
     srcs = glob(
         ["*.go"],

--- a/src/cluster/BUILD
+++ b/src/cluster/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "cluster",
     srcs = glob(
         ["*.go"],
@@ -89,8 +89,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":cluster"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":cluster",
         "//internal/cluster/distribution/eks/ekscluster",
         "//internal/common",
         "//internal/global",
@@ -117,10 +118,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":cluster"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":cluster",
         "//internal/cluster/distribution/eks/ekscluster",
         "//internal/common",
         "//internal/global",

--- a/src/cluster/clusteradapter/BUILD
+++ b/src/cluster/clusteradapter/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "clusteradapter",
     srcs = glob(
         ["*.go"],

--- a/src/dns/BUILD
+++ b/src/dns/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "dns",
     srcs = glob(
         ["*.go"],

--- a/src/dns/route53/BUILD
+++ b/src/dns/route53/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "route53",
     srcs = glob(
         ["*.go"],
@@ -20,8 +20,9 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":route53"],
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":route53",
         "//internal/common",
         "//internal/global",
         "//internal/secret/pkesecret",
@@ -37,10 +38,11 @@ go_test(
 
 go_test(
     name = "integration_test",
-    srcs = [":route53"],
+    srcs = glob(["*_test.go"]),
     flags = "-test.run ^TestIntegration$",
     labels = ["integration"],
     deps = [
+        ":route53",
         "//internal/common",
         "//internal/global",
         "//internal/secret/pkesecret",

--- a/src/dns/route53/model/BUILD
+++ b/src/dns/route53/model/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "model",
     srcs = glob(
         ["*.go"],

--- a/src/helm/BUILD
+++ b/src/helm/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "helm",
     srcs = glob(
         ["*.go"],

--- a/src/model/BUILD
+++ b/src/model/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "model",
     srcs = glob(
         ["*.go"],

--- a/src/secret/BUILD
+++ b/src/secret/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "secret",
     srcs = glob(
         ["*.go"],
@@ -17,6 +17,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":secret"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":secret"],
 )

--- a/src/secret/verify/BUILD
+++ b/src/secret/verify/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "verify",
     srcs = glob(
         ["*.go"],

--- a/src/utils/BUILD
+++ b/src/utils/BUILD
@@ -1,6 +1,6 @@
 subinclude("///pleasings2//go:compat")
 
-filegroup(
+go_library(
     name = "utils",
     srcs = glob(
         ["*.go"],
@@ -12,6 +12,6 @@ filegroup(
 
 go_test(
     name = "test",
-    srcs = [":utils"],
-    deps = [],
+    srcs = glob(["*_test.go"]),
+    deps = [":utils"],
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Supersedes #3082
| License         | Apache 2.0


### What's in this PR?
Use official go_* compatible rules.


### Why?
As we move forward with please, it would be nice to remain compatible with the official tools.