### PR TITLE
Cadence client error check and default config for the pipeline process

### DIFF
--- a/cmd/pipeline/config.go
+++ b/cmd/pipeline/config.go
@@ -181,4 +181,8 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 
 	v.SetDefault("spotmetrics::enabled", false)
 	v.SetDefault("spotmetrics::collectionInterval", 30*time.Second)
+
+	// Cadence configuration
+	v.SetDefault("cadence::createNonexistentDomain", false)
+	v.SetDefault("cadence::workflowExecutionRetentionPeriodInDays", 3)
 }

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -417,7 +417,7 @@ func main() {
 
 	workflowClient, err := cadence.NewClient(config.Cadence, zaplog.New(logur.WithFields(logger, map[string]interface{}{"component": "cadence-client"})))
 	if err != nil {
-		errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
+		emperror.Panic(errors.WrapIf(err, "Failed to configure Cadence client"))
 	}
 
 	releaseDeleter := cmd.CreateReleaseDeleter(config.Helm, db, commonSecretStore, commonLogger)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -236,7 +236,7 @@ func main() {
 
 		workflowClient, err := cadence.NewClient(config.Cadence, zaplog.New(logur.WithFields(logger, map[string]interface{}{"component": "cadence-client"})))
 		if err != nil {
-			errorHandler.Handle(errors.WrapIf(err, "Failed to configure Cadence client"))
+			emperror.Panic(errors.WrapIf(err, "Failed to configure Cadence client"))
 		}
 
 		commonSecretStore := commonadapter.NewSecretStore(secret.Store, commonadapter.OrgIDContextExtractorFunc(auth.GetCurrentOrganizationID))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bail out in case the cadence client cannot be created, otherwise execution will fail with a nil pointer dereference.

Also add default cadence configuration for the pipeline process, otherwise only the worker will be able to create the `pipeline` domain if `createNonexistentDomain` is enabled. This behaviour, that the pipeline process can also create the domain if it doesn't exist was introduced in https://github.com/banzaicloud/pipeline/pull/3319
