### PR TITLE
fix(EKS/CNPWF): fixed input field propagation

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
@@ -333,8 +333,9 @@ func (w CreateInfrastructureWorkflow) Execute(ctx workflow.Context, input Create
 	}
 
 	{ // Note: create node pools.
-		shouldStoreNodePool := false       // Note: stored at LegacyClusterAPI.CreateCluster request parsing.
-		shouldUpdateClusterStatus := false // Note: parent workflow handles status updates.
+		shouldCreateNodePoolLabelSet := false // Note: node pool label set operator is created and synced later.
+		shouldStoreNodePool := false          // Note: stored at LegacyClusterAPI.CreateCluster request parsing.
+		shouldUpdateClusterStatus := false    // Note: parent workflow handles status updates.
 
 		createNodePoolFutures := make([]workflow.Future, 0, len(input.NodePools))
 		createNodePoolErrors := make([]error, 0, len(input.NodePools))
@@ -379,6 +380,7 @@ func (w CreateInfrastructureWorkflow) Execute(ctx workflow.Context, input Create
 					input.CreatorUserID,
 					nodePool,
 					nodePoolSubnetIDs,
+					shouldCreateNodePoolLabelSet,
 					shouldStoreNodePool,
 					shouldUpdateClusterStatus,
 				))

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow.go
@@ -262,6 +262,7 @@ func createNodePool(
 	creatorUserID uint,
 	nodePool eks.NewNodePool,
 	nodePoolSubnetIDs []string,
+	shouldCreateNodePoolLabelSet bool,
 	shouldStoreNodePool bool,
 	shouldUpdateClusterStatus bool,
 ) error {
@@ -271,6 +272,7 @@ func createNodePool(
 		creatorUserID,
 		nodePool,
 		nodePoolSubnetIDs,
+		shouldCreateNodePoolLabelSet,
 		shouldStoreNodePool,
 		shouldUpdateClusterStatus,
 	).Get(ctx, nil)
@@ -285,15 +287,17 @@ func createNodePoolAsync(
 	creatorUserID uint,
 	nodePool eks.NewNodePool,
 	nodePoolSubnetIDs []string,
+	shouldCreateNodePoolLabelSet bool,
 	shouldStoreNodePool bool,
 	shouldUpdateClusterStatus bool,
 ) workflow.Future {
 	return workflow.ExecuteChildWorkflow(ctx, CreateNodePoolWorkflowName, CreateNodePoolWorkflowInput{
-		ClusterID:                 clusterID,
-		NodePool:                  nodePool,
-		NodePoolSubnetIDs:         nodePoolSubnetIDs,
-		ShouldStoreNodePool:       shouldStoreNodePool,
-		ShouldUpdateClusterStatus: shouldUpdateClusterStatus,
-		CreatorUserID:             creatorUserID,
+		ClusterID:                    clusterID,
+		NodePool:                     nodePool,
+		NodePoolSubnetIDs:            nodePoolSubnetIDs,
+		ShouldCreateNodePoolLabelSet: shouldCreateNodePoolLabelSet,
+		ShouldStoreNodePool:          shouldStoreNodePool,
+		ShouldUpdateClusterStatus:    shouldUpdateClusterStatus,
+		CreatorUserID:                creatorUserID,
 	})
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow_test.go
@@ -37,12 +37,13 @@ import (
 
 func TestCreateNodePool(t *testing.T) {
 	type inputType struct {
-		clusterID                 uint
-		creatorUserID             uint
-		nodePool                  eks.NewNodePool
-		nodePoolSubnetIDs         []string
-		shouldStoreNodePool       bool
-		shouldUpdateClusterStatus bool
+		clusterID                    uint
+		creatorUserID                uint
+		nodePool                     eks.NewNodePool
+		nodePoolSubnetIDs            []string
+		shouldCreateNodePoolLabelSet bool
+		shouldStoreNodePool          bool
+		shouldUpdateClusterStatus    bool
 	}
 
 	testCases := []struct {
@@ -54,24 +55,26 @@ func TestCreateNodePool(t *testing.T) {
 			caseDescription: "success",
 			expectedError:   nil,
 			input: inputType{
-				clusterID:                 1,
-				creatorUserID:             2,
-				nodePool:                  eks.NewNodePool{},
-				nodePoolSubnetIDs:         []string{},
-				shouldStoreNodePool:       true,
-				shouldUpdateClusterStatus: true,
+				clusterID:                    1,
+				creatorUserID:                2,
+				nodePool:                     eks.NewNodePool{},
+				nodePoolSubnetIDs:            []string{},
+				shouldCreateNodePoolLabelSet: true,
+				shouldStoreNodePool:          true,
+				shouldUpdateClusterStatus:    true,
 			},
 		},
 		{
 			caseDescription: "error",
 			expectedError:   errors.New("test error"),
 			input: inputType{
-				clusterID:                 1,
-				creatorUserID:             2,
-				nodePool:                  eks.NewNodePool{},
-				nodePoolSubnetIDs:         []string{},
-				shouldStoreNodePool:       true,
-				shouldUpdateClusterStatus: true,
+				clusterID:                    1,
+				creatorUserID:                2,
+				nodePool:                     eks.NewNodePool{},
+				nodePoolSubnetIDs:            []string{},
+				shouldCreateNodePoolLabelSet: true,
+				shouldStoreNodePool:          true,
+				shouldUpdateClusterStatus:    true,
 			},
 		},
 	}
@@ -103,6 +106,7 @@ func TestCreateNodePool(t *testing.T) {
 					testCase.input.creatorUserID,
 					testCase.input.nodePool,
 					testCase.input.nodePoolSubnetIDs,
+					testCase.input.shouldCreateNodePoolLabelSet,
 					testCase.input.shouldStoreNodePool,
 					testCase.input.shouldUpdateClusterStatus,
 				)
@@ -121,12 +125,13 @@ func TestCreateNodePool(t *testing.T) {
 
 func TestCreateNodePoolAsync(t *testing.T) {
 	type inputType struct {
-		clusterID                 uint
-		creatorUserID             uint
-		nodePool                  eks.NewNodePool
-		nodePoolSubnetIDs         []string
-		shouldStoreNodePool       bool
-		shouldUpdateClusterStatus bool
+		clusterID                    uint
+		creatorUserID                uint
+		nodePool                     eks.NewNodePool
+		nodePoolSubnetIDs            []string
+		shouldCreateNodePoolLabelSet bool
+		shouldStoreNodePool          bool
+		shouldUpdateClusterStatus    bool
 	}
 
 	testCases := []struct {
@@ -138,24 +143,26 @@ func TestCreateNodePoolAsync(t *testing.T) {
 			caseDescription: "success",
 			expectedError:   nil,
 			input: inputType{
-				clusterID:                 1,
-				creatorUserID:             2,
-				nodePool:                  eks.NewNodePool{},
-				nodePoolSubnetIDs:         []string{},
-				shouldStoreNodePool:       true,
-				shouldUpdateClusterStatus: true,
+				clusterID:                    1,
+				creatorUserID:                2,
+				nodePool:                     eks.NewNodePool{},
+				nodePoolSubnetIDs:            []string{},
+				shouldCreateNodePoolLabelSet: true,
+				shouldStoreNodePool:          true,
+				shouldUpdateClusterStatus:    true,
 			},
 		},
 		{
 			caseDescription: "error",
 			expectedError:   errors.New("test error"),
 			input: inputType{
-				clusterID:                 1,
-				creatorUserID:             2,
-				nodePool:                  eks.NewNodePool{},
-				nodePoolSubnetIDs:         []string{},
-				shouldStoreNodePool:       true,
-				shouldUpdateClusterStatus: true,
+				clusterID:                    1,
+				creatorUserID:                2,
+				nodePool:                     eks.NewNodePool{},
+				nodePoolSubnetIDs:            []string{},
+				shouldCreateNodePoolLabelSet: true,
+				shouldStoreNodePool:          true,
+				shouldUpdateClusterStatus:    true,
 			},
 		},
 	}
@@ -187,6 +194,7 @@ func TestCreateNodePoolAsync(t *testing.T) {
 					testCase.input.creatorUserID,
 					testCase.input.nodePool,
 					testCase.input.nodePoolSubnetIDs,
+					testCase.input.shouldCreateNodePoolLabelSet,
 					testCase.input.shouldStoreNodePool,
 					testCase.input.shouldUpdateClusterStatus,
 				)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added `shouldCreateNodePoolLabelSet` input field propagation to `EKS.CreateNodePoolWorkflow`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Missed an input field in a wrapper function in the `EKS.CreateNodePoolWorkflow` functions.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
