### PR TITLE
Increase please build timeout in CI

### DIFF
--- a/.plzconfig.ci
+++ b/.plzconfig.ci
@@ -1,3 +1,6 @@
 [cache]
 dir = .plz-cache
 dircompress = true
+
+[build]
+timeout = 900


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Increment build timeout to avoid the build fail intermittently. This is only a temporary workaround to let the cache populated and make subsequent builds more efficient.