### PR TITLE
eks: enterprise cluster update workflow

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -846,7 +846,7 @@ func main() {
 						map[string]intCluster.Service{
 							"eks": clusteradapter.NewEKSService(eks.NewService(
 								clusterStore,
-								eksadapter.NewClusterManager(workflowClient),
+								eksadapter.NewClusterManager(workflowClient, config.Pipeline.Enterprise),
 								eksadapter.NewNodePoolStore(db),
 								eksadapter.NewNodePoolManager(
 									workflow.NewAWSSessionFactory(secret.Store),

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
@@ -35,13 +35,13 @@ type UpdateClusterWorkflowInput struct {
 	ConfigSecretID   string
 
 	ClusterID   uint
-	ClusterUID  string
 	ClusterName string
 
 	Version string
 }
 
-type UpdateClusterWorkflow struct{}
+type UpdateClusterWorkflow struct {
+}
 
 func NewUpdateClusterWorkflow() UpdateClusterWorkflow {
 	return UpdateClusterWorkflow{}

--- a/src/cluster/autoscale.go
+++ b/src/cluster/autoscale.go
@@ -305,10 +305,6 @@ func DeployClusterAutoscaler(cluster CommonCluster, helmService HelmService) err
 	}
 
 	if isAutoscalerDeployedAlready(releaseName, cluster.GetID(), helmService) {
-		// no need to upgrade in case of EKS since we're using nodepool autodiscovery
-		if _, isEks := cluster.(*EKSCluster); isEks {
-			return nil
-		}
 		if len(nodeGroups) == 0 {
 			// delete
 			err := helmService.DeleteDeployment(context.TODO(), cluster.GetID(), releaseName, global.Config.Cluster.Namespace)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pipeline-enterprise/pull/101
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Starting the enterprise EKS cluster update workflow in case of an enterprise deployment.
Removing the autoscaler update skip in case of EKS.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Has to be merged after: https://github.com/banzaicloud/pipeline-enterprise/pull/101

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
