### PR TITLE
Add kube-fed to the list of platform helm repositories

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -425,6 +425,7 @@ dex:
 #        stable: "https://charts.helm.sh/stable"
 #        banzaicloud-stable: "https://kubernetes-charts.banzaicloud.com"
 #        loki: "https://grafana.github.io/loki/charts"
+#        kubefed-charts: "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts"
 
 #cloud:
 #    amazon:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,6 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::kubefed-charts", "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts")
 
 	// Cloud configuration
 	v.SetDefault("cloud::amazon::defaultRegion", "us-west-1")

--- a/internal/federation/deployment.go
+++ b/internal/federation/deployment.go
@@ -19,8 +19,6 @@ import (
 )
 
 type HelmService interface {
-	AddRepositoryIfNotExists(repository internalHelm.Repository) error
-
 	InstallOrUpgrade(
 		orgID uint,
 		c internalHelm.ClusterDataProvider,

--- a/internal/federation/reconcile_controller.go
+++ b/internal/federation/reconcile_controller.go
@@ -317,15 +317,7 @@ func (m *FederationReconciler) installFederationController(c cluster.CommonClust
 			fedControllerManager.Webhook.Repository
 	}
 
-	err := m.helmService.AddRepositoryIfNotExists(internalHelm.Repository{
-		Name: "kubefed-charts",
-		URL:  "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts",
-	})
-	if err != nil {
-		return errors.WrapIf(err, "failed to add kubefed-charts repo")
-	}
-
-	err = m.helmService.InstallOrUpgrade(
+	err := m.helmService.InstallOrUpgrade(
 		noOrgID,
 		c,
 		internalHelm.Release{

--- a/internal/helm/helmadapter/helm_service.go
+++ b/internal/helm/helmadapter/helm_service.go
@@ -251,32 +251,6 @@ func (h *helm3UnifiedReleaser) Delete(c helm.ClusterDataProvider, releaseName, n
 	return nil
 }
 
-func (h *helm3UnifiedReleaser) AddRepositoryIfNotExists(repository helm.Repository) error {
-	repos, err := h.helmService.ListRepositories(context.Background(), platformOrgID)
-	if err != nil {
-		return err
-	}
-	foundRepo := helm.Repository{}
-	for _, r := range repos {
-		if r.Name == repository.Name {
-			foundRepo = r
-			break
-		}
-	}
-
-	if (foundRepo == helm.Repository{}) {
-		// the repository is not added
-		return h.helmService.AddRepository(context.Background(), platformOrgID, repository)
-	}
-
-	if foundRepo.URL != repository.URL {
-		// the url is changed
-		return h.helmService.ModifyRepository(context.Background(), platformOrgID, repository)
-	}
-
-	return nil
-}
-
 func (h *helm3UnifiedReleaser) GetRelease(c helm.ClusterDataProvider, releaseName, namespace string) (helm.Release, error) {
 	return h.helmService.GetRelease(context.TODO(), platformOrgID, c.GetID(), releaseName, helm.Options{
 		Namespace: namespace,

--- a/internal/helm/integration_test.go
+++ b/internal/helm/integration_test.go
@@ -56,41 +56,12 @@ func TestIntegration(t *testing.T) {
 	// cluster setup and posthook style use cases
 	t.Run("helmInstall", testIntegrationInstall)
 
-	// covers the federation use case for adding a custom platform repository on the fly
-	t.Run("addPlatformRepository", testAddPlatformRepository)
-
 	// Env resolver
 	t.Run("platformEnvResolver", testPlatformEnvResolver)
 	t.Run("orgEnvResolver", testOrgEnvResolver)
 
 	// Releaser
 	t.Run("testReleaserHelm", testReleaserHelm)
-}
-
-func testAddPlatformRepository(t *testing.T) {
-	home := helmtesting.HelmHome(t)
-	db := helmtesting.SetupDatabase(t)
-	secretStore := helmtesting.SetupSecretStore()
-	_, clusterService := helmtesting.ClusterKubeConfig(t, clusterId)
-	config := helm.Config{
-		Home: home,
-		Repositories: map[string]string{
-			"stable": "https://charts.helm.sh/stable",
-		},
-	}
-
-	logger := common.NoopLogger{}
-	helmService, _ := cmd.CreateUnifiedHelmReleaser(config, db, secretStore, clusterService, helmadapter.NewOrgService(logger), logger)
-
-	for i := 0; i < 2; i++ {
-		err := helmService.AddRepositoryIfNotExists(helm.Repository{
-			Name: "kubefed",
-			URL:  "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts",
-		})
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-	}
 }
 
 func testIntegration(t *testing.T) {

--- a/internal/helm/service.go
+++ b/internal/helm/service.go
@@ -132,8 +132,6 @@ type UnifiedReleaser interface {
 	GetRelease(c ClusterDataProvider, releaseName, namespace string) (Release, error)
 
 	Delete(c ClusterDataProvider, releaseName, namespace string) error
-
-	AddRepositoryIfNotExists(repository Repository) error
 }
 
 // releaser collects and groups release related operations


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- kube-fed repository added as platform repository
- cleanup unecessary code (that added the above repository programatically)


### Why?
Platform repositories are not persisted; the above approach caused problems as it added the repo to the database (and no synchronisation logic is executed for platform repositories)  

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
