### PR TITLE
chore(make): improved start target DX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ start: docker-compose.override.yml ## Start docker development environment
 	docker-compose up -d
 	# Waiting for Dex to initialize with potential container restarts.
 	@ while ! docker-compose logs dex | grep -q "listening (http)" ; do sleep 1 ; echo "." ; done
+	# Note: remove the code below once Cadence 0.11.0 is used in docker compose.
+	# Issue: https://github.com/uber/cadence/issues/2764 in local/worker environment.
+	# Waiting for Cadence to initialize with potential container stops.
+	@ while ! docker-compose logs cadence | grep -q "cadence-sys-tl-scanner-workflow workflow successfully started" ; do if ! docker-compose ps | grep "pipeline_cadence_1" | awk '{print $5}' | grep -q "Up"; then docker-compose up -d ; fi ; sleep 1 ; echo "." ; done
 
 .PHONY: stop
 stop: ## Stop docker development environment

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ start: docker-compose.override.yml ## Start docker development environment
 	@ if [ docker-compose.override.yml -ot docker-compose.override.yml.dist ]; then diff -u docker-compose.override.yml* || (echo "!!! The distributed docker-compose.override.yml example changed. Please update your file accordingly (or at least touch it). !!!" && false); fi
 	mkdir -p .docker/volumes/{mysql,vault/file,vault/keys}
 	docker-compose up -d
+	# Waiting for Dex to initialize with potential container restarts.
+	@ while ! docker-compose logs dex | grep -q "listening (http)" ; do sleep 1 ; echo "." ; done
 
 .PHONY: stop
 stop: ## Stop docker development environment


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added waiting (and restarting) logic to `make start` in order to ensure both Dex and Cadence are properly initialized before the target returns successfully.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Dex sometimes restarts a couple times before it can start serving its content.
Cadence sometimes stops entirely and doesn't restart when it runs into an issue which will be fixed in version 0.11.0.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- [~Related Helm chart(s) updated (if needed)~
