### PR TITLE
Auth config fixes

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -18857,7 +18857,7 @@ components:
       type: object
     EKSAuthConfigUsers:
       properties:
-        group:
+        groups:
           items:
             type: string
           type: array
@@ -18868,7 +18868,7 @@ components:
       type: object
     EKSAuthConfigRoles:
       properties:
-        group:
+        groups:
           items:
             type: string
           type: array

--- a/.gen/pipeline/pipeline/model_eks_auth_config_roles.go
+++ b/.gen/pipeline/pipeline/model_eks_auth_config_roles.go
@@ -12,7 +12,7 @@ package pipeline
 
 type EksAuthConfigRoles struct {
 
-	Group []string `json:"group,omitempty"`
+	Groups []string `json:"groups,omitempty"`
 
 	Username string `json:"username,omitempty"`
 

--- a/.gen/pipeline/pipeline/model_eks_auth_config_users.go
+++ b/.gen/pipeline/pipeline/model_eks_auth_config_users.go
@@ -12,7 +12,7 @@ package pipeline
 
 type EksAuthConfigUsers struct {
 
-	Group []string `json:"group,omitempty"`
+	Groups []string `json:"groups,omitempty"`
 
 	Username string `json:"username,omitempty"`
 

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4513,7 +4513,7 @@ components:
         EKSAuthConfigUsers:
             type: object
             properties:
-                group:
+                groups:
                     type: array
                     items:
                         type: string
@@ -4525,7 +4525,7 @@ components:
         EKSAuthConfigRoles:
             type: object
             properties:
-                group:
+                groups:
                     type: array
                     items:
                         type: string

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -93,19 +93,16 @@ type AuthConfig struct {
 	MapAccounts []string   `json:"mapAccounts,omitempty" yaml:"mapAccounts,omitempty"`
 }
 
-type AuthConfigBaseFields struct {
-	Username string   `json:"username,omitempty" yaml:"username,omitempty"`
-	Groups   []string `json:"groups,omitempty" yaml:"groups,omitempty"`
-}
-
 type MapRoles struct {
-	AuthConfigBaseFields
-	RoleARN string `json:"rolearn,omitempty" yaml:"rolearn,omitempty"`
+	Groups   []string `json:"groups,omitempty" yaml:"groups,omitempty"`
+	RoleARN  string   `json:"rolearn,omitempty" yaml:"rolearn,omitempty"`
+	Username string   `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 type MapUsers struct {
-	AuthConfigBaseFields
-	UserARN string `json:"userarn,omitempty" yaml:"userarn,omitempty"`
+	Groups   []string `json:"groups,omitempty" yaml:"groups,omitempty"`
+	UserARN  string   `json:"userarn,omitempty" yaml:"userarn,omitempty"`
+	Username string   `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 // UpdateClusterAmazonEKS describes Amazon EKS's node fields of an UpdateCluster request


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Fix OpenAPI `groups` field
- Fix request decode
- Fix `mapAccounts` field merge to avoid these type of errors:
```
ERRO[2020-08-04T14:48:49+02:00] cluster create workflow failed: failed to merge config map: failed to unmarshal mapAccounts from: - account1
- otheraccount
: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}  clusterID=0 clusterName=pregnor-local-200804-aws-auth-config-success-3 organizationID=1
```

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
