### PR TITLE
Updated the EKS CloudFormation node pool template to the latest official available state

### DIFF
--- a/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
@@ -673,6 +673,10 @@ func TestListNodePools(t *testing.T) {
 							{
 								Parameters: []*cloudformation.Parameter{
 									{
+										ParameterKey:   aws.String("TemplateVersion"),
+										ParameterValue: aws.String("2.0.0"),
+									},
+									{
 										ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 										ParameterValue: aws.String("true"),
 									},
@@ -717,6 +721,10 @@ func TestListNodePools(t *testing.T) {
 						Stacks: []*cloudformation.Stack{
 							{
 								Parameters: []*cloudformation.Parameter{
+									{
+										ParameterKey:   aws.String("TemplateVersion"),
+										ParameterValue: aws.String("2.0.0"),
+									},
 									{
 										ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 										ParameterValue: aws.String("false"),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -155,6 +155,10 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 
 	stackParams = []*cloudformation.Parameter{
 		{
+			ParameterKey:   aws.String(eksStackTemplateVersionParameterKey),
+			ParameterValue: aws.String("2.0.0"),
+		},
+		{
 			ParameterKey:   aws.String("KeyName"),
 			ParameterValue: aws.String(input.SSHKeyName),
 		},

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -186,6 +186,10 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 
 	stackParams := []*cloudformation.Parameter{
 		{
+			ParameterKey:   aws.String(eksStackTemplateVersionParameterKey),
+			ParameterValue: aws.String("2.0.0"),
+		},
+		{
 			ParameterKey:     aws.String("KeyName"),
 			UsePreviousValue: aws.Bool(true),
 		},

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/cadence/activity"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
+	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 	"github.com/banzaicloud/pipeline/pkg/cadence/worker"
 	pkgCloudFormation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	sdkAmazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
@@ -102,6 +103,10 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 	}
 
 	stackParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(workflow.GetStackTemplateVersionKey()),
+			ParameterValue: aws.String("2.0.0"),
+		},
 		{
 			ParameterKey:     aws.String("KeyName"),
 			UsePreviousValue: aws.Bool(true),

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -63,7 +63,8 @@ type UpdateNodeGroupActivityInput struct {
 	NodeImage       string
 	DesiredCapacity int64
 
-	MaxBatchSize int
+	MaxBatchSize          int
+	MinInstancesInService int
 
 	ClusterTags map[string]string
 }
@@ -137,6 +138,10 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 			input.MaxBatchSize > 0,
 			fmt.Sprintf("%d", input.MaxBatchSize),
 		),
+		{
+			ParameterKey:   aws.String("NodeAutoScalingGroupMinInstancesInService"),
+			ParameterValue: aws.String(fmt.Sprintf("%d", input.MinInstancesInService)),
+		},
 		sdkCloudFormation.NewOptionalStackParameter(
 			"NodeAutoScalingInitSize",
 			input.DesiredCapacity > 0,

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -219,16 +219,17 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 
 	{
 		activityInput := UpdateNodeGroupActivityInput{
-			SecretID:        input.ProviderSecretID,
-			Region:          input.Region,
-			ClusterName:     input.ClusterName,
-			StackName:       input.StackName,
-			NodePoolName:    input.NodePoolName,
-			NodePoolVersion: nodePoolVersion,
-			NodeVolumeSize:  volumeSize,
-			NodeImage:       input.NodeImage,
-			MaxBatchSize:    input.Options.MaxBatchSize,
-			ClusterTags:     input.ClusterTags,
+			SecretID:              input.ProviderSecretID,
+			Region:                input.Region,
+			ClusterName:           input.ClusterName,
+			StackName:             input.StackName,
+			NodePoolName:          input.NodePoolName,
+			NodePoolVersion:       nodePoolVersion,
+			NodeVolumeSize:        volumeSize,
+			NodeImage:             input.NodeImage,
+			MaxBatchSize:          input.Options.MaxBatchSize,
+			MinInstancesInService: input.Options.MaxSurge,
+			ClusterTags:           input.ClusterTags,
 		}
 
 		activityOptions := activityOptions

--- a/internal/cluster/distribution/eks/service_test.go
+++ b/internal/cluster/distribution/eks/service_test.go
@@ -141,6 +141,10 @@ func TestNewNodePoolFromCFStack(t *testing.T) {
 				stack: &cloudformation.Stack{
 					Parameters: []*cloudformation.Parameter{
 						{
+							ParameterKey:   aws.String("TemplateVersion"),
+							ParameterValue: aws.String("2.0.0"),
+						},
+						{
 							ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 							ParameterValue: aws.String("not-a-bool"),
 						},
@@ -198,6 +202,10 @@ func TestNewNodePoolFromCFStack(t *testing.T) {
 				name: "node-pool",
 				stack: &cloudformation.Stack{
 					Parameters: []*cloudformation.Parameter{
+						{
+							ParameterKey:   aws.String("TemplateVersion"),
+							ParameterValue: aws.String("2.0.0"),
+						},
 						{
 							ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 							ParameterValue: aws.String("true"),

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -449,6 +449,18 @@ Resources:
       Roles:
         - !Ref NodeInstanceRoleId # Note: deliberately custom parameter.
 
+  # Note: we are using a preinitialized node security group parameter, possibly
+  # specified by the end user.
+  #
+  # NodeSecurityGroup:
+  #   Type: "AWS::EC2::SecurityGroup"
+  #   Properties:
+  #     GroupDescription: Security group for all nodes in the cluster
+  #     Tags:
+  #       - Key: !Sub kubernetes.io/cluster/${ClusterName}
+  #         Value: owned
+  #     VpcId: !Ref VpcId
+
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -58,7 +58,7 @@ Parameters:
     Description: Comma separated list of security groups for all nodes in the pool.
 
   KeyName:
-    Type: String
+    Type: "AWS::EC2::KeyPair::KeyName"
     Description: The EC2 Key Pair to allow SSH access to the instances
 
   # NodeAutoScalingGroupDesiredCapacity:

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -390,6 +390,19 @@ Parameters:
     Type: "AWS::EC2::VPC::Id"
     Description: The VPC of the worker instances
 
+Mappings:
+  PartitionMap:
+    aws:
+      EC2ServicePrincipal: "ec2.amazonaws.com"
+    aws-us-gov:
+      EC2ServicePrincipal: "ec2.amazonaws.com"
+    aws-cn:
+      EC2ServicePrincipal: "ec2.amazonaws.com.cn"
+    aws-iso:
+      EC2ServicePrincipal: "ec2.c2s.ic.gov"
+    aws-iso-b:
+      EC2ServicePrincipal: "ec2.sc2s.sgov.gov"
+
 Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
@@ -404,12 +417,37 @@ Conditions:
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
 
 Resources:
+  # Note: we are using preinitialized node instance roles, possibly specified by
+  # the end user.
+  #
+  # NodeInstanceRole:
+  #   Type: "AWS::IAM::Role"
+  #   Properties:
+  #     AssumeRolePolicyDocument:
+  #       Version: "2012-10-17"
+  #       Statement:
+  #         - Effect: Allow
+  #           Principal:
+  #             Service:
+  #               - !FindInMap [
+  #                   PartitionMap,
+  #                   !Ref "AWS::Partition",
+  #                   EC2ServicePrincipal,
+  #                 ]
+  #           Action:
+  #             - "sts:AssumeRole"
+  #     ManagedPolicyArns:
+  #       - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  #       - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+  #       - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  #     Path: /
+
   NodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       Path: /
       Roles:
-        - !Ref NodeInstanceRoleId
+        - !Ref NodeInstanceRoleId # Note: deliberately custom parameter.
 
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -28,6 +28,7 @@ Metadata:
           - NodeVolumeSize
           - KeyName
           - BootstrapArguments
+          - TemplateVersion
       - Label:
           default: Worker Network Configuration
         Parameters:
@@ -387,6 +388,10 @@ Parameters:
   Subnets:
     Type: "List<AWS::EC2::Subnet::Id>"
     Description: The subnets where workers can be created.
+
+  TemplateVersion:
+    Type: String
+    Description: Version of the template structure as metainformation for created stacks.
 
   TerminationDetachEnabled:
     Type: String

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -1,20 +1,19 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
+
 Description: Amazon EKS - Node Group
 
 Metadata:
   "AWS::CloudFormation::Interface":
     ParameterGroups:
-      -
-        Label:
+      - Label:
           default: EKS Cluster
         Parameters:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
           - CustomNodeSecurityGroups
           - NodeSecurityGroup
-      -
-        Label:
+      - Label:
           default: Worker Node Configuration
         Parameters:
           - NodeGroupName
@@ -28,15 +27,13 @@ Metadata:
           - NodeImageId
           - KeyName
           - BootstrapArguments
-      -
-        Label:
+      - Label:
           default: Worker Network Configuration
         Parameters:
           - VpcId
           - Subnets
 
 Parameters:
-
   BootstrapArguments:
     Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
     Default: ""
@@ -73,7 +70,6 @@ Parameters:
       Type: Number
       Description: Maximum size of Node Group ASG.
       Default: 3
-
   NodeGroupName:
       Description: Unique identifier for the Node Group.
       Type: String
@@ -468,8 +464,7 @@ Resources:
               InstanceMarketOptions:
                 !If
                   - IsSpotInstance
-                  -
-                    MarketType: spot
+                  - MarketType: spot
                     SpotOptions:
                       MaxPrice: !Ref NodeSpotPrice
                       SpotInstanceType: one-time
@@ -500,8 +495,7 @@ Resources:
               Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
           MinSize: !Ref NodeAutoScalingGroupMinSize
           MaxSize: !Ref NodeAutoScalingGroupMaxSize
-          VPCZoneIdentifier:
-              !Ref Subnets
+          VPCZoneIdentifier: !Ref Subnets
           Tags:
               - Key: Name
                 Value: !Sub ${ClusterName}-${NodeGroupName}-Node

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -162,6 +162,24 @@ Parameters:
       - c5n.4xlarge
       - c5n.9xlarge
       - c5n.18xlarge
+      - c6g.medium
+      - c6g.large
+      - c6g.xlarge
+      - c6g.2xlarge
+      - c6g.4xlarge
+      - c6g.8xlarge
+      - c6g.12xlarge
+      - c6g.16xlarge
+      - c6g.metal
+      - c6gd.medium
+      - c6gd.large
+      - c6gd.xlarge
+      - c6gd.2xlarge
+      - c6gd.4xlarge
+      - c6gd.8xlarge
+      - c6gd.12xlarge
+      - c6gd.16xlarge
+      - c6gd.metal
       - cc2.8xlarge
       - cr1.8xlarge
       - d2.xlarge
@@ -269,6 +287,24 @@ Parameters:
       - m5n.12xlarge
       - m5n.16xlarge
       - m5n.24xlarge
+      - m6g.medium
+      - m6g.large
+      - m6g.xlarge
+      - m6g.2xlarge
+      - m6g.4xlarge
+      - m6g.8xlarge
+      - m6g.12xlarge
+      - m6g.16xlarge
+      - m6g.metal
+      - m6gd.medium
+      - m6gd.large
+      - m6gd.xlarge
+      - m6gd.2xlarge
+      - m6gd.4xlarge
+      - m6gd.8xlarge
+      - m6gd.12xlarge
+      - m6gd.16xlarge
+      - m6gd.metal
       - p2.xlarge
       - p2.8xlarge
       - p2.16xlarge
@@ -342,6 +378,24 @@ Parameters:
       - r5n.12xlarge
       - r5n.16xlarge
       - r5n.24xlarge
+      - r6g.medium
+      - r6g.large
+      - r6g.xlarge
+      - r6g.2xlarge
+      - r6g.4xlarge
+      - r6g.8xlarge
+      - r6g.12xlarge
+      - r6g.16xlarge
+      - r6g.metal
+      - r6gd.medium
+      - r6gd.large
+      - r6gd.xlarge
+      - r6gd.2xlarge
+      - r6gd.4xlarge
+      - r6gd.8xlarge
+      - r6gd.12xlarge
+      - r6gd.16xlarge
+      - r6gd.metal
       - t1.micro
       - t2.nano
       - t2.micro

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -28,6 +28,7 @@ Metadata:
           - NodeVolumeSize
           - KeyName
           - BootstrapArguments
+          - DisableIMDSv1
           - TemplateVersion
       - Label:
           default: Worker Network Configuration
@@ -103,6 +104,13 @@ Parameters:
   NodeInstanceRoleId:
     Type: String
     Description: The role for node IAM profile
+
+  DisableIMDSv1:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "false"
+      - "true"
 
   NodeInstanceType:
     Type: String
@@ -423,6 +431,11 @@ Conditions:
         - !Ref NodeImageId
         - ""
 
+  IMDSv1Disabled:
+    "Fn::Equals":
+      - !Ref DisableIMDSv1
+      - "true"
+
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   NoCustomNodeSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroups, "" ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
@@ -591,6 +604,11 @@ Resources:
                      --region ${AWS::Region}
         MetadataOptions:
           HttpPutResponseHopLimit: 2
+          HttpEndpoint: enabled
+          HttpTokens: !If
+            - IMDSv1Disabled
+            - required
+            - optional
 
   NodeGroup:
     Type: "AWS::AutoScaling::AutoScalingGroup"

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -78,6 +78,11 @@ Parameters:
     Default: 3
     Description: Maximum size of Node Group ASG. Set to at least 1 greater than NodeAutoScalingGroupDesiredCapacity.
 
+  NodeAutoScalingGroupMinInstancesInService:
+    Type: Number
+    Default: 0
+    Description: Minimum number of nodes to be kept in service at any given time during a rolling update. This value must be less than NodeAutoScalingGroupMaxSize.
+
   NodeAutoScalingGroupMinSize:
     Type: Number
     Default: 1
@@ -638,5 +643,6 @@ Resources:
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: !Ref NodeAutoScalingGroupMaxBatchSize
+        MinInstancesInService: !If [ IsSpotInstance, 0, !Ref NodeAutoScalingGroupMinInstancesInService ] # Note: incompatible with spot instances.
         PauseTime: PT5M
     {{- end}}

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -1,13 +1,13 @@
 ---
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Amazon EKS - Node Group'
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Amazon EKS - Node Group
 
 Metadata:
-  AWS::CloudFormation::Interface:
+  "AWS::CloudFormation::Interface":
     ParameterGroups:
       -
         Label:
-          default: "EKS Cluster"
+          default: EKS Cluster
         Parameters:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
@@ -15,7 +15,7 @@ Metadata:
           - NodeSecurityGroup
       -
         Label:
-          default: "Worker Node Configuration"
+          default: Worker Node Configuration
         Parameters:
           - NodeGroupName
           - NodeAutoScalingGroupMinSize
@@ -30,7 +30,7 @@ Metadata:
           - BootstrapArguments
       -
         Label:
-          default: "Worker Network Configuration"
+          default: Worker Network Configuration
         Parameters:
           - VpcId
           - Subnets
@@ -38,13 +38,13 @@ Metadata:
 Parameters:
 
   BootstrapArguments:
-    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
+    Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
     Default: ""
     Type: String
 
   ClusterControlPlaneSecurityGroup:
       Description: The security group of the cluster control plane.
-      Type: AWS::EC2::SecurityGroup::Id
+      Type: "AWS::EC2::SecurityGroup::Id"
 
   ClusterName:
       Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
@@ -357,11 +357,11 @@ Parameters:
 
   Subnets:
     Description: The subnets where workers can be created.
-    Type: List<AWS::EC2::Subnet::Id>
+    Type: "List<AWS::EC2::Subnet::Id>"
 
   VpcId:
       Description: The VPC of the worker instances
-      Type: AWS::EC2::VPC::Id
+      Type: "AWS::EC2::VPC::Id"
 
   ClusterAutoscalerEnabled:
       Description: Enable Cluster Autoscaler (true/false)
@@ -373,7 +373,7 @@ Parameters:
 
   NodeSecurityGroup:
       Description: Security group for all nodes in the cluster.
-      Type: AWS::EC2::SecurityGroup::Id
+      Type: "AWS::EC2::SecurityGroup::Id"
 
   CustomNodeSecurityGroups:
       Description: Comma separated list of security groups for all nodes in the pool.
@@ -397,44 +397,44 @@ Conditions:
 
 Resources:
   NodeInstanceProfile:
-    Type: AWS::IAM::InstanceProfile
+    Type: "AWS::IAM::InstanceProfile"
     Properties:
-      Path: "/"
+      Path: /
       Roles:
       - !Ref NodeInstanceRoleId
 
   NodeSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
+    Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow node to communicate with each other
       GroupId: !Ref NodeSecurityGroup
       SourceSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: '-1'
+      IpProtocol: "-1"
       FromPort: 0
       ToPort: 65535
 
   NodeSecurityGroupFromControlPlaneIngress:
-    Type: AWS::EC2::SecurityGroupIngress
+    Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
       GroupId: !Ref NodeSecurityGroup
       SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: '-1'
+      IpProtocol: "-1"
       FromPort: 0
       ToPort: 65535
 
   ControlPlaneEgressToNodeSecurityGroup:
-    Type: AWS::EC2::SecurityGroupEgress
+    Type: "AWS::EC2::SecurityGroupEgress"
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       GroupId: !Ref ClusterControlPlaneSecurityGroup
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: '-1'
+      IpProtocol: "-1"
       FromPort: 0
       ToPort: 65535
 
   ClusterControlPlaneSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
+    Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow pods to communicate with the cluster API Server
       GroupId: !Ref ClusterControlPlaneSecurityGroup
@@ -444,11 +444,11 @@ Resources:
       FromPort: 443
 
   NodeSecurityGroupSsh:
-    Type: AWS::EC2::SecurityGroupIngress
+    Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow SSH access to node
       GroupId: !Ref NodeSecurityGroup
-      CidrIp: '0.0.0.0/0'
+      CidrIp: "0.0.0.0/0"
       IpProtocol: tcp
       ToPort: 22
       FromPort: 22
@@ -461,7 +461,7 @@ Resources:
                   - DeviceName: /dev/xvda
                     Ebs:
                         DeleteOnTermination: true
-                        VolumeSize: !If [ NodeVolumeSizeAuto, !Ref 'AWS::NoValue', !Ref NodeVolumeSize ]
+                        VolumeSize: !If [ NodeVolumeSizeAuto, !Ref "AWS::NoValue", !Ref NodeVolumeSize ]
                         VolumeType: gp2
               IamInstanceProfile:
                   Arn: !GetAtt NodeInstanceProfile.Arn
@@ -489,10 +489,10 @@ Resources:
                                --resource NodeGroup  \
                                --region ${AWS::Region}
               MetadataOptions:
-                  "HttpPutResponseHopLimit" : 2
+                  HttpPutResponseHopLimit: 2
 
   NodeGroup:
-      Type: AWS::AutoScaling::AutoScalingGroup
+      Type: "AWS::AutoScaling::AutoScalingGroup"
       Properties:
           DesiredCapacity: !Ref NodeAutoScalingInitSize
           LaunchTemplate:
@@ -504,17 +504,17 @@ Resources:
               !Ref Subnets
           Tags:
               - Key: Name
-                Value: !Sub "${ClusterName}-${NodeGroupName}-Node"
-                PropagateAtLaunch: 'true'
-              - Key: !Sub 'kubernetes.io/cluster/${ClusterName}'
-                Value: 'owned'
-                PropagateAtLaunch: 'true'
-              - Key: !If [ AutoscalerEnabled, 'k8s.io/cluster-autoscaler/enabled', 'k8s.io/cluster-autoscaler/disabled' ]
-                Value: 'true'
-                PropagateAtLaunch: 'false'
-              - Key: 'bzc:detach-asg-instance-on-termination'
-                Value: !Sub "${TerminationDetachEnabled}"
-                PropagateAtLaunch: 'false'
+                Value: !Sub ${ClusterName}-${NodeGroupName}-Node
+                PropagateAtLaunch: true
+              - Key: !Sub kubernetes.io/cluster/${ClusterName}
+                Value: owned
+                PropagateAtLaunch: true
+              - Key: !If [ AutoscalerEnabled, k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/disabled ]
+                Value: true
+                PropagateAtLaunch: false
+              - Key: "bzc:detach-asg-instance-on-termination"
+                Value: !Sub ${TerminationDetachEnabled}
+                PropagateAtLaunch: false
 
       {{- if .UpdatePolicyEnabled }}
       UpdatePolicy:

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -489,21 +489,49 @@ Resources:
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
-      FromPort: 0
+      FromPort: 0 # Note: unused because of IpProtocol -1.
       GroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: "-1"
+      IpProtocol: "-1" # Note: deliberately using all protocols and all ports.
       ToPort: 65535
+
+  # Note: unused because ControlPlaneEgressToNodeSecurityGroup allows all
+  # protocols and ports.
+  #
+  # ControlPlaneEgressToNodeSecurityGroupOn443:
+  #   Type: "AWS::EC2::SecurityGroupEgress"
+  # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
+  #   Properties:
+  #     Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
+  #     DestinationSecurityGroupId: !Ref NodeSecurityGroup
+  #     FromPort: 443
+  #     GroupId: !Ref ClusterControlPlaneSecurityGroup
+  #     IpProtocol: tcp
+  #     ToPort: 443
 
   NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
-      FromPort: 0
+      FromPort: 0 # Note: unused because of IpProtocol -1.
       GroupId: !Ref NodeSecurityGroup
-      IpProtocol: "-1"
+      IpProtocol: "-1" # Note: deliberately using all protocols and all ports.
       SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
       ToPort: 65535
+
+  # Note: unused because NodeSecurityGroupFromControlPlaneIngress allows all
+  # protocols and ports.
+  #
+  # NodeSecurityGroupFromControlPlaneOn443Ingress:
+  #   Type: "AWS::EC2::SecurityGroupIngress"
+  # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
+  #   Properties:
+  #     Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
+  #     FromPort: 443
+  #     GroupId: !Ref NodeSecurityGroup
+  #     IpProtocol: tcp
+  #     SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+  #     ToPort: 443
 
   NodeSecurityGroupSsh:
     Type: "AWS::EC2::SecurityGroupIngress"

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -463,6 +463,7 @@ Resources:
 
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       Description: Allow node to communicate with each other
       FromPort: 0
@@ -473,6 +474,7 @@ Resources:
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       Description: Allow pods to communicate with the cluster API Server
       FromPort: 443
@@ -483,6 +485,7 @@ Resources:
 
   ControlPlaneEgressToNodeSecurityGroup:
     Type: "AWS::EC2::SecurityGroupEgress"
+    # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -493,6 +496,7 @@ Resources:
 
   NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
       FromPort: 0
@@ -503,6 +507,7 @@ Resources:
 
   NodeSecurityGroupSsh:
     Type: "AWS::EC2::SecurityGroupIngress"
+    # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
     Properties:
       CidrIp: "0.0.0.0/0"
       Description: Allow SSH access to node

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -700,3 +700,19 @@ Resources:
         MinInstancesInService: !If [ IsSpotInstance, 0, !Ref NodeAutoScalingGroupMinInstancesInService ] # Note: incompatible with spot instances.
         PauseTime: PT5M
     {{- end}}
+
+Outputs:
+  # Note: node instance role is preinitialized.
+  #
+  # NodeInstanceRole:
+  #   Description: The node instance role
+  #   Value: !GetAtt NodeInstanceRole.Arn
+
+  # Note: node security group is preinitialized.
+  # NodeSecurityGroup:
+  #   Description: The security group for the node group
+  #   Value: !Ref NodeSecurityGroup
+
+  NodeAutoScalingGroup:
+    Description: The autoscaling group
+    Value: !Ref NodeGroup

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -40,333 +40,333 @@ Parameters:
     Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
 
   ClusterAutoscalerEnabled:
-      Type: String
-      Description: Enable Cluster Autoscaler (true/false)
+    Type: String
+    Description: Enable Cluster Autoscaler (true/false)
 
   ClusterControlPlaneSecurityGroup:
-      Type: "AWS::EC2::SecurityGroup::Id"
-      Description: The security group of the cluster control plane.
+    Type: "AWS::EC2::SecurityGroup::Id"
+    Description: The security group of the cluster control plane.
 
   ClusterName:
-      Type: String
-      Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
+    Type: String
+    Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
 
   CustomNodeSecurityGroups:
-      Type: String
-      Default: ""
-      Description: Comma separated list of security groups for all nodes in the pool.
+    Type: String
+    Default: ""
+    Description: Comma separated list of security groups for all nodes in the pool.
 
   KeyName:
     Type: String
     Description: The EC2 Key Pair to allow SSH access to the instances
 
   NodeAutoScalingGroupMaxBatchSize:
-      Type: Number
-      Default: 2
-      Description: Minimum size of Node Group ASG.
+    Type: Number
+    Default: 2
+    Description: Minimum size of Node Group ASG.
 
   NodeAutoScalingGroupMaxSize:
-      Type: Number
-      Default: 3
-      Description: Maximum size of Node Group ASG.
+    Type: Number
+    Default: 3
+    Description: Maximum size of Node Group ASG.
 
   NodeAutoScalingGroupMinSize:
-      Type: Number
-      Default: 1
-      Description: Minimum size of Node Group ASG.
+    Type: Number
+    Default: 1
+    Description: Minimum size of Node Group ASG.
 
   NodeAutoScalingInitSize:
-      Type: Number
-      Default: 1
-      Description: The initial size of Node Group ASG.
+    Type: Number
+    Default: 1
+    Description: The initial size of Node Group ASG.
 
   NodeGroupName:
-      Type: String
-      Description: Unique identifier for the Node Group.
+    Type: String
+    Description: Unique identifier for the Node Group.
 
   NodeImageId:
-      Type: String
-      Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+    Type: String
+    Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
 
   NodeInstanceRoleId:
-      Type: String
-      Description: The role for node IAM profile
+    Type: String
+    Description: The role for node IAM profile
 
   NodeInstanceType:
     Type: String
     Default: t2.medium
     AllowedValues:
-        - a1.medium
-        - a1.large
-        - a1.xlarge
-        - a1.2xlarge
-        - a1.4xlarge
-        - c1.medium
-        - c1.xlarge
-        - c3.large
-        - c3.xlarge
-        - c3.2xlarge
-        - c3.4xlarge
-        - c3.8xlarge
-        - c4.large
-        - c4.xlarge
-        - c4.2xlarge
-        - c4.4xlarge
-        - c4.8xlarge
-        - c5.large
-        - c5.xlarge
-        - c5.2xlarge
-        - c5.4xlarge
-        - c5.9xlarge
-        - c5.12xlarge
-        - c5.18xlarge
-        - c5.24xlarge
-        - c5.metal
-        - c5d.large
-        - c5d.xlarge
-        - c5d.2xlarge
-        - c5d.4xlarge
-        - c5d.9xlarge
-        - c5d.12xlarge
-        - c5d.18xlarge
-        - c5d.24xlarge
-        - c5d.metal
-        - c5n.large
-        - c5n.xlarge
-        - c5n.2xlarge
-        - c5n.4xlarge
-        - c5n.9xlarge
-        - c5n.18xlarge
-        - cc2.8xlarge
-        - cr1.8xlarge
-        - d2.xlarge
-        - d2.2xlarge
-        - d2.4xlarge
-        - d2.8xlarge
-        - f1.2xlarge
-        - f1.4xlarge
-        - f1.16xlarge
-        - g2.2xlarge
-        - g2.8xlarge
-        - g3s.xlarge
-        - g3.4xlarge
-        - g3.8xlarge
-        - g3.16xlarge
-        - h1.2xlarge
-        - h1.4xlarge
-        - h1.8xlarge
-        - h1.16xlarge
-        - hs1.8xlarge
-        - i2.xlarge
-        - i2.2xlarge
-        - i2.4xlarge
-        - i2.8xlarge
-        - i3.large
-        - i3.xlarge
-        - i3.2xlarge
-        - i3.4xlarge
-        - i3.8xlarge
-        - i3.16xlarge
-        - i3.metal
-        - i3en.large
-        - i3en.xlarge
-        - i3en.2xlarge
-        - i3en.3xlarge
-        - i3en.6xlarge
-        - i3en.12xlarge
-        - i3en.24xlarge
-        - inf1.xlarge
-        - inf1.2xlarge
-        - inf1.6xlarge
-        - inf1.24xlarge
-        - m1.small
-        - m1.medium
-        - m1.large
-        - m1.xlarge
-        - m2.xlarge
-        - m2.2xlarge
-        - m2.4xlarge
-        - m3.medium
-        - m3.large
-        - m3.xlarge
-        - m3.2xlarge
-        - m4.large
-        - m4.xlarge
-        - m4.2xlarge
-        - m4.4xlarge
-        - m4.10xlarge
-        - m4.16xlarge
-        - m5.large
-        - m5.xlarge
-        - m5.2xlarge
-        - m5.4xlarge
-        - m5.8xlarge
-        - m5.12xlarge
-        - m5.16xlarge
-        - m5.24xlarge
-        - m5.metal
-        - m5a.large
-        - m5a.xlarge
-        - m5a.2xlarge
-        - m5a.4xlarge
-        - m5a.8xlarge
-        - m5a.12xlarge
-        - m5a.16xlarge
-        - m5a.24xlarge
-        - m5ad.large
-        - m5ad.xlarge
-        - m5ad.2xlarge
-        - m5ad.4xlarge
-        - m5ad.12xlarge
-        - m5ad.24xlarge
-        - m5d.large
-        - m5d.xlarge
-        - m5d.2xlarge
-        - m5d.4xlarge
-        - m5d.8xlarge
-        - m5d.12xlarge
-        - m5d.16xlarge
-        - m5d.24xlarge
-        - m5d.metal
-        - m5dn.large
-        - m5dn.xlarge
-        - m5dn.2xlarge
-        - m5dn.4xlarge
-        - m5dn.8xlarge
-        - m5dn.12xlarge
-        - m5dn.16xlarge
-        - m5dn.24xlarge
-        - m5n.large
-        - m5n.xlarge
-        - m5n.2xlarge
-        - m5n.4xlarge
-        - m5n.8xlarge
-        - m5n.12xlarge
-        - m5n.16xlarge
-        - m5n.24xlarge
-        - p2.xlarge
-        - p2.8xlarge
-        - p2.16xlarge
-        - p3.2xlarge
-        - p3.8xlarge
-        - p3.16xlarge
-        - p3dn.24xlarge
-        - g4dn.xlarge
-        - g4dn.2xlarge
-        - g4dn.4xlarge
-        - g4dn.8xlarge
-        - g4dn.12xlarge
-        - g4dn.16xlarge
-        - g4dn.metal
-        - r3.large
-        - r3.xlarge
-        - r3.2xlarge
-        - r3.4xlarge
-        - r3.8xlarge
-        - r4.large
-        - r4.xlarge
-        - r4.2xlarge
-        - r4.4xlarge
-        - r4.8xlarge
-        - r4.16xlarge
-        - r5.large
-        - r5.xlarge
-        - r5.2xlarge
-        - r5.4xlarge
-        - r5.8xlarge
-        - r5.12xlarge
-        - r5.16xlarge
-        - r5.24xlarge
-        - r5.metal
-        - r5a.large
-        - r5a.xlarge
-        - r5a.2xlarge
-        - r5a.4xlarge
-        - r5a.8xlarge
-        - r5a.12xlarge
-        - r5a.16xlarge
-        - r5a.24xlarge
-        - r5ad.large
-        - r5ad.xlarge
-        - r5ad.2xlarge
-        - r5ad.4xlarge
-        - r5ad.12xlarge
-        - r5ad.24xlarge
-        - r5d.large
-        - r5d.xlarge
-        - r5d.2xlarge
-        - r5d.4xlarge
-        - r5d.8xlarge
-        - r5d.12xlarge
-        - r5d.16xlarge
-        - r5d.24xlarge
-        - r5d.metal
-        - r5dn.large
-        - r5dn.xlarge
-        - r5dn.2xlarge
-        - r5dn.4xlarge
-        - r5dn.8xlarge
-        - r5dn.12xlarge
-        - r5dn.16xlarge
-        - r5dn.24xlarge
-        - r5n.large
-        - r5n.xlarge
-        - r5n.2xlarge
-        - r5n.4xlarge
-        - r5n.8xlarge
-        - r5n.12xlarge
-        - r5n.16xlarge
-        - r5n.24xlarge
-        - t1.micro
-        - t2.nano
-        - t2.micro
-        - t2.small
-        - t2.medium
-        - t2.large
-        - t2.xlarge
-        - t2.2xlarge
-        - t3.nano
-        - t3.micro
-        - t3.small
-        - t3.medium
-        - t3.large
-        - t3.xlarge
-        - t3.2xlarge
-        - t3a.nano
-        - t3a.micro
-        - t3a.small
-        - t3a.medium
-        - t3a.large
-        - t3a.xlarge
-        - t3a.2xlarge
-        - u-6tb1.metal
-        - u-9tb1.metal
-        - u-12tb1.metal
-        - x1.16xlarge
-        - x1.32xlarge
-        - x1e.xlarge
-        - x1e.2xlarge
-        - x1e.4xlarge
-        - x1e.8xlarge
-        - x1e.16xlarge
-        - x1e.32xlarge
-        - z1d.large
-        - z1d.xlarge
-        - z1d.2xlarge
-        - z1d.3xlarge
-        - z1d.6xlarge
-        - z1d.12xlarge
-        - z1d.metal
+      - a1.medium
+      - a1.large
+      - a1.xlarge
+      - a1.2xlarge
+      - a1.4xlarge
+      - c1.medium
+      - c1.xlarge
+      - c3.large
+      - c3.xlarge
+      - c3.2xlarge
+      - c3.4xlarge
+      - c3.8xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.12xlarge
+      - c5.18xlarge
+      - c5.24xlarge
+      - c5.metal
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.12xlarge
+      - c5d.18xlarge
+      - c5d.24xlarge
+      - c5d.metal
+      - c5n.large
+      - c5n.xlarge
+      - c5n.2xlarge
+      - c5n.4xlarge
+      - c5n.9xlarge
+      - c5n.18xlarge
+      - cc2.8xlarge
+      - cr1.8xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - f1.2xlarge
+      - f1.4xlarge
+      - f1.16xlarge
+      - g2.2xlarge
+      - g2.8xlarge
+      - g3s.xlarge
+      - g3.4xlarge
+      - g3.8xlarge
+      - g3.16xlarge
+      - h1.2xlarge
+      - h1.4xlarge
+      - h1.8xlarge
+      - h1.16xlarge
+      - hs1.8xlarge
+      - i2.xlarge
+      - i2.2xlarge
+      - i2.4xlarge
+      - i2.8xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+      - i3.metal
+      - i3en.large
+      - i3en.xlarge
+      - i3en.2xlarge
+      - i3en.3xlarge
+      - i3en.6xlarge
+      - i3en.12xlarge
+      - i3en.24xlarge
+      - inf1.xlarge
+      - inf1.2xlarge
+      - inf1.6xlarge
+      - inf1.24xlarge
+      - m1.small
+      - m1.medium
+      - m1.large
+      - m1.xlarge
+      - m2.xlarge
+      - m2.2xlarge
+      - m2.4xlarge
+      - m3.medium
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.8xlarge
+      - m5.12xlarge
+      - m5.16xlarge
+      - m5.24xlarge
+      - m5.metal
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.8xlarge
+      - m5a.12xlarge
+      - m5a.16xlarge
+      - m5a.24xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.8xlarge
+      - m5d.12xlarge
+      - m5d.16xlarge
+      - m5d.24xlarge
+      - m5d.metal
+      - m5dn.large
+      - m5dn.xlarge
+      - m5dn.2xlarge
+      - m5dn.4xlarge
+      - m5dn.8xlarge
+      - m5dn.12xlarge
+      - m5dn.16xlarge
+      - m5dn.24xlarge
+      - m5n.large
+      - m5n.xlarge
+      - m5n.2xlarge
+      - m5n.4xlarge
+      - m5n.8xlarge
+      - m5n.12xlarge
+      - m5n.16xlarge
+      - m5n.24xlarge
+      - p2.xlarge
+      - p2.8xlarge
+      - p2.16xlarge
+      - p3.2xlarge
+      - p3.8xlarge
+      - p3.16xlarge
+      - p3dn.24xlarge
+      - g4dn.xlarge
+      - g4dn.2xlarge
+      - g4dn.4xlarge
+      - g4dn.8xlarge
+      - g4dn.12xlarge
+      - g4dn.16xlarge
+      - g4dn.metal
+      - r3.large
+      - r3.xlarge
+      - r3.2xlarge
+      - r3.4xlarge
+      - r3.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r5.12xlarge
+      - r5.16xlarge
+      - r5.24xlarge
+      - r5.metal
+      - r5a.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5a.12xlarge
+      - r5a.16xlarge
+      - r5a.24xlarge
+      - r5ad.large
+      - r5ad.xlarge
+      - r5ad.2xlarge
+      - r5ad.4xlarge
+      - r5ad.12xlarge
+      - r5ad.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.8xlarge
+      - r5d.12xlarge
+      - r5d.16xlarge
+      - r5d.24xlarge
+      - r5d.metal
+      - r5dn.large
+      - r5dn.xlarge
+      - r5dn.2xlarge
+      - r5dn.4xlarge
+      - r5dn.8xlarge
+      - r5dn.12xlarge
+      - r5dn.16xlarge
+      - r5dn.24xlarge
+      - r5n.large
+      - r5n.xlarge
+      - r5n.2xlarge
+      - r5n.4xlarge
+      - r5n.8xlarge
+      - r5n.12xlarge
+      - r5n.16xlarge
+      - r5n.24xlarge
+      - t1.micro
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.nano
+      - t3a.micro
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+      - u-6tb1.metal
+      - u-9tb1.metal
+      - u-12tb1.metal
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.xlarge
+      - x1e.2xlarge
+      - x1e.4xlarge
+      - x1e.8xlarge
+      - x1e.16xlarge
+      - x1e.32xlarge
+      - z1d.large
+      - z1d.xlarge
+      - z1d.2xlarge
+      - z1d.3xlarge
+      - z1d.6xlarge
+      - z1d.12xlarge
+      - z1d.metal
     ConstraintDescription: must be a valid EC2 instance type
     Description: EC2 instance type for the node instances
 
   NodeSecurityGroup:
-      Type: "AWS::EC2::SecurityGroup::Id"
-      Description: Security group for all nodes in the cluster.
+    Type: "AWS::EC2::SecurityGroup::Id"
+    Description: Security group for all nodes in the cluster.
 
   NodeSpotPrice:
-      Type: String
-      Description: The spot price for this ASG
+    Type: String
+    Description: The spot price for this ASG
 
   NodeVolumeSize:
     Type: Number
@@ -378,12 +378,12 @@ Parameters:
     Description: The subnets where workers can be created.
 
   TerminationDetachEnabled:
-      Type: String
-      Description: Enable detachment from ASG at instance termination (true/false)
+    Type: String
+    Description: Enable detachment from ASG at instance termination (true/false)
 
   VpcId:
-      Type: "AWS::EC2::VPC::Id"
-      Description: The VPC of the worker instances
+    Type: "AWS::EC2::VPC::Id"
+    Description: The VPC of the worker instances
 
 Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
@@ -398,7 +398,7 @@ Resources:
     Properties:
       Path: /
       Roles:
-      - !Ref NodeInstanceRoleId
+        - !Ref NodeInstanceRoleId
 
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
@@ -451,69 +451,69 @@ Resources:
       ToPort: 22
 
   NodeLaunchTemplate:
-      Type: "AWS::EC2::LaunchTemplate"
-      Properties:
-          LaunchTemplateData:
-              BlockDeviceMappings:
-                  - DeviceName: /dev/xvda
-                    Ebs:
-                        DeleteOnTermination: true
-                        VolumeSize: !If [ NodeVolumeSizeAuto, !Ref "AWS::NoValue", !Ref NodeVolumeSize ]
-                        VolumeType: gp2
-              IamInstanceProfile:
-                  Arn: !GetAtt NodeInstanceProfile.Arn
-              ImageId: !Ref NodeImageId
-              InstanceMarketOptions:
-                !If
-                  - IsSpotInstance
-                  - MarketType: spot
-                    SpotOptions:
-                      MaxPrice: !Ref NodeSpotPrice
-                      SpotInstanceType: one-time
-                  - !Ref "AWS::NoValue"
-              InstanceType: !Ref NodeInstanceType
-              KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
-              SecurityGroupIds:
-                  !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
-              UserData: !Base64
-                  "Fn::Sub": |
-                      #!/bin/bash
-                      set -o xtrace
-                      /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
-                      /opt/aws/bin/cfn-signal --exit-code $? \
-                               --stack  ${AWS::StackName} \
-                               --resource NodeGroup  \
-                               --region ${AWS::Region}
-              MetadataOptions:
-                  HttpPutResponseHopLimit: 2
+    Type: "AWS::EC2::LaunchTemplate"
+    Properties:
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              VolumeSize: !If [ NodeVolumeSizeAuto, !Ref "AWS::NoValue", !Ref NodeVolumeSize ]
+              VolumeType: gp2
+        IamInstanceProfile:
+          Arn: !GetAtt NodeInstanceProfile.Arn
+        ImageId: !Ref NodeImageId
+        InstanceMarketOptions:
+          !If
+            - IsSpotInstance
+            - MarketType: spot
+              SpotOptions:
+                MaxPrice: !Ref NodeSpotPrice
+                SpotInstanceType: one-time
+            - !Ref "AWS::NoValue"
+        InstanceType: !Ref NodeInstanceType
+        KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
+        SecurityGroupIds:
+          !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
+        UserData: !Base64
+          "Fn::Sub": |
+            #!/bin/bash
+            set -o xtrace
+            /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
+            /opt/aws/bin/cfn-signal --exit-code $? \
+                     --stack  ${AWS::StackName} \
+                     --resource NodeGroup  \
+                     --region ${AWS::Region}
+        MetadataOptions:
+          HttpPutResponseHopLimit: 2
 
   NodeGroup:
-      Type: "AWS::AutoScaling::AutoScalingGroup"
-      Properties:
-          DesiredCapacity: !Ref NodeAutoScalingInitSize
-          LaunchTemplate:
-              LaunchTemplateId: !Ref NodeLaunchTemplate
-              Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
-          MaxSize: !Ref NodeAutoScalingGroupMaxSize
-          MinSize: !Ref NodeAutoScalingGroupMinSize
-          Tags:
-              - Key: Name
-                PropagateAtLaunch: true
-                Value: !Sub ${ClusterName}-${NodeGroupName}-Node
-              - Key: !Sub kubernetes.io/cluster/${ClusterName}
-                PropagateAtLaunch: true
-                Value: owned
-              - Key: !If [ AutoscalerEnabled, k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/disabled ]
-                PropagateAtLaunch: false
-                Value: true
-              - Key: "bzc:detach-asg-instance-on-termination"
-                PropagateAtLaunch: false
-                Value: !Sub ${TerminationDetachEnabled}
-          VPCZoneIdentifier: !Ref Subnets
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      DesiredCapacity: !Ref NodeAutoScalingInitSize
+      LaunchTemplate:
+        LaunchTemplateId: !Ref NodeLaunchTemplate
+        Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
+      MaxSize: !Ref NodeAutoScalingGroupMaxSize
+      MinSize: !Ref NodeAutoScalingGroupMinSize
+      Tags:
+        - Key: Name
+          PropagateAtLaunch: true
+          Value: !Sub ${ClusterName}-${NodeGroupName}-Node
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          PropagateAtLaunch: true
+          Value: owned
+        - Key: !If [ AutoscalerEnabled, k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/disabled ]
+          PropagateAtLaunch: false
+          Value: true
+        - Key: "bzc:detach-asg-instance-on-termination"
+          PropagateAtLaunch: false
+          Value: !Sub ${TerminationDetachEnabled}
+      VPCZoneIdentifier: !Ref Subnets
 
-      {{- if .UpdatePolicyEnabled }}
-      UpdatePolicy:
-          AutoScalingRollingUpdate:
-              MaxBatchSize: !Ref NodeAutoScalingGroupMaxBatchSize
-              PauseTime: PT5M
-      {{- end}}
+    {{- if .UpdatePolicyEnabled }}
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: !Ref NodeAutoScalingGroupMaxBatchSize
+        PauseTime: PT5M
+    {{- end}}

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -39,6 +39,10 @@ Parameters:
     Default: ""
     Type: String
 
+  ClusterAutoscalerEnabled:
+      Description: Enable Cluster Autoscaler (true/false)
+      Type: String
+
   ClusterControlPlaneSecurityGroup:
       Description: The security group of the cluster control plane.
       Type: "AWS::EC2::SecurityGroup::Id"
@@ -47,29 +51,35 @@ Parameters:
       Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
       Type: String
 
+  CustomNodeSecurityGroups:
+      Description: Comma separated list of security groups for all nodes in the pool.
+      Type: String
+      Default: ""
+
   KeyName:
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: String
-
-  NodeAutoScalingInitSize:
-      Type: Number
-      Description: The initial size of Node Group ASG.
-      Default: 1
 
   NodeAutoScalingGroupMaxBatchSize:
       Type: Number
       Description: Minimum size of Node Group ASG.
       Default: 2
 
+  NodeAutoScalingGroupMaxSize:
+      Type: Number
+      Description: Maximum size of Node Group ASG.
+      Default: 3
+
   NodeAutoScalingGroupMinSize:
       Type: Number
       Description: Minimum size of Node Group ASG.
       Default: 1
 
-  NodeAutoScalingGroupMaxSize:
+  NodeAutoScalingInitSize:
       Type: Number
-      Description: Maximum size of Node Group ASG.
-      Default: 3
+      Description: The initial size of Node Group ASG.
+      Default: 1
+
   NodeGroupName:
       Description: Unique identifier for the Node Group.
       Type: String
@@ -77,6 +87,10 @@ Parameters:
   NodeImageId:
       Type: String
       Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+
+  NodeInstanceRoleId:
+      Description: The role for node IAM profile
+      Type: String
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances
@@ -346,6 +360,14 @@ Parameters:
         - z1d.metal
     ConstraintDescription: must be a valid EC2 instance type
 
+  NodeSecurityGroup:
+      Description: Security group for all nodes in the cluster.
+      Type: "AWS::EC2::SecurityGroup::Id"
+
+  NodeSpotPrice:
+      Type: String
+      Description: The spot price for this ASG
+
   NodeVolumeSize:
     Type: Number
     Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
@@ -355,34 +377,13 @@ Parameters:
     Description: The subnets where workers can be created.
     Type: "List<AWS::EC2::Subnet::Id>"
 
-  VpcId:
-      Description: The VPC of the worker instances
-      Type: "AWS::EC2::VPC::Id"
-
-  ClusterAutoscalerEnabled:
-      Description: Enable Cluster Autoscaler (true/false)
-      Type: String
-
-  NodeInstanceRoleId:
-      Description: The role for node IAM profile
-      Type: String
-
-  NodeSecurityGroup:
-      Description: Security group for all nodes in the cluster.
-      Type: "AWS::EC2::SecurityGroup::Id"
-
-  CustomNodeSecurityGroups:
-      Description: Comma separated list of security groups for all nodes in the pool.
-      Type: String
-      Default: ""
-
-  NodeSpotPrice:
-      Type: String
-      Description: The spot price for this ASG
-
   TerminationDetachEnabled:
       Description: Enable detachment from ASG at instance termination (true/false)
       Type: String
+
+  VpcId:
+      Description: The VPC of the worker instances
+      Type: "AWS::EC2::VPC::Id"
 
 Conditions:
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
@@ -409,15 +410,15 @@ Resources:
       FromPort: 0
       ToPort: 65535
 
-  NodeSecurityGroupFromControlPlaneIngress:
+  ClusterControlPlaneSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
-      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
-      GroupId: !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: "-1"
-      FromPort: 0
-      ToPort: 65535
+      Description: Allow pods to communicate with the cluster API Server
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
 
   ControlPlaneEgressToNodeSecurityGroup:
     Type: "AWS::EC2::SecurityGroupEgress"
@@ -429,15 +430,15 @@ Resources:
       FromPort: 0
       ToPort: 65535
 
-  ClusterControlPlaneSecurityGroupIngress:
+  NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
-      Description: Allow pods to communicate with the cluster API Server
-      GroupId: !Ref ClusterControlPlaneSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: tcp
-      ToPort: 443
-      FromPort: 443
+      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: "-1"
+      FromPort: 0
+      ToPort: 65535
 
   NodeSecurityGroupSsh:
     Type: "AWS::EC2::SecurityGroupIngress"

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -49,7 +49,7 @@ Parameters:
 
   ClusterName:
     Type: String
-    Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
+    Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
 
   CustomNodeSecurityGroups:
     Type: String
@@ -68,7 +68,7 @@ Parameters:
   NodeAutoScalingGroupMaxSize:
     Type: Number
     Default: 3
-    Description: Maximum size of Node Group ASG.
+    Description: Maximum size of Node Group ASG. Set to at least 1 greater than NodeAutoScalingGroupDesiredCapacity.
 
   NodeAutoScalingGroupMinSize:
     Type: Number
@@ -86,7 +86,7 @@ Parameters:
 
   NodeImageId:
     Type: String
-    Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+    Description: (Optional) Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
 
   NodeInstanceRoleId:
     Type: String
@@ -357,7 +357,7 @@ Parameters:
       - z1d.6xlarge
       - z1d.12xlarge
       - z1d.metal
-    ConstraintDescription: must be a valid EC2 instance type
+    ConstraintDescription: Must be a valid EC2 instance type
     Description: EC2 instance type for the node instances
 
   NodeSecurityGroup:
@@ -371,7 +371,7 @@ Parameters:
   NodeVolumeSize:
     Type: Number
     Default: 0
-    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
+    Description: Node volume size
 
   Subnets:
     Type: "List<AWS::EC2::Subnet::Id>"

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -21,7 +21,7 @@ Metadata:
           - NodeAutoScalingGroupMaxSize
           - NodeAutoScalingInitSize
           - NodeInstanceType
-          - NodeImageIdSSMParam
+          # - NodeImageIdSSMParam
           - NodeImageId
           - NodeSpotPrice
           - NodeVolumeSize
@@ -87,6 +87,11 @@ Parameters:
   NodeImageId:
     Type: String
     Description: (Optional) Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+
+  # NodeImageIdSSMParam:
+  #   Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+  #   Default: /aws/service/eks/optimized-ami/1.17/amazon-linux-2/recommended/image_id
+  #   Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances. Change this value to match the version of Kubernetes you are using.
 
   NodeInstanceRoleId:
     Type: String
@@ -388,6 +393,12 @@ Parameters:
 Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
+
+  HasNodeImageId: !Not
+    - "Fn::Equals":
+        - !Ref NodeImageId
+        - ""
+
   IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   NoCustomNodeSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroups, "" ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
@@ -462,7 +473,7 @@ Resources:
               VolumeType: gp2
         IamInstanceProfile:
           Arn: !GetAtt NodeInstanceProfile.Arn
-        ImageId: !Ref NodeImageId
+        ImageId: !Ref NodeImageId # Note: deliberately not allowing fallback to NodeImageIdSSMParam.
         InstanceMarketOptions:
           !If
             - IsSpotInstance

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -63,7 +63,7 @@ Parameters:
   NodeAutoScalingGroupMaxBatchSize:
     Type: Number
     Default: 2
-    Description: Minimum size of Node Group ASG.
+    Description: Maximum number of nodes to be updated at once during a rolling update.
 
   NodeAutoScalingGroupMaxSize:
     Type: Number

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -18,8 +18,9 @@ Metadata:
         Parameters:
           - NodeGroupName
           - NodeAutoScalingGroupMinSize
+          # - NodeAutoScalingGroupDesiredCapacity
           - NodeAutoScalingGroupMaxSize
-          - NodeAutoScalingInitSize
+          - NodeAutoScalingInitSize # Note: in place of NodeAutoScalingGroupDesiredCapacity for backward compatibility.
           - NodeInstanceType
           # - NodeImageIdSSMParam
           - NodeImageId
@@ -60,6 +61,11 @@ Parameters:
     Type: String
     Description: The EC2 Key Pair to allow SSH access to the instances
 
+  # NodeAutoScalingGroupDesiredCapacity:
+  #   Type: Number
+  #   Default: 1
+  #   Description: Desired capacity of Node Group ASG.
+
   NodeAutoScalingGroupMaxBatchSize:
     Type: Number
     Default: 2
@@ -78,7 +84,7 @@ Parameters:
   NodeAutoScalingInitSize:
     Type: Number
     Default: 1
-    Description: The initial size of Node Group ASG.
+    Description: (In place of NodeAutoScalingGroupDesiredCapacity) The initial size of Node Group ASG.
 
   NodeGroupName:
     Type: String

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -20,11 +20,11 @@ Metadata:
           - NodeAutoScalingGroupMinSize
           - NodeAutoScalingGroupMaxSize
           - NodeAutoScalingInitSize
-          - NodeVolumeSize
-          - NodeSpotPrice
           - NodeInstanceType
           - NodeImageIdSSMParam
           - NodeImageId
+          - NodeSpotPrice
+          - NodeVolumeSize
           - KeyName
           - BootstrapArguments
       - Label:
@@ -35,65 +35,64 @@ Metadata:
 
 Parameters:
   BootstrapArguments:
-    Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
-    Default: ""
     Type: String
+    Default: ""
+    Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
 
   ClusterAutoscalerEnabled:
-      Description: Enable Cluster Autoscaler (true/false)
       Type: String
+      Description: Enable Cluster Autoscaler (true/false)
 
   ClusterControlPlaneSecurityGroup:
-      Description: The security group of the cluster control plane.
       Type: "AWS::EC2::SecurityGroup::Id"
+      Description: The security group of the cluster control plane.
 
   ClusterName:
-      Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
       Type: String
+      Description: The cluster name provided when the cluster was created.  If it is incorrect, nodes will not be able to join the cluster.
 
   CustomNodeSecurityGroups:
-      Description: Comma separated list of security groups for all nodes in the pool.
       Type: String
       Default: ""
+      Description: Comma separated list of security groups for all nodes in the pool.
 
   KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instances
     Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances
 
   NodeAutoScalingGroupMaxBatchSize:
       Type: Number
-      Description: Minimum size of Node Group ASG.
       Default: 2
+      Description: Minimum size of Node Group ASG.
 
   NodeAutoScalingGroupMaxSize:
       Type: Number
-      Description: Maximum size of Node Group ASG.
       Default: 3
+      Description: Maximum size of Node Group ASG.
 
   NodeAutoScalingGroupMinSize:
       Type: Number
-      Description: Minimum size of Node Group ASG.
       Default: 1
+      Description: Minimum size of Node Group ASG.
 
   NodeAutoScalingInitSize:
       Type: Number
-      Description: The initial size of Node Group ASG.
       Default: 1
+      Description: The initial size of Node Group ASG.
 
   NodeGroupName:
-      Description: Unique identifier for the Node Group.
       Type: String
+      Description: Unique identifier for the Node Group.
 
   NodeImageId:
       Type: String
       Description: Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
 
   NodeInstanceRoleId:
-      Description: The role for node IAM profile
       Type: String
+      Description: The role for node IAM profile
 
   NodeInstanceType:
-    Description: EC2 instance type for the node instances
     Type: String
     Default: t2.medium
     AllowedValues:
@@ -359,10 +358,11 @@ Parameters:
         - z1d.12xlarge
         - z1d.metal
     ConstraintDescription: must be a valid EC2 instance type
+    Description: EC2 instance type for the node instances
 
   NodeSecurityGroup:
-      Description: Security group for all nodes in the cluster.
       Type: "AWS::EC2::SecurityGroup::Id"
+      Description: Security group for all nodes in the cluster.
 
   NodeSpotPrice:
       Type: String
@@ -370,27 +370,27 @@ Parameters:
 
   NodeVolumeSize:
     Type: Number
-    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
     Default: 0
+    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
 
   Subnets:
-    Description: The subnets where workers can be created.
     Type: "List<AWS::EC2::Subnet::Id>"
+    Description: The subnets where workers can be created.
 
   TerminationDetachEnabled:
-      Description: Enable detachment from ASG at instance termination (true/false)
       Type: String
+      Description: Enable detachment from ASG at instance termination (true/false)
 
   VpcId:
-      Description: The VPC of the worker instances
       Type: "AWS::EC2::VPC::Id"
+      Description: The VPC of the worker instances
 
 Conditions:
-  IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
-  NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
+  IsSpotInstance: !Not [ !Equals [ !Ref NodeSpotPrice, "" ] ]
   NoCustomNodeSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroups, "" ]
+  NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
 
 Resources:
   NodeInstanceProfile:
@@ -404,51 +404,51 @@ Resources:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow node to communicate with each other
-      GroupId: !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: "-1"
       FromPort: 0
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
       ToPort: 65535
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow pods to communicate with the cluster API Server
-      GroupId: !Ref ClusterControlPlaneSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: tcp
-      ToPort: 443
       FromPort: 443
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort: 443
 
   ControlPlaneEgressToNodeSecurityGroup:
     Type: "AWS::EC2::SecurityGroupEgress"
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
-      GroupId: !Ref ClusterControlPlaneSecurityGroup
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
-      IpProtocol: "-1"
       FromPort: 0
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: "-1"
       ToPort: 65535
 
   NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
-      GroupId: !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
-      IpProtocol: "-1"
       FromPort: 0
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
       ToPort: 65535
 
   NodeSecurityGroupSsh:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
-      Description: Allow SSH access to node
-      GroupId: !Ref NodeSecurityGroup
       CidrIp: "0.0.0.0/0"
+      Description: Allow SSH access to node
+      FromPort: 22
+      GroupId: !Ref NodeSecurityGroup
       IpProtocol: tcp
       ToPort: 22
-      FromPort: 22
 
   NodeLaunchTemplate:
       Type: "AWS::EC2::LaunchTemplate"
@@ -462,6 +462,7 @@ Resources:
                         VolumeType: gp2
               IamInstanceProfile:
                   Arn: !GetAtt NodeInstanceProfile.Arn
+              ImageId: !Ref NodeImageId
               InstanceMarketOptions:
                 !If
                   - IsSpotInstance
@@ -470,7 +471,6 @@ Resources:
                       MaxPrice: !Ref NodeSpotPrice
                       SpotInstanceType: one-time
                   - !Ref "AWS::NoValue"
-              ImageId: !Ref NodeImageId
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:
@@ -494,22 +494,22 @@ Resources:
           LaunchTemplate:
               LaunchTemplateId: !Ref NodeLaunchTemplate
               Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
-          MinSize: !Ref NodeAutoScalingGroupMinSize
           MaxSize: !Ref NodeAutoScalingGroupMaxSize
-          VPCZoneIdentifier: !Ref Subnets
+          MinSize: !Ref NodeAutoScalingGroupMinSize
           Tags:
               - Key: Name
+                PropagateAtLaunch: true
                 Value: !Sub ${ClusterName}-${NodeGroupName}-Node
-                PropagateAtLaunch: true
               - Key: !Sub kubernetes.io/cluster/${ClusterName}
-                Value: owned
                 PropagateAtLaunch: true
+                Value: owned
               - Key: !If [ AutoscalerEnabled, k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/disabled ]
+                PropagateAtLaunch: false
                 Value: true
-                PropagateAtLaunch: false
               - Key: "bzc:detach-asg-instance-on-termination"
-                Value: !Sub ${TerminationDetachEnabled}
                 PropagateAtLaunch: false
+                Value: !Sub ${TerminationDetachEnabled}
+          VPCZoneIdentifier: !Ref Subnets
 
       {{- if .UpdatePolicyEnabled }}
       UpdatePolicy:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3257 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated the EKS CloudFormation node pool template to the latest available version.
Due to the number of changes, see the change list at the additional notes.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To keep the corresponding CloudFormation template up to date with the latest official recommended one.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The changes are well separated in their dedicated commits so we can easily revert any of those if we wish to do so for any reason. The PR is advised to be reviewed by commit because the changes had been introduced iteratively and it's much easier to follow them that way then comparing the original state to the result.

Detailed change list:
1. Synced the formatting of the template to the source one to minimize the number of changes to merge starting from the next update. (quotation marks, line breaks, high level attribute ordering, low level attribute ordering, indentation)
2. Synced parameter descriptions to the source descriptions where one was available.
3. Corrected the description of `NodeAutoScalingGroupMaxBatchSize`.
4. Synced parameters and resources available in the source, commented out unused resources (no actual changes to existing resources, no new resources, some new, so far not used parameters).
5. Synced parameter types to the source (typedefed string type).
6. Synced default values to the source (the ones changed are not used, because all values are explicitly provided on creation in the current implementation).
7. According to the source, add the unused `NodeAutoScalingGroupDesiredCapacity`  parameter. Previously such attribute was not present in the official template describing the size of the autoscaling group at the moment (neither current/actual, nor desired).
8. According to the source, added a new bool parameter `DisableIMDSv1` to be able to disable the version 1 instance metadata service. Currently it is not in use, but the corresponding `NodeLaunchTemplate` is ready to use it in case we would like to turn it on.
9. Synced the node instance types to the ones available in the source (some new instance types are available).
10.  According to the source, added a new output to the stack template outputting the template's `NodeGroup` (other outputs are commented out, but this seemed to be a relevant result as the node group is created by the stack initialized from this template).
11. According to the source added the `MinInstancesInService` attribute to the `NodeGroup`'s `UpdatePolicy` and introduced a corresponding optional parameter `NodeAutoScalingGroupMinInstancesInService` (defaults to 0) which controls the minimum number of serving (functional) nodes at any moment during a node autoscaling group update. The implementation has been updated to set this to `updateOptions.MaxSurge`. Also created #3299 to revise the custom surge logic implementation we have in relation to this change. I deliberately wanted to separate the template update from the potential implementation changes branching off of the possibilities added by the update. I think this way it is easier to keep the integrity and functionality intact.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Manual test.
- ~Enterprise PR updating the `UpdateNodeGroupActivity` input parameters and usage.~
- ~Making sure the OSS version is released together with the enterprise version to avoid any potential activity input type mismatch (should be able to handle non-existing key and parse it into zero value, but it's best to make sure). (Is there any alternative than releasing a version from both after both PRs are merged?)~
