### PR TITLE
Added user security group propagation to EKS.ClusterAPI.CreateCluster

### DIFF
--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -122,6 +122,11 @@ type NodePool struct {
 	VolumeSize   int               `json:"volumeSize" yaml:"volumeSize"`
 	Image        string            `json:"image" yaml:"image"`
 	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	// SecurityGroups collects the user provided node security group IDs for the
+	// node pool.
+	SecurityGroups []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+
 	// Subnet for worker nodes of this node pool. If not specified than worker nodes
 	// are launched in the same subnet in one of the subnets from the list of subnets of the EKS cluster
 	Subnet *Subnet `json:"subnet,omitempty" yaml:"subnet,omitempty"`

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
@@ -226,11 +226,12 @@ func (c *EksClusterCreator) create(ctx context.Context, logger logrus.FieldLogge
 				MinSize: requestedNodePool.MinCount,
 				MaxSize: requestedNodePool.MaxCount,
 			},
-			VolumeSize:   requestedNodePool.VolumeSize,
-			InstanceType: requestedNodePool.InstanceType,
-			Image:        requestedNodePool.Image,
-			SpotPrice:    requestedNodePool.SpotPrice,
-			SubnetID:     subnetID,
+			VolumeSize:     requestedNodePool.VolumeSize,
+			InstanceType:   requestedNodePool.InstanceType,
+			Image:          requestedNodePool.Image,
+			SpotPrice:      requestedNodePool.SpotPrice,
+			SecurityGroups: requestedNodePool.SecurityGroups,
+			SubnetID:       subnetID,
 		}
 
 		nodePools = append(nodePools, nodePool)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
@@ -152,7 +152,11 @@ func (s *CreateInfraWorkflowTestSuite) Test_Successful_Create() {
 				InstanceType: "vm-type2-test",
 				Image:        "ami-test2",
 				SpotPrice:    "0.0",
-				SubnetID:     "subnet3",
+				SecurityGroups: []string{
+					"security-group-2",
+					"security-group-22",
+				},
+				SubnetID: "subnet3",
 			},
 		},
 		NodePoolSubnets: map[string][]Subnet{
@@ -353,7 +357,11 @@ func (s *CreateInfraWorkflowTestSuite) Test_Successful_Create() {
 			InstanceType: "vm-type2-test",
 			Image:        "ami-test2",
 			SpotPrice:    "0.0",
-			SubnetID:     "subnet3",
+			SecurityGroups: []string{
+				"security-group-2",
+				"security-group-22",
+			},
+			SubnetID: "subnet3",
 		},
 		NodePoolSubnetIDs: []string{
 			"subnet3",
@@ -452,7 +460,11 @@ func (s *CreateInfraWorkflowTestSuite) Test_Successful_Fail_To_Create_VPC() {
 				Image:        "ami-test2",
 				InstanceType: "vm-type2-test",
 				SpotPrice:    "0.0",
-				SubnetID:     "subnet3",
+				SecurityGroups: []string{
+					"security-group-2",
+					"security-group-22",
+				},
+				SubnetID: "subnet3",
 			},
 		},
 		NodePoolSubnets: map[string][]Subnet{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #3330 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Propagated user provided custom node security groups from the API request to the node pool CloudFormation stack creation in `EKS.ClusterAPI.CreateCluster`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To add a feature to the `EKS.ClusterAPI.CreateCluster` endpoint of user specified node pool node security groups.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Depends on #3332 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Wait for #3332 to be merged and rebase before merging.
