### PR TITLE
Allow changing the default network provider

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -443,6 +443,7 @@ dex:
 #        amazon:
 #            globalRegion: us-east-1
 #            defaultImages: {}
+#            defaultNetworkProvider: "cilium"
 
 cloudinfo:
     # Format: {baseUrl}/api/v1

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -73,8 +73,9 @@ type Config struct {
 
 		PKE struct {
 			Amazon struct {
-				GlobalRegion  string
-				DefaultImages map[string]string
+				GlobalRegion           string
+				DefaultImages          map[string]string
+				DefaultNetworkProvider string
 			}
 		}
 	}
@@ -121,6 +122,15 @@ func (c Config) Validate() error {
 	err = errors.Append(err, c.Helm.Validate())
 
 	return err
+}
+
+func (c Config) validateDistribution() error {
+	pkeDefaultNP := c.Distribution.PKE.Amazon.DefaultNetworkProvider
+	if pkeDefaultNP != "calico" && pkeDefaultNP != "cilium" {
+		return errors.New("pke aws: default network provider must be calico or cilium")
+	}
+
+	return nil
 }
 
 func (c *Config) Process() error {
@@ -818,6 +828,8 @@ traefik:
 	v.SetDefault("distribution::eks::ssh::generate", true)
 
 	v.SetDefault("distribution::pke::amazon::globalRegion", "us-east-1")
+	v.SetDefault("distribution::pke::amazon::defaultImages", map[string]string{})
+	v.SetDefault("distribution::pke::amazon::defaultNetworkProvider", "cilium")
 
 	v.SetDefault("cloudinfo::endpoint", "")
 	v.SetDefault("hollowtrees::endpoint", "")

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -148,6 +148,11 @@ var Config struct {
 				Generate bool
 			}
 		}
+		PKE struct {
+			Amazon struct {
+				DefaultNetworkProvider string
+			}
+		}
 	}
 	Helm struct {
 		Home         string

--- a/internal/pke/kubernetes.go
+++ b/internal/pke/kubernetes.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/banzaicloud/pipeline/internal/global"
 )
 
 const (
@@ -137,7 +139,7 @@ func (p NetworkPreparer) Prepare(n *Network) error {
 		p.logger.Debugf("%s.ServiceCIDR not specified, defaulting to [%s]", p.namespace, n.ServiceCIDR)
 	}
 	if n.Provider == "" {
-		n.Provider = DefaultNetwork
+		n.Provider = global.Config.Distribution.PKE.Amazon.DefaultNetworkProvider
 		p.logger.Debugf("%s.Provider not specified, defaulting to [%s]", p.namespace, n.Provider)
 	}
 	// TODO: ProviderConfig defaults

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -17,6 +17,7 @@ package pke
 import (
 	"github.com/pkg/errors"
 
+	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/pkg/common"
 )
 
@@ -159,7 +160,7 @@ func (pke *CreateClusterPKE) AddDefaults() error {
 		pke.Network.ServiceCIDR = "10.32.0.0/24"
 	}
 	if pke.Network.Provider == "" {
-		pke.Network.Provider = NPCilium
+		pke.Network.Provider = NetworkProvider(global.Config.Distribution.PKE.Amazon.DefaultNetworkProvider)
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Allow changing the default network provider


### Why?
In some environments cilium can't be used, so it makes sense to change the default to something else (eg. calico).