### PR TITLE
update hpa operator version

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -718,7 +718,7 @@ rbac:
 	})
 
 	v.SetDefault("cluster::autoscale::charts::hpaOperator::chart", "banzaicloud-stable/hpa-operator")
-	v.SetDefault("cluster::autoscale::charts::hpaOperator::version", "0.2.2")
+	v.SetDefault("cluster::autoscale::charts::hpaOperator::version", "0.3.0")
 	v.SetDefault("cluster::autoscale::charts::hpaOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::securityScan::enabled", true)

--- a/src/cluster/hooks.go
+++ b/src/cluster/hooks.go
@@ -364,6 +364,7 @@ func (hpa *HorizontalPodAutoscalerPostHook) Do(cluster CommonCluster) error {
 
 		metricsServerValues := make(map[string]interface{}, 0)
 		metricsServerValues["enabled"] = true
+		metricsServerValues["apiService"] = map[string]interface{}{"create": true}
 
 		// use InternalIP on VSphere
 		if cluster.GetCloud() == pkgCluster.Vsphere {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Use latest hpa operator chart with updated metrics server dependency.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
