### PR TITLE
chore: relocated misplaced activity init

### DIFF
--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -20,7 +20,6 @@ import (
 	"go.uber.org/cadence/workflow"
 
 	cluster2 "github.com/banzaicloud/pipeline/internal/cluster"
-	"github.com/banzaicloud/pipeline/internal/cluster/clusterworkflow"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks"
 	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/adapter"
 	eksworkflow "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
@@ -131,17 +130,6 @@ func registerEKSWorkflows(
 
 	waitELBsDeletionActivity := eksworkflow.NewWaitELBsDeletionActivity(awsSessionFactory)
 	activity.RegisterWithOptions(waitELBsDeletionActivity.Execute, activity.RegisterOptions{Name: eksworkflow.WaitELBsDeletionActivityName})
-
-	deleteNodePoolLabelSetActivity := clusterworkflow.NewDeleteNodePoolLabelSetActivity(
-		clusterDynamicClientFactory,
-		config.Cluster.Labels.Namespace,
-	)
-	activity.RegisterWithOptions(
-		deleteNodePoolLabelSetActivity.Execute,
-		activity.RegisterOptions{
-			Name: clusterworkflow.DeleteNodePoolLabelSetActivityName,
-		},
-	)
 
 	deleteStackActivity := awsworkflow.NewDeleteStackActivity(awsSessionFactory)
 	activity.RegisterWithOptions(deleteStackActivity.Execute, activity.RegisterOptions{Name: awsworkflow.DeleteStackActivityName})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -506,6 +506,17 @@ func main() {
 			)
 			activity.RegisterWithOptions(createNodePoolLabelSetActivity.Execute, activity.RegisterOptions{Name: clusterworkflow.CreateNodePoolLabelSetActivityName})
 
+			deleteNodePoolLabelSetActivity := clusterworkflow.NewDeleteNodePoolLabelSetActivity(
+				clusterDynamicClientFactory,
+				config.Cluster.Labels.Namespace,
+			)
+			activity.RegisterWithOptions(
+				deleteNodePoolLabelSetActivity.Execute,
+				activity.RegisterOptions{
+					Name: clusterworkflow.DeleteNodePoolLabelSetActivityName,
+				},
+			)
+
 			workflow.RegisterWithOptions(clusterworkflow.CreateNodePoolWorkflow, workflow.RegisterOptions{Name: clusterworkflow.CreateNodePoolWorkflowName})
 
 			setClusterStatusActivity := clusterworkflow.NewSetClusterStatusActivity(clusterStore)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Moved `DeleteNodePoolLabelSetActivity` from `cmd/worker/eks.go` to `cmd/worker/main.go`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

After recently refactoring the node pool label set deletion activity it is once again a generic activity, but it was located at a distribution specific initialization place.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
