### PR TITLE
chore(config.dist): removed `kubernetes.namespace`

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -127,9 +127,6 @@ dex:
     # apiCa: ""
 
 #kubernetes:
-#    # Namespace where Pipeline currently runs
-#    namespace: "default"
-#
 #    client:
 #        # Deny connecting to API servers other than ones listening on globally routable IPv4 addresses
 #        # This will be refactored according to https://github.com/banzaicloud/pipeline/issues/2263


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Removed the `kubernetes.namespace` value from the exhaustive config example.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This configuration value is never referenced from the code and is very hard to understand the coexistence of this and `cluster.namespace` and what they might be affecting.
I assume based on the comment for the removed field, at some point we switched from `kubernetes.namespace` to `cluster.namespace` but the former reference remained.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
