### PR TITLE
fix(OpenAPI/EKS/NPList): fixed volume size type

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -23336,7 +23336,7 @@ components:
         volumeSize:
           description: Size of the EBS volume in GBs of the nodes in the pool.
           example: 50
-          type: number
+          type: integer
         instanceType:
           description: Machine instance type.
           example: m4.xlarge

--- a/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
@@ -15,7 +15,7 @@ type EksNodePoolAllOf struct {
 	Autoscaling NodePoolAutoScaling `json:"autoscaling,omitempty"`
 
 	// Size of the EBS volume in GBs of the nodes in the pool.
-	VolumeSize float32 `json:"volumeSize,omitempty"`
+	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Machine instance type.
 	InstanceType string `json:"instanceType"`

--- a/.gen/pipeline/pipeline/model_node_pool.go
+++ b/.gen/pipeline/pipeline/model_node_pool.go
@@ -24,7 +24,7 @@ type NodePool struct {
 	Autoscaling NodePoolAutoScaling `json:"autoscaling,omitempty"`
 
 	// Size of the EBS volume in GBs of the nodes in the pool.
-	VolumeSize float32 `json:"volumeSize,omitempty"`
+	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Machine instance type.
 	InstanceType string `json:"instanceType"`

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4615,7 +4615,7 @@ components:
                             $ref: '#/components/schemas/NodePoolAutoScaling'
                         volumeSize:
                             description: Size of the EBS volume in GBs of the nodes in the pool.
-                            type: number
+                            type: integer
                             example: 50
                         instanceType:
                             description: Machine instance type.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
EKS node pool list volume size type float32->int32

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It's an integer value, using number instead of integer in the OpenAPI sepcification was a mistake.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] OpenAPI and Postman files updated (if needed)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
