### PR TITLE
fix(OpenAPI): fixed specification typos

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19360,7 +19360,7 @@ components:
       - providerConfig
       - roles
       type: object
-    AmazonPoviderConfig:
+    AmazonProviderConfig:
       properties:
         autoScalingGroup:
           $ref: '#/components/schemas/AmazonAutoScalingGroup'

--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -14,7 +14,7 @@ info:
 servers:
 - url: http://localhost:9090
 tags:
-- description: Clusters related funtions
+- description: Clusters related functions
   name: clusters
 - description: Deployment related functions for a cluster
   name: deployments
@@ -1426,7 +1426,7 @@ paths:
       - clusters
   /api/v1/orgs/{orgId}/clusters/{id}/nodes:
     get:
-      description: List cluser nodes
+      description: List cluster nodes
       operationId: ListNodes
       parameters:
       - description: Organization identifier
@@ -1552,7 +1552,7 @@ paths:
           description: Internal server error
       security:
       - bearerAuth: []
-      summary: List cluser nodes
+      summary: List cluster nodes
       tags:
       - clusters
   /api/v1/orgs/{orgId}/clusters/{id}/secrets:
@@ -4274,7 +4274,7 @@ paths:
         schema:
           type: string
         style: simple
-      - description: K8s reource type
+      - description: K8s resource type
         explode: true
         in: query
         name: resourceTypes
@@ -7136,7 +7136,7 @@ paths:
               schema:
                 example:
                 - /api/v1/orgs
-                - /api/v1/orgs/:orgid
+                - /api/v1/orgs/:orgId
                 items:
                   type: string
                 type: array
@@ -10285,7 +10285,7 @@ paths:
       - clusters
   /api/v1/orgs/{orgId}/cloud/google/projects:
     get:
-      description: Retrieves projects visible by the user represented by the secretid
+      description: Retrieves projects visible by the user represented by the secretId
         header from the google cloud
       operationId: ListProjects
       parameters:
@@ -17978,7 +17978,7 @@ paths:
           description: Internal server error
       security:
       - bearerAuth: []
-      summary: List cluser nodepool labels
+      summary: List cluster nodepool labels
       tags:
       - clusters
   /api/v1/orgs/{orgId}/processes:
@@ -18917,7 +18917,7 @@ components:
           description: Name of VM template available on vSphere to clone as the base
             of nodes. Overrides default value from the main cluster secret.
           example: '[{"simple":{"value":"centos-7-pke-201910021808","summary":"Name
-            of template to use when it''s unambigious."}},{"absolute":{"value":"/Datacenter/vm/centos-7-pke-201910021808"}}]'
+            of template to use when it''s unambiguous."}},{"absolute":{"value":"/Datacenter/vm/centos-7-pke-201910021808"}}]'
           type: string
         adminUsername:
           description: Name of admin user to deploy the generated SSH public key for.
@@ -19632,8 +19632,8 @@ components:
           type: integer
         count:
           description: If cluster autoscaler is not enabled this specifies the desired
-            ndoe count in the node pool. If cluster autoscaler is enabled this specifies
-            the initial node count in the ndoe pool.
+            node count in the node pool. If cluster autoscaler is enabled this specifies
+            the initial node count in the node pool.
           example: 1
           type: integer
         subnets:
@@ -21685,7 +21685,7 @@ components:
           currentReplicas: 1
           desiredReplicas: 1
           message: 'ScalingActive = true, lastTransitionTime: 2018-00-22T15:31:16Z,
-            the HPA was able to succesfully calculate a replica count from memory
+            the HPA was able to successfully calculate a replica count from memory
             resource'
       items:
         properties:
@@ -21754,7 +21754,7 @@ components:
           type: integer
         message:
           example: 'ScalingActive = true, lastTransitionTime: 2018-08-22T15:31:16Z,
-            the HPA was able to succesfully calculate a replica count from memory
+            the HPA was able to successfully calculate a replica count from memory
             resource'
           type: string
       type: object
@@ -21766,7 +21766,7 @@ components:
       example:
         result:
         - nginx:latest policy check failed
-        - busybox:latest policy sheck success
+        - busybox:latest policy check success
         image:
         - lastUpdated: 2018-11-11T14:35:38Z
           imageName: docker.io/redis
@@ -21793,7 +21793,7 @@ components:
         result:
           example:
           - nginx:latest policy check failed
-          - busybox:latest policy sheck success
+          - busybox:latest policy check success
           items:
             type: string
           type: array
@@ -23304,7 +23304,7 @@ components:
           description: Folder to create nodes in. Overrides default value from the
             main cluster secret.
           example: '[{"simple":{"value":"my-folder","summary":"The name of the folder
-            anywhere in the hierarchy when it''s unambigious."}},{"absolute":{"value":"/Datacenter/vm/my-folder","summary":"Absolute
+            anywhere in the hierarchy when it''s unambiguous."}},{"absolute":{"value":"/Datacenter/vm/my-folder","summary":"Absolute
             path to the folder. Most vSphere installations use paths prefixed with
             /Datacenter/vm/."}}]'
           type: string
@@ -23441,7 +23441,7 @@ components:
           additionalProperties:
             example: '{"customTagKey":"customTagValue"}'
             type: string
-          description: User definied tags to be added to created AWS resources. Empty
+          description: User defined tags to be added to created AWS resources. Empty
             keys and values are not permitted.
           type: object
       required:

--- a/.gen/pipeline/pipeline/model_amazon_provider_config.go
+++ b/.gen/pipeline/pipeline/model_amazon_provider_config.go
@@ -10,7 +10,7 @@
 
 package pipeline
 
-type AmazonPoviderConfig struct {
+type AmazonProviderConfig struct {
 
 	AutoScalingGroup AmazonAutoScalingGroup `json:"autoScalingGroup"`
 }

--- a/.gen/pipeline/pipeline/model_create_eks_properties_eks.go
+++ b/.gen/pipeline/pipeline/model_create_eks_properties_eks.go
@@ -36,6 +36,6 @@ type CreateEksPropertiesEks struct {
 	// List of access point types for the API server; public and private are the only valid values
 	ApiServerAccessPoints []string `json:"apiServerAccessPoints,omitempty"`
 
-	// User definied tags to be added to created AWS resources. Empty keys and values are not permitted.
+	// User defined tags to be added to created AWS resources. Empty keys and values are not permitted.
 	Tags map[string]string `json:"tags,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_update_node_pools_pke.go
+++ b/.gen/pipeline/pipeline/model_update_node_pools_pke.go
@@ -27,7 +27,7 @@ type UpdateNodePoolsPke struct {
 	// If cluster autoscaler is enabled for this node pool it sets the maximum node count the cluster autoscaler can upscale the node pool to.
 	MaxCount int32 `json:"maxCount,omitempty"`
 
-	// If cluster autoscaler is not enabled this specifies the desired ndoe count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the ndoe pool.
+	// If cluster autoscaler is not enabled this specifies the desired node count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the node pool.
 	Count int32 `json:"count,omitempty"`
 
 	// The subnet to create the node pool into. If this field is omitted than the subnet from the cluster level network configuration is used.

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -17,7 +17,7 @@ servers:
 tags:
     -
         name: clusters
-        description: Clusters related funtions
+        description: Clusters related functions
     -
         name: deployments
         description: Deployment related functions for a cluster
@@ -358,9 +358,9 @@ paths:
                 - bearerAuth: []
             tags:
                 - clusters
-            summary: List cluser nodes
+            summary: List cluster nodes
             operationId: ListNodes
-            description: List cluser nodes
+            description: List cluster nodes
             parameters:
                 - $ref: '#/components/parameters/orgId'
                 - $ref: '#/components/parameters/clusterId'
@@ -1025,7 +1025,7 @@ paths:
                     name: resourceTypes
                     in: query
                     required: false
-                    description: K8s reource type
+                    description: K8s resource type
                     schema:
                         type: string
             responses:
@@ -1609,7 +1609,7 @@ paths:
                                     type: string
                                 example: [
                                     "/api/v1/orgs",
-                                    "/api/v1/orgs/:orgid",
+                                    "/api/v1/orgs/:orgId",
                                 ]
 
     /api/v1/orgs/{orgId}/users:
@@ -2416,7 +2416,7 @@ paths:
                 - google
             summary: Retrieves projects visible for the user identified by the secret id
             operationId: ListProjects
-            description: Retrieves projects visible by the user represented by the secretid header from the google cloud
+            description: Retrieves projects visible by the user represented by the secretId header from the google cloud
             parameters:
                 - $ref: '#/components/parameters/orgId'
                 -
@@ -3696,7 +3696,7 @@ paths:
                 - bearerAuth: []
             tags:
                 - clusters
-            summary: List cluser nodepool labels
+            summary: List cluster nodepool labels
             operationId: ListNodepoolLabels
             description: List cluster nodepool labels
             parameters:
@@ -4396,7 +4396,7 @@ components:
                             example:
                                - simple:
                                      value: "my-folder"
-                                     summary: "The name of the folder anywhere in the hierarchy when it's unambigious."
+                                     summary: "The name of the folder anywhere in the hierarchy when it's unambiguous."
                                - absolute:
                                      value: "/Datacenter/vm/my-folder"
                                      summary: "Absolute path to the folder. Most vSphere installations use paths prefixed with /Datacenter/vm/."
@@ -4456,7 +4456,7 @@ components:
                     example:
                         - simple:
                               value: "centos-7-pke-201910021808"
-                              summary: "Name of template to use when it's unambigious."
+                              summary: "Name of template to use when it's unambiguous."
                         - absolute:
                               value: "/Datacenter/vm/centos-7-pke-201910021808"
                 adminUsername:
@@ -4827,7 +4827,7 @@ components:
                                 type: string
                                 example:
                                     customTagKey: customTagValue
-                            description: User definied tags to be added to created AWS resources. Empty keys and values are not permitted.
+                            description: User defined tags to be added to created AWS resources. Empty keys and values are not permitted.
         CreateACKProperties:
             type: object
             required:
@@ -5465,7 +5465,7 @@ components:
                 count:
                     type: integer
                     example: 1
-                    description: If cluster autoscaler is not enabled this specifies the desired ndoe count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the ndoe pool.
+                    description: If cluster autoscaler is not enabled this specifies the desired node count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the node pool.
                 subnets:
                     type: array
                     items:
@@ -6024,7 +6024,7 @@ components:
                                         example: "v1"
                                     deprecated:
                                         type: boolean
-                                        example: flase
+                                        example: false
                                     urls:
                                         type: array
                                         items:
@@ -6101,7 +6101,7 @@ components:
                                         example: "v1"
                                     deprecated:
                                         type: boolean
-                                        example: flase
+                                        example: false
                                     urls:
                                         type: array
                                         items:
@@ -7241,7 +7241,7 @@ components:
                     status:
                         currentReplicas: 1
                         desiredReplicas: 1
-                        message: 'ScalingActive = true, lastTransitionTime: 2018-00-22T15:31:16Z, the HPA was able to succesfully calculate a replica count from memory resource'
+                        message: 'ScalingActive = true, lastTransitionTime: 2018-00-22T15:31:16Z, the HPA was able to successfully calculate a replica count from memory resource'
             type: array
             items:
                 type: object
@@ -7309,7 +7309,7 @@ components:
                     type: integer
                     format: int32
                 message:
-                    example: 'ScalingActive = true, lastTransitionTime: 2018-08-22T15:31:16Z, the HPA was able to succesfully calculate a replica count from memory resource'
+                    example: 'ScalingActive = true, lastTransitionTime: 2018-08-22T15:31:16Z, the HPA was able to successfully calculate a replica count from memory resource'
                     type: string
 
         ScanLogList:
@@ -7331,7 +7331,7 @@ components:
                     items:
                         $ref: "#/components/schemas/ScanLogItemImage"
                 result:
-                    example: ['nginx:latest policy check failed', 'busybox:latest policy sheck success']
+                    example: ['nginx:latest policy check failed', 'busybox:latest policy check success']
                     type: array
                     items:
                         type: string

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -5139,13 +5139,13 @@ components:
                     type: object
                     # oneOf:
                     #     -
-                    #         $ref: '#/components/schemas/AmazonPoviderConfig'
+                    #         $ref: '#/components/schemas/AmazonProviderConfig'
                 hosts:
                     type: array
                     items:
                         $ref: '#/components/schemas/PKEHosts'
 
-        AmazonPoviderConfig:
+        AmazonProviderConfig:
             type: object
             required:
                 - autoScalingGroup


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixed OpenAPI specification typos

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because it grinds my gears to have typos in the public API specification.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
I decided not to touch path elements and field names for now because it requires deeper examination as we unfortunately seems to rely on them elsewhere such as YAML `rolearn`/`userarn` for AWS auth configuration, `K8Sconfig` direct field manipulation across the code and there were `orgid` references found as well.
These need more care and I'm postponing these efforts.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] OpenAPI and Postman files updated (if needed)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
