### PR TITLE
fix(ListNodePools): added subnet ID retrieval

### DIFF
--- a/internal/cluster/distribution/eks/eksadapter/node_pool_manager.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_manager.go
@@ -171,6 +171,7 @@ func (n nodePoolManager) ListNodePools(ctx context.Context, cluster cluster.Clus
 			NodeInstanceType            string `mapstructure:"NodeInstanceType"`
 			NodeSpotPrice               string `mapstructure:"NodeSpotPrice"`
 			NodeVolumeSize              int    `mapstructure:"NodeVolumeSize"`
+			Subnets                     string `mapstructure:"Subnets"`
 		}
 
 		err = sdkCloudFormation.ParseStackParameters(stackDescriptions.Stacks[0].Parameters, &nodePoolParameters)
@@ -192,6 +193,7 @@ func (n nodePoolManager) ListNodePools(ctx context.Context, cluster cluster.Clus
 			InstanceType: nodePoolParameters.NodeInstanceType,
 			Image:        nodePoolParameters.NodeImageID,
 			SpotPrice:    nodePoolParameters.NodeSpotPrice,
+			SubnetID:     nodePoolParameters.Subnets, // Note: currently we ensure exactly 1 value at creation.
 		}
 
 		nodePools = append(nodePools, nodePool)

--- a/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
@@ -85,6 +85,7 @@ func TestListNodePools(t *testing.T) {
 		"NodeInstanceType":            "node pool instance type",
 		"NodeImageId":                 "node pool image ID",
 		"NodeSpotPrice":               "node pool spot price",
+		"Subnets":                     "subnet-0123456789",
 	}
 	var exampleWorkflowClient client.Client
 	//
@@ -146,6 +147,7 @@ func TestListNodePools(t *testing.T) {
 		InstanceType: exampleStackParameters["NodeInstanceType"].(string),
 		Image:        exampleStackParameters["NodeImageId"].(string),
 		SpotPrice:    exampleStackParameters["NodeSpotPrice"].(string),
+		SubnetID:     exampleStackParameters["Subnets"].(string),
 	}
 	//
 	exampleUnstructuredList := make([]unstructured.Unstructured, len(exampleNodePoolNames))

--- a/internal/cluster/distribution/eks/service.go
+++ b/internal/cluster/distribution/eks/service.go
@@ -93,6 +93,7 @@ type NodePool struct {
 	InstanceType string            `mapstructure:"instanceType"`
 	Image        string            `mapstructure:"image"`
 	SpotPrice    string            `mapstructure:"spotPrice"`
+	SubnetID     string            `mapstructure:"subnetId"`
 }
 
 // Autoscaling describes the EKS node pool's autoscaling settings.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added missing subnet ID value to the node pool list output.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because it is a creation field, but was missing.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

CLI [PR](https://github.com/banzaicloud/banzaicloud.github.io/pull/1839).
Documentation [PR](https://github.com/banzaicloud/banzaicloud.github.io/pull/1839).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] CLI PR.
- [X] Documentation PR.
