### PR TITLE
Securityscan/update anchore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,9 +285,11 @@ apis/anchore/swagger.yaml:
 
 .PHONY: generate-anchore-client
 generate-anchore-client: apis/anchore/swagger.yaml ## Generate client from Anchore OpenAPI spec
+	$(call back_up_file,.gen/anchore/BUILD)
 	$(call generate_openapi_client,apis/anchore/swagger.yaml,anchore,.gen/anchore)
 	sed -i '' 's/whitelist_ids,omitempty/whitelist_ids/' .gen/anchore/model_mapping_rule.go
 	sed -i '' 's/params,omitempty/params/' .gen/anchore/model_policy_rule.go
+	$(call restore_backup_file,.gen/anchore/BUILD)
 
 snapshot: SNAPSHOT_REF ?= $(shell git symbolic-ref -q --short HEAD || git rev-parse HEAD)
 snapshot:

--- a/apis/anchore/BUILD
+++ b/apis/anchore/BUILD
@@ -10,7 +10,7 @@ genrule(
         _tag = "download",
         url = f"https://raw.githubusercontent.com/anchore/anchore-engine/{anchore_version}/anchore_engine/services/apiext/swagger/swagger.yaml",
         out = "swagger.yml", # important to avoid file name collision
-        hashes = ["c774047663ee445823cadf10bc0da8b0a223f894b3da54db5b94f691df1b1971"],
+        hashes = ["68a026c241503c521b9aa15aba94e1915ebcd755c1e44692c917b2f7b6c10d45"],
         licences = ["Apache-2.0"],
     )],
     outs = ["apis/anchore/swagger.yaml"],

--- a/apis/anchore/BUILD
+++ b/apis/anchore/BUILD
@@ -1,7 +1,7 @@
 subinclude("///pleasings2//openapi")
 
 # TODO: use an exact version
-anchore_version = "156836d"
+anchore_version = "fdc8379"
 
 genrule(
     name = "spec",

--- a/apis/anchore/BUILD
+++ b/apis/anchore/BUILD
@@ -1,7 +1,6 @@
 subinclude("///pleasings2//openapi")
 
-# TODO: use an exact version
-anchore_version = "fdc8379"
+anchore_version = "v0.8.0"
 
 genrule(
     name = "spec",

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -77,20 +77,10 @@ services:
             - 127.0.0.1:8088:8088
 
 # Uncomment the following two services to enable Anchore.
-#    anchore-db:
-#        image: "postgres:9"
-#        environment:
-#            - POSTGRES_PASSWORD=mysecretpassword
-#            - PGDATA=/var/lib/postgresql/data/pgdata/
-#        ports:
-#            - "5432:5432"
-#        volumes:
-#            - ./.docker/volumes/anchore-db:/var/lib/postgresql/data/pgdata/:z
-#
 #    anchore-engine:
 #        image: docker.io/anchore/anchore-engine:v0.5.1
 #        depends_on:
-#            - anchore-db
+#            - postgres
 #        environment:
 #            - ANCHORE_HOST_ID=dockerhostid-anchore-engine
 #            - ANCHORE_ENDPOINT_HOSTNAME=anchore-engine

--- a/etc/config/anchore.yaml
+++ b/etc/config/anchore.yaml
@@ -22,7 +22,7 @@ auto_restart_services: True
 # anchore-engine (enables metric gathering and /metrics route for all
 # services)
 #
-#metrics: 
+#metrics:
 #  enabled: True
 #
 
@@ -80,7 +80,7 @@ credentials:
        #auto_policy_sync: True
 
   database:
-    db_connect: 'postgresql+pg8000://postgres:mysecretpassword@anchore-db:5432/postgres'
+    db_connect: 'postgresql+pg8000://sparky:sparky123@postgres:5432/postgres'
     db_connect_args:
       timeout: 120
       ssl: False


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3087 
| License         | Apache 2.0


### What's in this PR?
Update commit hash for generating the anchore-engine client, based on the anchore-engine version v0.8.0.

### Why?
The latest stable anchore-engine version is v0.8.0

### Additional context
Anchore-engine client generation has run but the API hasn't changed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
