### PR TITLE
Added user security group propagation to EKS.ClusterAPI.UpdateCluster

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater.go
@@ -256,6 +256,7 @@ func newASGsFromRequestedUpdatedNodePools(
 			NodeVolumeSize:   nodePool.VolumeSize,
 			NodeImage:        nodePool.Image,
 			NodeInstanceType: nodePool.InstanceType,
+			SecurityGroups:   nodePool.SecurityGroups,
 			Labels:           nodePool.Labels,
 			Delete:           false,
 			Create:           false,
@@ -462,11 +463,12 @@ func newNodePoolsFromRequestedNewNodePools(
 				MinSize: nodePool.MinCount,
 				MaxSize: nodePool.MaxCount,
 			},
-			VolumeSize:   nodePool.VolumeSize,
-			InstanceType: nodePool.InstanceType,
-			Image:        nodePool.Image,
-			SpotPrice:    nodePool.SpotPrice,
-			SubnetID:     newNodePoolSubnetIDs[nodePoolName][0],
+			VolumeSize:     nodePool.VolumeSize,
+			InstanceType:   nodePool.InstanceType,
+			Image:          nodePool.Image,
+			SpotPrice:      nodePool.SpotPrice,
+			SecurityGroups: nodePool.SecurityGroups,
+			SubnetID:       newNodePoolSubnetIDs[nodePoolName][0],
 		})
 	}
 

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater_test.go
@@ -56,6 +56,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 						Labels: map[string]string{
 							"label-1": "value-1",
 						},
+						SecurityGroups: []string{
+							"security-group-1",
+							"security-group-11",
+						},
 						Subnet: &ekscluster.Subnet{
 							SubnetId:         "subnet-id-1",
 							Cidr:             "cidr-1",
@@ -74,6 +78,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 						Labels: map[string]string{
 							"label-2": "value-2",
 						},
+						SecurityGroups: []string{
+							"security-group-2",
+							"security-group-22",
+						},
 						Subnet: &ekscluster.Subnet{
 							SubnetId:         "subnet-id-2",
 							Cidr:             "cidr-2",
@@ -91,6 +99,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 						Image:        "image-3",
 						Labels: map[string]string{
 							"label-3": "value-3",
+						},
+						SecurityGroups: []string{
+							"security-group-3",
+							"security-group-33",
 						},
 						Subnet: &ekscluster.Subnet{
 							SubnetId:         "subnet-id-3",
@@ -125,6 +137,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 					NodeVolumeSize:   1,
 					NodeImage:        "image-1",
 					NodeInstanceType: "instance-type-1",
+					SecurityGroups: []string{
+						"security-group-1",
+						"security-group-11",
+					},
 					Labels: map[string]string{
 						"label-1": "value-1",
 					},
@@ -142,6 +158,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 					NodeVolumeSize:   2,
 					NodeImage:        "image-2",
 					NodeInstanceType: "instance-type-2",
+					SecurityGroups: []string{
+						"security-group-2",
+						"security-group-22",
+					},
 					Labels: map[string]string{
 						"label-2": "value-2",
 					},
@@ -159,6 +179,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 					NodeVolumeSize:   3,
 					NodeImage:        "image-3",
 					NodeInstanceType: "instance-type-3",
+					SecurityGroups: []string{
+						"security-group-3",
+						"security-group-33",
+					},
 					Labels: map[string]string{
 						"label-3": "value-3",
 					},
@@ -210,6 +234,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 						Labels: map[string]string{
 							"label-1": "value-1",
 						},
+						SecurityGroups: []string{
+							"security-group-1",
+							"security-group-11",
+						},
 						Subnet: &ekscluster.Subnet{
 							SubnetId:         "subnet-id-1",
 							Cidr:             "cidr-1",
@@ -230,6 +258,10 @@ func TestNewASGsFromRequestedUpdatedNodePools(t *testing.T) {
 					NodeVolumeSize:   1,
 					NodeImage:        "image-1",
 					NodeInstanceType: "instance-type-1",
+					SecurityGroups: []string{
+						"security-group-1",
+						"security-group-11",
+					},
 					Labels: map[string]string{
 						"label-1": "value-1",
 					},
@@ -684,6 +716,10 @@ func TestNewNodePoolsFromRequestedNewNodePools(t *testing.T) {
 						Labels: map[string]string{
 							"label-1": "value-1",
 						},
+						SecurityGroups: []string{
+							"security-group-1",
+							"security-group-11",
+						},
 						Subnet: &ekscluster.Subnet{
 							SubnetId:         "subnet-id-1",
 							Cidr:             "cidr-1",
@@ -744,7 +780,11 @@ func TestNewNodePoolsFromRequestedNewNodePools(t *testing.T) {
 						InstanceType: "instance-type-1",
 						Image:        "image-1",
 						SpotPrice:    "0.1",
-						SubnetID:     "subnet-id-1",
+						SecurityGroups: []string{
+							"security-group-1",
+							"security-group-11",
+						},
+						SubnetID: "subnet-id-1",
 					},
 					{
 						Name: "pool-2",

--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -219,6 +219,8 @@ func NewSubnetsFromEKSSubnets(
 	return matchedSubnets, nil
 }
 
+// TODO: remove when UpdateNodePoolWorkflow is refactored and this is not needed
+// anymore.
 type AutoscaleGroup struct {
 	Name             string
 	NodeSpotPrice    string
@@ -229,10 +231,15 @@ type AutoscaleGroup struct {
 	NodeVolumeSize   int
 	NodeImage        string
 	NodeInstanceType string
-	Labels           map[string]string
-	Delete           bool
-	Create           bool
-	CreatedBy        uint
+
+	// SecurityGroups collects the user specified custom node security group
+	// IDs.
+	SecurityGroups []string
+
+	Labels    map[string]string
+	Delete    bool
+	Create    bool
+	CreatedBy uint
 }
 
 type Clusters interface {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -66,8 +66,13 @@ type UpdateAsgActivityInput struct {
 	NodeVolumeSize   int
 	NodeImage        string
 	NodeInstanceType string
-	Labels           map[string]string
-	Tags             map[string]string
+
+	// SecurityGroups collects the user specified custom node security group
+	// IDs.
+	SecurityGroups []string
+
+	Labels map[string]string
+	Tags   map[string]string
 }
 
 // UpdateAsgActivityOutput holds the output data of the UpdateAsgActivityOutput
@@ -237,6 +242,10 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 		{
 			ParameterKey:     aws.String("NodeSecurityGroup"),
 			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:   aws.String("CustomNodeSecurityGroups"),
+			ParameterValue: aws.String(strings.Join(input.SecurityGroups, ",")),
 		},
 		{
 			ParameterKey:     aws.String("VpcId"),

--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -313,6 +313,7 @@ func (w EKSUpdateClusterWorkflow) Execute(ctx workflow.Context, input EKSUpdateC
 				NodeVolumeSize:   volumeSize,
 				NodeImage:        updatedNodePool.NodeImage,
 				NodeInstanceType: updatedNodePool.NodeInstanceType,
+				SecurityGroups:   updatedNodePool.SecurityGroups,
 				Labels:           updatedNodePool.Labels,
 				Tags:             input.Tags,
 			}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Propagated user provided custom node security groups from the API request to the node pool CloudFormation stack creation/modification in `EKS.ClusterAPI.UpdateCluster`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To add a feature to the `EKS.ClusterAPI.UpdateCluster` endpoint of user specified node pool node security groups.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Depends on #3326 , #3332, #3333 (technically these are convenience dependencies to avoid double work, especially in case changes are requested, but we are not in a rush, so it's best to do this orderly).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Manual test.
- [x] Wait for #3326 to be merged and rebase before merging.
- [x] Wait for #3332 to be merged and rebase before merging.
- [x] Wait for #3333 to be merged and rebase before merging.
