### PR TITLE
feat(EKS): added default node volume size configuration

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -491,6 +491,7 @@ func main() {
 			createNodePoolActivity := clusterworkflow.NewCreateNodePoolActivity(
 				clusterStore,
 				db,
+				config.Distribution.EKS.DefaultNodeVolumeSize,
 				clusteradapter.NewNodePoolStore(db, clusterStore),
 				eksadapter.NewNodePoolStore(db),
 				eksworkflow.NewAWSSessionFactory(secret.Store),

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -390,7 +390,7 @@ func main() {
 		registerAzureWorkflows(secretStore, tokenGenerator, azurePKEClusterStore)
 
 		// Register EKS specific workflows
-		err = registerEKSWorkflows(secret.Store, eksClusters)
+		err = registerEKSWorkflows(config, secret.Store, eksClusters)
 		if err != nil {
 			emperror.Panic(errors.WrapIf(err, "failed to register EKS workflows"))
 		}

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -428,8 +428,12 @@ dex:
 
 #distribution:
 #    eks:
+#
 #        # EKS Cloud Formation template location
 #        templateLocation: ./templates/eks
+#
+#        defaultNodeVolumeSize: 0 # GB, unset/0: max(50, AMISize)
+#
 #        # Expose admin kubeconfig over the API by default.
 #        # Set this to false to remove credentials from the config and make the user responsible for how they authenticate.
 #        exposeAdminKubeconfig: true

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -55,6 +55,7 @@ type CreateAsgActivityInput struct {
 	NodeMinCount     int
 	NodeMaxCount     int
 	Count            int
+	NodeVolumeSize   int
 	NodeImage        string
 	NodeInstanceType string
 	Labels           map[string]string
@@ -162,6 +163,10 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 		{
 			ParameterKey:   aws.String("NodeAutoScalingInitSize"),
 			ParameterValue: aws.String(fmt.Sprintf("%d", input.Count)),
+		},
+		{
+			ParameterKey:   aws.String("NodeVolumeSize"),
+			ParameterValue: aws.String(fmt.Sprintf("%d", input.NodeVolumeSize)),
 		},
 		{
 			ParameterKey:   aws.String("ClusterName"),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/ec2.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/ec2.go
@@ -1,0 +1,49 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+// EC2APIFactory provides an interface for instantiating AWS EC2 API objects.
+type EC2APIFactory interface {
+	// New instantiates an AWS CloudFormation API object based on the specified
+	// configurations.
+	New(configProvider client.ConfigProvider, configs ...*aws.Config) (ec2API ec2iface.EC2API)
+}
+
+// EC2Factory can instantiate am ec2.EC2 object.
+//
+// Implements the pkeworkflow.EC2APIFactory interface.
+type EC2Factory struct{}
+
+// NewEC2Factory instantiates an EC2Factory object.
+func NewEC2Factory() (factory *EC2Factory) {
+	return &EC2Factory{}
+}
+
+// New instantiates an AWS EC2 API object based on the specified configurations.
+//
+// Implements the pkeworkflow.EC2APIFactory interface.
+func (factory *EC2Factory) New(
+	configProvider client.ConfigProvider,
+	configs ...*aws.Config,
+) (ec2API ec2iface.EC2API) {
+	return ec2.New(configProvider, configs...)
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_ami_size_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_ami_size_activity.go
@@ -1,0 +1,75 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	GetAMISizeActivityName = "eks-get-ami-size-activity"
+)
+
+type GetAMISizeActivity struct {
+	awsFactory AWSFactory
+	ec2Factory EC2APIFactory
+}
+
+type GetAMISizeActivityInput struct {
+	EKSActivityInput
+	ImageID string
+}
+
+type GetAMISizeActivityOutput struct {
+	AMISize int
+}
+
+func NewGetAMISizeActivity(awsFactory AWSFactory, ec2Factory EC2APIFactory) *GetAMISizeActivity {
+	return &GetAMISizeActivity{
+		awsFactory: awsFactory,
+		ec2Factory: ec2Factory,
+	}
+}
+
+func (a *GetAMISizeActivity) Execute(ctx context.Context, input GetAMISizeActivityInput) (*GetAMISizeActivityOutput, error) {
+	awsClient, err := a.awsFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	ec2Client := a.ec2Factory.New(awsClient)
+
+	describeImagesInput := ec2.DescribeImagesInput{
+		ImageIds: []*string{
+			aws.String(input.ImageID),
+		},
+	}
+	result, err := ec2Client.DescribeImages(&describeImagesInput)
+	if err != nil {
+		return nil, errors.WrapIf(err, "describing AMI failed")
+	} else if len(result.Images) == 0 {
+		return nil, errors.NewWithDetails("describing AMI found no record", "image", input.ImageID)
+	} else if len(result.Images[0].BlockDeviceMappings) == 0 {
+		return nil, errors.NewWithDetails("describing AMI found no block device mappings", "image", input.ImageID)
+	}
+
+	return &GetAMISizeActivityOutput{
+		AMISize: int(aws.Int64Value(result.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize)),
+	}, nil
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity.go
@@ -1,0 +1,70 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"emperror.dev/errors"
+)
+
+const (
+	// SelectVolumeSizeActivityName is the unique name of the activity.
+	SelectVolumeSizeActivityName = "eks-select-volume-size-activity"
+
+	// unsetVolumeSize is the substituted value for 0/unspecified default volume
+	// size.
+	// nolint:gochecknoglobals // Note: this is a one time configuration, we decided to have in the context of this struct and it is more visible up here than in the middle of the corresponding function.
+	unsetVolumeSize = 50
+)
+
+type SelectVolumeSizeActivity struct {
+	defaultVolumeSize int
+}
+
+type SelectVolumeSizeActivityInput struct {
+	EKSActivityInput
+	AMISize int
+}
+
+type SelectVolumeSizeActivityOutput struct {
+	VolumeSize int
+}
+
+func NewSelectVolumeSizeActivity(defaultVolumeSize int) (activity *SelectVolumeSizeActivity) {
+	return &SelectVolumeSizeActivity{
+		defaultVolumeSize: defaultVolumeSize,
+	}
+}
+
+func (activity *SelectVolumeSizeActivity) Execute(ctx context.Context, input SelectVolumeSizeActivityInput) (output *SelectVolumeSizeActivityOutput, err error) {
+	output = &SelectVolumeSizeActivityOutput{}
+	if activity.defaultVolumeSize > 0 {
+		output.VolumeSize = activity.defaultVolumeSize
+	} else {
+		output.VolumeSize = int(math.Max(float64(unsetVolumeSize), float64(input.AMISize)))
+	}
+
+	if output.VolumeSize < input.AMISize {
+		return nil, errors.New(fmt.Sprintf(
+			"selected volume size of %d GB (default configuration) is less than the AMI size of %d GB",
+			output.VolumeSize, input.AMISize,
+		))
+	}
+
+	return output, nil
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -208,6 +208,10 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 			ParameterValue: aws.String(fmt.Sprintf("%d", input.Count)),
 		},
 		{
+			ParameterKey:     aws.String("NodeVolumeSize"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
 			ParameterKey:     aws.String("ClusterName"),
 			UsePreviousValue: aws.Bool(true),
 		},

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -120,6 +120,10 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 			UsePreviousValue: aws.Bool(true),
 		},
 		{
+			ParameterKey:     aws.String("NodeVolumeSize"),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
 			ParameterKey:     aws.String("ClusterName"),
 			UsePreviousValue: aws.Bool(true),
 		},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	Distribution struct {
 		EKS struct {
 			TemplateLocation      string
+			DefaultNodeVolumeSize int
 			ExposeAdminKubeconfig bool
 			SSH                   struct {
 				Generate bool

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -351,8 +351,8 @@ Parameters:
 
   NodeVolumeSize:
     Type: Number
-    Description: Node volume size
-    Default: 50
+    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
+    Default: 0
 
   Subnets:
     Description: The subnets where workers can be created.
@@ -386,6 +386,7 @@ Conditions:
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
+  NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
 
 Resources:
   NodeInstanceProfile:
@@ -453,7 +454,7 @@ Resources:
                   - DeviceName: /dev/xvda
                     Ebs:
                         DeleteOnTermination: true
-                        VolumeSize: !Ref NodeVolumeSize
+                        VolumeSize: !If [ NodeVolumeSizeAuto, !Ref 'AWS::NoValue', !Ref NodeVolumeSize ]
                         VolumeType: gp2
               IamInstanceProfile:
                   Arn: !GetAtt NodeInstanceProfile.Arn


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | closes #3129, closes #3130 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added default node volume size configuration option and propagation to node pool creation from both cluster and node pool create requests. Also added AMI size check logic to ensure only bigger volume sizes are allowed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To support configurable default node volume sizes. See the tickets for details.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Changed the discussed implementation plans because the cluster creation request doesn't go through the `NodePoolProcessor.ProcessNew()` function and has no access to AWS activities at API server side which made me realize the difference between the image and volume size defaults is that the image is statically selected while the volume size is a dynamic information so instead decided to implement the selection at workflow/activity level wherever necessary.

Create/Update explicit value proxy logic is going to be added later.
(Many Bothans died to bring us this small PR.)

For the record: this is the 3rd iteration, because I first took the PKE example, but realized EKS is a little differently architected at the moment, then tried taking the node image example, but realized it solves a little different problem (static vs. dynamic source) and finally settled on this one.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### Test results

#### Cluster create unset default

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-unset-default-pool1 | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T09:21:16.348+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "50"
}

# End: 2020-09-02T09:21:17.027+02:00
# Duration: 679ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-00a0f4a4f7f7a3b26")'

# Begin: 2020-09-02T09:34:23.930+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T07:13:25+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-00a0f4a4f7f7a3b26",
      "State": "attached",
      "VolumeId": "vol-07fc99f91bc99b303",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1a",
  "CreateTime": "2020-09-02T07:13:25.141000+00:00",
  "Encrypted": false,
  "Size": 50,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-07fc99f91bc99b303",
  "Iops": 150,
  "VolumeType": "gp2"
}

# End: 2020-09-02T09:34:24.894+02:00
# Duration: 964ms
# Exit code: 0
```

#### Cluster create set default (less than AMI image size)

`cluster create workflow failed: selected volume size of 1 GB (default configuration) is less than the AMI image size of 20 GB`
(Going to be updated once explicit volume size setting is also allowed.)

#### Cluster create set default (equal to AMI image size)

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-set-default-20-pool1 | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T09:36:42.018+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "20"
}

# End: 2020-09-02T09:36:43.044+02:00
# Duration: 1s26ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-0481e40faa2a14251")'

# Begin: 2020-09-02T09:38:37.323+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T07:34:24+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-0481e40faa2a14251",
      "State": "attached",
      "VolumeId": "vol-093df0cd642b5de8d",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1a",
  "CreateTime": "2020-09-02T07:34:24.243000+00:00",
  "Encrypted": false,
  "Size": 20,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-093df0cd642b5de8d",
  "Iops": 100,
  "VolumeType": "gp2"
}

# End: 2020-09-02T09:38:38.662+02:00
# Duration: 1s339ms
# Exit code: 0
```

#### Cluster create set default (more than AMI image size)

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-cluster-create-set-default-75-pool1 | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T15:32:58.095+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "75"
}

# End: 2020-09-02T15:32:59.236+02:00
# Duration: 1s141ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-0ae7274b54e976790")'

# Begin: 2020-09-02T15:33:45.850+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T13:29:30+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-0ae7274b54e976790",
      "State": "attached",
      "VolumeId": "vol-0cc78a6b6550d095e",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1a",
  "CreateTime": "2020-09-02T13:29:30.252000+00:00",
  "Encrypted": false,
  "Size": 75,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-0cc78a6b6550d095e",
  "Iops": 225,
  "VolumeType": "gp2"
}

# End: 2020-09-02T15:33:50.170+02:00
# Duration: 4s320ms
# Exit code: 0
```

#### Node pool create unset default

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-cluster-create-set-default-75-node-pool-unset-default-volume-size | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T16:01:27.081+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "50"
}

# End: 2020-09-02T16:01:28.099+02:00
# Duration: 1s18ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-04c118a7d40af25c8")'

# Begin: 2020-09-02T16:02:13.686+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T14:00:03+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-04c118a7d40af25c8",
      "State": "attached",
      "VolumeId": "vol-0255344c320df00f6",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1b",
  "CreateTime": "2020-09-02T14:00:03.917000+00:00",
  "Encrypted": false,
  "Size": 50,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-0255344c320df00f6",
  "Iops": 150,
  "VolumeType": "gp2"
}

# End: 2020-09-02T16:02:15.012+02:00
# Duration: 1s326ms
# Exit code: 0
```

#### Node pool create set default (less than AMI image size)

`selected volume size of 1 GB (default configuration) is less than the AMI image size of 20 GB`
(Going to be updated once explicit volume size setting is also allowed.)

#### Node pool create set default (equal to AMI image size)

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-node-pool-create-node-pool | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T15:06:57.067+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "20"
}

# End: 2020-09-02T15:06:57.775+02:00
# Duration: 708ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-02cfec64685cda33b")'

# Begin: 2020-09-02T15:10:04.156+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T10:39:49+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-02cfec64685cda33b",
      "State": "attached",
      "VolumeId": "vol-09e0c61701872a207",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1a",
  "CreateTime": "2020-09-02T10:39:49.659000+00:00",
  "Encrypted": false,
  "Size": 20,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-09e0c61701872a207",
  "Iops": 100,
  "VolumeType": "gp2"
}

# End: 2020-09-02T15:10:05.854+02:00
# Duration: 1s698ms
# Exit code: 0
```

#### Node pool create set default (more than AMI image size)

```shell
pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws cloudformation describe-stacks --stack-name pipeline-eks-nodepool-pregnor-local-200901-pipeline-3129-cluster-create-set-default-75-node-pool | jq -r '.Stacks[0].Parameters[] | select(.ParameterKey=="NodeVolumeSize")'

# Begin: 2020-09-02T15:53:33.147+02:00

{
  "ParameterKey": "NodeVolumeSize",
  "ParameterValue": "75"
}

# End: 2020-09-02T15:53:34.704+02:00
# Duration: 1s557ms
# Exit code: 0

pregnor_13855:Pregnor-BanzaiCloud-MBP152019@194.39.44.200/Users/pregnor/development/src/github.com/banzaicloud/pipeline-enterprise (master u=)
> aws ec2 describe-volumes | jq -r '.Volumes[] | select(.Attachments[].InstanceId=="i-0a0ecca0ef7eab644")'

# Begin: 2020-09-02T15:54:18.359+02:00

{
  "Attachments": [
    {
      "AttachTime": "2020-09-02T13:52:08+00:00",
      "Device": "/dev/xvda",
      "InstanceId": "i-0a0ecca0ef7eab644",
      "State": "attached",
      "VolumeId": "vol-0060494daba8d500d",
      "DeleteOnTermination": true
    }
  ],
  "AvailabilityZone": "eu-central-1b",
  "CreateTime": "2020-09-02T13:52:08.918000+00:00",
  "Encrypted": false,
  "Size": 75,
  "SnapshotId": "snap-073e1d7e24630a32f",
  "State": "in-use",
  "VolumeId": "vol-0060494daba8d500d",
  "Iops": 225,
  "VolumeType": "gp2"
}

# End: 2020-09-02T15:54:19.636+02:00
# Duration: 1s277ms
# Exit code: 0
```