### PR TITLE
Fixed EKS node pool CloudFormation template KeyName type

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -60,7 +60,7 @@ Parameters:
     Description: Comma separated list of security groups for all nodes in the pool.
 
   KeyName:
-    Type: "AWS::EC2::KeyPair::KeyName"
+    Type: String # Note: not using "AWS::EC2::KeyPair::KeyName", because it implicitly validates the value to existing keys and we want to allow using the empty value as well, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html .
     Description: The EC2 Key Pair to allow SSH access to the instances
 
   # NodeAutoScalingGroupDesiredCapacity:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed EKS node pool CloudFormation template `KeyName` type.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To avoid AWS type to bypass [implicit validation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html) for Pipeline-allowed empty value in certain environments.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
