### PR TITLE
chore: replaced beta env with try references, removed Cadence workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,6 @@ start: docker-compose.override.yml ## Start docker development environment
 	docker-compose up -d
 	# Waiting for Dex to initialize with potential container restarts.
 	@ while ! docker-compose logs dex | grep -q "listening (http)" ; do sleep 1 ; echo "." ; done
-	# Note: remove the code below once Cadence 0.11.0 is used in docker compose.
-	# Issue: https://github.com/uber/cadence/issues/2764 in local/worker environment.
-	# Waiting for Cadence to initialize with potential container stops.
-	@ while ! docker-compose logs cadence | grep -q "cadence-sys-tl-scanner-workflow workflow successfully started" ; do if ! docker-compose ps | grep "pipeline_cadence_1" | awk '{print $5}' | grep -q "Up"; then docker-compose up -d ; fi ; sleep 1 ; echo "." ; done
 
 .PHONY: stop
 stop: ## Stop docker development environment

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The main features of the platform are:
 * **Integrates cluster services:** _Automated solutions for DNS, observability, private registries, security scans, DR and lots more_
 * **Hook in:** _Go from commit to scale in minutes using the in-built container-native CI/CD workflow engine_
 
-Check out the developer beta if you would like to try out the platform:
+Check out the developer preview environment if you would like to try out the platform:
 <p align="center">
-  <a href="https://beta.banzaicloud.io">
+  <a href="https://try.pipeline.banzai.cloud">
   <img src="https://camo.githubusercontent.com/a487fb3128bcd1ef9fc1bf97ead8d6d6a442049a/68747470733a2f2f62616e7a6169636c6f75642e636f6d2f696d672f7472795f706970656c696e655f627574746f6e2e737667">
   </a>
 </p>

--- a/config/config.dev.yaml
+++ b/config/config.dev.yaml
@@ -68,8 +68,8 @@ dex:
     apiAddr: "127.0.0.1:5557"
 
 cloudinfo:
-    endpoint: "https://beta.banzaicloud.io/cloudinfo/api/v1"
+    endpoint: "https://try.pipeline.banzai.cloud/cloudinfo/api/v1"
 
 hollowtrees:
-    endpoint: "https://beta.banzaicloud.io/hollowtrees-alerts/api/v1"
+    endpoint: "https://try.pipeline.banzai.cloud/hollowtrees-alerts/api/v1"
     tokenSigningKey: "Th1s!sMyR4Nd0MStri4gPleaseChangeIt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,8 @@ services:
         depends_on:
             - ui
         environment:
-            CLOUDINFO_URL: https://beta.banzaicloud.io/cloudinfo
-            RECOMMENDER_URL: https://beta.banzaicloud.io/recommender
+            CLOUDINFO_URL: https://try.pipeline.banzai.cloud/cloudinfo
+            RECOMMENDER_URL: https://try.pipeline.banzai.cloud/recommender
 
     dex:
         image: banzaicloud/dex-shim:0.6.0

--- a/etc/docker/uiproxy/Dockerfile
+++ b/etc/docker/uiproxy/Dockerfile
@@ -10,8 +10,8 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 COPY nginx.conf /etc/nginx/nginx.tmpl
 RUN rm /etc/nginx/conf.d/default.conf
 
-ENV CLOUDINFO_URL=https://beta.banzaicloud.io/cloudinfo
-ENV RECOMMENDER_URL=https://beta.banzaicloud.io/recommender
+ENV CLOUDINFO_URL=https://try.pipeline.banzai.cloud/cloudinfo
+ENV RECOMMENDER_URL=https://try.pipeline.banzai.cloud/recommender
 ENV UI_URL=http://ui/ui
 
 CMD dockerize -template /etc/nginx/nginx.tmpl:/etc/nginx/nginx.conf -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log nginx

--- a/internal/secret/secrettype/secret.go
+++ b/internal/secret/secrettype/secret.go
@@ -248,7 +248,7 @@ var DefaultRules = map[string]Meta{
 	Google: {
 		Fields: []FieldMeta{
 			{Name: Type, Required: true, Description: "service_account"},
-			{Name: ProjectId, Required: true, Description: "Google Could Project Id. Find more about, Google Cloud secret fields here: https://beta.banzaicloud.io/docs/cloud-provider-credentials/google/gke_auth_credentials/#method-2-command-line"},
+			{Name: ProjectId, Required: true, Description: "Google Could Project Id. Find more about, Google Cloud secret fields here: https://banzaicloud.com/docs/pipeline/secrets/providers/gke_auth_credentials/#method-2-command-line"},
 			{Name: PrivateKeyId, Required: true, Description: "Id of you private key"},
 			{Name: PrivateKey, Required: true, Description: "Your private key "},
 			{Name: ClientEmail, Required: true, Description: "Google service account client email"},
@@ -266,7 +266,7 @@ var DefaultRules = map[string]Meta{
 	},
 	Oracle: {
 		Fields: []FieldMeta{
-			{Name: OracleUserOCID, Required: true, Description: "Your Oracle user OCID. Find more about, generating public key and fingerprint here: https://beta.banzaicloud.io/docs/cloud-provider-credentials/oracle/oke_auth_credentials/#generate-api-token"},
+			{Name: OracleUserOCID, Required: true, Description: "Your Oracle user OCID. Find more about, generating public key and fingerprint here: https://banzaicloud.com/docs/pipeline/secrets/providers/oci_auth_credentials/"},
 			{Name: OracleTenancyOCID, Required: true, Description: "Your tenancy OCID"},
 			{Name: OracleAPIKey, Required: true, Description: "Your public key"},
 			{Name: OracleAPIKeyFingerprint, Required: true, Description: "Fingerprint of you public key"},

--- a/internal/secret/types/type_google.go
+++ b/internal/secret/types/type_google.go
@@ -56,7 +56,7 @@ func (GoogleType) Definition() secret.TypeDefinition {
 	return secret.TypeDefinition{
 		Fields: []secret.FieldDefinition{
 			{Name: FieldGoogleType, Required: true, Description: "service_account"},
-			{Name: FieldGoogleProjectId, Required: true, Description: "Google Could Project Id. Find more about, Google Cloud secret fields here: https://beta.banzaicloud.io/docs/cloud-provider-credentials/google/gke_auth_credentials/#method-2-command-line"},
+			{Name: FieldGoogleProjectId, Required: true, Description: "Google Could Project Id. Find more about, Google Cloud secret fields here: https://banzaicloud.com/docs/pipeline/secrets/providers/gke_auth_credentials/#method-2-command-line"},
 			{Name: FieldGooglePrivateKeyId, Required: true, Description: "Id of you private key"},
 			{Name: FieldGooglePrivateKey, Required: true, Description: "Your private key "},
 			{Name: FieldGoogleClientEmail, Required: true, Description: "Google service account client email"},

--- a/internal/secret/types/type_oracle.go
+++ b/internal/secret/types/type_oracle.go
@@ -39,7 +39,7 @@ func (OracleType) Name() string {
 func (OracleType) Definition() secret.TypeDefinition {
 	return secret.TypeDefinition{
 		Fields: []secret.FieldDefinition{
-			{Name: FieldOracleUserOCID, Required: true, Description: "Your Oracle user OCID. Find more about, generating public key and fingerprint here: https://beta.banzaicloud.io/docs/cloud-provider-credentials/oracle/oke_auth_credentials/#generate-api-token"},
+			{Name: FieldOracleUserOCID, Required: true, Description: "Your Oracle user OCID. Find more about, generating public key and fingerprint here: https://banzaicloud.com/docs/pipeline/secrets/providers/oci_auth_credentials/"},
 			{Name: FieldOracleTenancyOCID, Required: true, Description: "Your tenancy OCID"},
 			{Name: FieldOracleAPIKey, Required: true, Description: "Your public key"},
 			{Name: FieldOracleAPIKeyFingerprint, Required: true, Description: "Fingerprint of you public key"},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
1. Removed Cadence workaround logic from `make start`
2. Replaced beta environment references with try environment references.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
1. Because the Cadence 0.13 update brought stability to the corresponding docker image starting process and the workaround logic is not needed anymore.
2. Because the beta environment is being discontinued.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
