### PR TITLE
feat(PKE/AWS): added default node volume size configuration

### DIFF
--- a/cmd/worker/aws.go
+++ b/cmd/worker/aws.go
@@ -40,7 +40,13 @@ func registerAwsWorkflows(
 	)
 
 	workflow.RegisterWithOptions(pkeworkflow.DeleteClusterWorkflow, workflow.RegisterOptions{Name: pkeworkflow.DeleteClusterWorkflowName})
-	workflow.RegisterWithOptions(pkeworkflow.UpdateClusterWorkflow, workflow.RegisterOptions{Name: pkeworkflow.UpdateClusterWorkflowName})
+
+	updateClusterWorkflow := pkeworkflow.UpdateClusterWorkflow{
+		DefaultNodeVolumeSize: config.Distribution.PKE.Amazon.DefaultNodeVolumeSize,
+	}
+	workflow.RegisterWithOptions(
+		updateClusterWorkflow.Execute, workflow.RegisterOptions{Name: pkeworkflow.UpdateClusterWorkflowName},
+	)
 
 	awsClientFactory := pkeworkflow.NewAWSClientFactory(secretStore)
 	ec2Factory := pkeworkflow.NewEC2Factory()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -378,11 +378,7 @@ func main() {
 		}
 
 		// Register amazon specific workflows and activities
-		registerAwsWorkflows(clusters, tokenGenerator, secretStore, imageSelector,
-			config.Distribution.PKE.Amazon.GlobalRegion,
-			config.Pipeline.External.URL,
-			config.Pipeline.External.Insecure,
-		)
+		registerAwsWorkflows(config, clusters, tokenGenerator, secretStore, imageSelector)
 
 		azurePKEClusterStore := azurePKEAdapter.NewClusterStore(db, commonadapter.NewLogger(logger))
 

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -448,6 +448,7 @@ dex:
 #            globalRegion: us-east-1
 #            defaultImages: {}
 #            defaultNetworkProvider: "cilium"
+#            defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)
 
 cloudinfo:
     # Format: {baseUrl}/api/v1

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -77,6 +77,7 @@ type Config struct {
 				GlobalRegion           string
 				DefaultImages          map[string]string
 				DefaultNetworkProvider string
+				DefaultNodeVolumeSize  int
 			}
 		}
 	}

--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -128,6 +128,7 @@ func (w CreateClusterWorkflow) Execute(ctx workflow.Context, input CreateCluster
 			nodePool.InstanceType,
 			nodePool.ImageID,
 			nodePool.VolumeSize,
+			0,
 		)
 
 		return err

--- a/internal/providers/pke/pkeworkflow/create_cluster.go
+++ b/internal/providers/pke/pkeworkflow/create_cluster.go
@@ -44,7 +44,8 @@ type CreateClusterWorkflowInput struct {
 }
 
 type CreateClusterWorkflow struct {
-	GlobalRegion string
+	DefaultNodeVolumeSize int
+	GlobalRegion          string
 }
 
 func (w CreateClusterWorkflow) Execute(ctx workflow.Context, input CreateClusterWorkflowInput) error {
@@ -128,7 +129,7 @@ func (w CreateClusterWorkflow) Execute(ctx workflow.Context, input CreateCluster
 			nodePool.InstanceType,
 			nodePool.ImageID,
 			nodePool.VolumeSize,
-			0,
+			w.DefaultNodeVolumeSize,
 		)
 
 		return err

--- a/internal/providers/pke/pkeworkflow/select_volume_size_activity.go
+++ b/internal/providers/pke/pkeworkflow/select_volume_size_activity.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	SelectVolumeSizeActivityName = "pke-select-volume-size-activity"
-	MinimalVolumeSize            = 50 // TODO make this a config
 )
 
 type SelectVolumeSizeActivity struct {

--- a/internal/providers/pke/pkeworkflow/update_cluster.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster.go
@@ -193,6 +193,7 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 			nodePool.InstanceType,
 			nodePool.ImageID,
 			nodePool.VolumeSize,
+			0,
 		)
 
 		return err

--- a/internal/providers/pke/pkeworkflow/update_cluster.go
+++ b/internal/providers/pke/pkeworkflow/update_cluster.go
@@ -40,7 +40,11 @@ type UpdateClusterWorkflowInput struct {
 	SubnetIDs                   []string
 }
 
-func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInput) error {
+type UpdateClusterWorkflow struct {
+	DefaultNodeVolumeSize int
+}
+
+func (w UpdateClusterWorkflow) Execute(ctx workflow.Context, input UpdateClusterWorkflowInput) error {
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Minute,
 		StartToCloseTimeout:    10 * time.Minute,
@@ -193,7 +197,7 @@ func UpdateClusterWorkflow(ctx workflow.Context, input UpdateClusterWorkflowInpu
 			nodePool.InstanceType,
 			nodePool.ImageID,
 			nodePool.VolumeSize,
-			0,
+			w.DefaultNodeVolumeSize,
 		)
 
 		return err


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3101 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added PKE AWS default node volume size configuration to the Pipeline configuration at `distribution.pke.amazon.defaultNodeVolumeSize` and incorporated it into the PKE volume size selection logic.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To make the default PKE AWS node volume size configurable.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

#### Test matrix

```yaml
defaultNodeVolumeSizeValues:
    - 0/unspecified
    - < AMI size
    - == AMI size
    - > AMI size
explicitVolumeSize:
    - not set
    - set
operations:
    - cluster create
    - cluster update
```

<details>
  <summary>0 default volume size</summary>

```yaml
# pipeline/config.yaml
distribution:
    pke:
        amazon:
            defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)

---

# ~/banzai_cluster_create.yaml
name: pregnor-pipeline-3101-default-0-50-2
location: eu-central-1
cloud: amazon
secretName: aws-pregnor
properties:
  pke:
    nodepools:
      - name: master
        roles:
          - master
        provider: amazon
        autoscaling: false
        providerConfig:
          autoScalingGroup:
            name: master
            zones:
              - eu-central-1c
            instanceType: c5.large
            launchConfigurationName: master
            spotPrice:
            size:
              desired: 1
              min: 1
              max: 1
      - name: pool1-create-no-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool1-create-no-explicit-volume-size
            zones:
              - eu-central-1a
            instanceType: t2.small
            launchConfigurationName: pool1-create-no-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
      - name: pool2-create-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool2-create-explicit-volume-size
            zones:
              - eu-central-1b
            instanceType: t2.small
            launchConfigurationName: pool2-create-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
            volumeSize: 22
    kubernetes:
      version: "1.18.2"
      rbac:
        enabled: true
    cri:
      runtime: containerd
```

```shell
curl --location --request PUT 'https://localhost:9090/pipeline/api/v1/orgs/1/clusters/3' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${TOKEN}' \
--data-raw '{
	"cloud": "amazon",
	"properties": {
		"pke": {
			"nodePools": {
				"master": {
					"minCount": 1,
					"maxCount": 1,
					"count": 1
				},
				"pool1-create-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool2-create-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool3-update-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool4-update-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1,
					"volumeSize": 23
				}
			}
		}
	}
}'
```

  <details>
    <summary>No explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-0-50-2-worker-pool1-create-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "50"
}
```

  </details>

  <details>
    <summary>No explicit volume size cluster update</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-0-50-2-worker-pool3-update-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "50"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-0-50-2-worker-pool2-create-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "22"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster update (PKE cluster update doesn't support specifying volume size)</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-0-50-2-worker-pool4-update-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "50"
}
```

  </details>

</details>

<details>
  <summary>< AMI default volume size</summary>

```yaml
# pipeline/config.yaml
distribution:
    pke:
        amazon:
            defaultNodeVolumeSize: 1 # GiB, 0/fallback: max(50, AMISize)

---

# ~/banzai_cluster_create.yaml
name: pregnor-pipeline-3101-default-less-than-AMI-2
location: eu-central-1
cloud: amazon
secretName: aws-pregnor
properties:
  pke:
    nodepools:
      - name: master
        roles:
          - master
        provider: amazon
        autoscaling: false
        providerConfig:
          autoScalingGroup:
            name: master
            zones:
              - eu-central-1c
            instanceType: c5.large
            launchConfigurationName: master
            spotPrice:
            size:
              desired: 1
              min: 1
              max: 1
      - name: pool1-create-no-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool1-create-no-explicit-volume-size
            zones:
              - eu-central-1a
            instanceType: t2.small
            launchConfigurationName: pool1-create-no-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
      - name: pool2-create-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool2-create-explicit-volume-size
            zones:
              - eu-central-1b
            instanceType: t2.small
            launchConfigurationName: pool2-create-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
            volumeSize: 22
    kubernetes:
      version: "1.18.2"
      rbac:
        enabled: true
    cri:
      runtime: containerd
```

```shell
> banzai cluster list

Id  Name                                           Distribution  Location      Version  CreatorName  CreatedAt                  Status    StatusMessage                                                                                                                                                                                                                                                                                                             
5   pregnor-pipeline-3101-default-less-than-AMI-3  pke           eu-central-1  1.18.2   pregnor      2020-10-27T08:01:27+01:00  ERROR     selected volume size of 1 GiB (source: default configured) for "c5.large" instance type using ami-0e342d72b12109f91 image is less than the AMI size of 8 GiB; selected volume size of 1 GiB (source: default configured) for "t2.small" instance type using ami-0e342d72b12109f91 image is less than the AMI size of 8 GiB
```

</details>

<details>
  <summary>== AMI default volume size</summary>

```yaml
# pipeline/config.yaml
distribution:
    pke:
        amazon:
            defaultNodeVolumeSize: 8 # GiB, 0/fallback: max(50, AMISize)

---

# ~/banzai_cluster_create.yaml
name: pregnor-pipeline-3101-default-equals-AMI-2
location: eu-central-1
cloud: amazon
secretName: aws-pregnor
properties:
  pke:
    nodepools:
      - name: master
        roles:
          - master
        provider: amazon
        autoscaling: false
        providerConfig:
          autoScalingGroup:
            name: master
            zones:
              - eu-central-1c
            instanceType: c5.large
            launchConfigurationName: master
            spotPrice:
            size:
              desired: 1
              min: 1
              max: 1
      - name: pool1-create-no-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool1-create-no-explicit-volume-size
            zones:
              - eu-central-1a
            instanceType: t2.small
            launchConfigurationName: pool1-create-no-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
      - name: pool2-create-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool2-create-explicit-volume-size
            zones:
              - eu-central-1b
            instanceType: t2.small
            launchConfigurationName: pool2-create-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
            volumeSize: 22
    kubernetes:
      version: "1.18.2"
      rbac:
        enabled: true
    cri:
      runtime: containerd
```

```shell
curl --location --request PUT 'https://localhost:9090/pipeline/api/v1/orgs/1/clusters/6' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${TOKEN}' \
--data-raw '{
	"cloud": "amazon",
	"properties": {
		"pke": {
			"nodePools": {
				"master": {
					"minCount": 1,
					"maxCount": 1,
					"count": 1
				},
				"pool1-create-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool2-create-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool3-update-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool4-update-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1,
                    "volumeSize": 23
				}
			}
		}
	}
}'
```

  <details>
    <summary>No explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-equals-AMI-2-worker-pool1-create-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "8"
}
```

  </details>

  <details>
    <summary>No explicit volume size cluster update</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-equals-AMI-2-worker-pool3-update-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "8"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-equals-AMI-2-worker-pool2-create-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "22"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster update (PKE cluster update doesn't support specifying volume size)</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-equals-AMI-2-worker-pool4-update-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "8"
}
```

  </details>

</details>

<details>
  <summary>> AMI default volume size</summary>

```yaml
# pipeline/config.yaml
distribution:
    pke:
        amazon:
            defaultNodeVolumeSize: 60 # GiB, 0/fallback: max(50, AMISize)

---

# ~/banzai_cluster_create.yaml
name: pregnor-pipeline-3101-default-greater-than-AMI
location: eu-central-1
cloud: amazon
secretName: aws-pregnor
properties:
  pke:
    nodepools:
      - name: master
        roles:
          - master
        provider: amazon
        autoscaling: false
        providerConfig:
          autoScalingGroup:
            name: master
            zones:
              - eu-central-1c
            instanceType: c5.large
            launchConfigurationName: master
            spotPrice:
            size:
              desired: 1
              min: 1
              max: 1
      - name: pool1-create-no-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool1-create-no-explicit-volume-size
            zones:
              - eu-central-1a
            instanceType: t2.small
            launchConfigurationName: pool1-create-no-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
      - name: pool2-create-explicit-volume-size
        roles:
          - worker
        provider: amazon
        autoscaling: true
        providerConfig:
          autoScalingGroup:
            name: pool2-create-explicit-volume-size
            zones:
              - eu-central-1b
            instanceType: t2.small
            launchConfigurationName: pool2-create-explicit-volume-size
            spotPrice: "0.0268"
            size:
              desired: 1
              min: 1
              max: 2
            volumeSize: 22
    kubernetes:
      version: "1.18.2"
      rbac:
        enabled: true
    cri:
      runtime: containerd
```

```shell
curl --location --request PUT 'https://localhost:9090/pipeline/api/v1/orgs/1/clusters/7' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${TOKEN}' \
--data-raw '{
	"cloud": "amazon",
	"properties": {
		"pke": {
			"nodePools": {
				"master": {
					"minCount": 1,
					"maxCount": 1,
					"count": 1
				},
				"pool1-create-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool2-create-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool3-update-no-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1
				},
				"pool4-update-explicit-volume-size": {
					"instanceType": "t2.small",
					"spotPrice": "0.0268",
					"autoscaling": true,
					"minCount": 1,
					"maxCount": 2,
					"count": 1,
                    "volumeSize": 23
				}
			}
		}
	}
}'
```

  <details>
    <summary>No explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-greater-than-AMI-worker-pool1-create-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "60"
}
```

  </details>

  <details>
    <summary>No explicit volume size cluster update</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-greater-than-AMI-worker-pool3-update-no-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "60"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster create</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-greater-than-AMI-worker-pool2-create-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "22"
}
```

  </details>

  <details>
    <summary>Explicit volume size cluster update (PKE cluster update doesn't support specifying volume size)</summary>

```shell
> aws --profile banzaicloud --region eu-central-1 cloudformation describe-stacks --stack-name pke-pool-pregnor-pipeline-3101-default-greater-than-AMI-worker-pool4-update-explicit-volume-size --output json | jq -r '.Stacks[].Parameters[] | select(.ParameterKey=="VolumeSize")'

{
  "ParameterKey": "VolumeSize",
  "ParameterValue": "60"
}
```

  </details>

</details>

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
