### PR TITLE
Improve docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,6 @@ jobs:
           echo ::set-output name=commit_hash::${GITHUB_SHA::8}
           echo ::set-output name=build_date::$(git show -s --format=%cI)
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,8 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,mode=max,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           build-args: |
             VERSION=${{ steps.tags.outputs.version }}
             COMMIT_HASH=${{ steps.tags.outputs.commit_hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.tags.outputs.tags }}
+          context: .
           cache-from: type=local,mode=max,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Calculate Docker image tags
         id: tags
         env:
@@ -256,6 +264,8 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
             VERSION=${{ steps.tags.outputs.version }}
             COMMIT_HASH=${{ steps.tags.outputs.commit_hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
+        if: ${{ github.event_name == 'push' }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+        if: ${{ github.event_name == 'push' }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,14 +203,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Calculate Docker image tags
         id: tags
         env:
@@ -266,9 +258,6 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.tags.outputs.tags }}
-          context: .
-          cache-from: type=local,mode=max,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           build-args: |
             VERSION=${{ steps.tags.outputs.version }}
             COMMIT_HASH=${{ steps.tags.outputs.commit_hash }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR adds a number of improvements to the Docker image build job:

- image layer caching
- skip logging into registries when not necessary
- remove unused qemu step (copy&paste error)


### Why?
Caching might speed up the Docker image build (time will tell).

Removing unnecessary steps from the workflow might have the same effect.


### Additional context
The cache size might not fit into the [limits](https://github.com/actions/cache#cache-limits)
