### PR TITLE
Split PKE distribution cloud flavours from clusteradapter.NewPKEService

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -859,7 +859,7 @@ func main() {
 
 					pkeServices := clusteradapter.NewPKEServices(
 						map[string]pkeDistribution.Service{
-							"aws": pkeDistribution.NewService(
+							"amazon": pkeDistribution.NewService(
 								clusterStore,
 								pkeawsadapter.NewNodePoolManager(
 									config.Pipeline.Enterprise,

--- a/internal/cluster/clusteradapter/distribution_pke.go
+++ b/internal/cluster/clusteradapter/distribution_pke.go
@@ -87,7 +87,6 @@ func (s pkeService) ListNodePools(ctx context.Context, clusterID uint) (nodePool
 }
 
 func NewPKEServices(services map[string]pke.Service) map[string]cluster.Service {
-
 	clusterServices := make(map[string]cluster.Service)
 	for v, svc := range services {
 		clusterServices["pke"+v] = NewPKEService(svc)

--- a/internal/cluster/clusteradapter/distribution_pke.go
+++ b/internal/cluster/clusteradapter/distribution_pke.go
@@ -85,3 +85,13 @@ func (s pkeService) ListNodePools(ctx context.Context, clusterID uint) (nodePool
 
 	return nodePoolList, nil
 }
+
+func NewPKEServices(services map[string]pke.Service) map[string]cluster.Service {
+
+	clusterServices := make(map[string]cluster.Service)
+	for v, svc := range services {
+		clusterServices["pke"+v] = NewPKEService(svc)
+	}
+
+	return clusterServices
+}

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -355,8 +355,7 @@ func (NotSupportedDistributionError) ServiceError() bool {
 }
 
 func (s service) getDistributionService(cluster Cluster) (Service, error) {
-	key := cluster.Distribution
-	service, ok := s.distributions[key]
+	service, ok := s.distributions[cluster.Distribution]
 	if !ok {
 		return nil, errors.WithStack(NotSupportedDistributionError{
 			ID:           cluster.ID,

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -356,9 +356,6 @@ func (NotSupportedDistributionError) ServiceError() bool {
 
 func (s service) getDistributionService(cluster Cluster) (Service, error) {
 	key := cluster.Distribution
-	if key == "pke" {
-		key += cluster.Cloud
-	}
 	service, ok := s.distributions[key]
 	if !ok {
 		return nil, errors.WithStack(NotSupportedDistributionError{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pipeline/issues/3197
| License         | Apache 2.0

### What's in this PR:
A simplified solution for the given ticket. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### TODO: 
- [ ] Is this simple code reorganisation is enough for now, or should we implement further changes like update code/logic to decide distribution in deeper parts and update all services according to this.