### PR TITLE
fix(template/EKS/NP): fixed parameter metadata

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -12,7 +12,7 @@ Metadata:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
           - NodeSecurityGroup
-          - CustomSecurityGroup
+          - SecurityGroups
       -
         Label:
           default: "Worker Node Configuration"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the EKS node pool CloudFormation template's metadata parameter listing regarding the newly introduced security groups.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because the parameter was renamed, but the template was not consolidated.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This doesn't affect the behavior of the template, it only affects the listing of the resulting parameters on the stack.

#3300 depends on this

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
