### PR TITLE
Added user security group propagation to EKS.NodePoolAPI.CreateNodePool

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -74,8 +74,13 @@ type CreateAsgActivityInput struct {
 	VpcID               string
 	SecurityGroupID     string
 	NodeSecurityGroupID string
-	NodeInstanceRoleID  string
-	Tags                map[string]string
+
+	// SecurityGroups collects the user specified custom node security group
+	// IDs.
+	SecurityGroups []string
+
+	NodeInstanceRoleID string
+	Tags               map[string]string
 }
 
 // CreateAsgActivityOutput holds the output data of the CreateAsgActivityOutput
@@ -205,6 +210,10 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 		{
 			ParameterKey:   aws.String("NodeSecurityGroup"),
 			ParameterValue: aws.String(input.NodeSecurityGroupID),
+		},
+		{
+			ParameterKey:   aws.String("CustomNodeSecurityGroups"),
+			ParameterValue: aws.String(strings.Join(input.SecurityGroups, ",")),
 		},
 		{
 			ParameterKey:   aws.String("VpcId"),
@@ -366,6 +375,7 @@ func createASGAsync(
 		VpcID:               vpcConfig.VpcID,
 		SecurityGroupID:     vpcConfig.SecurityGroupID,
 		NodeSecurityGroupID: vpcConfig.NodeSecurityGroupID,
+		SecurityGroups:      nodePool.SecurityGroups,
 		NodeInstanceRoleID:  path.Base(eksCluster.NodeInstanceRoleId),
 		Tags:                eksCluster.Cluster.Tags,
 	}

--- a/internal/cluster/distribution/eks/node_pool.go
+++ b/internal/cluster/distribution/eks/node_pool.go
@@ -32,11 +32,12 @@ type NewNodePool struct {
 		MinSize int  `mapstructure:"minSize"`
 		MaxSize int  `mapstructure:"maxSize"`
 	} `mapstructure:"autoscaling"`
-	VolumeSize   int    `mapstructure:"volumeSize"`
-	InstanceType string `mapstructure:"instanceType"`
-	Image        string `mapstructure:"image"`
-	SpotPrice    string `mapstructure:"spotPrice"`
-	SubnetID     string `mapstructure:"subnetId"`
+	VolumeSize     int      `mapstructure:"volumeSize"`
+	InstanceType   string   `mapstructure:"instanceType"`
+	Image          string   `mapstructure:"image"`
+	SpotPrice      string   `mapstructure:"spotPrice"`
+	SecurityGroups []string `mapstructure:"securityGroups"`
+	SubnetID       string   `mapstructure:"subnetId"`
 }
 
 // Validate semantically validates the new node pool.

--- a/internal/cluster/distribution/eks/service_test.go
+++ b/internal/cluster/distribution/eks/service_test.go
@@ -510,7 +510,11 @@ func TestServiceCreateNodePool(t *testing.T) {
 					Name:         "node-pool-name",
 					InstanceType: "instance-type",
 					Size:         1,
-					SubnetID:     "subnet-id",
+					SecurityGroups: []string{
+						"security-group-1",
+						"security-group-2",
+					},
+					SubnetID: "subnet-id",
 				},
 			},
 		},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3329 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Propagated user provided custom node security groups from the API request to the node pool CloudFormation stack creation in `EKS.NodePoolAPI.CreateNodePool`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To add a feature to the `EKS.NodePoolAPI.CreateNodePool` endpoint of user specified node pool node security groups.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
