### PR TITLE
ci: remove deprecated set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Start kind cluster
         run: |
           ./pleasew -p --profile ci run ///pleasings2//tools/k8s:kind -- create cluster --kubeconfig $HOME/.kube/config
-          echo "::set-env name=KUBECONFIG::$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
 
       - name: Test
         run: |


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Remove `set-env` from CI config


### Why?
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/