### PR TITLE
fix(TLS): configure TLS MinVersion to 1.3

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -1254,7 +1254,9 @@ func main() {
 
 		caCertFile, certFile, keyFile := config.Pipeline.CACertFile, config.Pipeline.CertFile, config.Pipeline.KeyFile
 		if certFile != "" && keyFile != "" {
-			tlsConfig := &tls.Config{}
+			tlsConfig := &tls.Config{
+				MinVersion: tls.VersionTLS13,
+			}
 
 			if caCertFile != "" {
 				tlsConfig, err = auth.TLSConfigForClientAuth(caCertFile)

--- a/cmd/pipelinectl/main.go
+++ b/cmd/pipelinectl/main.go
@@ -71,7 +71,10 @@ func main() {
 
 	cobra.OnInitialize(func() {
 		if !viper.GetBool("api.verify") {
-			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS13,
+			}
 		}
 	})
 

--- a/internal/app/pipelinectl/cli/commands/telemetry/telemetry.go
+++ b/internal/app/pipelinectl/cli/commands/telemetry/telemetry.go
@@ -115,7 +115,10 @@ func getTelemetry(options options) ([]*prom2json.Family, error) {
 func makeTransport(skipServerCertCheck bool) (*http.Transport, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = time.Second
-	tlsConfig := &tls.Config{InsecureSkipVerify: skipServerCertCheck}
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: skipServerCertCheck,
+		MinVersion:         tls.VersionTLS13,
+	}
 	transport.TLSClientConfig = tlsConfig
 	return transport, nil
 }

--- a/internal/security/anchore_client.go
+++ b/internal/security/anchore_client.go
@@ -335,6 +335,7 @@ func (a anchoreClient) getRestClient() *anchore.APIClient {
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: a.insecure,
+					MinVersion:         tls.VersionTLS13,
 				},
 			},
 		},

--- a/src/api/anchore_proxy.go
+++ b/src/api/anchore_proxy.go
@@ -94,7 +94,10 @@ func (ap AnchoreProxy) Proxy() gin.HandlerFunc {
 			return
 		}
 
-		proxy.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Insecure}}
+		proxy.Transport = &http.Transport{TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: config.Insecure,
+			MinVersion:         tls.VersionTLS13,
+		}}
 
 		proxy.ServeHTTP(c.Writer, c.Request)
 	}

--- a/src/api/cluster_auth.go
+++ b/src/api/cluster_auth.go
@@ -65,6 +65,7 @@ func NewClusterAuthAPI(
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: insecureSkipVerify,
+				MinVersion:         tls.VersionTLS13,
 			},
 		},
 	}

--- a/src/auth/oidc.go
+++ b/src/auth/oidc.go
@@ -92,6 +92,7 @@ func newOIDCProvider(config *OIDCProviderConfig, refreshTokenStore RefreshTokenS
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.InsecureSkipVerify,
+				MinVersion:         tls.VersionTLS13,
 			},
 		},
 	}

--- a/src/auth/tls.go
+++ b/src/auth/tls.go
@@ -37,6 +37,7 @@ func TLSConfigForClientAuth(caCertFile string) (*tls.Config, error) {
 	config := tls.Config{
 		ClientAuth: tls.VerifyClientCertIfGiven,
 		ClientCAs:  clientCertCAs,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	return &config, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Setting TLS minimum version to 1.3 everywhere.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To improve security standards throughout the project.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
