### PR TITLE
Fixed an edge case bug + Refactored the EKS node pool CloudFormation template version handling

### DIFF
--- a/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_manager_test.go
@@ -673,10 +673,6 @@ func TestListNodePools(t *testing.T) {
 							{
 								Parameters: []*cloudformation.Parameter{
 									{
-										ParameterKey:   aws.String("TemplateVersion"),
-										ParameterValue: aws.String("2.0.0"),
-									},
-									{
 										ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 										ParameterValue: aws.String("true"),
 									},
@@ -725,10 +721,6 @@ func TestListNodePools(t *testing.T) {
 						Stacks: []*cloudformation.Stack{
 							{
 								Parameters: []*cloudformation.Parameter{
-									{
-										ParameterKey:   aws.String("TemplateVersion"),
-										ParameterValue: aws.String("2.0.0"),
-									},
 									{
 										ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 										ParameterValue: aws.String("false"),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -160,10 +160,6 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 
 	stackParams = []*cloudformation.Parameter{
 		{
-			ParameterKey:   aws.String(eksStackTemplateVersionParameterKey),
-			ParameterValue: aws.String("2.0.0"),
-		},
-		{
 			ParameterKey:   aws.String("KeyName"),
 			ParameterValue: aws.String(input.SSHKeyName),
 		},

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_node_pool_workflow_test.go
@@ -307,9 +307,8 @@ func TestCreateNodePoolWorkflowExecute(t *testing.T) {
 			caseDescription: "parse subnet stack parameters error -> error",
 			expectedError: errors.New(
 				"parsing subnet stack parameters failed" +
-					": parsing values failed" +
-					": missing requested value AvailabilityZoneName" +
-					"; missing requested value SubnetBlock",
+					": missing expected key AvailabilityZoneName" +
+					"; missing expected key SubnetBlock",
 			),
 			input: inputType{
 				workflow: NewCreateNodePoolWorkflow(),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/get_cf_stack_activity_test.go
@@ -557,12 +557,11 @@ func TestGetCFStackOutputs(t *testing.T) {
 			output: outputType{
 				expectedError: errors.New(
 					"parsing stack outputs failed" +
-						": parsing values failed" +
-						": missing requested value Bool" +
-						"; missing requested value Float" +
-						"; missing requested value Int" +
-						"; missing requested value String" +
-						"; missing requested value Uint",
+						": missing expected key Bool" +
+						"; missing expected key Float" +
+						"; missing expected key Int" +
+						"; missing expected key String" +
+						"; missing expected key Uint",
 				),
 				expectedOutputs: &expectedOutputsType{},
 			},
@@ -761,12 +760,11 @@ func TestGetCFStackParameters(t *testing.T) {
 			output: outputType{
 				expectedError: errors.New(
 					"parsing stack parameters failed" +
-						": parsing values failed" +
-						": missing requested value Bool" +
-						"; missing requested value Float" +
-						"; missing requested value Int" +
-						"; missing requested value String" +
-						"; missing requested value Uint",
+						": missing expected key Bool" +
+						"; missing expected key Float" +
+						"; missing expected key Int" +
+						"; missing expected key String" +
+						"; missing expected key Uint",
 				),
 				expectedParameters: &expectedParametersType{},
 			},

--- a/internal/cluster/distribution/eks/eksprovider/workflow/templates.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/templates.go
@@ -15,9 +15,6 @@
 package workflow
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
-
 	internalcloudformation "github.com/banzaicloud/pipeline/internal/cloudformation"
 	"github.com/banzaicloud/pipeline/internal/global"
 )
@@ -27,11 +24,6 @@ const (
 	eksVPCTemplateName      = "amazon-eks-vpc-cf.yaml"
 	eksSubnetTemplateName   = "amazon-eks-subnet-cf.yaml"
 	eksNodePoolTemplateName = "amazon-eks-nodepool-cf.yaml"
-
-	// eksStackTemplateVersionParameterKey defines the key of the parameter
-	// holding the version of the template the stack had been created from. The
-	// template version is used to handle stack compatibility.
-	eksStackTemplateVersionParameterKey = "TemplateVersion"
 )
 
 // GetVPCTemplate returns the CloudFormation template for creating VPC for EKS cluster
@@ -60,28 +52,4 @@ func GetIAMTemplate() (string, error) {
 	return internalcloudformation.GetCloudFormationTemplate(
 		global.Config.Distribution.EKS.TemplateLocation, eksIAMTemplateName,
 	)
-}
-
-// GetStackTemplateVersion returns the version of the CloudFormation template
-// the stack had been created from.
-func GetStackTemplateVersion(stack *cloudformation.Stack) string {
-	if stack == nil {
-		return ""
-	} else if len(stack.Parameters) == 0 {
-		return "1.0.0"
-	}
-
-	for _, parameter := range stack.Parameters {
-		if aws.StringValue(parameter.ParameterKey) == eksStackTemplateVersionParameterKey {
-			return aws.StringValue(parameter.ParameterValue)
-		}
-	}
-
-	return "1.0.0"
-}
-
-// GetStackTemplateVersionKey returns the key of the parameter holding the
-// version of the CloudFormation template the stack had been created from.
-func GetStackTemplateVersionKey() string {
-	return eksStackTemplateVersionParameterKey
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -191,10 +191,6 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 
 	stackParams := []*cloudformation.Parameter{
 		{
-			ParameterKey:   aws.String(eksStackTemplateVersionParameterKey),
-			ParameterValue: aws.String("2.0.0"),
-		},
-		{
 			ParameterKey:     aws.String("KeyName"),
 			UsePreviousValue: aws.Bool(true),
 		},

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/cadence/activity"
 
 	"github.com/banzaicloud/pipeline/internal/cluster"
-	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
 	"github.com/banzaicloud/pipeline/pkg/cadence/worker"
 	pkgCloudFormation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	sdkAmazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
@@ -107,10 +106,6 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 	}
 
 	stackParams := []*cloudformation.Parameter{
-		{
-			ParameterKey:   aws.String(workflow.GetStackTemplateVersionKey()),
-			ParameterValue: aws.String("2.0.0"),
-		},
 		{
 			ParameterKey:     aws.String("KeyName"),
 			UsePreviousValue: aws.Bool(true),

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -32,6 +32,7 @@ import (
 	pkgCloudFormation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	sdkAmazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
 	sdkCloudFormation "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon/cloudformation"
+	"github.com/banzaicloud/pipeline/pkg/sdk/semver"
 )
 
 const awsNoUpdatesError = "No updates are to be performed."
@@ -68,7 +69,7 @@ type UpdateNodeGroupActivityInput struct {
 
 	ClusterTags map[string]string
 
-	TemplateVersion string
+	CurrentTemplateVersion semver.Version
 }
 
 type UpdateNodeGroupActivityOutput struct {
@@ -117,7 +118,7 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 		),
 		sdkCloudFormation.NewOptionalStackParameter(
 			"CustomNodeSecurityGroups",
-			input.SecurityGroups != nil || input.TemplateVersion == "1.0.0",
+			input.SecurityGroups != nil || input.CurrentTemplateVersion.IsLessThan("2.0.0"), // Note: older templates cannot use non-existing previous value.
 			strings.Join(input.SecurityGroups, ","),
 		),
 		{

--- a/internal/cluster/distribution/eks/service.go
+++ b/internal/cluster/distribution/eks/service.go
@@ -123,7 +123,7 @@ func NewNodePoolFromCFStack(name string, labels map[string]string, stack *cloudf
 		NodeInstanceType            string `mapstructure:"NodeInstanceType"`
 		NodeSpotPrice               string `mapstructure:"NodeSpotPrice"`
 		NodeVolumeSize              int    `mapstructure:"NodeVolumeSize"`
-		CustomNodeSecurityGroups    string `mapstructure:"CustomNodeSecurityGroups,omitempty"`
+		CustomNodeSecurityGroups    string `mapstructure:"CustomNodeSecurityGroups,omitempty"` // Note: CustomNodeSecurityGroups is only available from template version 2.0.0.
 		Subnets                     string `mapstructure:"Subnets"`
 	}
 

--- a/internal/cluster/distribution/eks/service_test.go
+++ b/internal/cluster/distribution/eks/service_test.go
@@ -183,8 +183,7 @@ func TestNewNodePoolFromCFStack(t *testing.T) {
 				expectedNodePool: NodePool{
 					Name:   "node-pool",
 					Status: NodePoolStatusError,
-					StatusMessage: "parsing values failed" +
-						": parsing ClusterAutoscalerEnabled value not-a-bool failed" +
+					StatusMessage: "1 error(s) decoding:\n\n* error decoding 'ClusterAutoscalerEnabled'" +
 						": strconv.ParseBool: parsing \"not-a-bool\": invalid syntax",
 				},
 			},

--- a/internal/cluster/distribution/eks/service_test.go
+++ b/internal/cluster/distribution/eks/service_test.go
@@ -141,10 +141,6 @@ func TestNewNodePoolFromCFStack(t *testing.T) {
 				stack: &cloudformation.Stack{
 					Parameters: []*cloudformation.Parameter{
 						{
-							ParameterKey:   aws.String("TemplateVersion"),
-							ParameterValue: aws.String("2.0.0"),
-						},
-						{
 							ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 							ParameterValue: aws.String("not-a-bool"),
 						},
@@ -202,10 +198,6 @@ func TestNewNodePoolFromCFStack(t *testing.T) {
 				name: "node-pool",
 				stack: &cloudformation.Stack{
 					Parameters: []*cloudformation.Parameter{
-						{
-							ParameterKey:   aws.String("TemplateVersion"),
-							ParameterValue: aws.String("2.0.0"),
-						},
 						{
 							ParameterKey:   aws.String("ClusterAutoscalerEnabled"),
 							ParameterValue: aws.String("true"),

--- a/pkg/sdk/providers/amazon/cloudformation/cloudformation.go
+++ b/pkg/sdk/providers/amazon/cloudformation/cloudformation.go
@@ -24,6 +24,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/banzaicloud/pipeline/pkg/sdk/semver"
 )
 
 // decodeStackValue is a mapstructure decode function which parses a string
@@ -110,6 +112,8 @@ func parseStackValue(rawValue string, resultType interface{}) (result interface{
 		return strconv.ParseFloat(rawValue, 0)
 	case int:
 		return strconv.Atoi(rawValue)
+	case semver.Version:
+		return semver.NewVersionFromString(rawValue)
 	case string:
 		return rawValue, nil
 	case uint:

--- a/pkg/sdk/providers/amazon/cloudformation/cloudformation_test.go
+++ b/pkg/sdk/providers/amazon/cloudformation/cloudformation_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/stretchr/testify/require"
+
+	"github.com/banzaicloud/pipeline/pkg/sdk/semver"
 )
 
 func TestDecodeStackValue(t *testing.T) {
@@ -319,6 +321,10 @@ func TestParseStackOutputs(t *testing.T) {
 						OutputValue: aws.String("-5"),
 					},
 					{
+						OutputKey:   aws.String("SemanticVersion"),
+						OutputValue: aws.String("1.2.3-dev.4"),
+					},
+					{
 						OutputKey:   aws.String("String"),
 						OutputValue: aws.String("value"),
 					},
@@ -331,12 +337,13 @@ func TestParseStackOutputs(t *testing.T) {
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &map[string]string{
-					"Bool":   "true",
-					"Extra":  "output",
-					"Float":  "0.5",
-					"Int":    "-5",
-					"String": "value",
-					"Uint":   "5",
+					"Bool":            "true",
+					"Extra":           "output",
+					"Float":           "0.5",
+					"Int":             "-5",
+					"SemanticVersion": "1.2.3-dev.4",
+					"String":          "value",
+					"Uint":            "5",
 				},
 			},
 		},
@@ -344,11 +351,12 @@ func TestParseStackOutputs(t *testing.T) {
 			caseName: "struct -> success",
 			input: inputType{
 				objectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{},
 				outputs: []*cloudformation.Output{
 					{
@@ -368,6 +376,10 @@ func TestParseStackOutputs(t *testing.T) {
 						OutputValue: aws.String("-5"),
 					},
 					{
+						OutputKey:   aws.String("SemanticVersion"),
+						OutputValue: aws.String("1.2.3-dev.4"),
+					},
+					{
 						OutputKey:   aws.String("String"),
 						OutputValue: aws.String("value"),
 					},
@@ -380,17 +392,19 @@ func TestParseStackOutputs(t *testing.T) {
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{
-					Bool:   true,
-					Float:  0.5,
-					Int:    -5,
-					String: "value",
-					Uint:   5,
+					Bool:            true,
+					Float:           0.5,
+					Int:             -5,
+					SemanticVersion: semver.NewVersionFromStringOrPanic("1.2.3-dev.4"),
+					String:          "value",
+					Uint:            5,
 				},
 			},
 		},
@@ -456,6 +470,10 @@ func TestParseStackParameters(t *testing.T) {
 						ParameterValue: aws.String("-5"),
 					},
 					{
+						ParameterKey:   aws.String("SemanticVersion"),
+						ParameterValue: aws.String("1.2.3-dev.4"),
+					},
+					{
 						ParameterKey:   aws.String("String"),
 						ParameterValue: aws.String("value"),
 					},
@@ -468,12 +486,13 @@ func TestParseStackParameters(t *testing.T) {
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &map[string]string{
-					"Bool":   "true",
-					"Extra":  "parameter",
-					"Float":  "0.5",
-					"Int":    "-5",
-					"String": "value",
-					"Uint":   "5",
+					"Bool":            "true",
+					"Extra":           "parameter",
+					"Float":           "0.5",
+					"Int":             "-5",
+					"SemanticVersion": "1.2.3-dev.4",
+					"String":          "value",
+					"Uint":            "5",
 				},
 			},
 		},
@@ -481,11 +500,12 @@ func TestParseStackParameters(t *testing.T) {
 			caseName: "struct -> success",
 			input: inputType{
 				objectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{},
 				parameters: []*cloudformation.Parameter{
 					{
@@ -505,6 +525,10 @@ func TestParseStackParameters(t *testing.T) {
 						ParameterValue: aws.String("-5"),
 					},
 					{
+						ParameterKey:   aws.String("SemanticVersion"),
+						ParameterValue: aws.String("1.2.3-dev.4"),
+					},
+					{
 						ParameterKey:   aws.String("String"),
 						ParameterValue: aws.String("value"),
 					},
@@ -517,17 +541,19 @@ func TestParseStackParameters(t *testing.T) {
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{
-					Bool:   true,
-					Float:  0.5,
-					Int:    -5,
-					String: "value",
-					Uint:   5,
+					Bool:            true,
+					Float:           0.5,
+					Int:             -5,
+					SemanticVersion: semver.NewVersionFromStringOrPanic("1.2.3-dev.4"),
+					String:          "value",
+					Uint:            5,
 				},
 			},
 		},
@@ -629,6 +655,28 @@ func TestParseStackValue(t *testing.T) {
 			output: outputType{
 				expectedError:  nil,
 				expectedResult: 5,
+			},
+		},
+		{
+			caseName: "invalid semver.Version value error",
+			input: inputType{
+				rawValue:   "version-value",
+				resultType: semver.Version(""),
+			},
+			output: outputType{
+				expectedError:  errors.New("invalid version version-value"),
+				expectedResult: semver.Version(""),
+			},
+		},
+		{
+			caseName: "valid semver.Version value success",
+			input: inputType{
+				rawValue:   "1.2.3-dev.4",
+				resultType: semver.Version(""),
+			},
+			output: outputType{
+				expectedError:  nil,
+				expectedResult: semver.NewVersionFromStringOrPanic("1.2.3-dev.4"),
 			},
 		},
 		{
@@ -787,30 +835,33 @@ func TestParseStackValues(t *testing.T) {
 			caseName: "map[string]string -> success",
 			input: inputType{
 				rawValues: map[string]string{
-					"Bool":   "true",
-					"Extra":  "parameter",
-					"Float":  "0.5",
-					"Int":    "-5",
-					"String": "value",
-					"Uint":   "5",
+					"Bool":            "true",
+					"Extra":           "parameter",
+					"Float":           "0.5",
+					"Int":             "-5",
+					"SemanticVersion": "1.2.3-dev.4",
+					"String":          "value",
+					"Uint":            "5",
 				},
 				objectPointer: &map[string]string{
-					"Bool":   "",
-					"Float":  "",
-					"Int":    "",
-					"String": "",
-					"Uint":   "",
+					"Bool":            "",
+					"Float":           "",
+					"Int":             "",
+					"SemanticVersion": "",
+					"String":          "",
+					"Uint":            "",
 				},
 			},
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &map[string]string{
-					"Bool":   "true",
-					"Extra":  "parameter",
-					"Float":  "0.5",
-					"Int":    "-5",
-					"String": "value",
-					"Uint":   "5",
+					"Bool":            "true",
+					"Extra":           "parameter",
+					"Float":           "0.5",
+					"Int":             "-5",
+					"SemanticVersion": "1.2.3-dev.4",
+					"String":          "value",
+					"Uint":            "5",
 				},
 			},
 		},
@@ -818,41 +869,46 @@ func TestParseStackValues(t *testing.T) {
 			caseName: "struct -> success",
 			input: inputType{
 				rawValues: map[string]string{
-					"Bool":   "true",
-					"Extra":  "parameter",
-					"Float":  "0.5",
-					"Int":    "-5",
-					"String": "value",
-					"Uint":   "5",
+					"Bool":            "true",
+					"Extra":           "parameter",
+					"Float":           "0.5",
+					"Int":             "-5",
+					"SemanticVersion": "1.2.3-dev.4",
+					"String":          "value",
+					"Uint":            "5",
 				},
 				objectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{
-					Bool:   false,
-					Float:  0.0,
-					Int:    0,
-					String: "",
-					Uint:   uint(0),
+					Bool:            false,
+					Float:           0.0,
+					Int:             0,
+					SemanticVersion: semver.NewVersionFromStringOrPanic("0.0.0"),
+					String:          "",
+					Uint:            uint(0),
 				},
 			},
 			output: outputType{
 				expectedError: nil,
 				expectedObjectPointer: &struct {
-					Bool   bool
-					Float  float64
-					Int    int
-					String string
-					Uint   uint
+					Bool            bool
+					Float           float64
+					Int             int
+					SemanticVersion semver.Version
+					String          string
+					Uint            uint
 				}{
-					Bool:   true,
-					Float:  0.5,
-					Int:    -5,
-					String: "value",
-					Uint:   uint(5),
+					Bool:            true,
+					Float:           0.5,
+					Int:             -5,
+					SemanticVersion: semver.NewVersionFromStringOrPanic("1.2.3-dev.4"),
+					String:          "value",
+					Uint:            uint(5),
 				},
 			},
 		},

--- a/pkg/sdk/semver/compared.go
+++ b/pkg/sdk/semver/compared.go
@@ -1,0 +1,56 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+const (
+	// ComparedLess is the comparison result describing the receiver is less
+	// than the argument.
+	ComparedLess = Compared(-1)
+
+	// ComparedEqual is the comparison result describing the receiver is equal
+	// to the argument.
+	ComparedEqual = Compared(0)
+
+	// ComparedGreater is the comparison result describing the receiver is
+	// greater than the argument.
+	ComparedGreater = Compared(1)
+)
+
+// Compared describes pseudo-enum results of version comparisons.
+type Compared int
+
+// CompareIns compares two int values and returns the result as a Compared
+// value.
+func CompareInts(first, second int) (result Compared) {
+	if first < second {
+		return ComparedLess
+	} else if first > second {
+		return ComparedGreater
+	}
+
+	return ComparedEqual
+}
+
+// CompareStrings compares two string values and returns the result as a
+// Compared value.
+func CompareStrings(first, second string) (result Compared) {
+	if first < second {
+		return ComparedLess
+	} else if first > second {
+		return ComparedGreater
+	}
+
+	return ComparedEqual
+}

--- a/pkg/sdk/semver/compared_test.go
+++ b/pkg/sdk/semver/compared_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareInts(t *testing.T) {
+	type inputType struct {
+		first  int
+		second int
+	}
+
+	testCases := []struct {
+		caseDescription string
+		expectedResult  Compared
+		input           inputType
+	}{
+		{
+			caseDescription: "first < second -> successful ComparedLess",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				first:  0,
+				second: 1,
+			},
+		},
+		{
+			caseDescription: "first == second -> successful ComparedEqual",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				first:  2,
+				second: 2,
+			},
+		},
+		{
+			caseDescription: "first > second -> successful ComparedGreater",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				first:  4,
+				second: 3,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualResult := CompareInts(testCase.input.first, testCase.input.second)
+
+			require.Equal(t, testCase.expectedResult, actualResult)
+		})
+	}
+}
+
+func TestCompareStrings(t *testing.T) {
+	type inputType struct {
+		first  string
+		second string
+	}
+
+	testCases := []struct {
+		caseDescription string
+		expectedResult  Compared
+		input           inputType
+	}{
+		{
+			caseDescription: "first < second -> successful ComparedLess",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				first:  "0",
+				second: "1",
+			},
+		},
+		{
+			caseDescription: "first == second -> successful ComparedEqual",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				first:  "2",
+				second: "2",
+			},
+		},
+		{
+			caseDescription: "first > second -> successful ComparedGreater",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				first:  "4",
+				second: "3",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualResult := CompareStrings(testCase.input.first, testCase.input.second)
+
+			require.Equal(t, testCase.expectedResult, actualResult)
+		})
+	}
+}

--- a/pkg/sdk/semver/error.go
+++ b/pkg/sdk/semver/error.go
@@ -1,0 +1,22 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import "emperror.dev/errors"
+
+// ErrorInvalidVersion returns an invalid version error object.
+func ErrorInvalidVersion(version string) (err error) {
+	return errors.Errorf("invalid version %s", version)
+}

--- a/pkg/sdk/semver/error_test.go
+++ b/pkg/sdk/semver/error_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"testing"
+
+	"emperror.dev/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorInvalidVersion(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedErr        error
+		inputVersionString string
+	}{
+		{
+			caseDescription:    "invalid-version -> invalid-version error",
+			expectedErr:        errors.New("invalid version invalid-version"),
+			inputVersionString: "invalid-version",
+		},
+		{
+			caseDescription:    "not-a-version -> not-a-version success",
+			expectedErr:        errors.New("invalid version not-a-version"),
+			inputVersionString: "not-a-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualErr := ErrorInvalidVersion(testCase.inputVersionString)
+
+			require.EqualError(t, actualErr, testCase.expectedErr.Error())
+		})
+	}
+}

--- a/pkg/sdk/semver/version.go
+++ b/pkg/sdk/semver/version.go
@@ -1,0 +1,495 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Version provides an implicitly string-serializable semantic version type
+// implementation with semantic version helper functions.
+//
+// The package implements the Semantic Versioning 2.0.0 specification from
+// https://semver.org/.
+package semver
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// BuildPartRawRegex contains the raw regular expression string decsribing
+	// the allowed string schema of a build part of a semantic version.
+	BuildPartRawRegex = `[0-9a-zA-Z-]+`
+
+	// DecimalDigitsRawRegex contains the raw regular expression string
+	// describing the allowed string schema of a string containing only decimal
+	// digits.
+	DecimalDigitsRawRegex = `[0-9]+`
+
+	// PrereleasePartRawRegex contains the raw regular expression string
+	// describing the allowed string schema of a prerelease part of a semantic
+	// version.
+	PrereleasePartRawRegex = VersionPartRawRegex + `|\d*[a-zA-Z-][0-9a-zA-Z-]*`
+
+	// VersionRawRegex contains the raw regular expression string describing the
+	// allowed string schema of a semantic version.
+	VersionRawRegex = `^(` + VersionPartRawRegex + `)\.(` + VersionPartRawRegex + `)\.(` + VersionPartRawRegex + `)` +
+		`(?:-((?:` + PrereleasePartRawRegex + `)(?:\.(?:` + PrereleasePartRawRegex + `))*))?` +
+		`(?:\+(` + BuildPartRawRegex + `(?:\.` + BuildPartRawRegex + `)*))?$`
+
+	// VersionPartRawRegex contains the raw regular expression string describing
+	// the allowed string schema of a major, minor or patch part of a semantic
+	// version.
+	VersionPartRawRegex = `0|[1-9]\d*`
+
+	// ZeroVersion is the version representation of the "0.0.0" version.
+	ZeroVersion = Version("0.0.0")
+)
+
+var (
+	// DecimalDigitsRegex is the regular expression describing the allowed string
+	// schema of a string containing only decimal digits.
+	DecimalDigitsRegex = regexp.MustCompile(DecimalDigitsRawRegex) // nolint:gochecknoglobals // Note: intentional.
+
+	// VersionRegex is the regular expression describing the allowed string schema
+	// of a semantic version.
+	VersionRegex = regexp.MustCompile(VersionRawRegex) // nolint:gochecknoglobals // Note: intentional.
+)
+
+// Version represents a semantic version with corresponding helper functions for
+// structured part access and is aiming to be a string drop-in replacement type
+// (with the exception of operators for which helper functions are provided).
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+type Version string
+
+// NewBuildVersion creates a version from the specified value by appending the
+// provided build metadata to the possibly existing values.
+//
+// WARNING: f the old version is invalid, it is returned without any changes.
+func NewBuildVersion(oldVersion Version, newBuildMetadata ...string) (newVersion Version) {
+	if !oldVersion.IsValid() {
+		return oldVersion
+	}
+
+	oldMajor, oldMinor, oldPatch, oldPrereleases, oldBuilds := oldVersion.Parts()
+
+	// Note: validation ensures no error.
+	newVersion, _ = NewVersion(oldMajor, oldMinor, oldPatch, oldPrereleases, append(oldBuilds, newBuildMetadata...))
+
+	return newVersion
+}
+
+// NewMajorVersion creates a version from the specified value by incrementing
+// the major version.
+//
+// WARNING: f the old version is invalid, it is returned without any changes.
+func NewMajorVersion(oldVersion Version) (newVersion Version) {
+	if !oldVersion.IsValid() {
+		return oldVersion
+	}
+
+	oldMajor, _, _, _, oldBuilds := oldVersion.Parts() // nolint:dogsled // Note: intentional performance/usability.
+
+	// Note: validation ensures no error.
+	newVersion, _ = NewVersion(oldMajor+1, 0, 0, nil, oldBuilds)
+
+	return newVersion
+}
+
+// NewMinorVersion creates a version from the specified value by incrementing
+// the minor version.
+//
+// WARNING: f the old version is invalid, it is returned without any changes.
+func NewMinorVersion(oldVersion Version) (newVersion Version) {
+	if !oldVersion.IsValid() {
+		return oldVersion
+	}
+
+	oldMajor, oldMinor, _, _, oldBuilds := oldVersion.Parts()
+
+	// Note: validation ensures no error.
+	newVersion, _ = NewVersion(oldMajor, oldMinor+1, 0, nil, oldBuilds)
+
+	return newVersion
+}
+
+// NewPatchVersion creates a version from the specified value by incrementing
+// the patch version.
+//
+// WARNING: f the old version is invalid, it is returned without any changes.
+func NewPatchVersion(oldVersion Version) (newVersion Version) {
+	if !oldVersion.IsValid() {
+		return oldVersion
+	}
+
+	oldMajor, oldMinor, oldPatch, _, oldBuilds := oldVersion.Parts()
+
+	// Note: validation ensures no error.
+	newVersion, _ = NewVersion(oldMajor, oldMinor, oldPatch+1, nil, oldBuilds)
+
+	return newVersion
+}
+
+// NewPrereleaseVersion creates a version from the specified value by doing the
+// first applicable action of the following list in order to increment the
+// prerelease version>
+//
+// 1. IF there is no prerelease version, it is added with a decimal 1
+// identifier.
+//
+// 2. If there is a prerelease version already and the last identifier of the
+// prerelease version is not a decimal, a new prerelease identifier is added
+// with a decimal 1 value.
+//
+// 3. If there is a prerelease version already and the last identifier of the
+// prerelease version is a decimal, it is incremented by 1.
+//
+// WARNING: if the old version is invalid, it is returned without any changes.
+func NewPrereleaseVersion(oldVersion Version) (newVersion Version) {
+	if !oldVersion.IsValid() {
+		return oldVersion
+	}
+
+	oldMajor, oldMinor, oldPatch, oldPrereleases, oldBuilds := oldVersion.Parts()
+
+	newPrereleases := make([]string, len(oldPrereleases))
+	_ = copy(newPrereleases, oldPrereleases) // Note: creation ensures the correct capacity.
+
+	if len(oldPrereleases) == 0 ||
+		!DecimalDigitsRegex.MatchString(oldPrereleases[len(oldPrereleases)-1]) {
+		newPrereleases = append(newPrereleases, "1")
+	} else {
+		oldPreleaseDecimal, _ := strconv.Atoi(oldPrereleases[len(oldPrereleases)-1]) // Note: regex ensures no error.
+
+		newPrereleases[len(newPrereleases)-1] = strconv.FormatInt(int64(oldPreleaseDecimal+1), 10)
+	}
+
+	// Note: validation ensures no error.
+	newVersion, _ = NewVersion(oldMajor, oldMinor, oldPatch, newPrereleases, oldBuilds)
+
+	return newVersion
+}
+
+// NewVersion returns a version object created from the specified parts or an
+// error.
+func NewVersion(major, minor, patch int, prereleases, builds []string) (version Version, err error) {
+	versionString := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+
+	if len(prereleases) > 0 {
+		versionString += "-" + strings.Join(prereleases, ".")
+	}
+
+	if len(builds) > 0 {
+		versionString += "+" + strings.Join(builds, ".")
+	}
+
+	return NewVersionFromString(versionString)
+}
+
+// NewVersionFromString returns a version object created from the specified
+// string or an error.
+func NewVersionFromString(candidate string) (version Version, err error) {
+	if !IsValidVersionString(candidate) {
+		return Version(""), ErrorInvalidVersion(candidate)
+	}
+
+	return Version(candidate), nil
+}
+
+// NewVersionFromStringOrPanic returns a version object created from the
+// specified string or panics.
+func NewVersionFromStringOrPanic(candidate string) (version Version) {
+	version, err := NewVersionFromString(candidate)
+	if err != nil {
+		panic(err)
+	}
+
+	return version
+}
+
+// NewVersion returns a version object created from the specified parts or
+// panics.
+func NewVersionOrPanic(major, minor, patch int, prereleases, builds []string) (version Version) {
+	version, err := NewVersion(major, minor, patch, prereleases, builds)
+	if err != nil {
+		panic(err)
+	}
+
+	return version
+}
+
+// Build returns the build part of a semantic version as a string.
+//
+// WARNING: for an invalid semantic version this function returns the empty
+// string.
+//
+// WARNING: the returned build part does not contain the leading plus.
+func (version Version) Build() (build string) {
+	_, _, _, _, build = version.RawParts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return build
+}
+
+// Builds returns the build parts of a semantic version as a string slice.
+//
+// WARNING: for an invalid semantic version this function returns nil.
+//
+// WARNING: the returned build parts do not contain the leading plus.
+func (version Version) Builds() (builds []string) {
+	_, _, _, _, builds = version.Parts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return builds
+}
+
+// Check checks whether the version is a valid semantic version and returns
+// error if it is not.
+func (version Version) Check() (err error) {
+	if !version.IsValid() {
+		return ErrorInvalidVersion(version.String())
+	}
+
+	return nil
+}
+
+// Compare compares the receiver version to the specified other version
+// comparing major, minor, patch, prerelease version parts.
+//
+// WARNING: the comparison ignores the build metadata part of the versions.
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+func (version Version) Compare(otherVersion Version) (result Compared) {
+	versionMajor, versionMinor, versionPatch, versionPrereleases, _ := version.Parts()
+	otherMajor, otherMinor, otherPatch, otherPrereleases, _ := otherVersion.Parts()
+
+	if versionMajor != otherMajor {
+		return CompareInts(versionMajor, otherMajor)
+	} else if versionMinor != otherMinor {
+		return CompareInts(versionMinor, otherMinor)
+	} else if versionPatch != otherPatch {
+		return CompareInts(versionPatch, otherPatch)
+	}
+
+	versionPrereleaseCount := len(versionPrereleases)
+	otherVersionPrereleaseCount := len(otherPrereleases)
+	if (versionPrereleaseCount == 0) != (otherVersionPrereleaseCount == 0) {
+		// Note: exactly one of the counts is 0, the version with 0 prerelease
+		// count is the greater version of the two (reversing the comparison).
+		return CompareInts(otherVersionPrereleaseCount, versionPrereleaseCount)
+	}
+
+	for index := 0; index != versionPrereleaseCount && index != otherVersionPrereleaseCount; index++ {
+		versionPart := versionPrereleases[index]
+		otherPart := otherPrereleases[index]
+		if versionPart == otherPart { // Note: parts are alphabetically equal, they would be decimally equal as well.
+			continue
+		}
+
+		isVersionPartDecimal := DecimalDigitsRegex.MatchString(versionPart)
+		isOtherPartDecimal := DecimalDigitsRegex.MatchString(otherPart)
+		if isVersionPartDecimal != isOtherPartDecimal &&
+			isVersionPartDecimal { // Note: decimal is less than non-decimal.
+			return ComparedLess
+		} else if isVersionPartDecimal != isOtherPartDecimal &&
+			isOtherPartDecimal {
+			return ComparedGreater
+		} else if isVersionPartDecimal { // && isOtherPartDecimal // Note: compare decimally.
+			versionDecimalPart, _ := strconv.Atoi(versionPart) // Note: the regex and condition ensures no error here.
+			otherDecimalPart, _ := strconv.Atoi(otherPart)     // Note: the regex and condition ensures no error here.
+
+			result = CompareInts(versionDecimalPart, otherDecimalPart)
+			if result != ComparedEqual {
+				return result
+			}
+		} else { // Note: compare alphabetically.
+			result = CompareStrings(versionPart, otherPart)
+			if result != ComparedEqual {
+				return result
+			}
+		}
+	}
+
+	return CompareInts(versionPrereleaseCount, otherVersionPrereleaseCount)
+}
+
+// Equals returns true if the receiver version is equal to the specified
+// version, false otherwise.
+//
+// WARNING: the comparison ignores the build metadata part of the versions.
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+func (version Version) Equals(otherVersion Version) (areEqual bool) {
+	return version.Compare(otherVersion) == ComparedEqual
+}
+
+// IsGreaterThan returns true if the receiver version is greater than the
+// specified version comparing major, minor, patch and prerelease versions
+// according to the semantic version specification.
+//
+// WARNING: the comparison ignores the build metadata part of the versions.
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+func (version Version) IsGreaterThan(otherVersion Version) (isGreaterThan bool) {
+	return version.Compare(otherVersion) == ComparedGreater
+}
+
+// IsInRange returns true if the receiver version is in the range of the
+// specified boundaries and false otherwise.
+//
+// WARNING: the lower boundary is inclusive, while the upper boundary is
+// exclusive. This is due to the fact most version range checks require these
+// semantics.
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+func (version Version) IsInRange(inclusiveLowerBoundary, exclusiveUpperBoundary Version) (isInRange bool) {
+	return !version.IsLessThan(inclusiveLowerBoundary) &&
+		version.IsLessThan(exclusiveUpperBoundary)
+}
+
+// IsLessThan returns true if the receiver version is less than the specified
+// version comparing major, minor, patch and prerelease versions according to
+// the semantic version specification.
+//
+// WARNING: the comparison ignores the build metadata part of the versions.
+//
+// WARNING: invalid semantic versions are treated similarly to the "0.0.0"
+// version.
+func (version Version) IsLessThan(otherVersion Version) (isLessThan bool) {
+	return version.Compare(otherVersion) == ComparedLess
+}
+
+// IsValid returns true if the version is a valid semantic version, false
+// otherwise.
+func (version Version) IsValid() (isValid bool) {
+	return VersionRegex.MatchString(version.String())
+}
+
+// Major returns the major version part of a semantic version.
+//
+// WARNING: for an invalid semantic version this function returns 0.
+func (version Version) Major() (major int) {
+	major, _, _, _, _ = version.Parts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return major
+}
+
+// Minor returns the minor version part of a semantic version.
+//
+// WARNING: for an invalid semantic version this function returns 0.
+func (version Version) Minor() (minor int) {
+	_, minor, _, _, _ = version.Parts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return minor
+}
+
+// Parts returns the different parts of a semantic version as separate fields.
+//
+// WARNING: for an invalid semantic version this function returns the default 0
+// and nil values.
+//
+// WARNING: the returned prereleases part does not contain the leading hyphen.
+// The returned builds part does not contain the leading plus.
+func (version Version) Parts() (major, minor, patch int, prereleases, builds []string) {
+	rawMajor, rawMinor, rawPatch, rawPrerelease, rawBuild := version.RawParts() // Note: valid semantic version.
+
+	major, _ = strconv.Atoi(rawMajor) // Note: the regex ensures no error here.
+	minor, _ = strconv.Atoi(rawMinor) // Note: the regex ensures no error here.
+	patch, _ = strconv.Atoi(rawPatch) // Note: the regex ensures no error here.
+
+	if rawPrerelease != "" {
+		prereleases = strings.Split(rawPrerelease, ".")
+	}
+
+	if rawBuild != "" {
+		builds = strings.Split(rawBuild, ".")
+	}
+
+	return major, minor, patch, prereleases, builds
+}
+
+// Patch returns the patch version part of a semantic version.
+//
+// WARNING: for an invalid semantic version this function returns 0.
+func (version Version) Patch() (patch int) {
+	_, _, patch, _, _ = version.Parts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return patch
+}
+
+// Prerelease returns the prerelease part of a semantic version as a string.
+//
+// WARNING: for an invalid semantic version this function returns the empty
+// string.
+//
+// WARNING: the returned prerelease part does not contain the leading hyphen.
+func (version Version) Prerelease() (prerelease string) {
+	_, _, _, prerelease, _ = version.RawParts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return prerelease
+}
+
+// Prereleases returns the prerelease parts of a semantic version as a string
+// slice.
+//
+// WARNING: for an invalid semantic version this function returns nil.
+//
+// WARNING: the returned prerelease parts do not contain the leading hyphen.
+func (version Version) Prereleases() (prereleases []string) {
+	_, _, _, prereleases, _ = version.Parts() // nolint:dogsled // Note: intentional performance/usability choice.
+
+	return prereleases
+}
+
+// RawParts returns the possible known parts of a semantic version as raw
+// strings.
+//
+// WARNING: for an invalid semantic version this function returns the parts of
+// the "0.0.0" valid semantic version.
+func (version Version) RawParts() (major, minor, patch, prerelease, build string) {
+	submatches := VersionRegex.FindStringSubmatch(version.String())
+	if len(submatches) != 6 {
+		return "0", "0", "0", "", ""
+	}
+
+	return submatches[1], submatches[2], submatches[3], submatches[4], submatches[5]
+}
+
+// String returns the string representation of the version.
+func (version Version) String() (versionString string) {
+	return string(version)
+}
+
+// CheckVersionString checks whether the specified string would be a valid
+// version and returns error if it would not.
+func CheckVersionString(candidate string) (err error) {
+	if !VersionRegex.MatchString(candidate) {
+		return ErrorInvalidVersion(candidate)
+	}
+
+	return nil
+}
+
+// IsValidVersionString determines whether the specified string would be a valid
+// version.
+func IsValidVersionString(candidate string) (isValid bool) {
+	if !VersionRegex.MatchString(candidate) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/sdk/semver/version_test.go
+++ b/pkg/sdk/semver/version_test.go
@@ -1,0 +1,2309 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckVersionString(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedErr     error
+		inputCandidate  string
+	}{
+		{
+			caseDescription: "valid -> true",
+			expectedErr:     nil,
+			inputCandidate:  "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "invalid -> false",
+			expectedErr:     ErrorInvalidVersion("invalid-version"),
+			inputCandidate:  "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualErr := CheckVersionString(testCase.inputCandidate)
+
+			if testCase.expectedErr == nil {
+				require.NoError(t, actualErr)
+			} else {
+				require.EqualError(t, actualErr, testCase.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func TestIsValidVersionString(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedIsValid bool
+		inputCandidate  string
+	}{
+		{
+			caseDescription: "valid -> true",
+			expectedIsValid: true,
+			inputCandidate:  "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "invalid -> false",
+			expectedIsValid: false,
+			inputCandidate:  "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsValid := IsValidVersionString(testCase.inputCandidate)
+
+			require.Equal(t, testCase.expectedIsValid, actualIsValid)
+		})
+	}
+}
+
+func TestNewBuildVersion(t *testing.T) {
+	type inputType struct {
+		oldVersion       Version
+		newBuildMetadata []string
+	}
+
+	testCases := []struct {
+		caseDescription    string
+		expectedNewVersion Version
+		input              inputType
+	}{
+		{
+			caseDescription:    "full -> success keep version, append build metadata",
+			expectedNewVersion: "1.2.3-prerelease.4+build.5.1.metadata",
+			input: inputType{
+				oldVersion:       "1.2.3-prerelease.4+build.5",
+				newBuildMetadata: []string{"1", "metadata"},
+			},
+		},
+		{
+			caseDescription:    "partial -> success keep version, append build metadata",
+			expectedNewVersion: "6.7.8+1.metadata",
+			input: inputType{
+				oldVersion:       "6.7.8",
+				newBuildMetadata: []string{"1", "metadata"},
+			},
+		},
+		{
+			caseDescription:    "invalid -> success return old version",
+			expectedNewVersion: "invalid-version",
+			input: inputType{
+				oldVersion:       "invalid-version",
+				newBuildMetadata: []string{"1", "metadata"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualNewVersion := NewBuildVersion(testCase.input.oldVersion, testCase.input.newBuildMetadata...)
+
+			require.Equal(t, testCase.expectedNewVersion, actualNewVersion)
+		})
+	}
+}
+
+func TestNewMajorVersion(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedNewVersion Version
+		inputOldVersion    Version
+	}{
+		{
+			caseDescription:    "full -> success increment major, 0 minor, 0 patch, nil prerelease, keep build",
+			expectedNewVersion: "2.0.0+build.5",
+			inputOldVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:    "partial -> success increment minor, 0 patch",
+			expectedNewVersion: "7.0.0",
+			inputOldVersion:    "6.7.8",
+		},
+		{
+			caseDescription:    "invalid -> success return old version",
+			expectedNewVersion: "invalid-version",
+			inputOldVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualNewVersion := NewMajorVersion(testCase.inputOldVersion)
+
+			require.Equal(t, testCase.expectedNewVersion, actualNewVersion)
+		})
+	}
+}
+
+func TestNewMinorVersion(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedNewVersion Version
+		inputOldVersion    Version
+	}{
+		{
+			caseDescription:    "full -> success increment minor, 0 patch, nil prerelease, keep build",
+			expectedNewVersion: "1.3.0+build.5",
+			inputOldVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:    "partial -> success increment minor, 0 patch",
+			expectedNewVersion: "6.8.0",
+			inputOldVersion:    "6.7.8",
+		},
+		{
+			caseDescription:    "invalid -> success return old version",
+			expectedNewVersion: "invalid-version",
+			inputOldVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualNewVersion := NewMinorVersion(testCase.inputOldVersion)
+
+			require.Equal(t, testCase.expectedNewVersion, actualNewVersion)
+		})
+	}
+}
+
+func TestNewPatchVersion(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedNewVersion Version
+		inputOldVersion    Version
+	}{
+		{
+			caseDescription:    "full -> success increment patch, nil prerelease",
+			expectedNewVersion: "1.2.4+build.5",
+			inputOldVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:    "partial -> success increment patch",
+			expectedNewVersion: "6.7.9",
+			inputOldVersion:    "6.7.8",
+		},
+		{
+			caseDescription:    "invalid -> success return old version",
+			expectedNewVersion: "invalid-version",
+			inputOldVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualNewVersion := NewPatchVersion(testCase.inputOldVersion)
+
+			require.Equal(t, testCase.expectedNewVersion, actualNewVersion)
+		})
+	}
+}
+
+func TestNewPrereleaseVersion(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedNewVersion Version
+		inputOldVersion    Version
+	}{
+		{
+			caseDescription:    "no prerelease -> success append 1 prerelease",
+			expectedNewVersion: "1.2.3-1",
+			inputOldVersion:    "1.2.3",
+		},
+		{
+			caseDescription:    "string last prerelease identifier -> success append 1 prerelease",
+			expectedNewVersion: "1.2.3-prerelease.1+build.5",
+			inputOldVersion:    "1.2.3-prerelease+build.5",
+		},
+		{
+			caseDescription:    "decimal last prerelease identifier -> success increment prerelease",
+			expectedNewVersion: "1.2.3-prerelease.2+build.5",
+			inputOldVersion:    "1.2.3-prerelease.1+build.5",
+		},
+		{
+			caseDescription:    "invalid -> success return old version",
+			expectedNewVersion: "invalid-version",
+			inputOldVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualNewVersion := NewPrereleaseVersion(testCase.inputOldVersion)
+
+			require.Equal(t, testCase.expectedNewVersion, actualNewVersion)
+		})
+	}
+}
+
+func TestNewVersion(t *testing.T) {
+	type inputType struct {
+		major       int
+		minor       int
+		patch       int
+		prereleases []string
+		builds      []string
+	}
+
+	type outputType struct {
+		expectedVersion Version
+		expectedErr     error
+	}
+
+	testCases := []struct {
+		caseDescription string
+		input           inputType
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			input: inputType{
+				major:       1,
+				minor:       2,
+				patch:       3,
+				prereleases: []string{"prerelease", "4"},
+				builds:      []string{"build", "5"},
+			},
+			output: outputType{
+				expectedVersion: Version("1.2.3-prerelease.4+build.5"),
+				expectedErr:     nil,
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			input: inputType{
+				major: 6,
+				minor: 7,
+				patch: 8,
+			},
+			output: outputType{
+				expectedVersion: Version("6.7.8"),
+				expectedErr:     nil,
+			},
+		},
+		{
+			caseDescription: "invalid -> error",
+			input: inputType{
+				major:       0,
+				minor:       0,
+				patch:       1,
+				prereleases: []string{"ű"},
+			},
+			output: outputType{
+				expectedVersion: Version(""),
+				expectedErr:     ErrorInvalidVersion("0.0.1-ű"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualVersion, actualErr := NewVersion(
+				testCase.input.major,
+				testCase.input.minor,
+				testCase.input.patch,
+				testCase.input.prereleases,
+				testCase.input.builds,
+			)
+
+			if testCase.output.expectedErr == nil {
+				require.NoError(t, actualErr)
+			} else {
+				require.EqualError(t, actualErr, testCase.output.expectedErr.Error())
+			}
+			require.Equal(t, testCase.output.expectedVersion, actualVersion)
+		})
+	}
+}
+
+func TestNewVersionOrPanic(t *testing.T) {
+	type inputType struct {
+		major       int
+		minor       int
+		patch       int
+		prereleases []string
+		builds      []string
+	}
+
+	type outputType struct {
+		expectedVersion     Version
+		expectedShouldPanic bool
+	}
+
+	testCases := []struct {
+		caseDescription string
+		input           inputType
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			input: inputType{
+				major:       1,
+				minor:       2,
+				patch:       3,
+				prereleases: []string{"prerelease", "4"},
+				builds:      []string{"build", "5"},
+			},
+			output: outputType{
+				expectedVersion:     Version("1.2.3-prerelease.4+build.5"),
+				expectedShouldPanic: false,
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			input: inputType{
+				major: 6,
+				minor: 7,
+				patch: 8,
+			},
+			output: outputType{
+				expectedVersion:     Version("6.7.8"),
+				expectedShouldPanic: false,
+			},
+		},
+		{
+			caseDescription: "invalid -> error",
+			input: inputType{
+				major:       0,
+				minor:       0,
+				patch:       1,
+				prereleases: []string{"ű"},
+			},
+			output: outputType{
+				expectedVersion:     Version(""),
+				expectedShouldPanic: true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			if testCase.output.expectedShouldPanic {
+				require.Panics(t, func() {
+					_ = NewVersionOrPanic(
+						testCase.input.major,
+						testCase.input.minor,
+						testCase.input.patch,
+						testCase.input.prereleases,
+						testCase.input.builds,
+					)
+				})
+			} else {
+				actualVersion := NewVersionOrPanic(
+					testCase.input.major,
+					testCase.input.minor,
+					testCase.input.patch,
+					testCase.input.prereleases,
+					testCase.input.builds,
+				)
+
+				require.Equal(t, testCase.output.expectedVersion, actualVersion)
+			}
+		})
+	}
+}
+
+func TestNewVersionFromString(t *testing.T) {
+	type outputType struct {
+		expectedVersion Version
+		expectedErr     error
+	}
+
+	testCases := []struct {
+		caseDescription string
+		inputCandidate  string
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			inputCandidate:  "1.2.3-prerelease.4+build.5",
+			output: outputType{
+				expectedVersion: Version("1.2.3-prerelease.4+build.5"),
+				expectedErr:     nil,
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			inputCandidate:  "6.7.8",
+			output: outputType{
+				expectedVersion: Version("6.7.8"),
+				expectedErr:     nil,
+			},
+		},
+		{
+			caseDescription: "invalid -> error",
+			inputCandidate:  "invalid-version",
+			output: outputType{
+				expectedVersion: Version(""),
+				expectedErr:     ErrorInvalidVersion("invalid-version"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualVersion, actualErr := NewVersionFromString(testCase.inputCandidate)
+
+			if testCase.output.expectedErr == nil {
+				require.NoError(t, actualErr)
+			} else {
+				require.EqualError(t, actualErr, testCase.output.expectedErr.Error())
+			}
+			require.Equal(t, testCase.output.expectedVersion, actualVersion)
+		})
+	}
+}
+
+func TestNewVersionFromStringOrPanic(t *testing.T) {
+	type outputType struct {
+		expectedVersion     Version
+		expectedShouldPanic bool
+	}
+
+	testCases := []struct {
+		caseDescription string
+		inputCandidate  string
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			inputCandidate:  "1.2.3-prerelease.4+build.5",
+			output: outputType{
+				expectedVersion:     Version("1.2.3-prerelease.4+build.5"),
+				expectedShouldPanic: false,
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			inputCandidate:  "6.7.8",
+			output: outputType{
+				expectedVersion:     Version("6.7.8"),
+				expectedShouldPanic: false,
+			},
+		},
+		{
+			caseDescription: "invalid -> error",
+			inputCandidate:  "invalid-version",
+			output: outputType{
+				expectedVersion:     Version(""),
+				expectedShouldPanic: true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			if testCase.output.expectedShouldPanic {
+				require.Panics(t, func() { _ = NewVersionFromStringOrPanic(testCase.inputCandidate) })
+			} else {
+				actualVersion := NewVersionFromStringOrPanic(testCase.inputCandidate)
+
+				require.Equal(t, testCase.output.expectedVersion, actualVersion)
+			}
+		})
+	}
+}
+
+func TestVersionBuild(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedBuild   string
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedBuild:   "build.5",
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedBuild:   "",
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> success",
+			expectedBuild:   "",
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualBuild := testCase.inputVersion.Build()
+
+			require.Equal(t, testCase.expectedBuild, actualBuild)
+		})
+	}
+}
+
+func TestVersionBuilds(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedBuilds  []string
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedBuilds:  []string{"build", "5"},
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedBuilds:  nil,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> success",
+			expectedBuilds:  nil,
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualBuilds := testCase.inputVersion.Builds()
+
+			require.Equal(t, testCase.expectedBuilds, actualBuilds)
+		})
+	}
+}
+
+func TestVersionCheck(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedErr     error
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedErr:     nil,
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedErr:     nil,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> error",
+			expectedErr:     ErrorInvalidVersion("invalid-version"),
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualErr := testCase.inputVersion.Check()
+
+			if testCase.expectedErr == nil {
+				require.NoError(t, actualErr)
+			} else {
+				require.EqualError(t, actualErr, testCase.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	type inputType struct {
+		version      Version
+		otherVersion Version
+	}
+
+	testCases := []struct {
+		caseDescription string
+		expectedResult  Compared
+		input           inputType
+	}{
+		{
+			caseDescription: "major less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription: "major greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "1.1.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.1.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.0",
+				otherVersion: "1.2.1",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.1",
+				otherVersion: "1.2.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, one prerelease less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, one prerelease greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, one prerelease decimal less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.string",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, one prerelease decimal greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3-prerelease.string",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prereleases decimal less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.1",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prerelease decimal greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3-prerelease.1",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prerelease string less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.3-prerelease.alpha",
+				otherVersion: "1.2.3-prerelease.beta",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prerelease string greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3-prerelease.beta",
+				otherVersion: "1.2.3-prerelease.alpha",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prerelease shorter less -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription: "major equal, minor equal, patch equal, prerelease longer greater -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription: "all equal -> equal success",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				version:      "1.2.3-prerelease.4",
+				otherVersion: "1.2.3-prerelease.4",
+			},
+		},
+		{
+			caseDescription: "all equal with differing builds -> equal success",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				version:      "1.2.3-prerelease.4+build.5",
+				otherVersion: "1.2.3-prerelease.4+build.6",
+			},
+		},
+		{
+			caseDescription: "invalid version, valid zero other version -> equal success",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: ZeroVersion,
+			},
+		},
+		{
+			caseDescription: "invalid version, valid non-zero other version -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription: "valid zero version, invalid other version -> equal success",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				version:      ZeroVersion,
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription: "valid non-zero version, invalid other version -> greater success",
+			expectedResult:  ComparedGreater,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription: "invalid version, invalid other version -> equal success",
+			expectedResult:  ComparedEqual,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "other-invalid-version",
+			},
+		},
+		{
+			caseDescription: "specification example 1 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription: "specification example 2 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "2.1.0",
+			},
+		},
+		{
+			caseDescription: "specification example 3 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "2.1.0",
+				otherVersion: "2.1.1",
+			},
+		},
+		{
+			caseDescription: "specification example 4 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription: "specification example 5 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0-alpha.1",
+			},
+		},
+		{
+			caseDescription: "specification example 6 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha.1",
+				otherVersion: "1.0.0-alpha.beta",
+			},
+		},
+		{
+			caseDescription: "specification example 7 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription: "specification example 8 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription: "specification example 9 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription: "specification example 10 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-beta",
+				otherVersion: "1.0.0-beta.2",
+			},
+		},
+		{
+			caseDescription: "specification example 11 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-beta.2",
+				otherVersion: "1.0.0-beta.11",
+			},
+		},
+		{
+			caseDescription: "specification example 12 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-beta.11",
+				otherVersion: "1.0.0-rc.1",
+			},
+		},
+		{
+			caseDescription: "specification example 13 -> less success",
+			expectedResult:  ComparedLess,
+			input: inputType{
+				version:      "1.0.0-rc.1",
+				otherVersion: "1.0.0",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualResult := testCase.input.version.Compare(testCase.input.otherVersion)
+
+			require.Equal(t, testCase.expectedResult, actualResult)
+		})
+	}
+}
+
+func TestVersionEquals(t *testing.T) {
+	type inputType struct {
+		version      Version
+		otherVersion Version
+	}
+
+	testCases := []struct {
+		caseDescription  string
+		expectedAreEqual bool
+		input            inputType
+	}{
+		{
+			caseDescription:  "major difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "0.0.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:  "minor difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.1.0",
+				otherVersion: "1.2.0",
+			},
+		},
+		{
+			caseDescription:  "patch difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.2.2",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription:  "version prerelease difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "2.2.3",
+			},
+		},
+		{
+			caseDescription:  "other prerelease difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "2.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription:  "decimal prerelease difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.3",
+				otherVersion: "2.2.3-prerelease.4",
+			},
+		},
+		{
+			caseDescription:  "string prerelease difference -> false success",
+			expectedAreEqual: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.4.alpha",
+				otherVersion: "2.2.3-prerelease.4.beta",
+			},
+		},
+		{
+			caseDescription:  "no build equal -> true success",
+			expectedAreEqual: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.4",
+				otherVersion: "1.2.3-prerelease.4",
+			},
+		},
+		{
+			caseDescription:  "build difference equal -> true success",
+			expectedAreEqual: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.4+build.4",
+				otherVersion: "1.2.3-prerelease.4+build.5",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualAreEqual := testCase.input.version.Equals(testCase.input.otherVersion)
+
+			require.Equal(t, testCase.expectedAreEqual, actualAreEqual)
+		})
+	}
+}
+
+func TestVersionIsGreaterThan(t *testing.T) {
+	type inputType struct {
+		version      Version
+		otherVersion Version
+	}
+
+	testCases := []struct {
+		caseDescription       string
+		expectedIsGreaterThan bool
+		input                 inputType
+	}{
+		{
+			caseDescription:       "major less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription:       "major greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "1.1.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.1.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.0",
+				otherVersion: "1.2.1",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.1",
+				otherVersion: "1.2.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, one prerelease less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, one prerelease greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, one prerelease decimal less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.string",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, one prerelease decimal greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.string",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prereleases decimal less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.1",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prerelease decimal greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.1",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prerelease string less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.alpha",
+				otherVersion: "1.2.3-prerelease.beta",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prerelease string greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.beta",
+				otherVersion: "1.2.3-prerelease.alpha",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prerelease shorter less -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:       "major equal, minor equal, patch equal, prerelease longer greater -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription:       "all equal -> equal success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.4",
+				otherVersion: "1.2.3-prerelease.4",
+			},
+		},
+		{
+			caseDescription:       "all equal with differing builds -> equal success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.4+build.5",
+				otherVersion: "1.2.3-prerelease.4+build.6",
+			},
+		},
+		{
+			caseDescription:       "invalid version, valid zero other version -> equal success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: ZeroVersion,
+			},
+		},
+		{
+			caseDescription:       "invalid version, valid non-zero other version -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription:       "valid zero version, invalid other version -> equal success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      ZeroVersion,
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription:       "valid non-zero version, invalid other version -> greater success",
+			expectedIsGreaterThan: true,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription:       "invalid version, invalid other version -> equal success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "other-invalid-version",
+			},
+		},
+		{
+			caseDescription:       "specification example 1 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription:       "specification example 2 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "2.1.0",
+			},
+		},
+		{
+			caseDescription:       "specification example 3 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "2.1.0",
+				otherVersion: "2.1.1",
+			},
+		},
+		{
+			caseDescription:       "specification example 4 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:       "specification example 5 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0-alpha.1",
+			},
+		},
+		{
+			caseDescription:       "specification example 6 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha.1",
+				otherVersion: "1.0.0-alpha.beta",
+			},
+		},
+		{
+			caseDescription:       "specification example 7 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:       "specification example 8 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:       "specification example 9 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:       "specification example 10 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-beta",
+				otherVersion: "1.0.0-beta.2",
+			},
+		},
+		{
+			caseDescription:       "specification example 11 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-beta.2",
+				otherVersion: "1.0.0-beta.11",
+			},
+		},
+		{
+			caseDescription:       "specification example 12 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-beta.11",
+				otherVersion: "1.0.0-rc.1",
+			},
+		},
+		{
+			caseDescription:       "specification example 13 -> less success",
+			expectedIsGreaterThan: false,
+			input: inputType{
+				version:      "1.0.0-rc.1",
+				otherVersion: "1.0.0",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsGreaterThan := testCase.input.version.IsGreaterThan(testCase.input.otherVersion)
+
+			require.Equal(t, testCase.expectedIsGreaterThan, actualIsGreaterThan)
+		})
+	}
+}
+
+func TestVersionIsInRange(t *testing.T) {
+	type inputType struct {
+		version                Version
+		inclusiveLowerBoundary Version
+		exclusiveUpperBoundary Version
+	}
+
+	testCases := []struct {
+		caseDescription   string
+		expectedIsInRange bool
+		input             inputType
+	}{
+		{
+			caseDescription:   "major below lower boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "0.0.0",
+				inclusiveLowerBoundary: "1.0.0",
+				exclusiveUpperBoundary: "3.0.0",
+			},
+		},
+		{
+			caseDescription:   "major equals lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.0.0",
+				inclusiveLowerBoundary: "1.0.0",
+				exclusiveUpperBoundary: "3.0.0",
+			},
+		},
+		{
+			caseDescription:   "major between boundaries -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "2.0.0",
+				inclusiveLowerBoundary: "1.0.0",
+				exclusiveUpperBoundary: "3.0.0",
+			},
+		},
+		{
+			caseDescription:   "major equals upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "3.0.0",
+				inclusiveLowerBoundary: "1.0.0",
+				exclusiveUpperBoundary: "3.0.0",
+			},
+		},
+		{
+			caseDescription:   "major above upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "4.0.0",
+				inclusiveLowerBoundary: "1.0.0",
+				exclusiveUpperBoundary: "3.0.0",
+			},
+		},
+		{
+			caseDescription:   "minor below lower boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.1.0",
+				inclusiveLowerBoundary: "1.2.0",
+				exclusiveUpperBoundary: "1.4.0",
+			},
+		},
+		{
+			caseDescription:   "minor equals lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.0",
+				inclusiveLowerBoundary: "1.2.0",
+				exclusiveUpperBoundary: "1.4.0",
+			},
+		},
+		{
+			caseDescription:   "minor between boundaries -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.3.0",
+				inclusiveLowerBoundary: "1.2.0",
+				exclusiveUpperBoundary: "1.4.0",
+			},
+		},
+		{
+			caseDescription:   "minor equals upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.4.0",
+				inclusiveLowerBoundary: "1.2.0",
+				exclusiveUpperBoundary: "1.4.0",
+			},
+		},
+		{
+			caseDescription:   "minor above upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.5.0",
+				inclusiveLowerBoundary: "1.2.0",
+				exclusiveUpperBoundary: "1.4.0",
+			},
+		},
+		{
+			caseDescription:   "patch below lower boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.2",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "patch equals lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "patch between boundaries -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.4",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "patch equals upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.5",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "patch above upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.6",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "prerelease below lower boundary by prerelease -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.3-prerelease",
+				inclusiveLowerBoundary: "1.2.3",
+				exclusiveUpperBoundary: "1.2.5",
+			},
+		},
+		{
+			caseDescription:   "prerelease below lower boundary by prerelease identifier -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.3-prerelease.3",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6",
+			},
+		},
+		{
+			caseDescription:   "prerelease equals lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6",
+			},
+		},
+		{
+			caseDescription:   "prerelease between boundaries -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.5",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6",
+			},
+		},
+		{
+			caseDescription:   "prerelease equals upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.3-prerelease.6",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6",
+			},
+		},
+		{
+			caseDescription:   "prerelease above upper boundary -> false success",
+			expectedIsInRange: false,
+			input: inputType{
+				version:                "1.2.3-prerelease.7",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6",
+			},
+		},
+		{
+			caseDescription:   "build does not affect range, below lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4+build.4",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4+build.5",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6+build.7",
+			},
+		},
+		{
+			caseDescription:   "build does not affect range, equals lower boundary -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4+build.5",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4+build.5",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6+build.7",
+			},
+		},
+		{
+			caseDescription:   "build does not affect range, between boundaries -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4+build.6",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4+build.5",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6+build.7",
+			},
+		},
+		{
+			caseDescription:   "build does not affect range, equals upper boundary  -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4+build.7",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4+build.5",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6+build.7",
+			},
+		},
+		{
+			caseDescription:   "build does not affect range, above upper boundary  -> true success",
+			expectedIsInRange: true,
+			input: inputType{
+				version:                "1.2.3-prerelease.4+build.8",
+				inclusiveLowerBoundary: "1.2.3-prerelease.4+build.5",
+				exclusiveUpperBoundary: "1.2.3-prerelease.6+build.7",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsInRange := testCase.input.version.IsInRange(
+				testCase.input.inclusiveLowerBoundary,
+				testCase.input.exclusiveUpperBoundary,
+			)
+
+			require.Equal(t, testCase.expectedIsInRange, actualIsInRange)
+		})
+	}
+}
+
+func TestVersionIsLessThan(t *testing.T) {
+	type inputType struct {
+		version      Version
+		otherVersion Version
+	}
+
+	testCases := []struct {
+		caseDescription    string
+		expectedIsLessThan bool
+		input              inputType
+	}{
+		{
+			caseDescription:    "major less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription:    "major greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "1.1.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.1.0",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.0",
+				otherVersion: "1.2.1",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.1",
+				otherVersion: "1.2.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, one prerelease less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, one prerelease greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, one prerelease decimal less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.string",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, one prerelease decimal greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.string",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prereleases decimal less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease.1",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prerelease decimal greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.1",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prerelease string less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease.alpha",
+				otherVersion: "1.2.3-prerelease.beta",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prerelease string greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.beta",
+				otherVersion: "1.2.3-prerelease.alpha",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prerelease shorter less -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.2.3-prerelease",
+				otherVersion: "1.2.3-prerelease.0",
+			},
+		},
+		{
+			caseDescription:    "major equal, minor equal, patch equal, prerelease longer greater -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.0",
+				otherVersion: "1.2.3-prerelease",
+			},
+		},
+		{
+			caseDescription:    "all equal -> equal success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.4",
+				otherVersion: "1.2.3-prerelease.4",
+			},
+		},
+		{
+			caseDescription:    "all equal with differing builds -> equal success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3-prerelease.4+build.5",
+				otherVersion: "1.2.3-prerelease.4+build.6",
+			},
+		},
+		{
+			caseDescription:    "invalid version, valid zero other version -> equal success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: ZeroVersion,
+			},
+		},
+		{
+			caseDescription:    "invalid version, valid non-zero other version -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "1.2.3",
+			},
+		},
+		{
+			caseDescription:    "valid zero version, invalid other version -> equal success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      ZeroVersion,
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription:    "valid non-zero version, invalid other version -> greater success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "1.2.3",
+				otherVersion: "invalid-version",
+			},
+		},
+		{
+			caseDescription:    "invalid version, invalid other version -> equal success",
+			expectedIsLessThan: false,
+			input: inputType{
+				version:      "invalid-version",
+				otherVersion: "other-invalid-version",
+			},
+		},
+		{
+			caseDescription:    "specification example 1 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0",
+				otherVersion: "2.0.0",
+			},
+		},
+		{
+			caseDescription:    "specification example 2 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "2.0.0",
+				otherVersion: "2.1.0",
+			},
+		},
+		{
+			caseDescription:    "specification example 3 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "2.1.0",
+				otherVersion: "2.1.1",
+			},
+		},
+		{
+			caseDescription:    "specification example 4 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0",
+			},
+		},
+		{
+			caseDescription:    "specification example 5 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha",
+				otherVersion: "1.0.0-alpha.1",
+			},
+		},
+		{
+			caseDescription:    "specification example 6 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha.1",
+				otherVersion: "1.0.0-alpha.beta",
+			},
+		},
+		{
+			caseDescription:    "specification example 7 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:    "specification example 8 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:    "specification example 9 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-alpha.beta",
+				otherVersion: "1.0.0-beta",
+			},
+		},
+		{
+			caseDescription:    "specification example 10 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-beta",
+				otherVersion: "1.0.0-beta.2",
+			},
+		},
+		{
+			caseDescription:    "specification example 11 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-beta.2",
+				otherVersion: "1.0.0-beta.11",
+			},
+		},
+		{
+			caseDescription:    "specification example 12 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-beta.11",
+				otherVersion: "1.0.0-rc.1",
+			},
+		},
+		{
+			caseDescription:    "specification example 13 -> less success",
+			expectedIsLessThan: true,
+			input: inputType{
+				version:      "1.0.0-rc.1",
+				otherVersion: "1.0.0",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsLessThan := testCase.input.version.IsLessThan(testCase.input.otherVersion)
+
+			require.Equal(t, testCase.expectedIsLessThan, actualIsLessThan)
+		})
+	}
+}
+
+func TestVersionIsValid(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedIsValid bool
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> valid",
+			expectedIsValid: true,
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> valid",
+			expectedIsValid: true,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> invalid",
+			expectedIsValid: false,
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsValid := testCase.inputVersion.IsValid()
+
+			require.Equal(t, testCase.expectedIsValid, actualIsValid)
+		})
+	}
+}
+
+func TestVersionMajor(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedMajor   int
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedMajor:   1,
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedMajor:   6,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> success",
+			expectedMajor:   0,
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualMajor := testCase.inputVersion.Major()
+
+			require.Equal(t, testCase.expectedMajor, actualMajor)
+		})
+	}
+}
+
+func TestVersionMinor(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedMinor   int
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedMinor:   2,
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedMinor:   7,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> success",
+			expectedMinor:   0,
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualMinor := testCase.inputVersion.Minor()
+
+			require.Equal(t, testCase.expectedMinor, actualMinor)
+		})
+	}
+}
+
+func TestVersionParts(t *testing.T) {
+	type outputType struct {
+		expectedMajor       int
+		expectedMinor       int
+		expectedPatch       int
+		expectedPrereleases []string
+		expectedBuilds      []string
+	}
+
+	testCases := []struct {
+		caseDescription string
+		inputVersion    Version
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+			output: outputType{
+				expectedMajor:       1,
+				expectedMinor:       2,
+				expectedPatch:       3,
+				expectedPrereleases: []string{"prerelease", "4"},
+				expectedBuilds:      []string{"build", "5"},
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			inputVersion:    "6.7.8",
+			output: outputType{
+				expectedMajor:       6,
+				expectedMinor:       7,
+				expectedPatch:       8,
+				expectedPrereleases: nil,
+				expectedBuilds:      nil,
+			},
+		},
+		{
+			caseDescription: "invalid -> success",
+			inputVersion:    "invalid-version",
+			output: outputType{
+				expectedMajor:       0,
+				expectedMinor:       0,
+				expectedPatch:       0,
+				expectedPrereleases: nil,
+				expectedBuilds:      nil,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualMajor, actualMinor, actualPatch, actualPrereleases, actualBuilds := testCase.inputVersion.Parts()
+
+			require.Equal(t, testCase.output.expectedMajor, actualMajor)
+			require.Equal(t, testCase.output.expectedMinor, actualMinor)
+			require.Equal(t, testCase.output.expectedPatch, actualPatch)
+			require.Equal(t, testCase.output.expectedPrereleases, actualPrereleases)
+			require.Equal(t, testCase.output.expectedBuilds, actualBuilds)
+		})
+	}
+}
+
+func TestVersionPatch(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedPatch   int
+		inputVersion    Version
+	}{
+		{
+			caseDescription: "full -> success",
+			expectedPatch:   3,
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription: "partial -> success",
+			expectedPatch:   8,
+			inputVersion:    "6.7.8",
+		},
+		{
+			caseDescription: "invalid -> success",
+			expectedPatch:   0,
+			inputVersion:    "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualPatch := testCase.inputVersion.Patch()
+
+			require.Equal(t, testCase.expectedPatch, actualPatch)
+		})
+	}
+}
+
+func TestVersionPrerelease(t *testing.T) {
+	testCases := []struct {
+		caseDescription    string
+		expectedPrerelease string
+		inputVersion       Version
+	}{
+		{
+			caseDescription:    "full -> success",
+			expectedPrerelease: "prerelease.4",
+			inputVersion:       "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:    "partial -> success",
+			expectedPrerelease: "",
+			inputVersion:       "6.7.8",
+		},
+		{
+			caseDescription:    "invalid -> success",
+			expectedPrerelease: "",
+			inputVersion:       "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualPrerelease := testCase.inputVersion.Prerelease()
+
+			require.Equal(t, testCase.expectedPrerelease, actualPrerelease)
+		})
+	}
+}
+
+func TestVersionPrereleases(t *testing.T) {
+	testCases := []struct {
+		caseDescription     string
+		expectedPrereleases []string
+		inputVersion        Version
+	}{
+		{
+			caseDescription:     "full -> success",
+			expectedPrereleases: []string{"prerelease", "4"},
+			inputVersion:        "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:     "partial -> success",
+			expectedPrereleases: nil,
+			inputVersion:        "6.7.8",
+		},
+		{
+			caseDescription:     "invalid -> success",
+			expectedPrereleases: nil,
+			inputVersion:        "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualPrereleases := testCase.inputVersion.Prereleases()
+
+			require.Equal(t, testCase.expectedPrereleases, actualPrereleases)
+		})
+	}
+}
+
+func TestVersionRawParts(t *testing.T) {
+	type outputType struct {
+		expectedMajor      string
+		expectedMinor      string
+		expectedPatch      string
+		expectedPrerelease string
+		expectedBuild      string
+	}
+
+	testCases := []struct {
+		caseDescription string
+		inputVersion    Version
+		output          outputType
+	}{
+		{
+			caseDescription: "full -> success",
+			inputVersion:    "1.2.3-prerelease.4+build.5",
+			output: outputType{
+				expectedMajor:      "1",
+				expectedMinor:      "2",
+				expectedPatch:      "3",
+				expectedPrerelease: "prerelease.4",
+				expectedBuild:      "build.5",
+			},
+		},
+		{
+			caseDescription: "partial -> success",
+			inputVersion:    "6.7.8",
+			output: outputType{
+				expectedMajor:      "6",
+				expectedMinor:      "7",
+				expectedPatch:      "8",
+				expectedPrerelease: "",
+				expectedBuild:      "",
+			},
+		},
+		{
+			caseDescription: "invalid -> success",
+			inputVersion:    "invalid-version",
+			output: outputType{
+				expectedMajor:      "0",
+				expectedMinor:      "0",
+				expectedPatch:      "0",
+				expectedPrerelease: "",
+				expectedBuild:      "",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualMajor, actualMinor, actualPatch, actualPrerelease, actualBuild := testCase.inputVersion.RawParts()
+
+			require.Equal(t, testCase.output.expectedMajor, actualMajor)
+			require.Equal(t, testCase.output.expectedMinor, actualMinor)
+			require.Equal(t, testCase.output.expectedPatch, actualPatch)
+			require.Equal(t, testCase.output.expectedPrerelease, actualPrerelease)
+			require.Equal(t, testCase.output.expectedBuild, actualBuild)
+		})
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	testCases := []struct {
+		caseDescription       string
+		expectedVersionString string
+		inputVersion          Version
+	}{
+		{
+			caseDescription:       "1.2.3-prerelease.4+build.5 -> success",
+			expectedVersionString: "1.2.3-prerelease.4+build.5",
+			inputVersion:          "1.2.3-prerelease.4+build.5",
+		},
+		{
+			caseDescription:       "invalid -> success",
+			expectedVersionString: "invalid-version",
+			inputVersion:          "invalid-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualVersionString := testCase.inputVersion.String()
+
+			require.Equal(t, testCase.expectedVersionString, actualVersionString)
+		})
+	}
+}

--- a/pkg/sdk/semver/versions.go
+++ b/pkg/sdk/semver/versions.go
@@ -1,0 +1,50 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+// Versions defines a version collection (slice) type for sorting purposes.
+type Versions []Version
+
+// Len returns the length of the collection.
+func (versions Versions) Len() (length int) {
+	return len(versions)
+}
+
+// Less returns true if the collection item behind the first specified index is
+// less than the collection item behind the second provided index.
+func (versions Versions) Less(firstIndex, secondIndex int) (isLessThan bool) {
+	if versions == nil ||
+		firstIndex < 0 ||
+		firstIndex > len(versions) ||
+		secondIndex < 0 ||
+		secondIndex > len(versions) {
+		return false
+	}
+
+	return versions[firstIndex].IsLessThan(versions[secondIndex])
+}
+
+// Swap replaces the collection items behind the specified indices with each other.
+func (versions Versions) Swap(firstIndex, secondIndex int) {
+	if versions == nil ||
+		firstIndex < 0 ||
+		firstIndex > len(versions) ||
+		secondIndex < 0 ||
+		secondIndex > len(versions) {
+		return
+	}
+
+	versions[firstIndex], versions[secondIndex] = versions[secondIndex], versions[firstIndex]
+}

--- a/pkg/sdk/semver/versions_test.go
+++ b/pkg/sdk/semver/versions_test.go
@@ -1,0 +1,249 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionsLen(t *testing.T) {
+	testCases := []struct {
+		caseDescription string
+		expectedLength  int
+		inputVersions   Versions
+	}{
+		{
+			caseDescription: "nil versions -> 0 success",
+			expectedLength:  0,
+			inputVersions:   nil,
+		},
+		{
+			caseDescription: "empty versions -> 0 success",
+			expectedLength:  0,
+			inputVersions:   Versions([]Version{}),
+		},
+		{
+			caseDescription: "not empty versions -> len(Versions) success",
+			expectedLength:  3,
+			inputVersions:   Versions([]Version{"1.2.3", "4.5.6", "7.8.9"}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualLength := testCase.inputVersions.Len()
+
+			require.Equal(t, testCase.expectedLength, actualLength)
+		})
+	}
+}
+
+func TestVersionsLess(t *testing.T) {
+	type inputType struct {
+		versions    Versions
+		firstIndex  int
+		secondIndex int
+	}
+
+	testCases := []struct {
+		caseDescription    string
+		expectedIsLessThan bool
+		input              inputType
+	}{
+		{
+			caseDescription:    "nil versions -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    nil,
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "empty versions -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "less -> true success",
+			expectedIsLessThan: true,
+			input: inputType{
+				versions:    Versions([]Version{"1.2.3", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "equal -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"1.2.3", "1.2.3"}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "greater -> true success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "first index < 0 -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  -1,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "first index > len(versions) -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  999,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:    "second index < 0 -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: -1,
+			},
+		},
+		{
+			caseDescription:    "second index > len(versions) -> false success",
+			expectedIsLessThan: false,
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: 999,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			actualIsLessThan := testCase.input.versions.Less(testCase.input.firstIndex, testCase.input.secondIndex)
+
+			require.Equal(t, testCase.expectedIsLessThan, actualIsLessThan)
+		})
+	}
+}
+
+func TestVersionsSwap(t *testing.T) {
+	type inputType struct {
+		versions    Versions
+		firstIndex  int
+		secondIndex int
+	}
+
+	testCases := []struct {
+		caseDescription  string
+		expectedVersions Versions
+		input            inputType
+	}{
+		{
+			caseDescription:  "nil versions -> original versions",
+			expectedVersions: nil,
+			input: inputType{
+				versions:    nil,
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:  "empty versions -> original versions",
+			expectedVersions: Versions([]Version{}),
+			input: inputType{
+				versions:    Versions([]Version{}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:  "not empty versions -> swapped success",
+			expectedVersions: Versions([]Version{"4.5.6", "1.2.3"}),
+			input: inputType{
+				versions:    Versions([]Version{"1.2.3", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:  "first index < 0 -> original versions",
+			expectedVersions: Versions([]Version{"7.8.9", "4.5.6"}),
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  -1,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:  "first index > len(versions) -> original versions",
+			expectedVersions: Versions([]Version{"7.8.9", "4.5.6"}),
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  999,
+				secondIndex: 1,
+			},
+		},
+		{
+			caseDescription:  "second index < 0 -> original versions",
+			expectedVersions: Versions([]Version{"7.8.9", "4.5.6"}),
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: -1,
+			},
+		},
+		{
+			caseDescription:  "second index > len(versions) -> original versions",
+			expectedVersions: Versions([]Version{"7.8.9", "4.5.6"}),
+			input: inputType{
+				versions:    Versions([]Version{"7.8.9", "4.5.6"}),
+				firstIndex:  0,
+				secondIndex: 999,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			testCase.input.versions.Swap(testCase.input.firstIndex, testCase.input.secondIndex)
+
+			require.Equal(t, testCase.expectedVersions, testCase.input.versions)
+		})
+	}
+}

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -458,7 +458,8 @@ Parameters:
 
   TemplateVersion:
     Type: String
-    Description: Version of the template structure as metainformation for created stacks.
+    Default: "2.0.1"
+    Description: Current version of the template structure as metainformation for created stacks.
 
   TerminationDetachEnabled:
     Type: String


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed a bug which caused the current template version not being retrieved for the node pool stacks which are updated when all node pool version attributes were changed during the update due to a left in condition for old value retrieval.

Refactored the EKS node pool CloudFormation template version handling.

1. Simplified `TemplateVersion` handling and make it easier to use/update.
Single point to track the latest node pool version as the default value of the `TemplateVersion` parameter in the template itself, keeping the update requirement local when the template changes, so no manual setting/update is required from code to keep all new stacks up to date with the latest template version.
2. Changed the `TemplateVersion` handling in the Golang code to use a strongly typed semantic version representation with helper functions instead of a "weakly typed string".
3. Refactored the CloudFormation stack parameter value parsing to handle the strongly typed semantic version and also tuned it a little bit to make full use of `mapstructure` and avoid double direction decoding/parsing (this resulted in 1.5 function being dropped completely at the expense of implementing a proxy function interface).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

This is useful to ease the implementation of #3347, because it requires another template version update (new parameters being introduced) so I fine-tuned the template version handling for that purpose.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using `NodePoolAPI.UpdateNodePool` with both enterprise and open-source Pipeline implementation due to the condition and template version retrieval change.
Double checked Template version, it updates as expected.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
