### PR TITLE
Ability to set multiple custom node security groups to EKS node pool CF template

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -375,10 +375,10 @@ Parameters:
       Description: Security group for all nodes in the cluster.
       Type: AWS::EC2::SecurityGroup::Id
 
-  CustomSecurityGroup:
-      Description: Cusotm security group for all nodes in the cluster.
+  CustomNodeSecurityGroupIds:
+      Description: Comma separated list of custom security groups for all nodes in the pool.
       Type: String
-      Default: "NONE"
+      Default: ""
 
   NodeSpotPrice:
       Type: String
@@ -393,7 +393,7 @@ Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
-  HasCustomSecurityGroup: !Not [ !Equals [ !Ref CustomSecurityGroup, "NONE" ] ]
+  NoCustomSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroupIds, "" ]
 
 Resources:
   NodeInstanceProfile:
@@ -478,8 +478,7 @@ Resources:
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:
-                  - !If [ HasCustomSecurityGroup, !Ref CustomSecurityGroup, !Ref 'AWS::NoValue' ]
-                  - Ref: NodeSecurityGroup
+                  !If [NoCustomSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroupIds ] ]  ] ]
               UserData: !Base64
                   "Fn::Sub": |
                       #!/bin/bash

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -375,8 +375,8 @@ Parameters:
       Description: Security group for all nodes in the cluster.
       Type: AWS::EC2::SecurityGroup::Id
 
-  CustomNodeSecurityGroupIds:
-      Description: Comma separated list of custom security groups for all nodes in the pool.
+  SecurityGroups:
+      Description: Comma separated list of security groups for all nodes in the pool.
       Type: String
       Default: ""
 
@@ -393,7 +393,7 @@ Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
-  NoCustomSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroupIds, "" ]
+  NoCustomSecurityGroups: !Equals [ !Ref SecurityGroups, "" ]
 
 Resources:
   NodeInstanceProfile:
@@ -478,7 +478,7 @@ Resources:
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:
-                  !If [NoCustomSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroupIds ] ]  ] ]
+                  !If [NoCustomSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref SecurityGroups ] ]  ] ]
               UserData: !Base64
                   "Fn::Sub": |
                       #!/bin/bash


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3313  
| License         | Apache 2.0


### What's in this PR?
Possibility  to send a list of comma separated list of custom node security groups in CustomNodeSecurityGroupIds paramter for EKS node pool template.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
