### PR TITLE
Increase EKS node volume size

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -352,7 +352,7 @@ Parameters:
   NodeVolumeSize:
     Type: Number
     Description: Node volume size
-    Default: 20
+    Default: 50
 
   Subnets:
     Description: The subnets where workers can be created.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Increase default node volume size to 50GB

### Why?
This is a temporary fix to solve ephemeral storage issues.


### Additional context
We use 50GB as a default for PKE as well
