### PR TITLE
Stylistically fixed EKS node pool CloudFormation template parameter order

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -59,6 +59,13 @@ Parameters:
     Default: ""
     Description: Comma separated list of security groups for all nodes in the pool.
 
+  DisableIMDSv1:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "false"
+      - "true"
+
   KeyName:
     Type: String # Note: not using "AWS::EC2::KeyPair::KeyName", because it implicitly validates the value to existing keys and we want to allow using the empty value as well, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html .
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -109,13 +116,6 @@ Parameters:
   NodeInstanceRoleId:
     Type: String
     Description: The role for node IAM profile
-
-  DisableIMDSv1:
-    Type: String
-    Default: "false"
-    AllowedValues:
-      - "false"
-      - "true"
 
   NodeInstanceType:
     Type: String


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Stylistically fixed EKS node pool CloudFormation template parameter order.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To restore parameter ordering.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
