### PR TITLE
objectstore_test: retry the most flaky part

### DIFF
--- a/pkg/providers/amazon/objectstore/objectstore_test.go
+++ b/pkg/providers/amazon/objectstore/objectstore_test.go
@@ -340,7 +340,12 @@ func testObjectStoreDelete(t *testing.T) {
 
 	err = s.DeleteBucket(bucketName)
 	if err != nil {
-		t.Fatal("could not test bucket deletion: ", err.Error())
+		// this test seems to be the most flaky one, give it another chance
+		time.Sleep(time.Second)
+		err = s.DeleteBucket(bucketName)
+		if err != nil {
+			t.Fatal("could not test bucket deletion: ", err.Error())
+		}
 	}
 
 	head := &s3.HeadBucketInput{


### PR DESCRIPTION
### What's in this PR?
My short research about failing integration test runs showed that this single API call fails most of the time. This may be caused by the kind of eventual consistency of bucket creation.

### Why?
No idea about other low effort solution.
