### PR TITLE
Add mergeable checks to ensure PRs and issues are properly labeled

### DIFF
--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,2 @@
+[*.yml]
+indent_size = 2

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -13,11 +13,11 @@ mergeable:
       - do: description
         and:
           - must_exclude:
-              regex: '\[ \]'
-              message: 'Remaining tasks in the description.'
+            regex: '\[ \]'
+            message: 'Remaining tasks in the description.'
           - must_exclude:
-              regex: 'no\|yes|fixes #X, partially #Y, mentioned in #Z'
-              message: 'Please fill out the PR template.'
+            regex: 'no\|yes|fixes #X, partially #Y, mentioned in #Z'
+            message: 'Please fill out the PR template.'
         no_empty:
           enabled: true
           message: 'Description matter and should not be empty. Provide detail with **what** was changed, **why** it was changed, and **how** it was changed.'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -7,9 +7,13 @@ mergeable:
           regex: '^(\[wip\]|wip:)'
           message: 'WIP tag in PR title'
       - do: label
-        must_exclude:
-          regex: 'wip'
-          message: 'WIP label on PR'
+        and:
+          - must_exclude:
+            regex: 'wip'
+            message: 'WIP label on PR'
+          - must_include:
+            regex: 'kind|area'
+            message: 'Please add at least kind and area labels to the pull request. Consider adding as many as fits the contents of this PR.'
       - do: description
         and:
           - must_exclude:
@@ -21,3 +25,16 @@ mergeable:
         no_empty:
           enabled: true
           message: 'Description matter and should not be empty. Provide detail with **what** was changed, **why** it was changed, and **how** it was changed.'
+
+  - when: issues.opened
+    validate:
+      - do: label
+        and:
+          - must_include:
+            regex: '^kind/'
+          - must_include:
+            regex: '^area/'
+    fail:
+      - do: comment
+        payload:
+          body: Please add labels to your pull request.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR configures mergeable to enforce label policies on PRs and issues.


### Why?
We use GitHub to track tasks/issues/pull requests. That means we open tons of issues and PRs. The large number of items often makes searching harder which is why we use labels. Unfortunately, labeling issues and PRs is often forgotten.


### Additional context
This is just a rough example of what mergeable can do for us. Here is the full documentation: https://mergeable.readthedocs.io/en/latest/usage.html

We can enforce policies for required labels, but we should also remind developers to use as much labels as possible. I'm not sure what's the right way to do that yet.


### To Do
- [ ] Agree on a labeling policy (required labels, suggested labels)
- [ ] Review existing labels