### PR TITLE
Add UseIntanceStorage param to EKS node pool CF template

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -269,8 +269,8 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 			ParameterValue: aws.String(fmt.Sprint(terminationDetachEnabled)),
 		},
 		{
-			ParameterKey:   aws.String("BootstrapArguments"),
-			ParameterValue: aws.String(fmt.Sprintf("--kubelet-extra-args '--node-labels %v'", strings.Join(nodeLabels, ","))),
+			ParameterKey:   aws.String("KubeletExtraArguments"),
+			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
 	}
 	clientRequestToken := sdkAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateAsgActivityName)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -302,8 +302,8 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 			ParameterValue: aws.String(fmt.Sprint(terminationDetachEnabled)),
 		},
 		{
-			ParameterKey:   aws.String("BootstrapArguments"),
-			ParameterValue: aws.String(fmt.Sprintf("--kubelet-extra-args '--node-labels %v'", strings.Join(nodeLabels, ","))),
+			ParameterKey:   aws.String("KubeletExtraArguments"),
+			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
 	}
 

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -234,8 +234,8 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 			UsePreviousValue: aws.Bool(true),
 		},
 		{
-			ParameterKey:   aws.String("BootstrapArguments"),
-			ParameterValue: aws.String(fmt.Sprintf("--kubelet-extra-args '--node-labels %v'", strings.Join(nodeLabels, ","))),
+			ParameterKey:   aws.String("KubeletExtraArguments"),
+			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
 	}
 

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -30,6 +30,8 @@ Metadata:
           - NodeVolumeSize
           - KeyName
           - BootstrapArguments
+          - KubeletExtraArguments
+          - UseInstanceStore
           - DisableIMDSv1
           - TemplateVersion
       - Label:
@@ -42,7 +44,7 @@ Parameters:
   BootstrapArguments:
     Type: String
     Default: ""
-    Description: "Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
+    Description: "Arguments to pass to the bootstrap script beside the kubelet parameters. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
 
   ClusterAutoscalerEnabled:
     Type: String
@@ -76,6 +78,11 @@ Parameters:
   #   Type: Number
   #   Default: 1
   #   Description: Desired capacity of Node Group ASG.
+
+  KubeletExtraArguments:
+      Type: String
+      Default: ""
+      Description: "Arguments to pass to the bootstrap script as kubelet parameters."
 
   NodeAutoScalingGroupMaxBatchSize:
     Type: Number
@@ -481,9 +488,18 @@ Parameters:
     Type: String
     Description: Enable detachment from ASG at instance termination (true/false)
 
+  UseInstanceStore:
+      Type: String
+      Default: "false"
+      "AllowedValues":
+        - "true"
+        - "false"
+      Description: "Mount and setup available instance stores for Kubelet if available."
+
   VpcId:
     Type: "AWS::EC2::VPC::Id"
     Description: The VPC of the worker instances
+
 
 Mappings:
   PartitionMap:
@@ -676,14 +692,52 @@ Resources:
         SecurityGroupIds:
           !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
         UserData: !Base64
-          "Fn::Sub": |
-            #!/bin/bash
-            set -o xtrace
-            /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
-            /opt/aws/bin/cfn-signal --exit-code $? \
-                     --stack  ${AWS::StackName} \
-                     --resource NodeGroup  \
-                     --region ${AWS::Region}
+            "Fn::Join":
+                - "\n"
+                -
+                    - "#!/bin/bash"
+                    - "set -o xtrace"
+                    - !Sub "if [ \"${UseInstanceStore}\" == \"true\" ]; then"
+                    - "  SSD_NVME_DEVICE_LIST=($(lsblk -l -o name,model | grep \"Instance Storage\" | cut -d \" \" -f 1 | sed -e \"s/.*/\\/dev\\/&/\" || true))"
+                    - "  SSD_NVME_DEVICE_COUNT=${#SSD_NVME_DEVICE_LIST[@]}"
+                    - "  RAID_DEVICE=${RAID_DEVICE:-/dev/md0}"
+                    - "  RAID_CHUNK_SIZE=${RAID_CHUNK_SIZE:-512}  # Kilo Bytes"
+                    - "  FILESYSTEM_BLOCK_SIZE=${FILESYSTEM_BLOCK_SIZE:-4096}  # Bytes"
+                    - "  STRIDE=$(expr $RAID_CHUNK_SIZE \\* 1024 / $FILESYSTEM_BLOCK_SIZE || true)"
+                    - "  STRIPE_WIDTH=$(expr $SSD_NVME_DEVICE_COUNT \\* $STRIDE || true)"
+                    - "  case $SSD_NVME_DEVICE_COUNT in"
+                    - "  \"0\")"
+                    - "     echo 'No devices found of type \"Amazon EC2 NVMe Instance Storage\"'"
+                    - "     ;;"
+                    - "  \"1\")"
+                    - "     echo \"Format nvme device $SSD_NVME_DEVICE_LIST\""
+                    - "     mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE $SSD_NVME_DEVICE_LIST"
+                    - "     DEVICE=$SSD_NVME_DEVICE_LIST"
+                    - "     ;;"
+                    - "  *)"
+                    - "     yum install mdadm -y"
+                    - "     mdadm --create --verbose $RAID_DEVICE --level=0 -c ${RAID_CHUNK_SIZE} --raid-devices=${#SSD_NVME_DEVICE_LIST[@]} ${SSD_NVME_DEVICE_LIST[*]}"
+                    - "     while [ -n \"$(mdadm --detail $RAID_DEVICE | grep -ioE 'State :.*resyncing')\" ]; do"
+                    - "       echo \"Raid is resyncing..\""
+                    - "       sleep 1"
+                    - "     done"
+                    - "     echo \"Raid0 device $RAID_DEVICE has been created with disks ${SSD_NVME_DEVICE_LIST[*]}\""
+                    - "     mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE -E stride=$STRIDE,stripe-width=$STRIPE_WIDTH $RAID_DEVICE"
+                    - "     DEVICE=$RAID_DEVICE"
+                    - "     ;;"
+                    - "  esac"
+                    - "  if [ $SSD_NVME_DEVICE_COUNT -gt 0 ]; then"
+                    - "    mkdir /media/local"
+                    - "    mount -o defaults,noatime,discard,nobarrier $DEVICE /media/local"
+                    - "    mkdir /media/local/kubelet"
+                    - !Sub "    /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '--root-dir /media/local/kubelet ${KubeletExtraArguments}'"
+                    - "  else"
+                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}'"
+                    - "  fi"
+                    - "else"
+                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}'"
+                    - "fi"
+                    - !Sub "/opt/aws/bin/cfn-signal --exit-code $? --stack  ${AWS::StackName} --resource NodeGroup --region ${AWS::Region}"
         MetadataOptions:
           HttpPutResponseHopLimit: 2
           HttpEndpoint: enabled

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -691,53 +691,51 @@ Resources:
         KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
         SecurityGroupIds:
           !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
-        UserData: !Base64
-            "Fn::Join":
-                - "\n"
-                -
-                    - "#!/bin/bash"
-                    - "set -o xtrace"
-                    - !Sub "if [ \"${UseInstanceStore}\" == \"true\" ]; then"
-                    - "  SSD_NVME_DEVICE_LIST=($(lsblk -l -o name,model | grep \"Instance Storage\" | cut -d \" \" -f 1 | sed -e \"s/.*/\\/dev\\/&/\" || true))"
-                    - "  SSD_NVME_DEVICE_COUNT=${#SSD_NVME_DEVICE_LIST[@]}"
-                    - "  RAID_DEVICE=${RAID_DEVICE:-/dev/md0}"
-                    - "  RAID_CHUNK_SIZE=${RAID_CHUNK_SIZE:-512}  # Kilo Bytes"
-                    - "  FILESYSTEM_BLOCK_SIZE=${FILESYSTEM_BLOCK_SIZE:-4096}  # Bytes"
-                    - "  STRIDE=$(expr $RAID_CHUNK_SIZE \\* 1024 / $FILESYSTEM_BLOCK_SIZE || true)"
-                    - "  STRIPE_WIDTH=$(expr $SSD_NVME_DEVICE_COUNT \\* $STRIDE || true)"
-                    - "  case $SSD_NVME_DEVICE_COUNT in"
-                    - "  \"0\")"
-                    - "     echo 'No devices found of type \"Amazon EC2 NVMe Instance Storage\"'"
-                    - "     ;;"
-                    - "  \"1\")"
-                    - "     echo \"Format nvme device $SSD_NVME_DEVICE_LIST\""
-                    - "     mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE $SSD_NVME_DEVICE_LIST"
-                    - "     DEVICE=$SSD_NVME_DEVICE_LIST"
-                    - "     ;;"
-                    - "  *)"
-                    - "     yum install mdadm -y"
-                    - "     mdadm --create --verbose $RAID_DEVICE --level=0 -c ${RAID_CHUNK_SIZE} --raid-devices=${#SSD_NVME_DEVICE_LIST[@]} ${SSD_NVME_DEVICE_LIST[*]}"
-                    - "     while [ -n \"$(mdadm --detail $RAID_DEVICE | grep -ioE 'State :.*resyncing')\" ]; do"
-                    - "       echo \"Raid is resyncing..\""
-                    - "       sleep 1"
-                    - "     done"
-                    - "     echo \"Raid0 device $RAID_DEVICE has been created with disks ${SSD_NVME_DEVICE_LIST[*]}\""
-                    - "     mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE -E stride=$STRIDE,stripe-width=$STRIPE_WIDTH $RAID_DEVICE"
-                    - "     DEVICE=$RAID_DEVICE"
-                    - "     ;;"
-                    - "  esac"
-                    - "  if [ $SSD_NVME_DEVICE_COUNT -gt 0 ]; then"
-                    - "    mkdir /media/local"
-                    - "    mount -o defaults,noatime,discard,nobarrier $DEVICE /media/local"
-                    - "    mkdir /media/local/kubelet"
-                    - !Sub "    /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '--root-dir /media/local/kubelet ${KubeletExtraArguments}' ${BootstrapArguments}"
-                    - "  else"
-                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}"
-                    - "  fi"
-                    - "else"
-                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}"
-                    - "fi"
-                    - !Sub "/opt/aws/bin/cfn-signal --exit-code $? --stack  ${AWS::StackName} --resource NodeGroup --region ${AWS::Region}"
+        UserData:
+            Fn::Base64:
+                Fn::Sub: |
+                      #!/usr/bin/env bash
+                      set -o xtrace
+                      if [ \"${UseInstanceStore}\" == \"true\" ]; then
+                        SSD_NVME_DEVICE_LIST=($(lsblk -l -o name,model | grep "Instance Storage" | cut -d " " -f 1 | sed -e "s/.*/\\/dev\\/&/" || true))
+                        SSD_NVME_DEVICE_COUNT=${!#SSD_NVME_DEVICE_LIST[@]}
+                        RAID_DEVICE=${!RAID_DEVICE:-/dev/md0}
+                        RAID_CHUNK_SIZE=${!RAID_CHUNK_SIZE:-512}
+                        FILESYSTEM_BLOCK_SIZE=${!FILESYSTEM_BLOCK_SIZE:-4096}
+                        STRIDE=$(expr $RAID_CHUNK_SIZE \* 1024 / $FILESYSTEM_BLOCK_SIZE || true)
+                        STRIPE_WIDTH=$(expr $SSD_NVME_DEVICE_COUNT \* $STRIDE || true)
+                        case $SSD_NVME_DEVICE_COUNT in
+                        "0")
+                          echo "No devices found of type Amazon EC2 NVMe Instance Storage"
+                          ;;
+                        "1")
+                          echo "Format nvme device $SSD_NVME_DEVICE_LIST"
+                          mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE $SSD_NVME_DEVICE_LIST
+                          DEVICE=$SSD_NVME_DEVICE_LIST
+                          ;;
+                        *)
+                          yum install mdadm -y
+                          mdadm --create --verbose $RAID_DEVICE --level=0 -c ${!RAID_CHUNK_SIZE} --raid-devices=${!#SSD_NVME_DEVICE_LIST[@]} ${!SSD_NVME_DEVICE_LIST[*]}
+                          while [ -n "$(mdadm --detail $RAID_DEVICE | grep -ioE 'State :.*resyncing')" ]; do
+                            echo "Raid is resyncing.."
+                            sleep 1
+                          done
+                          echo "Raid0 device $RAID_DEVICE has been created with disks ${!SSD_NVME_DEVICE_LIST[*]}"
+                          mkfs.ext4 -m 0 -b $FILESYSTEM_BLOCK_SIZE -E stride=$STRIDE,stripe-width=$STRIPE_WIDTH $RAID_DEVICE
+                          DEVICE=$RAID_DEVICE
+                          ;;
+                        esac
+                        if [ $SSD_NVME_DEVICE_COUNT -gt 0 ]; then
+                          mkdir /media/local
+                          mount -o defaults,noatime,discard,nobarrier $DEVICE /media/local
+                          mkdir /media/local/kubelet
+                          /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '--root-dir /media/local/kubelet ${KubeletExtraArguments}' ${BootstrapArguments}
+                        else
+                          /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}
+                        fi
+                      else
+                        /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}
+                      fi
         MetadataOptions:
           HttpPutResponseHopLimit: 2
           HttpEndpoint: enabled

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -481,7 +481,7 @@ Parameters:
 
   TemplateVersion:
     Type: String
-    Default: "2.1.0"
+    Default: "2.2.0"
     Description: Current version of the template structure as metainformation for created stacks.
 
   TerminationDetachEnabled:

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -491,7 +491,7 @@ Parameters:
   UseInstanceStore:
       Type: String
       Default: "false"
-      "AllowedValues":
+      AllowedValues:
         - "true"
         - "false"
       Description: "Mount and setup available instance stores for Kubelet if available."

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -696,7 +696,7 @@ Resources:
                 Fn::Sub: |
                       #!/usr/bin/env bash
                       set -o xtrace
-                      if [ \"${UseInstanceStore}\" == \"true\" ]; then
+                      if [ "${UseInstanceStore}" == "true" ]; then
                         SSD_NVME_DEVICE_LIST=($(lsblk -l -o name,model | grep "Instance Storage" | cut -d " " -f 1 | sed -e "s/.*/\\/dev\\/&/" || true))
                         SSD_NVME_DEVICE_COUNT=${!#SSD_NVME_DEVICE_LIST[@]}
                         RAID_DEVICE=${!RAID_DEVICE:-/dev/md0}

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -44,7 +44,7 @@ Parameters:
   BootstrapArguments:
     Type: String
     Default: ""
-    Description: "Arguments to pass to the bootstrap script beside the kubelet parameters. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
+    Description: "Additional arguments to pass to the bootstrap script beside the kubelet parameters. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami"
 
   ClusterAutoscalerEnabled:
     Type: String
@@ -730,12 +730,12 @@ Resources:
                     - "    mkdir /media/local"
                     - "    mount -o defaults,noatime,discard,nobarrier $DEVICE /media/local"
                     - "    mkdir /media/local/kubelet"
-                    - !Sub "    /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '--root-dir /media/local/kubelet ${KubeletExtraArguments}'"
+                    - !Sub "    /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '--root-dir /media/local/kubelet ${KubeletExtraArguments}' ${BootstrapArguments}"
                     - "  else"
-                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}'"
+                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}"
                     - "  fi"
                     - "else"
-                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}'"
+                    - !Sub "  /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}"
                     - "fi"
                     - !Sub "/opt/aws/bin/cfn-signal --exit-code $? --stack  ${AWS::StackName} --resource NodeGroup --region ${AWS::Region}"
         MetadataOptions:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3352 
| License         | Apache 2.0


### What's in this PR?
Adds an additional parameter to EKS node pool CF template `UseIntanceStorage` which works as follows:

- UseIntanceStorage = true and number of available NVMe disks on instance type (for ex. i3.large) > 0, user data script will try to list available NVMe disks, format and mount on /media/local path. This path will be set as root dir for kubelet. In case of multiple disks they will be mounted as a RAID device.

- UseIntanceStorage = true and there are no available NVMe disks on instance type (for ex. c3.large) or UseIntanceStorage = false, no root dir is set for kubelet, bootstrap should work as before. 

### Why?
To allow customers using NVMe disks for EmptyDir volumes when is available depending on chosen instance type.
(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)