### PR TITLE
chore(Makefile): added generation plz BUILD file backups, fixed backup/restore message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,10 +320,10 @@ varexport-%: ; @echo $*=$($*)
 #
 # $1 - source file path to back up.
 define back_up_file
+	$(eval source_file_path := $(1))
 	@echo "- Backing up $(source_file_path)."
 
 	$(call check_binary,realpath,coreutils)
-	$(eval source_file_path := $(1))
 
 	$(eval source_file_path := $(shell realpath --relative-to=. $(source_file_path)))
 	$(eval backup_file_path := $(shell echo "$(TEMPORARY_DIRECTORY)/$(source_file_path)"))
@@ -360,10 +360,10 @@ endef
 # $1 - target file path whose backup is to be restored from the temporary
 # directory.
 define restore_backup_file
+	$(eval target_file_path := $(1))
 	@echo "- Restoring $(target_file_path)."
 
 	$(call check_binary,realpath,coreutils)
-	$(eval target_file_path := $(1))
 
 	$(eval target_file_path := $(shell realpath --relative-to=. $(target_file_path)))
 	$(eval backup_file_path := $(shell echo "$(TEMPORARY_DIRECTORY)/$(target_file_path)"))

--- a/Makefile
+++ b/Makefile
@@ -278,16 +278,20 @@ apis/cloudinfo/openapi.yaml:
 
 .PHONY: generate-cloudinfo-client
 generate-cloudinfo-client: apis/cloudinfo/openapi.yaml ## Generate client from Cloudinfo OpenAPI spec
+	$(call back_up_file,.gen/cloudinfo/BUILD)
 	$(call generate_openapi_client,apis/cloudinfo/openapi.yaml,cloudinfo,.gen/cloudinfo)
+	$(call restore_backup_file,.gen/cloudinfo/BUILD)
 
 apis/anchore/swagger.yaml:
 	curl https://raw.githubusercontent.com/anchore/anchore-engine/${ANCHORE_VERSION}/anchore_engine/services/apiext/swagger/swagger.yaml | tr '\n' '\r' | sed $$'s/- Images\r      - Vulnerabilities/- Images/g' | tr '\r' '\n' | sed '/- Image Content/d; /- Policy Evaluation/d; /- Queries/d' > apis/anchore/swagger.yaml
 
 .PHONY: generate-anchore-client
 generate-anchore-client: apis/anchore/swagger.yaml ## Generate client from Anchore OpenAPI spec
+	$(call back_up_file,.gen/anchore/BUILD)
 	$(call generate_openapi_client,apis/anchore/swagger.yaml,anchore,.gen/anchore)
 	sed -i '' 's/whitelist_ids,omitempty/whitelist_ids/' .gen/anchore/model_mapping_rule.go
 	sed -i '' 's/params,omitempty/params/' .gen/anchore/model_policy_rule.go
+	$(call restore_backup_file,.gen/anchore/BUILD)
 
 snapshot: SNAPSHOT_REF ?= $(shell git symbolic-ref -q --short HEAD || git rev-parse HEAD)
 snapshot:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
1. Added plz BUILD configuration backup for file generations regarding Anchore and CloudInfo clients.
2. Fixed the backup/restore message.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
1. To preserve the plz BUILD configuration file.
2. It lacked the exact path being backed up

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
