### PR TITLE
Bump anchore-policy-validator chart version

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -728,7 +728,7 @@ rbac:
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::anchore::insecure", false)
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.6.0")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.6.1")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	// v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3346 
| License         | Apache 2.0


### What's in this PR?
Update `anchore-policy-validator` helm chart version

### Why?
The latest version of the chart uses the `ghcr.io/banzaicloud/anchore-image-validator:0.4.4` image.

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
