### PR TITLE
fix(Token): fixed cluster token validation

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -188,14 +188,16 @@ func (m TokenManager) GenerateToken(
 	tokenText string,
 	tokenName string,
 	storeSecret bool,
-) (string, string, error) {
-	tokenID, signedToken, err := m.generator.GenerateToken(sub, expiresAt, string(tokenType), tokenText)
+) (tokenID string, signedToken string, err error) {
+	tokenID, signedToken, err = m.generator.GenerateToken(sub, expiresAt, string(tokenType), tokenText)
 	if err != nil {
 		return "", "", err
 	}
 
 	token := auth.NewToken(tokenID, tokenName)
-	token.ExpiresAt = &expiresAt
+	if expiresAt != NoExpiration {
+		token.ExpiresAt = &expiresAt
+	}
 
 	if storeSecret {
 		token.Value = signedToken


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the JWT token storing and thus validation with the new go-jose JWT implementation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The cluster tokens are non-expiring, but they were stored with an explicit expiration set to 0 explicit time (0001-01-01T00:00:00Z), because at one point where we converted between non-pointer to pointer expiration the address of the zero value time was taken instead of setting expiration to nil.

Example: (token saved with no expiration/zero time value)
```json
{
  "token": {
    "expiresAt": "0001-01-01T00:00:00Z",
    "id": "c81ee9e4-e925-40b6-8034-9e8b7d0b79b8",
    "name": "clusters/1/14",
    "value": "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsiaHR0cHM6Ly9waXBlbGluZS5iYW56YWljbG91ZC5jb20iXSwiaWF0IjoxNjA0NTk4NzcxLCJpc3MiOiJodHRwczovL2JhbnphaWNsb3VkLmNvbS8iLCJqdGkiOiJjODFlZTllNC1lOTI1LTQwYjYtODAzNC05ZThiN2QwYjc5YjgiLCJzY29wZSI6ImFwaTppbnZva2UiLCJzdWIiOiJjbHVzdGVycy8xLzE0IiwidGV4dCI6ImNsdXN0ZXJzLzEvMTQiLCJ0eXBlIjoiY2x1c3RlciJ9.you_thought_so"
  }
}
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Among long term design ideas up for debate:

1. we should use time pointers everywhere or no time pointers at all, but converting between values and pointers is always erroneous, especially when the zero value has a special meaning and not equals the semantic of any other value.
2. we should consider updating the Vault auth lookup token parsing to handle zero time value as well as nil value (it's a pointer there), because I think this is a somewhat "common" serialization issue.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)
