### PR TITLE
set the cluster name as backup name

### DIFF
--- a/src/api/ark/backupservice/enable.go
+++ b/src/api/ark/backupservice/enable.go
@@ -113,7 +113,7 @@ func Enable(helmService helm.UnifiedReleaser) func(c *gin.Context) {
 		}
 
 		spec := &api.CreateBackupRequest{
-			Name:   api.BaseScheduleName,
+			Name:   svc.GetCluster().GetName(),
 			Labels: request.Labels,
 			TTL: metav1.Duration{
 				Duration: scheduleTTL,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3262 
| License         | Apache 2.0

### What's in this PR?
Set the name of the cluster as prefix for backups instead of `cluster-backup` which is used currently as it's more meaningful as user friendly when for ex. user has to select from a list of backups.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please 
- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
