### PR TITLE
Bump anchore-policy-validator chart version

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -697,7 +697,7 @@ rbac:
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::anchore::insecure", false)
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.5.8")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.6.0")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	// v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related: https://github.com/banzaicloud/anchore-image-validator/pull/60
| License         | Apache 2.0


### What's in this PR?
Update `anchore-policy-validator` chart version.
https://github.com/banzaicloud/anchore-image-validator/releases/tag/anchore-policy-validator%2F0.6.0

### Why?
The new version of the chart doesn't deploy the default policy creator job.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Related Helm chart(s) updated (if needed)
