### PR TITLE
fix(EKSEncryptionConfig): clarified error message

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
@@ -597,14 +597,14 @@ func validateEncryptionConfiguration(encryptionConfig []pkgEks.EncryptionConfig,
 	resources := encryptionConfigItem.Resources
 
 	if keyARN == "" {
-		return errors.NewWithDetails("invalid empty value", "key", "encryptionConfig[0].Provider.KeyARN")
+		return errors.NewWithDetails("invalid empty keyARN value", "key", "encryptionConfig[0].Provider.KeyARN")
 	} else if !strings.HasPrefix(keyARN, "arn:aws:kms") {
 		return errors.NewWithDetails("invalid non-KMS ARN or non-ARN value specified",
 			"keyARN", keyARN)
 	}
 
 	if resources == nil {
-		return errors.NewWithDetails("invalid nil value", "key", "encryptionConfig[0].Resources")
+		return errors.NewWithDetails("invalid nil resources value", "key", "encryptionConfig[0].Resources")
 	} else if len(resources) != 1 {
 		return errors.NewWithDetails("invalid encryption configuration resource count",
 			"expectedCount", 1, "actualCount", len(resources), "encryptionConfig[0].Resources", resources)

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator_test.go
@@ -86,7 +86,7 @@ func TestValidateEncryptionConfiguration(t *testing.T) {
 				},
 			},
 			output: outputType{
-				expectedError: errors.NewWithDetails("invalid empty value"),
+				expectedError: errors.NewWithDetails("invalid empty keyARN value"),
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func TestValidateEncryptionConfiguration(t *testing.T) {
 				},
 			},
 			output: outputType{
-				expectedError: errors.NewWithDetails("invalid nil value"),
+				expectedError: errors.NewWithDetails("invalid nil resources value"),
 			},
 		},
 		{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Clarified the error message content.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because the details are not added to the response returned to the user and this seemed a much less risky short-term solution than trying to find out whether we can add each detail to the response automatically. That approach requires more consideration.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
