### PR TITLE
Fixed node pool deletion to only delete existing CF stacks

### DIFF
--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -158,6 +158,11 @@ func registerEKSWorkflows(
 	getOrphanNicsActivity := eksworkflow.NewGetOrphanNICsActivity(awsSessionFactory)
 	activity.RegisterWithOptions(getOrphanNicsActivity.Execute, activity.RegisterOptions{Name: eksworkflow.GetOrphanNICsActivityName})
 
+	listStoredNodePoolsActivity := eksworkflow.NewListStoredNodePoolsActivity(nodePoolStore)
+	activity.RegisterWithOptions(listStoredNodePoolsActivity.Execute, activity.RegisterOptions{
+		Name: eksworkflow.ListStoredNodePoolsActivityName,
+	})
+
 	deleteOrphanNicActivity := eksworkflow.NewDeleteOrphanNICActivity(awsSessionFactory)
 	activity.RegisterWithOptions(deleteOrphanNicActivity.Execute, activity.RegisterOptions{Name: eksworkflow.DeleteOrphanNICActivityName})
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/list_stored_node_pools.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/list_stored_node_pools.go
@@ -1,0 +1,97 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"emperror.dev/errors"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
+)
+
+const ListStoredNodePoolsActivityName = "eks-list-stored-node-pools"
+
+// ListStoredNodePoolsActivity collects the necessary component dependencies
+// for executing a stored node pool retrieval operation.
+type ListStoredNodePoolsActivity struct {
+	nodePoolStore eks.NodePoolStore
+}
+
+// ListStoredNodePoolsActivityInput encapsulates the dynamic parameters of the
+// stored node pool retrieval operation.
+type ListStoredNodePoolsActivityInput struct {
+	ClusterID                   uint
+	ClusterName                 string
+	OptionalListedNodePoolNames []string
+	OrganizationID              uint
+}
+
+type ListStoredNodePoolsActivityOutput struct {
+	NodePools map[string]eks.ExistingNodePool
+}
+
+// NewListStoredNodePoolsActivity instantiates an activity object for deleting
+// stored node pools.
+func NewListStoredNodePoolsActivity(nodePoolStore eks.NodePoolStore) *ListStoredNodePoolsActivity {
+	return &ListStoredNodePoolsActivity{
+		nodePoolStore: nodePoolStore,
+	}
+}
+
+// Execute executes a stored node pool deletion operation with the specified
+// input parameters.
+func (a *ListStoredNodePoolsActivity) Execute(
+	ctx context.Context, input ListStoredNodePoolsActivityInput,
+) (output *ListStoredNodePoolsActivityOutput, err error) {
+	nodePools, err := a.nodePoolStore.ListNodePools(ctx, input.OrganizationID, input.ClusterID, input.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	output = &ListStoredNodePoolsActivityOutput{
+		NodePools: make(map[string]eks.ExistingNodePool, len(nodePools)),
+	}
+
+	if len(input.OptionalListedNodePoolNames) == 0 {
+		for nodePoolName := range nodePools {
+			output.NodePools[nodePoolName] = nodePools[nodePoolName]
+		}
+	} else {
+		var errs []error
+		var isExisting bool
+		for _, nodePoolName := range input.OptionalListedNodePoolNames {
+			output.NodePools[nodePoolName], isExisting = nodePools[nodePoolName]
+			if !isExisting {
+				errs = append(errs, errors.NewWithDetails(
+					fmt.Sprintf("node pool %s not found", nodePoolName), "nodePools", nodePools,
+				))
+			}
+		}
+
+		if len(errs) != 0 {
+			return nil, errors.Combine(errs...)
+		}
+	}
+
+	return output, nil
+}
+
+// Register registers the stored node pool deletion activity.
+func (a ListStoredNodePoolsActivity) Register() {
+	activity.RegisterWithOptions(a.Execute, activity.RegisterOptions{Name: ListStoredNodePoolsActivityName})
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/list_stored_node_pools_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/list_stored_node_pools_test.go
@@ -1,0 +1,297 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"emperror.dev/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/testsuite"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
+)
+
+func TestListStoredNodePoolsActivityExecute(t *testing.T) {
+	type caseInputType struct {
+		input         ListStoredNodePoolsActivityInput
+		inputActivity *ListStoredNodePoolsActivity
+	}
+
+	type caseOutputType struct {
+		expectedError  error
+		expectedOutput *ListStoredNodePoolsActivityOutput
+	}
+
+	nodePoolStoreListNodePoolsID := "NodePoolStore.ListNodePools"
+
+	mockCalls := func(
+		t *testing.T, caseInput caseInputType, caseMockData map[string][]interface{}, caseMockErrors map[string]error,
+	) {
+		if caseMockData == nil {
+			caseMockData = map[string][]interface{}{} // NotE: using nil output values.
+		}
+		if caseMockErrors == nil {
+			caseMockErrors = map[string]error{} // NotE: using nil mock errors.
+		}
+
+		mocks := []string{
+			nodePoolStoreListNodePoolsID,
+		}
+
+		previousMockCalls := make(map[string]int, len(mocks))
+		for _, mockID := range mocks {
+			switch mockID {
+			case nodePoolStoreListNodePoolsID:
+				mock := caseInput.inputActivity.nodePoolStore.(*eks.MockNodePoolStore).On(
+					"ListNodePools",
+					mock.Anything,
+					caseInput.input.OrganizationID,
+					caseInput.input.ClusterID,
+					caseInput.input.ClusterName,
+				)
+
+				err := caseMockErrors[mockID]
+				if err == nil {
+					mock.Return(append(caseMockData[mockID], nil)...).Once()
+				} else {
+					mock.Return(nil, caseMockErrors[mockID]).Once()
+				}
+			default:
+				t.Errorf(
+					"unexpected mock call, no mock method is available for this mock ID,"+
+						" mock ID: '%s', ordered mock ID occurrences: '%+v'",
+					mockID, mocks,
+				)
+				t.FailNow()
+
+				return
+			}
+
+			if caseMockErrors[mockID] != nil {
+				return
+			}
+
+			previousMockCalls[mockID] += 1
+		}
+	}
+
+	testCases := []struct {
+		caseDescription string
+		caseInput       caseInputType
+		caseOutput      caseOutputType
+		caseMockData    map[string][]interface{}
+		caseMockErrors  map[string]error
+	}{
+		{
+			caseDescription: nodePoolStoreListNodePoolsID + " error",
+			caseInput: caseInputType{
+				input: ListStoredNodePoolsActivityInput{},
+				inputActivity: &ListStoredNodePoolsActivity{
+					nodePoolStore: &eks.MockNodePoolStore{},
+				},
+			},
+			caseOutput: caseOutputType{
+				expectedError:  errors.New("test error: " + nodePoolStoreListNodePoolsID),
+				expectedOutput: nil,
+			},
+			caseMockData: map[string][]interface{}{
+				nodePoolStoreListNodePoolsID: {
+					nil,
+				},
+			},
+			caseMockErrors: map[string]error{
+				nodePoolStoreListNodePoolsID: errors.New("test error: " + nodePoolStoreListNodePoolsID),
+			},
+		},
+		{
+			caseDescription: "not found error",
+			caseInput: caseInputType{
+				input: ListStoredNodePoolsActivityInput{
+					OptionalListedNodePoolNames: []string{
+						"node-pool-1",
+						"node-pool-2",
+					},
+				},
+				inputActivity: &ListStoredNodePoolsActivity{
+					nodePoolStore: &eks.MockNodePoolStore{},
+				},
+			},
+			caseOutput: caseOutputType{
+				expectedError:  errors.New("node pool node-pool-1 not found; node pool node-pool-2 not found"),
+				expectedOutput: nil,
+			},
+			caseMockData: map[string][]interface{}{
+				nodePoolStoreListNodePoolsID: {
+					nil,
+				},
+			},
+		},
+		{
+			caseDescription: "unfiltered success",
+			caseInput: caseInputType{
+				input: ListStoredNodePoolsActivityInput{
+					OptionalListedNodePoolNames: nil,
+				},
+				inputActivity: &ListStoredNodePoolsActivity{
+					nodePoolStore: &eks.MockNodePoolStore{},
+				},
+			},
+			caseOutput: caseOutputType{
+				expectedError: nil,
+				expectedOutput: &ListStoredNodePoolsActivityOutput{
+					NodePools: map[string]eks.ExistingNodePool{
+						"pool1": {Name: "pool1"},
+						"pool2": {Name: "pool2"},
+						"pool3": {Name: "pool3"},
+						"pool4": {Name: "pool4"},
+						"pool5": {Name: "pool5"},
+					},
+				},
+			},
+			caseMockData: map[string][]interface{}{
+				nodePoolStoreListNodePoolsID: {
+					map[string]eks.ExistingNodePool{
+						"pool1": {Name: "pool1"},
+						"pool2": {Name: "pool2"},
+						"pool3": {Name: "pool3"},
+						"pool4": {Name: "pool4"},
+						"pool5": {Name: "pool5"},
+					},
+				},
+			},
+		},
+		{
+			caseDescription: "filtered success",
+			caseInput: caseInputType{
+				input: ListStoredNodePoolsActivityInput{
+					OptionalListedNodePoolNames: []string{
+						"pool5",
+						"pool3",
+						"pool1",
+					},
+				},
+				inputActivity: &ListStoredNodePoolsActivity{
+					nodePoolStore: &eks.MockNodePoolStore{},
+				},
+			},
+			caseOutput: caseOutputType{
+				expectedError: nil,
+				expectedOutput: &ListStoredNodePoolsActivityOutput{
+					NodePools: map[string]eks.ExistingNodePool{
+						"pool1": {Name: "pool1"},
+						"pool3": {Name: "pool3"},
+						"pool5": {Name: "pool5"},
+					},
+				},
+			},
+			caseMockData: map[string][]interface{}{
+				nodePoolStoreListNodePoolsID: {
+					map[string]eks.ExistingNodePool{
+						"pool1": {Name: "pool1"},
+						"pool2": {Name: "pool2"},
+						"pool3": {Name: "pool3"},
+						"pool4": {Name: "pool4"},
+						"pool5": {Name: "pool5"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			environment := (&testsuite.WorkflowTestSuite{}).NewTestActivityEnvironment()
+			environment.RegisterActivityWithOptions(
+				testCase.caseInput.inputActivity.Execute,
+				activity.RegisterOptions{
+					Name: t.Name(),
+				},
+			)
+
+			mockCalls(t, testCase.caseInput, testCase.caseMockData, testCase.caseMockErrors)
+
+			actualValue, actualError := environment.ExecuteActivity(t.Name(), testCase.caseInput.input)
+			var actualOutput *ListStoredNodePoolsActivityOutput
+			if actualValue != nil &&
+				actualValue.HasValue() {
+				err := actualValue.Get(&actualOutput)
+				require.NoError(t, err)
+			}
+
+			if testCase.caseOutput.expectedError == nil {
+				require.Nil(t, actualError)
+			} else {
+				require.EqualError(t, actualError, testCase.caseOutput.expectedError.Error())
+			}
+			require.Equal(t, testCase.caseOutput.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestListStoredNodePoolsActivityRegister(t *testing.T) {
+	testCases := []struct {
+		caseName      string
+		inputActivity *ListStoredNodePoolsActivity
+	}{
+		{
+			caseName:      "example",
+			inputActivity: &ListStoredNodePoolsActivity{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseName, func(t *testing.T) {
+			testCase.inputActivity.Register()
+		})
+	}
+}
+
+func TestNewListStoredNodePoolsActivity(t *testing.T) {
+	testCases := []struct {
+		caseName           string
+		expectedActivity   *ListStoredNodePoolsActivity
+		inputNodePoolStore eks.NodePoolStore
+	}{
+		{
+			caseName:           "nil node pool store",
+			expectedActivity:   &ListStoredNodePoolsActivity{},
+			inputNodePoolStore: nil,
+		},
+		{
+			caseName: "not nil node pool store",
+			expectedActivity: &ListStoredNodePoolsActivity{
+				nodePoolStore: &eks.MockNodePoolStore{},
+			},
+			inputNodePoolStore: &eks.MockNodePoolStore{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseName, func(t *testing.T) {
+			actualActivity := NewListStoredNodePoolsActivity(testCase.inputNodePoolStore)
+
+			require.Equal(t, testCase.expectedActivity, actualActivity)
+		})
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #3185 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added an optional `StaackID` input parameter and a `DescribeStack` call to the EKS `DeleteStackActivity` and created a `ListStoredNodePoolsActivity` to provide the stack ID for the node pool stack deletion calls.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In order to determine if a stack exists before trying to delete it, so never-existed-stacks, deleting stacks and already deleted stacks are not going to receive another `DeleteStack` request.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Manual testing is going to include an EKS cluster creation with multiple node pools, deleting the AWS CloudFormation stack of the node pool manually and then requesting a node pool delete with any of the 3 available methods.

<details>
  <summary>Deleted stack, DeleteNodePool</summary>

```shell
> banzai cluster create --file ~/banzai_cluster_create.yaml 

? Do you want a recommendation on your node groups? No
The current state of the request:

{
  "cloud": "amazon",
  "location": "eu-central-1",
  "name": "pregnor-pipeline-3185-11",
  "properties": {
    "eks": {
      "authConfig": {
        "mapAccounts": [
          "account1",
          "otheraccount"
        ],
        "mapRoles": [
          {
            "groups": [
              "system:bootstrappers",
              "system:nodes"
            ],
            "rolearn": "arn:aws:iam::555555555555:role/devel-nodes-NodeInstanceRole-74RF4UBDUKL6",
            "username": "system:node:{{EC2PrivateDNSName}}"
          }
        ],
        "mapUsers": [
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::555555555555:user/admin",
            "username": "admin"
          },
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::111122223333:user/ops-user",
            "username": "ops-user"
          }
        ]
      },
      "iam": {
        "clusterRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-cluster-role",
        "defaultUser": true,
        "nodeInstanceRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-node-instance-role"
      },
      "nodePools": {
        "pool1": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0679560513f0899ac"
          },
          "volumeSize": 22
        },
        "pool2": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        },
        "pool3": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        }
      },
      "subnets": [
        {
          "subnetId": "subnet-0679560513f0899ac"
        },
        {
          "subnetId": "subnet-0afa9a1f390f7f7b4"
        }
      ],
      "version": "1.17.9",
      "vpc": {
        "vpcId": "vpc-0b99b1266f4e6e0c2"
      }
    }
  },
  "secretName": "aws-pregnor-acquia"
}
? Do you want to edit the cluster request in your text editor? No
? Do you want to CREATE the cluster "pregnor-pipeline-3185-11" now? Yes
INFO[0010] cluster is being created                     
INFO[0010] you can check its status with the command `banzai cluster get "pregnor-pipeline-3185-11"` 
Id  Name                    
80  pregnor-pipeline-3185-11

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running

> banzai cluster nodepool list

? Cluster: pregnor-pipeline-3185-11
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status  StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0afa9a1f390f7f7b4  READY                
pool3  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0afa9a1f390f7f7b4  READY                

> banzai cluster nodepool list

? Cluster: pregnor-pipeline-3185-11
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status    StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                  
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0afa9a1f390f7f7b4  READY                  
pool3  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0afa9a1f390f7f7b4  DELETING               

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool delete pool3 

delete process initiated for node pool 'pool3'

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status  StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0afa9a1f390f7f7b4  READY                
```

</details>

<details>
  <summary>Deleted stack, LegacyUpdateCluster</summary>

```shell
> banzai cluster create --file ~/banzai_cluster_create.yaml 

? Do you want a recommendation on your node groups? No
The current state of the request:

{
  "cloud": "amazon",
  "location": "eu-central-1",
  "name": "pregnor-pipeline-3185-11",
  "properties": {
    "eks": {
      "authConfig": {
        "mapAccounts": [
          "account1",
          "otheraccount"
        ],
        "mapRoles": [
          {
            "groups": [
              "system:bootstrappers",
              "system:nodes"
            ],
            "rolearn": "arn:aws:iam::555555555555:role/devel-nodes-NodeInstanceRole-74RF4UBDUKL6",
            "username": "system:node:{{EC2PrivateDNSName}}"
          }
        ],
        "mapUsers": [
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::555555555555:user/admin",
            "username": "admin"
          },
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::111122223333:user/ops-user",
            "username": "ops-user"
          }
        ]
      },
      "iam": {
        "clusterRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-cluster-role",
        "defaultUser": true,
        "nodeInstanceRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-node-instance-role"
      },
      "nodePools": {
        "pool1": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0679560513f0899ac"
          },
          "volumeSize": 22
        },
        "pool2": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        },
        "pool3": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        }
      },
      "subnets": [
        {
          "subnetId": "subnet-0679560513f0899ac"
        },
        {
          "subnetId": "subnet-0afa9a1f390f7f7b4"
        }
      ],
      "version": "1.17.9",
      "vpc": {
        "vpcId": "vpc-0b99b1266f4e6e0c2"
      }
    }
  },
  "secretName": "aws-pregnor-acquia"
}
? Do you want to edit the cluster request in your text editor? No
? Do you want to CREATE the cluster "pregnor-pipeline-3185-11" now? Yes
INFO[0010] cluster is being created                     
INFO[0010] you can check its status with the command `banzai cluster get "pregnor-pipeline-3185-11"` 
Id  Name                    
80  pregnor-pipeline-3185-11

# pool3 was deleted during the DeleteNodePool test case.

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status  StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status    StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                  
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  DELETING    

> curl --location --request PUT 'https://localhost:9090/pipeline/api/v1/orgs/1/clusters/80' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${TOKEN}' \
--data-raw '{
	"cloud": "amazon",
	"properties": {
		"eks": {
			"nodePools": {
                "pool1": {
                    "spotPrice": "0.01",
                    "count": 1,
                    "minCount": 1,
                    "maxCount": 2,
                    "autoscaling": true,
                    "volumeSize": 22,
                    "instanceType": "t2.small",
                    "subnet": {
                        "subnetId": "subnet-0679560513f0899ac"
                    }
                }
			}
		}
	}
}'

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status    StatusMessage        
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  UPDATING  Update is in progress           

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status    StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                  
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  DELETING    

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status  StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                
```

</details>

<details>
  <summary>Deleted stack, DeleteCluster</summary>

```shell
> banzai cluster create --file ~/banzai_cluster_create.yaml 

? Do you want a recommendation on your node groups? No
The current state of the request:

{
  "cloud": "amazon",
  "location": "eu-central-1",
  "name": "pregnor-pipeline-3185-11",
  "properties": {
    "eks": {
      "authConfig": {
        "mapAccounts": [
          "account1",
          "otheraccount"
        ],
        "mapRoles": [
          {
            "groups": [
              "system:bootstrappers",
              "system:nodes"
            ],
            "rolearn": "arn:aws:iam::555555555555:role/devel-nodes-NodeInstanceRole-74RF4UBDUKL6",
            "username": "system:node:{{EC2PrivateDNSName}}"
          }
        ],
        "mapUsers": [
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::555555555555:user/admin",
            "username": "admin"
          },
          {
            "groups": [
              "system:masters"
            ],
            "userarn": "arn:aws:iam::111122223333:user/ops-user",
            "username": "ops-user"
          }
        ]
      },
      "iam": {
        "clusterRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-cluster-role",
        "defaultUser": true,
        "nodeInstanceRoleId": "/test/path/elements/pregnor-pipeline-3185-eks-node-instance-role"
      },
      "nodePools": {
        "pool1": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0679560513f0899ac"
          },
          "volumeSize": 22
        },
        "pool2": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        },
        "pool3": {
          "autoscaling": true,
          "count": 1,
          "instanceType": "t2.small",
          "maxCount": 2,
          "minCount": 1,
          "spotPrice": "0.01",
          "subnet": {
            "subnetId": "subnet-0afa9a1f390f7f7b4"
          },
          "volumeSize": 22
        }
      },
      "subnets": [
        {
          "subnetId": "subnet-0679560513f0899ac"
        },
        {
          "subnetId": "subnet-0afa9a1f390f7f7b4"
        }
      ],
      "version": "1.17.9",
      "vpc": {
        "vpcId": "vpc-0b99b1266f4e6e0c2"
      }
    }
  },
  "secretName": "aws-pregnor-acquia"
}
? Do you want to edit the cluster request in your text editor? No
? Do you want to CREATE the cluster "pregnor-pipeline-3185-11" now? Yes
INFO[0010] cluster is being created                     
INFO[0010] you can check its status with the command `banzai cluster get "pregnor-pipeline-3185-11"` 
Id  Name                    
80  pregnor-pipeline-3185-11

# pool2 and pool3 were deleted during the DeleteNodePool and LegacyUpdateCluster test case.

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status  StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  READY                

> banzai cluster --cluster-name pregnor-pipeline-3185-11 nodepool list

Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice  SubnetID                  Status    StatusMessage
pool1  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01       subnet-0679560513f0899ac  DELETING               

> banzai cluster delete

? Cluster: pregnor-pipeline-3185-11
Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status   StatusMessage     
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  RUNNING  Cluster is running
? Do you want to DELETE the cluster? Yes
INFO[0005] Deleting cluster &{202 Accepted 202 HTTP/1.1 1 1 map[Content-Length:[0] Date:[Sat, 17 Oct 2020 06:53:11 GMT]] 0xc000309bc0 0 [] false false map[] 0xc0001c6700 0xc0001554a0} 
Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status    StatusMessage             
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  DELETING  Termination is in progress

> banzai cluster list

Id  Name                      Distribution  Location      Version  CreatorName  CreatedAt                  Status    StatusMessage             
80  pregnor-pipeline-3185-11  eks           eu-central-1  1.17.9   pregnor      2020-10-17T07:05:45+02:00  DELETING  Termination is in progress

> banzai cluster list

Id  Name  Distribution  Location  Version  CreatorName  CreatedAt  Status  StatusMessage
```

</details>

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Manual test.
- [x] Wait for #3238 to be merged, rebase onto it and then merge this.
