### PR TITLE
Renamed EKS node pool CloudFormation template's SecurityGroups to CustomNodeSecurityGroups

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -11,8 +11,8 @@ Metadata:
         Parameters:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
+          - CustomNodeSecurityGroups
           - NodeSecurityGroup
-          - SecurityGroups
       -
         Label:
           default: "Worker Node Configuration"
@@ -375,7 +375,7 @@ Parameters:
       Description: Security group for all nodes in the cluster.
       Type: AWS::EC2::SecurityGroup::Id
 
-  SecurityGroups:
+  CustomNodeSecurityGroups:
       Description: Comma separated list of security groups for all nodes in the pool.
       Type: String
       Default: ""
@@ -393,7 +393,7 @@ Conditions:
   AutoscalerEnabled:  !Equals [ !Ref ClusterAutoscalerEnabled, "true" ]
   HasKeyName: !Not [ !Equals [ !Ref KeyName, "" ] ]
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
-  NoCustomSecurityGroups: !Equals [ !Ref SecurityGroups, "" ]
+  NoCustomNodeSecurityGroups: !Equals [ !Ref CustomNodeSecurityGroups, "" ]
 
 Resources:
   NodeInstanceProfile:
@@ -478,7 +478,7 @@ Resources:
               InstanceType: !Ref NodeInstanceType
               KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
               SecurityGroupIds:
-                  !If [NoCustomSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref SecurityGroups ] ]  ] ]
+                  !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
               UserData: !Base64
                   "Fn::Sub": |
                       #!/bin/bash


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Renamed the EKS node pool CloudFormation template's `SecurityGroups` to `CustomNodeSecurityGroups`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

After multiple discussions with involved parties this is the preferable naming convention for now.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~ (currently this parameter is not used)
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
