### PR TITLE
Extend pke/aws nodepool update request with volume size and imageId

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19821,6 +19821,13 @@ components:
             the initial node count in the node pool.
           example: 1
           type: integer
+        image:
+          example: ami-06d1667f
+          type: string
+        volumeSize:
+          description: Size of the EBS volume in GBs of the nodes in the pool.
+          example: 50
+          type: integer
         subnets:
           description: The subnet to create the node pool into. If this field is omitted
             than the subnet from the cluster level network configuration is used.

--- a/.gen/pipeline/pipeline/model_update_node_pools_pke.go
+++ b/.gen/pipeline/pipeline/model_update_node_pools_pke.go
@@ -30,6 +30,11 @@ type UpdateNodePoolsPke struct {
 	// If cluster autoscaler is not enabled this specifies the desired node count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the node pool.
 	Count int32 `json:"count,omitempty"`
 
+	Image string `json:"image,omitempty"`
+
+	// Size of the EBS volume in GBs of the nodes in the pool.
+	VolumeSize int32 `json:"volumeSize,omitempty"`
+
 	// The subnet to create the node pool into. If this field is omitted than the subnet from the cluster level network configuration is used.
 	Subnets []string `json:"subnets,omitempty"`
 

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -5451,6 +5451,8 @@ components:
                         #         $ref: '#/components/schemas/CreateUpdateOKEProperties'
                         #     -
                         #         $ref: '#/components/schemas/UpdateACKProperties'
+                        #     -
+                        #         $ref: '#/components/schemas/UpdatePKEProperties'
                     example:
                         google:
                             master:
@@ -5611,6 +5613,13 @@ components:
                     type: integer
                     example: 1
                     description: If cluster autoscaler is not enabled this specifies the desired node count in the node pool. If cluster autoscaler is enabled this specifies the initial node count in the node pool.
+                image:
+                    type: string
+                    example: "ami-06d1667f"
+                volumeSize:
+                    description: Size of the EBS volume in GBs of the nodes in the pool.
+                    example: 50
+                    type: integer
                 subnets:
                     type: array
                     items:

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -57,6 +57,8 @@ type UpdateNodePool struct {
 	MinCount     int               `json:"minCount" yaml:"minCount"`
 	MaxCount     int               `json:"maxCount" yaml:"maxCount"`
 	Count        int               `json:"count" yaml:"count"`
+	Image        string            `json:"image" yaml:"image"`
+	VolumeSize   int               `json:"volumeSize" yaml:"volumeSize"`
 	Subnets      Subnets           `json:"subnets,omitempty" yaml:"subnets,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 }

--- a/src/cluster/ec2_pke.go
+++ b/src/cluster/ec2_pke.go
@@ -353,6 +353,8 @@ func createNodePoolsFromPKERequest(nodePools pke.UpdateNodePools) []pkeworkflow.
 			Count:        count,
 			Autoscaling:  nodePool.Autoscaling,
 			InstanceType: nodePool.InstanceType,
+			ImageID:      nodePool.Image,
+			VolumeSize:   nodePool.VolumeSize,
 			SpotPrice:    nodePool.SpotPrice,
 		}
 		for _, subnet := range nodePool.Subnets {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3102 #3103
| License         | Apache 2.0


### What's in this PR?
PKE/AWS update cluster request did not take and propagated any volume size and imageId from the request. 
The PR contains implementations to fix that issue.

### Checklist

- [ ] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] OpenAPI and Postman files updated (if needed)

