### PR TITLE
fix(API): error logging and error response handling

### DIFF
--- a/internal/common/secret.go
+++ b/internal/common/secret.go
@@ -51,6 +51,12 @@ func (e SecretNotFoundError) Details() []interface{} {
 	return []interface{}{"secretId", e.SecretID}
 }
 
+// NotFound tells a client that this error is related to a resource being not
+// found. Can be used to translate the error to eg. status code.
+func (SecretNotFoundError) NotFound() bool {
+	return true
+}
+
 // ServiceError tells the consumer whether this error is caused by invalid input supplied by the client.
 // Client errors are usually returned to the consumer without retrying the operation.
 func (SecretNotFoundError) ServiceError() bool {

--- a/internal/platform/appkit/transport/http/problem_service.go
+++ b/internal/platform/appkit/transport/http/problem_service.go
@@ -1,0 +1,60 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	appkiterrors "github.com/sagikazarmark/appkit/errors"
+	appkithttp "github.com/sagikazarmark/appkit/transport/http"
+
+	"github.com/banzaicloud/pipeline/pkg/problems"
+)
+
+// ServiceProblemMatcher is a problem matcher for service errors.
+// If the returned error matches the following interface, a special service problem is returned by NewProblem:
+// 	type ServiceError interface {
+// 		ServiceError() bool
+// 	}
+type serviceProblemMatcher struct{}
+
+// NewServiceProblemMatcher returns a problem matcher for service errors.
+// If the returned error matches the following interface, a special service problem is returned by NewProblem:
+// 	type ServiceError interface {
+// 		ServiceError() bool
+// 	}
+func NewServiceProblemMatcher() appkithttp.ProblemMatcher {
+	return serviceProblemMatcher{}
+}
+
+func (matcher serviceProblemMatcher) MatchError(err error) bool {
+	return appkiterrors.IsServiceError(err)
+}
+
+func (matcher serviceProblemMatcher) NewProblem(_ context.Context, err error) interface{} {
+	if appkiterrors.IsServiceError(err) {
+		var serviceError interface {
+			Error() string
+			ServiceError() bool
+		}
+		errors.As(err, &serviceError)
+
+		return problems.NewDetailedProblem(http.StatusInternalServerError, serviceError.Error())
+	}
+
+	return problems.NewDetailedProblem(http.StatusUnprocessableEntity, err.Error())
+}

--- a/internal/platform/appkit/transport/http/problems.go
+++ b/internal/platform/appkit/transport/http/problems.go
@@ -20,6 +20,12 @@ import (
 
 // DefaultProblemMatchers is a list of default ProblemMatchers.
 // nolint: gochecknoglobals
-var DefaultProblemMatchers = append([]appkithttp.ProblemMatcher{
-	NewValidationWithViolationsProblemMatcher(),
-}, appkithttp.DefaultProblemMatchers...)
+var DefaultProblemMatchers = append(
+	[]appkithttp.ProblemMatcher{
+		NewValidationWithViolationsProblemMatcher(),
+	},
+	append(
+		appkithttp.DefaultProblemMatchers,
+		NewServiceProblemMatcher(),
+	)...,
+)

--- a/src/secret/store.go
+++ b/src/secret/store.go
@@ -474,6 +474,10 @@ type MismatchError struct {
 	ValidType  string
 }
 
+func (MismatchError) BadRequest() bool {
+	return true
+}
+
 func (m MismatchError) Error() string {
 	if m.Err == nil {
 		return fmt.Sprintf("missmatch secret type %s versus %s", m.SecretType, m.ValidType)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed 3 issues around API error response and its logging.

1. Implemented the `NotFound` error interface on the `SecretNotFoundError` service error type so the corresponding status problem matcher would catch it and turn it into a special (404) status error.
2. Implemented the `BadRequest` error interface on the `MismatchError` service error type so the corresponding status problem matcher would catch it and turn it into a special (400) status error.
3. Errors not having API level problem matchers (e.g. errors without dedicated response encoder) returned `500 Internal server error, something went wrong` responses, changed this to `500 Internal server error, <error.Error()>` in case the error implements the service error interface.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

During the review of #3187 a discussion emerged regarding errors during cluster creation while listing node pools which wasn't part of that PR's scope, but contained valid user expectations. This is the fix for the issue of proper API error response.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Implement status problem matchers for known service errors along with the new matcher to handle service errors properly instead of 500 something went wrong. (See the first two commits, existing error matchers were used with interface implementations.)
- [x] Discuss how to proceed with the response encoder, error handler, error encoder behaviors. (We want to catch service errors in the response encoder's error encoding branch.)
- [x] Discuss whether we want to log 500 service errors or not-500 errors. (We are already logging them, but we explicitly avoid logging service errors.)
