### PR TITLE
fix(#3280/AWS/DeleteStack): fixed existence check

### DIFF
--- a/internal/cluster/infrastructure/aws/awsworkflow/delete_stack_activity.go
+++ b/internal/cluster/infrastructure/aws/awsworkflow/delete_stack_activity.go
@@ -16,6 +16,7 @@ package awsworkflow
 
 import (
 	"context"
+	"fmt"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
@@ -81,7 +82,9 @@ func (a *DeleteStackActivity) Execute(ctx context.Context, input DeleteStackActi
 	describeStacksOutput, err := cloudformationClient.DescribeStacks(describeStacksInput)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == cloudformation.ErrCodeStackInstanceNotFoundException {
+			if awsErr.Code() == cloudformation.ErrCodeStackInstanceNotFoundException ||
+				(awsErr.Code() == "ValidationError" &&
+					awsErr.Message() == fmt.Sprintf("Stack with id %s does not exist", stackIdentifier)) {
 				// Note: no stack found for the corresponding stack name.
 				return nil
 			}


### PR DESCRIPTION
Handled pre-creation failure non-existent CloudFormation stack properly.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3280 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the handling of non-existent CloudFormation stack handling in `AWSCommon.DeleteStackActivity` by adding the corresponding validation error to the non-existent stack error handling branch on the existence check.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because there are different errors for already deleted and never created stacks, only the former was handled before.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Unfortunately I couldn't find any predefined error code/message for this case in https://github.com/aws/aws-sdk-go.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
