### PR TITLE
fix(AWS): added unique client request token

### DIFF
--- a/internal/cluster/clusterworkflow/activity_create_node_pool.go
+++ b/internal/cluster/clusterworkflow/activity_create_node_pool.go
@@ -20,6 +20,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/jinzhu/gorm"
 	"github.com/mitchellh/mapstructure"
+	"go.uber.org/cadence/activity"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
@@ -28,6 +29,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/global"
 	"github.com/banzaicloud/pipeline/pkg/cadence"
 	"github.com/banzaicloud/pipeline/pkg/providers"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	"github.com/banzaicloud/pipeline/src/model"
 )
 
@@ -132,7 +134,7 @@ func (a CreateNodePoolActivity) Execute(ctx context.Context, input CreateNodePoo
 			SecretID:                  c.SecretID.ResourceID, // TODO: the underlying secret store is the legacy one
 			Region:                    c.Location,
 			ClusterName:               c.Name,
-			AWSClientRequestTokenBase: c.UID,
+			AWSClientRequestTokenBase: pkgAmazon.NewNormalizedClientRequestToken(activity.GetInfo(ctx).WorkflowExecution.ID),
 		}
 
 		var vpcActivityOutput *eksworkflow.GetVpcConfigActivityOutput

--- a/internal/cluster/clusterworkflow/activity_delete_node_pool.go
+++ b/internal/cluster/clusterworkflow/activity_delete_node_pool.go
@@ -18,11 +18,13 @@ import (
 	"context"
 
 	"emperror.dev/errors"
+	"go.uber.org/cadence/activity"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	eksworkflow "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 	"github.com/banzaicloud/pipeline/pkg/cadence"
 	"github.com/banzaicloud/pipeline/pkg/providers"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const DeleteNodePoolActivityName = "delete-node-pool"
@@ -65,7 +67,7 @@ func (a DeleteNodePoolActivity) Execute(ctx context.Context, input DeleteNodePoo
 				SecretID:                  c.SecretID.ResourceID,
 				Region:                    c.Location,
 				ClusterName:               c.Name,
-				AWSClientRequestTokenBase: c.UID,
+				AWSClientRequestTokenBase: pkgAmazon.NewNormalizedClientRequestToken(activity.GetInfo(ctx).WorkflowExecution.ID),
 			},
 			StackName: eksworkflow.GenerateNodePoolStackName(c.Name, input.NodePoolName),
 		}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -141,14 +141,6 @@ func generateK8sConfig(clusterName string, apiEndpoint string, certificateAuthor
 	}
 }
 
-func generateRequestToken(uuid string, activityName string) string {
-	token := uuid + "-" + activityName
-	if len(token) > 64 {
-		token = token[0:63]
-	}
-	return token
-}
-
 func packageCFError(err error, stackName string, clientRequestToken string, cloudformationClient *cloudformation.CloudFormation, errMessage string) error {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const CreateAsgActivityName = "eks-create-asg"
@@ -203,7 +204,7 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 			ParameterValue: aws.String(fmt.Sprintf("--kubelet-extra-args '--node-labels %v'", strings.Join(nodeLabels, ","))),
 		},
 	}
-	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, CreateAsgActivityName)
+	clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateAsgActivityName)
 
 	createStackInput := &cloudformation.CreateStackInput{
 		ClientRequestToken: aws.String(clientRequestToken),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/cadence/activity"
 
 	internalAmazon "github.com/banzaicloud/pipeline/internal/providers/amazon"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const CreateEksControlPlaneActivityName = "eks-create-control-plane"
@@ -148,7 +149,7 @@ func (a *CreateEksControlPlaneActivity) Execute(ctx context.Context, input Creat
 			tags[k] = aws.String(v)
 		}
 
-		requestToken := generateRequestToken(input.AWSClientRequestTokenBase, CreateEksControlPlaneActivityName)
+		requestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateEksControlPlaneActivityName)
 
 		logger.Info("create EKS cluster")
 		logger.Debug("clientRequestToken: ", requestToken)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_iam_roles_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_iam_roles_activity.go
@@ -22,6 +22,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/iam"
+
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const CreateIamRolesActivityName = "eks-create-iam-roles"
@@ -116,7 +118,7 @@ func (a *CreateIamRolesActivity) Execute(ctx context.Context, input CreateIamRol
 
 	cloudformationClient := cloudformation.New(session)
 
-	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, CreateIamRolesActivityName)
+	clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateIamRolesActivityName)
 
 	createStackInput := &cloudformation.CreateStackInput{
 		ClientRequestToken: aws.String(clientRequestToken),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
@@ -20,6 +20,8 @@ import (
 	"emperror.dev/errors"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
+
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const CreateInfraWorkflowName = "eks-create-infra"
@@ -101,7 +103,7 @@ func CreateInfrastructureWorkflow(ctx workflow.Context, input CreateInfrastructu
 		SecretID:                  input.SecretID,
 		Region:                    input.Region,
 		ClusterName:               input.ClusterName,
-		AWSClientRequestTokenBase: input.ClusterUID,
+		AWSClientRequestTokenBase: pkgAmazon.NewNormalizedClientRequestToken(workflow.GetInfo(ctx).WorkflowExecution.ID),
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, ao)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
@@ -145,7 +145,7 @@ func (s *CreateInfraWorkflowTestSuite) Test_Successful_Create() {
 		SecretID:                  workflowInput.SecretID,
 		Region:                    workflowInput.Region,
 		ClusterName:               workflowInput.ClusterName,
-		AWSClientRequestTokenBase: workflowInput.ClusterUID,
+		AWSClientRequestTokenBase: "default-test-workflow-id",
 	}
 
 	s.env.OnActivity(CreateIamRolesActivityName, mock.Anything, CreateIamRolesActivityInput{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_subnet_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_subnet_activity.go
@@ -21,6 +21,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"go.uber.org/cadence/activity"
+
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const CreateSubnetActivityName = "eks-create-subnet"
@@ -114,7 +116,7 @@ func (a *CreateSubnetActivity) Execute(ctx context.Context, input CreateSubnetAc
 			},
 		}
 
-		clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, CreateSubnetActivityName)
+		clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateSubnetActivityName)
 		createStackInput := &cloudformation.CreateStackInput{
 			ClientRequestToken: aws.String(input.AWSClientRequestTokenBase),
 			DisableRollback:    aws.Bool(true),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_vpc_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_vpc_activity.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
@@ -120,7 +121,7 @@ func (a *CreateVpcActivity) Execute(ctx context.Context, input CreateVpcActivity
 	}
 	cloudformationClient := cloudformation.New(session)
 
-	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, CreateVpcActivityName)
+	clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateVpcActivityName)
 	createStackInput := &cloudformation.CreateStackInput{
 		ClientRequestToken: aws.String(clientRequestToken),
 		DisableRollback:    aws.Bool(true),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_infra.go
@@ -20,6 +20,8 @@ import (
 	"emperror.dev/errors"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
+
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const DeleteInfraWorkflowName = "eks-delete-infra"
@@ -78,7 +80,7 @@ func DeleteInfrastructureWorkflow(ctx workflow.Context, input DeleteInfrastructu
 		SecretID:                  input.SecretID,
 		Region:                    input.Region,
 		ClusterName:               input.ClusterName,
-		AWSClientRequestTokenBase: input.ClusterUID,
+		AWSClientRequestTokenBase: pkgAmazon.NewNormalizedClientRequestToken(workflow.GetInfo(ctx).WorkflowExecution.ID),
 	}
 
 	// get VPC ID

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_infra_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_infra_test.go
@@ -86,10 +86,11 @@ func (s *DeleteClusterInfraWorkflowTestSuite) Test_Successful_Delete_Infra() {
 	}
 
 	eksActivityInput := EKSActivityInput{
-		OrganizationID: workflowInput.OrganizationID,
-		SecretID:       workflowInput.SecretID,
-		Region:         workflowInput.Region,
-		ClusterName:    workflowInput.ClusterName,
+		OrganizationID:            workflowInput.OrganizationID,
+		SecretID:                  workflowInput.SecretID,
+		Region:                    workflowInput.Region,
+		ClusterName:               workflowInput.ClusterName,
+		AWSClientRequestTokenBase: "default-test-workflow-id",
 	}
 
 	s.env.OnActivity(GetVpcConfigActivityName, mock.Anything, GetVpcConfigActivityInput{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_stack_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_stack_activity.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
@@ -69,7 +70,7 @@ func (a *DeleteStackActivity) Execute(ctx context.Context, input DeleteStackActi
 
 	logger.Info("deleting stack")
 
-	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, DeleteStackActivityName)
+	clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, DeleteStackActivityName)
 	deleteStackInput := &cloudformation.DeleteStackInput{
 		ClientRequestToken: aws.String(clientRequestToken),
 		StackName:          aws.String(input.StackName),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
@@ -248,7 +249,7 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 		},
 	}
 
-	clientRequestToken := generateRequestToken(input.AWSClientRequestTokenBase, UpdateAsgActivityName)
+	clientRequestToken := pkgAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, UpdateAsgActivityName)
 
 	// we don't reuse the creation time template, since it may have changed
 	updateStackInput := &cloudformation.UpdateStackInput{

--- a/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
+++ b/internal/providers/pke/pkeworkflow/create_aws_worker_pool_activity.go
@@ -29,6 +29,7 @@ import (
 	cloudformation2 "github.com/banzaicloud/pipeline/internal/cloudformation"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/pke/pkeaws"
 	"github.com/banzaicloud/pipeline/internal/providers/amazon"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
@@ -122,9 +123,9 @@ func (a *CreateWorkerPoolActivity) Execute(ctx context.Context, input CreateWork
 	}
 
 	stackInput := &cloudformation.CreateStackInput{
-		StackName:    aws.String(stackName),
-		TemplateBody: aws.String(template),
-		// ClientRequestToken: aws.String(string(activity.GetInfo(ctx).ActivityID)),
+		StackName:          aws.String(stackName),
+		TemplateBody:       aws.String(template),
+		ClientRequestToken: aws.String(pkgAmazon.NewNormalizedClientRequestToken(activity.GetInfo(ctx).WorkflowExecution.ID)),
 		Parameters: []*cloudformation.Parameter{
 			{
 				ParameterKey:   aws.String("ClusterName"),

--- a/internal/providers/pke/pkeworkflow/delete_aws_pool_activity.go
+++ b/internal/providers/pke/pkeworkflow/delete_aws_pool_activity.go
@@ -23,7 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"go.uber.org/cadence/activity"
 
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 )
 
@@ -71,8 +73,8 @@ func (a *DeletePoolActivity) Execute(ctx context.Context, input DeletePoolActivi
 	}
 
 	stackInput := &cloudformation.DeleteStackInput{
-		StackName: aws.String(stackName),
-		// ClientRequestToken: aws.String(string(activity.GetInfo(ctx).ActivityID)),
+		StackName:          aws.String(stackName),
+		ClientRequestToken: aws.String(pkgAmazon.NewNormalizedClientRequestToken(activity.GetInfo(ctx).WorkflowExecution.ID)),
 	}
 
 	_, err = cfClient.DeleteStack(stackInput)

--- a/pkg/providers/amazon/client_request_token.go
+++ b/pkg/providers/amazon/client_request_token.go
@@ -1,0 +1,52 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package amazon
+
+import (
+	"regexp"
+	"strings"
+)
+
+// clientRequestTokenNotAllowedCharacters is the regular expression matching
+// characters not allowed in a client request token.
+//
+// Regular expression: https://regex101.com/r/yG9DFU/1
+//
+// Source: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html
+var clientRequestTokenNotAllowedCharactersRegexp = regexp.MustCompile("[^0-9a-zA-Z-]") // nolint:gochecknoglobals // Note: best way I know to avoid multiple initializations of single regular expression.
+
+// NewClientRequestToken creates an AWS CloudFormation client request token from
+// the specified elements.
+//
+// 1. The elements are joint by a dash separator.
+// 2. Not allowed characters are replaced by dashes.
+// 3. The prefix dashes are trimmed.
+// 4. The resulting string is truncated to 64 characters.
+//
+// Source: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html
+func NewNormalizedClientRequestToken(elements ...string) (normalizedClientRequestToken string) {
+	normalizedClientRequestToken = strings.Join(elements, "-")
+	normalizedClientRequestToken = clientRequestTokenNotAllowedCharactersRegexp.ReplaceAllString(
+		normalizedClientRequestToken,
+		"-",
+	)
+	normalizedClientRequestToken = strings.TrimLeft(normalizedClientRequestToken, "-")
+
+	if len(normalizedClientRequestToken) > 64 {
+		normalizedClientRequestToken = normalizedClientRequestToken[:64]
+	}
+
+	return normalizedClientRequestToken
+}

--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -25,6 +25,7 @@ import (
 	eksWorkflow "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 	"github.com/banzaicloud/pipeline/pkg/brn"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+	pkgAmazon "github.com/banzaicloud/pipeline/pkg/providers/amazon"
 )
 
 const EKSUpdateClusterWorkflowName = "eks-update-cluster"
@@ -99,13 +100,12 @@ func EKSUpdateClusterWorkflow(ctx workflow.Context, input EKSUpdateClusterstruct
 		"cluster", input.ClusterName,
 	)
 
-	workflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
 	commonActivityInput := eksWorkflow.EKSActivityInput{
 		OrganizationID:            input.OrganizationID,
 		SecretID:                  input.SecretID,
 		Region:                    input.Region,
 		ClusterName:               input.ClusterName,
-		AWSClientRequestTokenBase: workflowID,
+		AWSClientRequestTokenBase: pkgAmazon.NewNormalizedClientRequestToken(workflow.GetInfo(ctx).WorkflowExecution.ID),
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, ao)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3016 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Replaced cluster UUID, generated UUID and empty AWS client request tokens with Cadence workflow ID.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To provide a client request token that is unique among different "requests", but are the same between activity retries so AWS can handle same-stack requests in an idempotent fashion. ActivityID is not used, because it would be different for the same same-stack operation between activity retries.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
