### PR TITLE
Velero API: add option to pass service account role ARN when enabling backups

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -22913,6 +22913,12 @@ components:
             to the cluster.
           example: false
           type: boolean
+        serviceAccountRoleARN:
+          description: relevant only in case of Amazon clusters. This a third option
+            to give permissions for volume snapshots to Velero, besides the default
+            NodeInstance role or cluster secret deployment.
+          example: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+          type: string
         storageAccount:
           description: required only case of Azure
           example: my-storage-account

--- a/.gen/pipeline/pipeline/model_enable_ark_request.go
+++ b/.gen/pipeline/pipeline/model_enable_ark_request.go
@@ -27,6 +27,9 @@ type EnableArkRequest struct {
 	// relevant only in case of Amazon clusters. By default set to false in which case you must add snapshot permissions to your node instance role. Should you set to true Pipeline will deploy your cluster secret to the cluster.
 	UseClusterSecret bool `json:"useClusterSecret,omitempty"`
 
+	// relevant only in case of Amazon clusters. This a third option to give permissions for volume snapshots to Velero, besides the default NodeInstance role or cluster secret deployment.
+	ServiceAccountRoleARN string `json:"serviceAccountRoleARN,omitempty"`
+
 	// required only case of Azure
 	StorageAccount string `json:"storageAccount,omitempty"`
 

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -8171,6 +8171,10 @@ components:
                     type: boolean
                     example: false
                     description: "relevant only in case of Amazon clusters. By default set to false in which case you must add snapshot permissions to your node instance role. Should you set to true Pipeline will deploy your cluster secret to the cluster."
+                serviceAccountRoleARN:
+                    type: string
+                    example: "arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME"
+                    description: "relevant only in case of Amazon clusters. This a third option to give permissions for volume snapshots to Velero, besides the default NodeInstance role or cluster secret deployment."
                 storageAccount:
                     type: string
                     example: "my-storage-account"

--- a/internal/ark/api/deployments.go
+++ b/internal/ark/api/deployments.go
@@ -26,11 +26,12 @@ type PersistDeploymentRequest struct {
 type EnableBackupServiceRequest struct {
 	CreateBucketRequest
 
-	Schedule         string            `json:"schedule" binding:"required"`
-	TTL              string            `json:"ttl" binding:"required"`
-	Labels           map[string]string `json:"labels,omitempty"`
-	Options          BackupOptions     `json:"options,omitempty"`
-	UseClusterSecret bool              `json:"useClusterSecret,omitempty"`
+	Schedule              string            `json:"schedule" binding:"required"`
+	TTL                   string            `json:"ttl" binding:"required"`
+	Labels                map[string]string `json:"labels,omitempty"`
+	Options               BackupOptions     `json:"options,omitempty"`
+	UseClusterSecret      bool              `json:"useClusterSecret,omitempty"`
+	ServiceAccountRoleARN string            `json:"serviceAccountRoleARN,omitempty"`
 }
 
 // EnableBackupServiceResponse describes Pipeline's EnableBackupServiceRequest API response

--- a/internal/ark/api/posthook.go
+++ b/internal/ark/api/posthook.go
@@ -16,7 +16,8 @@ package api
 
 // RestoreFromBackupParams describes RestoreFromBackup posthook params
 type RestoreFromBackupParams struct {
-	BackupID         uint           `json:"backupId"`
-	Options          RestoreOptions `json:"options,omitempty"`
-	UseClusterSecret bool           `json:"useClusterSecret,omitempty"`
+	BackupID              uint           `json:"backupId"`
+	Options               RestoreOptions `json:"options,omitempty"`
+	UseClusterSecret      bool           `json:"useClusterSecret,omitempty"`
+	ServiceAccountRoleARN string         `json:"serviceAccountRoleARN,omitempty"`
 }

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -100,7 +100,8 @@ func (s *DeploymentsService) GetActiveDeployment() (*ClusterBackupDeploymentsMod
 }
 
 // Deploy deploys ARK with helm configured to use the given bucket and mode
-func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBackupBucketsModel, restoreMode bool, useClusterSecret bool) error {
+func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBackupBucketsModel,
+	restoreMode bool, useClusterSecret bool, serviceAccountRoleARN string) error {
 	var deployment *ClusterBackupDeploymentsModel
 	if !restoreMode {
 		_, err := s.GetActiveDeployment()
@@ -148,9 +149,10 @@ func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBack
 				ResourceGroup:  bucket.ResourceGroup,
 			},
 		},
-		BucketSecret:     bucketSecret,
-		UseClusterSecret: useClusterSecret,
-		RestoreMode:      restoreMode,
+		BucketSecret:          bucketSecret,
+		UseClusterSecret:      useClusterSecret,
+		ServiceAccountRoleARN: serviceAccountRoleARN,
+		RestoreMode:           restoreMode,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error service getting config")

--- a/internal/ark/posthook/posthook.go
+++ b/internal/ark/posthook/posthook.go
@@ -65,7 +65,7 @@ func RestoreFromBackup(
 		return err
 	}
 
-	err = svc.GetDeploymentsService().Deploy(helmService, &backup.Bucket, true, params.UseClusterSecret, "")
+	err = svc.GetDeploymentsService().Deploy(helmService, &backup.Bucket, true, params.UseClusterSecret, params.ServiceAccountRoleARN)
 	if err != nil {
 		return err
 	}

--- a/internal/ark/posthook/posthook.go
+++ b/internal/ark/posthook/posthook.go
@@ -65,7 +65,7 @@ func RestoreFromBackup(
 		return err
 	}
 
-	err = svc.GetDeploymentsService().Deploy(helmService, &backup.Bucket, true, params.UseClusterSecret)
+	err = svc.GetDeploymentsService().Deploy(helmService, &backup.Bucket, true, params.UseClusterSecret, "")
 	if err != nil {
 		return err
 	}

--- a/src/api/ark/backupservice/enable.go
+++ b/src/api/ark/backupservice/enable.go
@@ -108,7 +108,7 @@ func Enable(helmService helm.UnifiedReleaser) func(c *gin.Context) {
 			return
 		}
 
-		err = svc.GetDeploymentsService().Deploy(helmService, bucket, false, request.UseClusterSecret)
+		err = svc.GetDeploymentsService().Deploy(helmService, bucket, false, request.UseClusterSecret, request.ServiceAccountRoleARN)
 		if err != nil {
 			err = errors.WrapIf(err, "could not deploy backup service")
 			common.ErrorHandler.Handle(err)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3362 
| License         | Apache 2.0


### What's in this PR?
Add serviceAccountRoleARN field to Enable backup API call.

### Why?
When enabling Velero backups, the user should have the options to pass a service account role ARN. Pipeline will annotate Velero Service Account with this value, which will be a third options beside using cluster secret deployment or NodeInstancreProfile.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

