### PR TITLE
API: add custom node security group list to EKS nodepools (#3314)

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19339,6 +19339,15 @@ components:
           type: string
         subnet:
           $ref: '#/components/schemas/EKSSubnet'
+        securityGroups:
+          description: List of additional custom security groups for all nodes in
+            the pool.
+          example:
+          - sg-00000xxxx0000xxx1
+          - sg-00000xxxx0000xxx2
+          items:
+            type: string
+          type: array
       required:
       - instanceType
       - maxCount
@@ -23614,6 +23623,15 @@ components:
         subnetId:
           example: subnet-xxxxxxxxxxxxxx
           type: string
+        securityGroups:
+          description: List of additional custom security groups for all nodes in
+            the pool.
+          example:
+          - sg-00000xxxx0000xxx1
+          - sg-00000xxxx0000xxx2
+          items:
+            type: string
+          type: array
       required:
       - instanceType
     EksUpdateNodePoolRequest_allOf:
@@ -23641,6 +23659,15 @@ components:
             field is empty or 0 on-demand instances are used instead of spot instances.
           example: "0.2"
           type: string
+        securityGroups:
+          description: List of additional custom security groups for all nodes in
+            the pool.
+          example:
+          - sg-00000xxxx0000xxx1
+          - sg-00000xxxx0000xxx2
+          items:
+            type: string
+          type: array
         options:
           $ref: '#/components/schemas/BaseUpdateNodePoolOptions'
     PkeAwsUpdateNodePoolRequest_allOf:

--- a/.gen/pipeline/pipeline/model_eks_node_pool.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool.go
@@ -32,4 +32,7 @@ type EksNodePool struct {
 	Image string `json:"image,omitempty"`
 
 	Subnet EksSubnet `json:"subnet,omitempty"`
+
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
@@ -27,4 +27,7 @@ type EksNodePoolAllOf struct {
 	SpotPrice string `json:"spotPrice,omitempty"`
 
 	SubnetId string `json:"subnetId,omitempty"`
+
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
@@ -36,5 +36,8 @@ type EksUpdateNodePoolRequest struct {
 	// The upper limit price for the requested spot instance. If this field is empty or 0 on-demand instances are used instead of spot instances.
 	SpotPrice string `json:"spotPrice,omitempty"`
 
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
@@ -29,5 +29,8 @@ type EksUpdateNodePoolRequestAllOf struct {
 	// The upper limit price for the requested spot instance. If this field is empty or 0 on-demand instances are used instead of spot instances.
 	SpotPrice string `json:"spotPrice,omitempty"`
 
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_node_pool.go
+++ b/.gen/pipeline/pipeline/model_node_pool.go
@@ -36,4 +36,7 @@ type NodePool struct {
 	SpotPrice string `json:"spotPrice,omitempty"`
 
 	SubnetId string `json:"subnetId,omitempty"`
+
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_node_pool_summary.go
+++ b/.gen/pipeline/pipeline/model_node_pool_summary.go
@@ -38,6 +38,9 @@ type NodePoolSummary struct {
 
 	SubnetId string `json:"subnetId,omitempty"`
 
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	// Current status of the node pool.
 	Status string `json:"status,omitempty"`
 

--- a/.gen/pipeline/pipeline/model_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_update_node_pool_request.go
@@ -35,5 +35,8 @@ type UpdateNodePoolRequest struct {
 	// The upper limit price for the requested spot instance. If this field is empty or 0 on-demand instances are used instead of spot instances.
 	SpotPrice string `json:"spotPrice,omitempty"`
 
+	// List of additional custom security groups for all nodes in the pool.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4685,6 +4685,12 @@ components:
                         subnetId:
                             type: string
                             example: "subnet-xxxxxxxxxxxxxx"
+                        securityGroups:
+                            description: List of additional custom security groups for all nodes in the pool.
+                            type: array
+                            items:
+                                type: string
+                            example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
 
         UpdateNodePoolRequest:
             oneOf:
@@ -4778,6 +4784,12 @@ components:
                             description: The upper limit price for the requested spot instance. If this field is empty or 0 on-demand instances are used instead of spot instances.
                             type: string
                             example: "0.2"
+                        securityGroups:
+                            description: List of additional custom security groups for all nodes in the pool.
+                            type: array
+                            items:
+                                type: string
+                            example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
                         options:
                             $ref: '#/components/schemas/BaseUpdateNodePoolOptions'
 
@@ -4887,6 +4899,12 @@ components:
                     example: "ami-06d1667f"
                 subnet:
                     $ref: '#/components/schemas/EKSSubnet'
+                securityGroups:
+                    description: List of additional custom security groups for all nodes in the pool.
+                    type: array
+                    items:
+                        type: string
+                    example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
 
         CreateEKSProperties:
             type: object


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3314 
| License         | Apache 2.0


### What's in this PR?
Add 'securityGroups' field to EKS node pool properties (create, update) 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
