### PR TITLE
Add custom security group to EKS node pool template (#3294)

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -12,6 +12,7 @@ Metadata:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
           - NodeSecurityGroup
+          - CustomSecurityGroup
       -
         Label:
           default: "Worker Node Configuration"
@@ -374,6 +375,11 @@ Parameters:
       Description: Security group for all nodes in the cluster.
       Type: AWS::EC2::SecurityGroup::Id
 
+  CustomSecurityGroup:
+      Description: Cusotm security group for all nodes in the cluster.
+      Type: String
+      Default: "NONE"
+
   NodeSpotPrice:
       Type: String
       Description: The spot price for this ASG
@@ -387,6 +393,7 @@ Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
+  HasCustomSecurityGroup: !Not [ !Equals [ !Ref CustomSecurityGroup, "NONE" ] ]
 
 Resources:
   NodeInstanceProfile:
@@ -471,6 +478,7 @@ Resources:
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:
+                  - !If [ HasCustomSecurityGroup, !Ref CustomSecurityGroup, !Ref 'AWS::NoValue' ]
                   - Ref: NodeSecurityGroup
               UserData: !Base64
                   "Fn::Sub": |


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3294 
| License         | Apache 2.0


### What's in this PR?
Add new param `CustomSecurityGroup` to EKS node pool CF template. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
