### PR TITLE
fix(oidc): downgraded TLS to 1.2

### DIFF
--- a/src/auth/oidc.go
+++ b/src/auth/oidc.go
@@ -92,7 +92,7 @@ func newOIDCProvider(config *OIDCProviderConfig, refreshTokenStore RefreshTokenS
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.InsecureSkipVerify,
-				MinVersion:         tls.VersionTLS13,
+				MinVersion:         tls.VersionTLS12,
 			},
 		},
 	}


### PR DESCRIPTION
Dex doesn't support TLS 1.3 yet.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Downgraded TLS 1.2 on OIDC provider to support old Dex.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because old Dex does not support TLS 1.3 yet.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
