### PR TITLE
Do not preserve unknown fields of the ServiceInstance CRD

### DIFF
--- a/lib/integrated-service-sdk/Makefile
+++ b/lib/integrated-service-sdk/Makefile
@@ -1,6 +1,5 @@
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:preserveUnknownFields=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/lib/integrated-service-sdk/config/crd/bases/integrated-service.banzaicloud.io_serviceinstances.yaml
+++ b/lib/integrated-service-sdk/config/crd/bases/integrated-service.banzaicloud.io_serviceinstances.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: ServiceInstanceList
     plural: serviceinstances
     singular: serviceinstance
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Disables the `preserveUnknownFields` feature for the CRD.

### Why?
If preserveUnknownFields is enabled then unknown fields of the CRD are not validated by clients which can lead to hard to debug issues.