### PR TITLE
Fixed EKS UpdateCluster to include SecurityGroups in node pool version calculation

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -34,6 +34,7 @@ import (
 	pkgCloudformation "github.com/banzaicloud/pipeline/pkg/providers/amazon/cloudformation"
 	sdkAmazon "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon"
 	sdkCloudformation "github.com/banzaicloud/pipeline/pkg/sdk/providers/amazon/cloudformation"
+	"github.com/banzaicloud/pipeline/pkg/sdk/semver"
 )
 
 const UpdateAsgActivityName = "eks-update-asg"
@@ -73,6 +74,8 @@ type UpdateAsgActivityInput struct {
 
 	Labels map[string]string
 	Tags   map[string]string
+
+	CurrentTemplateVersion semver.Version
 }
 
 // UpdateAsgActivityOutput holds the output data of the UpdateAsgActivityOutput


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed EKS UpdateCluster's node pool version.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

When SecurityGroup was added to EKS UpdateCluster, it was left out of the node pool version calculation.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This PR was built on top of #3357 in order to not introduce the same edge case bug here.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

