### PR TITLE
Separate integrated service workflows for the v1 (legacy) and v2 implementations

### DIFF
--- a/.idea/runConfigurations/Debug_Worker_IS_test.xml
+++ b/.idea/runConfigurations/Debug_Worker_IS_test.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug Worker IS test" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="pipeline" />
+    <working_directory value="$PROJECT_DIR$/" />
+    <parameters value="--config=internal/integratedservices/testconfig/config.yaml" />
+    <envs>
+      <env name="VAULT_ADDR" value="http://127.0.0.1:8200" />
+      <env name="PIPELINE_CONFIG_DIR" value="config" />
+    </envs>
+    <kind value="DIRECTORY" />
+    <filePath value="$PROJECT_DIR$/" />
+    <package value="github.com/banzaicloud/pipeline" />
+    <directory value="$PROJECT_DIR$/cmd/worker/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Debug_Worker_IS_test_V2.xml
+++ b/.idea/runConfigurations/Debug_Worker_IS_test_V2.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug Worker IS test V2" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="pipeline" />
+    <working_directory value="$PROJECT_DIR$/" />
+    <parameters value="--config=internal/integratedservices/testconfig/config-v2.yaml" />
+    <envs>
+      <env name="VAULT_ADDR" value="http://127.0.0.1:8200" />
+      <env name="PIPELINE_CONFIG_DIR" value="config" />
+    </envs>
+    <kind value="DIRECTORY" />
+    <filePath value="$PROJECT_DIR$/" />
+    <package value="github.com/banzaicloud/pipeline" />
+    <directory value="$PROJECT_DIR$/cmd/worker/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -1067,8 +1067,13 @@ func main() {
 				}
 			}
 
-			// todo only integrated service v1 is used here! - investigate: is it possible to use the router?
-			hpaApi := api.NewHPAAPI(isServiceV1, clientFactory, configFactory, commonClusterGetter, errorHandler)
+			var hpaApi api.HPAAPI
+			if config.IntegratedService.V2 {
+				hpaApi = api.NewHPAAPI(isRouter, clientFactory, configFactory, commonClusterGetter, errorHandler)
+			} else {
+				hpaApi = api.NewHPAAPI(isServiceV1, clientFactory, configFactory, commonClusterGetter, errorHandler)
+			}
+
 			cRouter.GET("/hpa", hpaApi.GetHpaResource)
 			cRouter.PUT("/hpa", hpaApi.PutHpaResource)
 			cRouter.DELETE("/hpa", hpaApi.DeleteHpaResource)

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -1042,7 +1042,6 @@ func main() {
 						isServiceV1,
 						kitxendpoint.Combine(endpointMiddleware...),
 					)
-
 				}
 
 				{

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -1030,10 +1030,6 @@ func main() {
 
 				var endpoints integratedservicesdriver.Endpoints
 				// use the desired version of integrated services as backend, use the v1 by default
-				endpoints = integratedservicesdriver.MakeEndpoints(
-					isServiceV1,
-					kitxendpoint.Combine(endpointMiddleware...),
-				)
 
 				if config.IntegratedService.V2 {
 					// use the router if v2 is switched on
@@ -1041,6 +1037,12 @@ func main() {
 						isRouter,
 						kitxendpoint.Combine(endpointMiddleware...),
 					)
+				} else {
+					endpoints = integratedservicesdriver.MakeEndpoints(
+						isServiceV1,
+						kitxendpoint.Combine(endpointMiddleware...),
+					)
+
 				}
 
 				{

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -923,7 +923,7 @@ func main() {
 						integratedServiceManagers = append(integratedServiceManagers, integratedServiceDNS.NewIntegratedServicesManager(clusterPropertyGetter, clusterPropertyGetter, config.Cluster.DNS.Config))
 					}
 
-					integratedServiceOperationDispatcher := integratedserviceadapter.MakeCadenceIntegratedServiceOperationDispatcher(workflowClient, commonLogger)
+					integratedServiceOperationDispatcher := integratedserviceadapter.NewCadenceOperationDispatcher(workflowClient, commonLogger)
 					integratedServiceManagerRegistry := integratedservices.MakeIntegratedServiceManagerRegistry(integratedServiceManagers)
 					specConversions := map[string]integratedservices.SpecConversion{
 						integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),

--- a/cmd/worker/clusterfeature.go
+++ b/cmd/worker/clusterfeature.go
@@ -33,9 +33,11 @@ func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegist
 	}
 
 	{
-		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceDeleteActivityName, isV2)
-		a := clusterfeatureworkflow.MakeIntegratedServiceDeleteActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		if !isV2 {
+			activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceDeleteActivityName, isV2)
+			a := clusterfeatureworkflow.MakeIntegratedServiceDeleteActivity(featureRepository)
+			worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		}
 	}
 
 	{
@@ -45,14 +47,19 @@ func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegist
 	}
 
 	{
-		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetSpecActivityName, isV2)
-		a := clusterfeatureworkflow.MakeIntegratedServiceSetSpecActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		if !isV2 {
+			// this activity is not used
+			activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetSpecActivityName, isV2)
+			a := clusterfeatureworkflow.MakeIntegratedServiceSetSpecActivity(featureRepository)
+			worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		}
 	}
 
 	{
-		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetStatusActivityName, isV2)
-		a := clusterfeatureworkflow.MakeIntegratedServiceSetStatusActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		if !isV2 {
+			activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetStatusActivityName, isV2)
+			a := clusterfeatureworkflow.MakeIntegratedServiceSetStatusActivity(featureRepository)
+			worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
+		}
 	}
 }

--- a/cmd/worker/clusterfeature.go
+++ b/cmd/worker/clusterfeature.go
@@ -24,7 +24,11 @@ import (
 )
 
 func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, workflowName string, isV2 bool) {
-	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: workflowName})
+	if isV2 {
+		worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflowV2, workflow.RegisterOptions{Name: workflowName})
+	} else {
+		worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: workflowName})
+	}
 
 	{
 		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceApplyActivityName, isV2)

--- a/cmd/worker/clusterfeature.go
+++ b/cmd/worker/clusterfeature.go
@@ -23,31 +23,36 @@ import (
 	clusterfeatureworkflow "github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter/workflow"
 )
 
-func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, workflowName string) {
+func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, workflowName string, isV2 bool) {
 	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: workflowName})
 
 	{
+		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceApplyActivityName, isV2)
 		a := clusterfeatureworkflow.MakeIntegratedServicesApplyActivity(featureOperatorRegistry)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceApplyActivityName})
+		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
 	}
 
 	{
+		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceDeleteActivityName, isV2)
 		a := clusterfeatureworkflow.MakeIntegratedServiceDeleteActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceDeleteActivityName})
+		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
 	}
 
 	{
+		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceDeactivateActivityName, isV2)
 		a := clusterfeatureworkflow.MakeIntegratedServiceDeactivateActivity(featureOperatorRegistry)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceDeactivateActivityName})
+		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
 	}
 
 	{
+		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetSpecActivityName, isV2)
 		a := clusterfeatureworkflow.MakeIntegratedServiceSetSpecActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceSetSpecActivityName})
+		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
 	}
 
 	{
+		activityName := clusterfeatureworkflow.GetActivityName(clusterfeatureworkflow.IntegratedServiceSetStatusActivityName, isV2)
 		a := clusterfeatureworkflow.MakeIntegratedServiceSetStatusActivity(featureRepository)
-		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceSetStatusActivityName})
+		worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: activityName})
 	}
 }

--- a/cmd/worker/clusterfeature.go
+++ b/cmd/worker/clusterfeature.go
@@ -23,11 +23,8 @@ import (
 	clusterfeatureworkflow "github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter/workflow"
 )
 
-func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, isV2 bool) {
-	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceJobWorkflowName})
-
-	// register the new workflow for handling v2 integrated services
-	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflowV2, workflow.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceJobWorkflowV2Name})
+func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, workflowName string) {
+	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: workflowName})
 
 	{
 		a := clusterfeatureworkflow.MakeIntegratedServicesApplyActivity(featureOperatorRegistry)

--- a/cmd/worker/clusterfeature.go
+++ b/cmd/worker/clusterfeature.go
@@ -24,12 +24,10 @@ import (
 )
 
 func registerClusterFeatureWorkflows(worker worker.Worker, featureOperatorRegistry integratedservices.IntegratedServiceOperatorRegistry, featureRepository integratedservices.IntegratedServiceRepository, isV2 bool) {
-	workflowFunc := clusterfeatureworkflow.IntegratedServiceJobWorkflow
-	if isV2 {
-		workflowFunc = clusterfeatureworkflow.IntegratedServiceJobWorkflowV2
-	}
+	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflow, workflow.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceJobWorkflowName})
 
-	worker.RegisterWorkflowWithOptions(workflowFunc, workflow.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceJobWorkflowName})
+	// register the new workflow for handling v2 integrated services
+	worker.RegisterWorkflowWithOptions(clusterfeatureworkflow.IntegratedServiceJobWorkflowV2, workflow.RegisterOptions{Name: clusterfeatureworkflow.IntegratedServiceJobWorkflowV2Name})
 
 	{
 		a := clusterfeatureworkflow.MakeIntegratedServicesApplyActivity(featureOperatorRegistry)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -718,8 +718,8 @@ func main() {
 				),
 			})
 
-			registerClusterFeatureWorkflows(worker, featureOperatorRegistry, featureRepository, clusterfeatureworkflow.IntegratedServiceJobWorkflowName)
-			registerClusterFeatureWorkflows(worker, featureOperatorRegistryV2, featureRepositoryV2, clusterfeatureworkflow.IntegratedServiceJobWorkflowV2Name)
+			registerClusterFeatureWorkflows(worker, featureOperatorRegistry, featureRepository, clusterfeatureworkflow.IntegratedServiceJobWorkflowName, false)
+			registerClusterFeatureWorkflows(worker, featureOperatorRegistryV2, featureRepositoryV2, clusterfeatureworkflow.IntegratedServiceJobWorkflowV2Name, true)
 		}
 
 		group.Add(appkitrun.CadenceWorkerRun(worker))

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -68,6 +68,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
 	"github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter"
+	clusterfeatureworkflow "github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter/workflow"
 	"github.com/banzaicloud/pipeline/internal/integratedservices/services"
 	integratedServiceDNS "github.com/banzaicloud/pipeline/internal/integratedservices/services/dns"
 	"github.com/banzaicloud/pipeline/internal/integratedservices/services/dns/dnsadapter"
@@ -583,8 +584,9 @@ func main() {
 
 			logger := commonadapter.NewLogger(logger) // TODO: make this a context aware logger
 
-			var featureRepository integratedservices.IntegratedServiceRepository
-			if config.IntegratedService.V2 {
+			var featureRepository, featureRepositoryV2 integratedservices.IntegratedServiceRepository
+			// V2 setup
+			{
 				specConversions := map[string]integratedservices.SpecConversion{
 					integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 				}
@@ -592,8 +594,11 @@ func main() {
 					integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.OutputResolver{},
 				}
 				serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, outputResolvers)
-				featureRepository = integratedserviceadapter.NewCustomResourceRepository(clusterManager.KubeConfigFunc(), commonLogger, serviceConversion, config.Cluster.Namespace)
-			} else {
+				featureRepositoryV2 = integratedserviceadapter.NewCustomResourceRepository(clusterManager.KubeConfigFunc(), commonLogger, serviceConversion, config.Cluster.Namespace)
+			}
+
+			// V1 setup
+			{
 				featureRepository = integratedserviceadapter.NewGormIntegratedServiceRepository(db, logger)
 			}
 
@@ -644,18 +649,8 @@ func main() {
 
 			expirerService := adapter.NewAsyncExpiryService(workflowClient, logger)
 
-			var dnsISOp integratedservices.IntegratedServiceOperator
-			if config.IntegratedService.V2 {
-				dnsISOp = integratedServiceDNS.NewDNSISOperator(
-					clusterGetter,
-					clusterService,
-					orgDomainService,
-					commonSecretStore,
-					config.Cluster.DNS.Config,
-					logger,
-				)
-			} else {
-				dnsISOp = integratedServiceDNS.MakeIntegratedServiceOperator(
+			featureOperatorRegistry := integratedservices.MakeIntegratedServiceOperatorRegistry([]integratedservices.IntegratedServiceOperator{
+				integratedServiceDNS.MakeIntegratedServiceOperator(
 					clusterGetter,
 					clusterService,
 					unifiedHelmReleaser,
@@ -663,11 +658,7 @@ func main() {
 					orgDomainService,
 					commonSecretStore,
 					config.Cluster.DNS.Config,
-				)
-			}
-
-			featureOperatorRegistry := integratedservices.MakeIntegratedServiceOperatorRegistry([]integratedservices.IntegratedServiceOperator{
-				dnsISOp,
+				),
 				securityscan.MakeIntegratedServiceOperator(
 					config.Cluster.SecurityScan.Config,
 					clusterGetter,
@@ -716,8 +707,19 @@ func main() {
 					intsvcingressadapter.NewOrgDomainService(config.Cluster.DNS.BaseDomain, orgGetter),
 				),
 			})
+			featureOperatorRegistryV2 := integratedservices.MakeIntegratedServiceOperatorRegistry([]integratedservices.IntegratedServiceOperator{
+				integratedServiceDNS.NewDNSISOperator(
+					clusterGetter,
+					clusterService,
+					orgDomainService,
+					commonSecretStore,
+					config.Cluster.DNS.Config,
+					logger,
+				),
+			})
 
-			registerClusterFeatureWorkflows(worker, featureOperatorRegistry, featureRepository, config.IntegratedService.V2)
+			registerClusterFeatureWorkflows(worker, featureOperatorRegistry, featureRepository, clusterfeatureworkflow.IntegratedServiceJobWorkflowName)
+			registerClusterFeatureWorkflows(worker, featureOperatorRegistryV2, featureRepositoryV2, clusterfeatureworkflow.IntegratedServiceJobWorkflowV2Name)
 		}
 
 		group.Add(appkitrun.CadenceWorkerRun(worker))

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,6 @@ require (
 	go.uber.org/yarpc v1.45.0
 	go.uber.org/zap v1.14.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/internal/integratedservices/functional_suite_test.go
+++ b/internal/integratedservices/functional_suite_test.go
@@ -126,7 +126,7 @@ func (s *Suite) SetupSuite() {
 
 	s.integratedServiceServiceCreaterV2 = func(kubeConfigFunc integratedservices.ClusterKubeConfigFunc, managers ...integratedservices.IntegratedServiceManager) (integratedservices.Service, error) {
 		registry := integratedservices.MakeIntegratedServiceManagerRegistry(managers)
-		dispatcher := integratedserviceadapter.MakeCadenceIntegratedServiceOperationDispatcher(workflowClient, commonLogger)
+		dispatcher := integratedserviceadapter.NewCadenceOperationDispatcher(workflowClient, commonLogger)
 		specConversions := map[string]integratedservices.SpecConversion{
 			integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 		}

--- a/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcher.go
+++ b/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcher.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/client"
 
 	"github.com/banzaicloud/pipeline/internal/common"
@@ -81,19 +80,7 @@ func (d CadenceIntegratedServiceOperationDispatcher) dispatchOperation(ctx conte
 }
 
 func (d CadenceIntegratedServiceOperationDispatcher) IsBeingDispatched(ctx context.Context, clusterID uint, integratedServiceName string) (bool, error) {
-	const workflowName = workflow.IntegratedServiceJobWorkflowName
-	workflowID := getWorkflowID(workflowName, clusterID, integratedServiceName)
-
-	response, err := d.cadenceClient.DescribeWorkflowExecution(ctx, workflowID, "")
-	if err != nil {
-		notExists := &shared.EntityNotExistsError{}
-		if errors.As(err, &notExists) {
-			return false, nil
-		}
-		return false, errors.WrapIfWithDetails(err, "unable to describe workflow for service",
-			"workflowId", workflowID, "service", integratedServiceName)
-	}
-	return response.WorkflowExecutionInfo.CloseTime == nil, nil
+	return false, errors.New("method not applicable for the v1 implementation")
 }
 
 func getWorkflowID(workflowName string, clusterID uint, integratedServiceName string) string {

--- a/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcherV2.go
+++ b/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcherV2.go
@@ -1,0 +1,79 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integratedserviceadapter
+
+import (
+	"context"
+	"time"
+
+	"emperror.dev/errors"
+	"go.uber.org/cadence/client"
+
+	"github.com/banzaicloud/pipeline/internal/common"
+	"github.com/banzaicloud/pipeline/internal/integratedservices"
+	"github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter/workflow"
+)
+
+// OperationDispatcher component dispatching operations related to the new version of the integrated services
+type OperationDispatcher struct {
+	cadenceClient client.Client
+	logger        common.Logger
+}
+
+// NewCadenceOperationDispatcher returns the new version Uber Cadence based implementation of IntegratedServiceOperationDispatcher
+func NewCadenceOperationDispatcher(
+	cadenceClient client.Client,
+	logger common.Logger,
+) OperationDispatcher {
+	return OperationDispatcher{
+		cadenceClient: cadenceClient,
+		logger:        logger,
+	}
+}
+
+// DispatchApply dispatches an Apply request to an integrated service manager asynchronously
+func (d OperationDispatcher) DispatchApply(ctx context.Context, clusterID uint, integratedServiceName string, spec integratedservices.IntegratedServiceSpec) error {
+	return d.dispatchOperation(ctx, workflow.OperationApply, clusterID, integratedServiceName, spec)
+}
+
+// DispatchDeactivate dispatches a Deactivate request to an integrated service manager asynchronously
+func (d OperationDispatcher) DispatchDeactivate(ctx context.Context, clusterID uint, integratedServiceName string, spec integratedservices.IntegratedServiceSpec) error {
+	return d.dispatchOperation(ctx, workflow.OperationDeactivate, clusterID, integratedServiceName, spec)
+}
+
+func (d OperationDispatcher) dispatchOperation(ctx context.Context, op string, clusterID uint, integratedServiceName string, spec integratedservices.IntegratedServiceSpec) error {
+	const workflowName = workflow.IntegratedServiceJobWorkflowV2Name
+	workflowID := getWorkflowID(workflowName, clusterID, integratedServiceName)
+	const signalName = workflow.IntegratedServiceJobSignalName
+	signalArg := workflow.IntegratedServiceJobSignalInput{
+		Operation:              op,
+		IntegratedServiceSpecs: spec,
+		RetryInterval:          1 * time.Minute,
+	}
+	options := client.StartWorkflowOptions{
+		TaskList:                     "pipeline",
+		ExecutionStartToCloseTimeout: 3 * time.Hour,
+		WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
+	}
+	workflowInput := workflow.IntegratedServiceJobWorkflowInput{
+		ClusterID:             clusterID,
+		IntegratedServiceName: integratedServiceName,
+	}
+	_, err := d.cadenceClient.SignalWithStartWorkflow(ctx, workflowID, signalName, signalArg, options, workflowName, workflowInput)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "signal with start workflow failed", "workflowId", workflowID)
+	}
+	return nil
+}

--- a/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcherV2.go
+++ b/internal/integratedservices/integratedserviceadapter/cadence_integrated_service_operation_dispatcherV2.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/client"
 
 	"github.com/banzaicloud/pipeline/internal/common"
@@ -76,4 +77,20 @@ func (d OperationDispatcher) dispatchOperation(ctx context.Context, op string, c
 		return errors.WrapIfWithDetails(err, "signal with start workflow failed", "workflowId", workflowID)
 	}
 	return nil
+}
+
+func (d OperationDispatcher) IsBeingDispatched(ctx context.Context, clusterID uint, integratedServiceName string) (bool, error) {
+	const workflowName = workflow.IntegratedServiceJobWorkflowV2Name
+	workflowID := getWorkflowID(workflowName, clusterID, integratedServiceName)
+
+	response, err := d.cadenceClient.DescribeWorkflowExecution(ctx, workflowID, "")
+	if err != nil {
+		notExists := &shared.EntityNotExistsError{}
+		if errors.As(err, &notExists) {
+			return false, nil
+		}
+		return false, errors.WrapIfWithDetails(err, "unable to describe workflow for service",
+			"workflowId", workflowID, "service", integratedServiceName)
+	}
+	return response.WorkflowExecutionInfo.CloseTime == nil, nil
 }

--- a/internal/integratedservices/integratedserviceadapter/reconciler_test.go
+++ b/internal/integratedservices/integratedserviceadapter/reconciler_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integratedserviceadapter
+
+import (
+	"testing"
+
+	"github.com/banzaicloud/integrated-service-sdk/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestVersion(t *testing.T) {
+	testData := map[string]struct {
+		availableVersions map[string][]string
+		currentVersion    string
+		expectedVersion   string
+		expectError       bool
+	}{
+		"no versions at all": {
+			expectError: true,
+		},
+		"available versions in order": {
+			availableVersions: map[string][]string{
+				"1.0.0": {},
+				"2.0.0": {},
+				"3.0.0": {},
+			},
+			expectedVersion: "3.0.0",
+		},
+		"current version should also count": {
+			availableVersions: map[string][]string{
+				"1.0.0": {},
+				"2.0.0": {},
+				"3.0.0": {},
+			},
+			currentVersion:  "4.0.0",
+			expectedVersion: "4.0.0",
+		},
+		"unordered available versions": {
+			availableVersions: map[string][]string{
+				"1.0.0": {},
+				"4.0.0": {},
+				"3.0.0": {},
+			},
+			expectedVersion: "4.0.0",
+		},
+		"latest version has v prefix": {
+			availableVersions: map[string][]string{
+				"2.0.0":  {},
+				"v3.0.0": {},
+				"1.0.0":  {},
+			},
+			expectedVersion: "v3.0.0",
+		},
+		"latest version does not have v prefix": {
+			availableVersions: map[string][]string{
+				"v2.0.0": {},
+				"3.0.0":  {},
+				"v1.0.0": {},
+			},
+			expectedVersion: "3.0.0",
+		},
+		"handle invalid versions": {
+			availableVersions: map[string][]string{
+				"v2.0.0": {},
+				"asd":    {},
+				"3.0.0":  {},
+				"v1.0.0": {},
+			},
+			expectedVersion: "3.0.0",
+			expectError:     true,
+		},
+	}
+
+	for name, td := range testData {
+		t.Run(name, func(t *testing.T) {
+			latest, err := getLatestVersion(v1alpha1.ServiceInstance{
+				Status: v1alpha1.ServiceInstanceStatus{
+					AvailableVersions: td.availableVersions,
+					Version:           td.currentVersion,
+				},
+			})
+			if td.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, td.expectedVersion, latest)
+		})
+	}
+}

--- a/internal/integratedservices/integratedserviceadapter/workflow/common.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/common.go
@@ -17,6 +17,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"go.uber.org/cadence/activity"
@@ -54,4 +55,12 @@ func wait(ctx context.Context, duration time.Duration) error {
 	case <-ctx.Done():
 	}
 	return ctx.Err()
+}
+
+func GetActivityName(v1Name string, isV2 bool) string {
+	if isV2 {
+		return strings.Join([]string{v1Name, "v2"}, "-")
+	}
+
+	return v1Name
 }

--- a/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
@@ -110,13 +110,6 @@ func IntegratedServiceJobWorkflowV2(ctx workflow.Context, input IntegratedServic
 		return err
 	}
 
-	switch op := signalInput.Operation; op {
-	case OperationApply:
-	case OperationDeactivate:
-	default:
-		workflow.GetLogger(ctx).Error("unsupported operation", zap.String("operation", op))
-	}
-
 	return nil
 }
 

--- a/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
@@ -27,6 +27,9 @@ import (
 // IntegratedServiceJobWorkflowName is the name the IntegratedServiceJobWorkflow is registered under
 const IntegratedServiceJobWorkflowName = "integrated-service-job"
 
+// IntegratedServiceJobWorkflowV2Name name of the v2 integrated service workflow
+const IntegratedServiceJobWorkflowV2Name = "integrated-service-job-v2"
+
 // IntegratedServiceJobSignalName is the name of signal with which jobs can be sent to the workflow
 const IntegratedServiceJobSignalName = "job"
 

--- a/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
@@ -70,7 +70,7 @@ func IntegratedServiceJobWorkflow(ctx workflow.Context, input IntegratedServiceJ
 		return err
 	}
 
-	if err := executeJobs(ctx, input, &signalInput, jobsChannel); err != nil {
+	if err := executeJobs(ctx, input, &signalInput, jobsChannel, false); err != nil {
 		if err := setIntegratedServiceStatus(ctx, input, integratedservices.IntegratedServiceStatusError); err != nil {
 			workflow.GetLogger(ctx).Error("failed to set integrated service status", zap.Error(err))
 		}
@@ -83,7 +83,7 @@ func IntegratedServiceJobWorkflow(ctx workflow.Context, input IntegratedServiceJ
 			return err
 		}
 	case OperationDeactivate:
-		if err := deleteIntegratedService(ctx, input); err != nil {
+		if err := deleteIntegratedService(ctx, input, false); err != nil {
 			return err
 		}
 	default:
@@ -106,15 +106,14 @@ func IntegratedServiceJobWorkflowV2(ctx workflow.Context, input IntegratedServic
 	var signalInput IntegratedServiceJobSignalInput
 	jobsChannel.Receive(ctx, &signalInput) // wait until the first job arrives
 
-	if err := executeJobs(ctx, input, &signalInput, jobsChannel); err != nil {
+	if err := executeJobs(ctx, input, &signalInput, jobsChannel, true); err != nil {
 		return err
 	}
 
 	switch op := signalInput.Operation; op {
 	case OperationApply:
-		// todo revisit this: do nothing / success flow
 	case OperationDeactivate:
-		if err := deleteIntegratedService(ctx, input); err != nil {
+		if err := deleteIntegratedService(ctx, input, true); err != nil {
 			return err
 		}
 	default:
@@ -124,17 +123,17 @@ func IntegratedServiceJobWorkflowV2(ctx workflow.Context, input IntegratedServic
 	return nil
 }
 
-func getActivity(workflowInput IntegratedServiceJobWorkflowInput, signalInput IntegratedServiceJobSignalInput) (string, interface{}, error) {
+func getActivity(workflowInput IntegratedServiceJobWorkflowInput, signalInput IntegratedServiceJobSignalInput, isV2 bool) (string, interface{}, error) {
 	switch op := signalInput.Operation; op {
 	case OperationApply:
-		return IntegratedServiceApplyActivityName, IntegratedServiceApplyActivityInput{
+		return GetActivityName(IntegratedServiceApplyActivityName, isV2), IntegratedServiceApplyActivityInput{
 			ClusterID:             workflowInput.ClusterID,
 			IntegratedServiceName: workflowInput.IntegratedServiceName,
 			IntegratedServiceSpec: signalInput.IntegratedServiceSpecs,
 			RetryInterval:         signalInput.RetryInterval,
 		}, nil
 	case OperationDeactivate:
-		return IntegratedServiceDeactivateActivityName, IntegratedServiceDeactivateActivityInput{
+		return GetActivityName(IntegratedServiceDeactivateActivityName, isV2), IntegratedServiceDeactivateActivityInput{
 			ClusterID:             workflowInput.ClusterID,
 			IntegratedServiceName: workflowInput.IntegratedServiceName,
 			IntegratedServiceSpec: signalInput.IntegratedServiceSpecs,
@@ -145,9 +144,9 @@ func getActivity(workflowInput IntegratedServiceJobWorkflowInput, signalInput In
 	}
 }
 
-func executeJobs(ctx workflow.Context, workflowInput IntegratedServiceJobWorkflowInput, signalInputPtr *IntegratedServiceJobSignalInput, jobsChannel workflow.Channel) error {
+func executeJobs(ctx workflow.Context, workflowInput IntegratedServiceJobWorkflowInput, signalInputPtr *IntegratedServiceJobSignalInput, jobsChannel workflow.Channel, isV2 bool) error {
 	for {
-		activityName, activityInput, err := getActivity(workflowInput, *signalInputPtr)
+		activityName, activityInput, err := getActivity(workflowInput, *signalInputPtr, isV2)
 		if err != nil {
 			return err
 		}
@@ -193,10 +192,10 @@ func setIntegratedServiceStatus(ctx workflow.Context, input IntegratedServiceJob
 	return workflow.ExecuteActivity(ctx, IntegratedServiceSetStatusActivityName, activityInput).Get(ctx, nil)
 }
 
-func deleteIntegratedService(ctx workflow.Context, input IntegratedServiceJobWorkflowInput) error {
+func deleteIntegratedService(ctx workflow.Context, input IntegratedServiceJobWorkflowInput, isV2 bool) error {
 	activityInput := IntegratedServiceDeleteActivityInput{
 		ClusterID:             input.ClusterID,
 		IntegratedServiceName: input.IntegratedServiceName,
 	}
-	return workflow.ExecuteActivity(ctx, IntegratedServiceDeleteActivityName, activityInput).Get(ctx, nil)
+	return workflow.ExecuteActivity(ctx, GetActivityName(IntegratedServiceDeleteActivityName, isV2), activityInput).Get(ctx, nil)
 }

--- a/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
@@ -113,9 +113,6 @@ func IntegratedServiceJobWorkflowV2(ctx workflow.Context, input IntegratedServic
 	switch op := signalInput.Operation; op {
 	case OperationApply:
 	case OperationDeactivate:
-		if err := deleteIntegratedService(ctx, input, true); err != nil {
-			return err
-		}
 	default:
 		workflow.GetLogger(ctx).Error("unsupported operation", zap.String("operation", op))
 	}

--- a/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
+++ b/internal/integratedservices/integratedserviceadapter/workflow/integrated_service_job_workflow.go
@@ -40,6 +40,9 @@ const (
 	OperationDeactivate = "deactivate"
 )
 
+// integratedServicesV2 readable flag for signaling the implementation version
+const integratedServicesV2 bool = true
+
 // IntegratedServiceJobWorkflowInput defines the fixed inputs of the IntegratedServiceJobWorkflow
 type IntegratedServiceJobWorkflowInput struct {
 	ClusterID             uint
@@ -70,7 +73,7 @@ func IntegratedServiceJobWorkflow(ctx workflow.Context, input IntegratedServiceJ
 		return err
 	}
 
-	if err := executeJobs(ctx, input, &signalInput, jobsChannel, false); err != nil {
+	if err := executeJobs(ctx, input, &signalInput, jobsChannel, !integratedServicesV2); err != nil {
 		if err := setIntegratedServiceStatus(ctx, input, integratedservices.IntegratedServiceStatusError); err != nil {
 			workflow.GetLogger(ctx).Error("failed to set integrated service status", zap.Error(err))
 		}
@@ -106,7 +109,7 @@ func IntegratedServiceJobWorkflowV2(ctx workflow.Context, input IntegratedServic
 	var signalInput IntegratedServiceJobSignalInput
 	jobsChannel.Receive(ctx, &signalInput) // wait until the first job arrives
 
-	if err := executeJobs(ctx, input, &signalInput, jobsChannel, true); err != nil {
+	if err := executeJobs(ctx, input, &signalInput, jobsChannel, integratedServicesV2); err != nil {
 		return err
 	}
 

--- a/internal/integratedservices/interface.go
+++ b/internal/integratedservices/interface.go
@@ -93,6 +93,14 @@ func IsIntegratedServiceNotFoundError(err error) bool {
 	return errors.As(err, &notFoundErr) && notFoundErr.IntegratedServiceNotFound()
 }
 
+// IsIntegratedServiceNotFoundError returns true when the specified error is a "integrated service is unknown" error
+func IsUnknownIntegratedServiceError(err error) bool {
+	var unknownSvcErr interface {
+		Unknown() bool
+	}
+	return errors.As(err, &unknownSvcErr) && unknownSvcErr.Unknown()
+}
+
 // IntegratedServiceManager is a collection of integrated service specific methods that are used synchronously when responding to integrated service related requests.
 type IntegratedServiceManager interface {
 	IntegratedServiceOutputProducer

--- a/internal/integratedservices/interface.go
+++ b/internal/integratedservices/interface.go
@@ -93,7 +93,7 @@ func IsIntegratedServiceNotFoundError(err error) bool {
 	return errors.As(err, &notFoundErr) && notFoundErr.IntegratedServiceNotFound()
 }
 
-// IsIntegratedServiceNotFoundError returns true when the specified error is a "integrated service is unknown" error
+// IsUnknownIntegratedServiceError returns true when the specified error is a "integrated service is unknown" error
 func IsUnknownIntegratedServiceError(err error) bool {
 	var unknownSvcErr interface {
 		Unknown() bool

--- a/internal/integratedservices/registry.go
+++ b/internal/integratedservices/registry.go
@@ -99,3 +99,9 @@ func (UnknownIntegratedServiceError) NotFound() bool {
 func (UnknownIntegratedServiceError) ServiceError() bool {
 	return true
 }
+
+// Unknown tells a client that this error is related to a resource being unsupported.
+// Can be used to translate the error to eg. status code.
+func (UnknownIntegratedServiceError) Unknown() bool {
+	return true
+}

--- a/internal/integratedservices/servicerouter.go
+++ b/internal/integratedservices/servicerouter.go
@@ -79,8 +79,17 @@ func (s serviceRouter) Activate(ctx context.Context, clusterID uint, serviceName
 		return errors.WrapIf(err, "failed to retrieve integrated service from the legacy service")
 	}
 
+	if err := s.serviceV2.Activate(ctx, clusterID, serviceName, spec); err != nil {
+		if IsUnknownIntegratedServiceError(err) {
+			// fallback to the legacy !
+			return s.serviceV1.Activate(ctx, clusterID, serviceName, spec)
+		}
+
+		return err
+	}
+
 	// delegate to the new implementation
-	return s.serviceV2.Activate(ctx, clusterID, serviceName, spec)
+	return nil
 }
 
 func (s serviceRouter) Deactivate(ctx context.Context, clusterID uint, serviceName string) error {

--- a/internal/integratedservices/servicerouter.go
+++ b/internal/integratedservices/servicerouter.go
@@ -70,7 +70,6 @@ func (s serviceRouter) Details(ctx context.Context, clusterID uint, serviceName 
 			return detailsV1, nil
 		}
 	} else if !IsUnknownIntegratedServiceError(errV1) {
-		// ignore the unknown service error, proceed to the new implementation
 		return IntegratedService{}, errors.Wrapf(errV1, "failed to retrieve legacy integrated service details")
 	}
 

--- a/internal/integratedservices/servicerouter_test.go
+++ b/internal/integratedservices/servicerouter_test.go
@@ -158,7 +158,10 @@ func (suite *ServiceRouterSuite) TestDetails_ServiceOnV2() {
 	// Given
 	// the IS is not found by the legacy service
 	suite.serviceV1.On("Details", suite.ctx, suite.clusterID, "IS2").
-		Return(IntegratedService{}, integratedServiceNotFoundError{clusterID: suite.clusterID, integratedServiceName: "IS2"})
+		Return(IntegratedService{
+			Name:   "IS2",
+			Status: IntegratedServiceStatusInactive,
+		}, nil)
 
 	// serviceV2 returns the requested IS / serviceV1 doesn't get called
 	suite.serviceV2.On("Details", suite.ctx, suite.clusterID, "IS2").
@@ -256,10 +259,11 @@ func (suite *ServiceRouterSuite) TestActivate_NotFoundOnLegacy() {
 	// Given
 	// the IS is NOT found by the legacy service
 	suite.serviceV1.On("Details", suite.ctx, suite.clusterID, "IS2").
-		Return(IntegratedService{}, integratedServiceNotFoundError{
-			clusterID:             suite.clusterID,
-			integratedServiceName: "IS2",
-		})
+		Return(
+			IntegratedService{
+				Name:   "IS2",
+				Status: IntegratedServiceStatusInactive,
+			}, nil)
 
 	// the activation is delegated to the new service
 	suite.serviceV2.On("Activate", suite.ctx, suite.clusterID, "IS2", IntegratedServiceSpec{}).Return(nil)
@@ -386,10 +390,10 @@ func (suite *ServiceRouterSuite) TestActivate_ServiceUnknownOnV2() {
 
 	// the IS is NOT found by the legacy service
 	suite.serviceV1.On("Details", ctx, suite.clusterID, "IS").
-		Return(IntegratedService{}, integratedServiceNotFoundError{
-			clusterID:             suite.clusterID,
-			integratedServiceName: "IS",
-		})
+		Return(IntegratedService{
+			Name:   "IS",
+			Status: IntegratedServiceStatusInactive,
+		}, nil)
 
 	// the service is unknown by the V2 implementation
 	suite.serviceV2.On("Activate", ctx, suite.clusterID, "IS", IntegratedServiceSpec{}).Return(UnknownIntegratedServiceError{})


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
Separation of workflows for the new version of integrated services


### Why?
Legacy and new implementation should be available during the transition to the new version, this separation facilitates this approach.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

