### PR TITLE
give better version number for builds from detached heads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OPENAPI_DESCRIPTOR = apis/pipeline/pipeline.yaml
 BUILD_DIR ?= build
 BUILD_PACKAGE = ${PACKAGE}/cmd/pipeline
 TEMPORARY_DIRECTORY = tmp
-VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "`git describe --tags`-`git symbolic-ref -q --short HEAD 2>/dev/null || git describe --all --exact-match | sed 's!heads/!!'`")
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
 HELM_VERSION = $(shell cat go.mod | grep helm.sh/helm/v3 | grep -v "=>" | cut -d" " -f2 | sed s/^v//)


### PR DESCRIPTION
The version was empty if `make build-release` was run on an untagged detached head.

Examples:

```
0.60.0-21-gfac732148-fix-version-guessing
       # 21 commits after 0.60.0, 
           # commit fac732148,
                     # the current top of the fix-version-guessing branch
0.60.0-21-gfac732148-master
0.60.0-22-g8245381df-   # if not a tag and not the top of a branch (do we want to handle this?)
0.58.0-4-gbd36844e8-pke-log
0.60.999
```
