### PR TITLE
vsphere: pass vcpu and ram to cloneSpec

### DIFF
--- a/internal/providers/vsphere/pke/adapter/gorm_store.go
+++ b/internal/providers/vsphere/pke/adapter/gorm_store.go
@@ -65,8 +65,8 @@ type nodePoolModel struct {
 	Size          int
 	MaxSize       uint
 	MinSize       uint
-	VCPU          int `gorm:"column:vcpu"`
-	RAM           int
+	VCPU          int        `gorm:"column:vcpu"`
+	RAM           int        // MiB
 	Name          string     `gorm:"unique_index:idx_vsphere_pke_np_cluster_id_name"`
 	Roles         rolesModel `gorm:"type:json"`
 	AdminUsername string

--- a/internal/providers/vsphere/pke/cluster.go
+++ b/internal/providers/vsphere/pke/cluster.go
@@ -28,7 +28,7 @@ type NodePool struct {
 	CreatedBy     uint
 	Size          int
 	VCPU          int
-	RAM           int
+	RAM           int // MiB
 	Name          string
 	Roles         []string
 	AdminUsername string

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -96,7 +96,7 @@ type NodePool struct {
 	Size          int
 	AdminUsername string
 	VCPU          int
-	RAM           int
+	RAM           int // MiB
 	TemplateName  string
 }
 

--- a/internal/providers/vsphere/pke/driver/preparers.go
+++ b/internal/providers/vsphere/pke/driver/preparers.go
@@ -87,6 +87,13 @@ func (p NodePoolPreparer) Prepare(ctx context.Context, nodePool *NodePool) error
 		return validationErrorf("%s.Name must be specified", p.namespace)
 	}
 
+	if nodePool.RAM < 4 || nodePool.RAM > 6128<<10 {
+		return validationErrorf("%s.RAM must be between 4 MiB and 6128 GiB", p.namespace)
+	}
+	if nodePool.RAM%4 != 0 {
+		return validationErrorf("%s.RAM must be multiple of 4 (MiB)", p.namespace)
+	}
+
 	if nodePool.hasRole(pkgPKE.RoleMaster) && nodePool.Size == 0 {
 		p.logger.Debug("Master node pool size should be >= 0, defaulting to 1")
 		nodePool.Size = 1

--- a/internal/providers/vsphere/pke/workflow/create_node_activity.go
+++ b/internal/providers/vsphere/pke/workflow/create_node_activity.go
@@ -73,7 +73,7 @@ type CreateNodeActivityInput struct {
 type Node struct {
 	AdminUsername          string
 	VCPU                   int
-	RAM                    int
+	RAM                    int // MiB
 	Name                   string
 	SSHPublicKey           string
 	UserDataScriptParams   map[string]string
@@ -122,7 +122,11 @@ func generateVMConfigs(input CreateNodeActivityInput) (*types.VirtualMachineConf
 		return nil, err
 	}
 
-	vmConfig := types.VirtualMachineConfigSpec{}
+	vmConfig := types.VirtualMachineConfigSpec{
+		NumCPUs:           int32(input.VCPU),
+		NumCoresPerSocket: int32(input.VCPU),
+		MemoryMB:          int64(input.RAM),
+	}
 	vmConfig.ExtraConfig = append(vmConfig.ExtraConfig,
 		&types.OptionValue{Key: "disk.enableUUID", Value: "true"}, // needed for pv mounting
 		&types.OptionValue{Key: "guestinfo.userdata.encoding", Value: "gzip+base64"},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
VCPU and RAM inputs were missing from the clone specification when creating nodes.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
