### PR TITLE
Refactor EKSActivityInput to AWSCommonActivityInput

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -155,19 +155,6 @@ func packageCFError(err error, stackName string, clientRequestToken string, clou
 	return err
 }
 
-// EKSActivityInput holds common input data for all activities
-type EKSActivityInput struct {
-	OrganizationID uint
-	SecretID       string
-
-	Region string
-
-	ClusterName string
-
-	// 64 chars length unique unique identifier that identifies the create CloudFormation
-	AWSClientRequestTokenBase string
-}
-
 type EncryptionConfig struct {
 	Provider  Provider
 	Resources []string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -48,7 +48,7 @@ type BootstrapActivity struct {
 
 // BootstrapActivityInput holds input data
 type BootstrapActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	KubernetesVersion   string
 	NodeInstanceRoleArn string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -44,7 +44,7 @@ type CreateAsgActivity struct {
 
 // CreateAsgActivityInput holds data needed for setting up IAM roles
 type CreateAsgActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	ClusterID uint
 
@@ -244,9 +244,9 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 	stackID := aws.StringValue(createStackOutput.StackId)
 	err = a.nodePoolStore.UpdateNodePoolStackID(
 		ctx,
-		input.EKSActivityInput.OrganizationID,
+		input.AWSCommonActivityInput.OrganizationID,
 		input.ClusterID,
-		input.EKSActivityInput.ClusterName,
+		input.AWSCommonActivityInput.ClusterName,
 		input.Name,
 		stackID,
 	)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_cluster_user_access_key_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_cluster_user_access_key_activity.go
@@ -40,7 +40,7 @@ type CreateClusterUserAccessKeyActivity struct {
 
 // CreateClusterUserAccessKeyActivityInput holds data needed for setting up IAM user access key for the cluster user
 type CreateClusterUserAccessKeyActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	UserName       string
 	UseDefaultUser bool

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
@@ -41,7 +41,7 @@ type CreateEksControlPlaneActivity struct {
 
 // CreateEksControlPlaneActivityInput holds data needed for setting up EKS control plane
 type CreateEksControlPlaneActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	KubernetesVersion     string
 	EncryptionConfig      []EncryptionConfig

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_iam_roles_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_iam_roles_activity.go
@@ -38,7 +38,7 @@ type CreateIamRolesActivity struct {
 
 // CreateIamRolesActivityInput holds data needed for setting up IAM roles
 type CreateIamRolesActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	// name of the cloud formation template stack
 	StackName string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_subnet_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_subnet_activity.go
@@ -38,7 +38,7 @@ type CreateSubnetActivity struct {
 // CreateSubnetActivityInput holds data needed for setting up
 // a Subnet for EKS cluster
 type CreateSubnetActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	// the ID of the VPC to create the subnet into
 	VpcID string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_vpc_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_vpc_activity.go
@@ -42,7 +42,7 @@ type CreateVpcActivity struct {
 // CreateVpcActivityInput holds data needed for setting up
 // VPC for EKS cluster
 type CreateVpcActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	// name of the cloud formation template stack
 	StackName string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_control_plane_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_control_plane_activity.go
@@ -36,7 +36,7 @@ type DeleteControlPlaneActivity struct {
 }
 
 type DeleteControlPlaneActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 }
 
 //   DeleteControlPlaneActivityOutput holds the output data of the DeleteControlPlaneActivity

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_node_pool_workflow.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_node_pool_workflow.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/clusterworkflow"
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
 	pkgCadence "github.com/banzaicloud/pipeline/pkg/cadence"
 	sdkAmazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
 )
@@ -103,7 +104,7 @@ func (w DeleteNodePoolWorkflow) Execute(ctx workflow.Context, input DeleteNodePo
 
 	{
 		activityInput := DeleteStackActivityInput{
-			EKSActivityInput: EKSActivityInput{
+			AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{
 				OrganizationID: input.OrganizationID,
 				SecretID:       input.SecretID,
 				Region:         input.Region,

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_node_pool_workflow_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_node_pool_workflow_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster"
 	"github.com/banzaicloud/pipeline/internal/cluster/clusterworkflow"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
 	pkgcadence "github.com/banzaicloud/pipeline/pkg/cadence"
 	sdkamazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
 )
@@ -140,7 +141,7 @@ func (workflowTestSuite *DeleteNodePoolWorkflowTestSuite) TestDeleteNodePoolWork
 				}
 			case DeleteStackActivityName:
 				activityInput := DeleteStackActivityInput{
-					EKSActivityInput: EKSActivityInput{
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{
 						OrganizationID: input.input.OrganizationID,
 						SecretID:       input.input.SecretID,
 						Region:         input.input.Region,

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_orphan_nic_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_orphan_nic_activity.go
@@ -34,7 +34,7 @@ type DeleteOrphanNICActivity struct {
 }
 
 type DeleteOrphanNICActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	NicID string
 }
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_ssh_key_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_ssh_key_activity.go
@@ -34,7 +34,7 @@ type DeleteSshKeyActivity struct {
 }
 
 type DeleteSshKeyActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	SSHKeyName string
 }
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_stack_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_stack_activity.go
@@ -38,7 +38,7 @@ type DeleteStackActivity struct {
 }
 
 type DeleteStackActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	StackID string
 
 	// name of the cloud formation template stack

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_ami_size_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_ami_size_activity.go
@@ -34,7 +34,7 @@ type GetAMISizeActivity struct {
 }
 
 type GetAMISizeActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	ImageID string
 }
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity.go
@@ -34,7 +34,7 @@ type GetCFStackActivity struct {
 }
 
 type GetCFStackActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	StackName string
 }
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity_test.go
@@ -134,8 +134,8 @@ func TestGetCFStackActivityExecute(t *testing.T) {
 			input: inputType{
 				activity: nil,
 				input: GetCFStackActivityInput{
-					EKSActivityInput: EKSActivityInput{},
-					StackName:        "stack-name",
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{},
+					StackName:              "stack-name",
 				},
 			},
 			output: outputType{
@@ -149,8 +149,8 @@ func TestGetCFStackActivityExecute(t *testing.T) {
 			input: inputType{
 				activity: NewGetCFStackActivity(&awsworkflow.MockAWSFactory{}, &awsworkflow.MockCloudFormationAPIFactory{}),
 				input: GetCFStackActivityInput{
-					EKSActivityInput: EKSActivityInput{},
-					StackName:        "stack-name",
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{},
+					StackName:              "stack-name",
 				},
 			},
 			output: outputType{
@@ -174,8 +174,8 @@ func TestGetCFStackActivityExecute(t *testing.T) {
 			input: inputType{
 				activity: NewGetCFStackActivity(&awsworkflow.MockAWSFactory{}, &awsworkflow.MockCloudFormationAPIFactory{}),
 				input: GetCFStackActivityInput{
-					EKSActivityInput: EKSActivityInput{},
-					StackName:        "stack-name",
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{},
+					StackName:              "stack-name",
 				},
 			},
 			output: outputType{
@@ -216,8 +216,8 @@ func TestGetCFStackActivityExecute(t *testing.T) {
 			input: inputType{
 				activity: NewGetCFStackActivity(&awsworkflow.MockAWSFactory{}, &awsworkflow.MockCloudFormationAPIFactory{}),
 				input: GetCFStackActivityInput{
-					EKSActivityInput: EKSActivityInput{},
-					StackName:        "stack-name",
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{},
+					StackName:              "stack-name",
 				},
 			},
 			output: outputType{
@@ -261,8 +261,8 @@ func TestGetCFStackActivityExecute(t *testing.T) {
 			input: inputType{
 				activity: NewGetCFStackActivity(&awsworkflow.MockAWSFactory{}, &awsworkflow.MockCloudFormationAPIFactory{}),
 				input: GetCFStackActivityInput{
-					EKSActivityInput: EKSActivityInput{},
-					StackName:        "stack-name",
+					AWSCommonActivityInput: awsworkflow.AWSCommonActivityInput{},
+					StackName:              "stack-name",
 				},
 			},
 			output: outputType{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_orphan_nics_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_orphan_nics_activity.go
@@ -33,7 +33,7 @@ type GetOrphanNICsActivity struct {
 }
 
 type GetOrphanNICsActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	VpcID            string
 	SecurityGroupIDs []string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_owned_elbs_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_owned_elbs_activity.go
@@ -35,7 +35,7 @@ type GetOwnedELBsActivity struct {
 // GetOwnedELBsActivityInput holds fields needed to retrieve all ELBs provisioned by
 // an EKS cluster
 type GetOwnedELBsActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	VpcID string
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_subnet_stacks_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_subnet_stacks_activity.go
@@ -34,7 +34,7 @@ type GetSubnetStacksActivity struct {
 }
 
 type GetSubnetStacksActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 }
 
 type GetSubnetStacksActivityOutput struct {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_vpc_config_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_vpc_config_activity.go
@@ -35,7 +35,7 @@ type GetVpcConfigActivity struct {
 
 // GetVpcConfigActivityInput holds data needed for setting up IAM roles
 type GetVpcConfigActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	// name of the cloud formation template stack
 	StackName string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -51,7 +51,7 @@ type UpdateAsgActivity struct {
 
 // UpdateAsgActivityInput holds data needed for setting up IAM roles
 type UpdateAsgActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	// name of the cloud formation template stack
 	StackName        string

--- a/internal/cluster/distribution/eks/eksprovider/workflow/upload_ssh_key_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/upload_ssh_key_activity.go
@@ -36,7 +36,7 @@ type UploadSSHKeyActivity struct {
 
 //  UploadSSHKeyActivityInput holds data needed to upload SSH key
 type UploadSSHKeyActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	SSHKeyName  string
 	SSHSecretID string
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/validate_iam_role.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/validate_iam_role.go
@@ -33,7 +33,7 @@ type ValidateIAMRoleActivity struct {
 
 //  ValidateIAMRoleActivityInput holds data needed to validate IAM Role
 type ValidateIAMRoleActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 
 	ClusterRoleID string
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/wait_elbs_deletion_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/wait_elbs_deletion_activity.go
@@ -36,7 +36,7 @@ type WaitELBsDeletionActivity struct {
 
 // WaitELBsDeletionActivity holds the names of the ELBs to wait for to be deleted
 type WaitELBsDeletionActivityActivityInput struct {
-	EKSActivityInput
+	awsworkflow.AWSCommonActivityInput
 	LoadBalancerNames []string
 }
 

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -118,7 +118,7 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 		return err
 	}
 
-	eksActivityInput := eksWorkflow.EKSActivityInput{
+	AWSCommonActivityInput := awsworkflow.AWSCommonActivityInput{
 		OrganizationID:            input.OrganizationID,
 		SecretID:                  providerSecretID.ResourceID,
 		Region:                    input.Region,
@@ -131,8 +131,8 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 	if effectiveImage == "" ||
 		effectiveVolumeSize == 0 { // Note: needing CF stack for original information for version.
 		getCFStackInput := eksWorkflow.GetCFStackActivityInput{
-			EKSActivityInput: eksActivityInput,
-			StackName:        eksWorkflow.GenerateNodePoolStackName(input.ClusterName, input.NodePoolName),
+			AWSCommonActivityInput: AWSCommonActivityInput,
+			StackName:              eksWorkflow.GenerateNodePoolStackName(input.ClusterName, input.NodePoolName),
 		}
 		var getCFStackOutput eksWorkflow.GetCFStackActivityOutput
 		processActivity := process.StartActivity(ctx, eksWorkflow.GetCFStackActivityName)
@@ -165,8 +165,8 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 		var amiSize int
 		{
 			activityInput := eksWorkflow.GetAMISizeActivityInput{
-				EKSActivityInput: eksActivityInput,
-				ImageID:          effectiveImage,
+				AWSCommonActivityInput: AWSCommonActivityInput,
+				ImageID:                effectiveImage,
 			}
 			var activityOutput eksWorkflow.GetAMISizeActivityOutput
 			processActivity := process.StartActivity(ctx, eksWorkflow.GetAMISizeActivityName)

--- a/internal/cluster/infrastructure/aws/awsworkflow/amazon.go
+++ b/internal/cluster/infrastructure/aws/awsworkflow/amazon.go
@@ -18,6 +18,19 @@ import (
 	"github.com/banzaicloud/pipeline/src/secret"
 )
 
+// AWSCommonActivityInput holds common input data for all activities
+type AWSCommonActivityInput struct {
+	OrganizationID uint
+	SecretID       string
+
+	Region string
+
+	ClusterName string
+
+	// 64 chars length unique unique identifier that identifies the create CloudFormation
+	AWSClientRequestTokenBase string
+}
+
 type SecretStore interface {
 	Get(orgnaizationID uint, secretID string) (*secret.SecretItemResponse, error)
 	GetByName(orgnaizationID uint, secretID string) (*secret.SecretItemResponse, error)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #3251 #3242 
| License         | Apache 2.0


### What's in this PR?
Refactor EKSActivityInput to AWSCommonActivityInput so DeleteStackActivity can be refactored to a common package in a follow-up PR. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

