### PR TITLE
Add output resolvers to handle v2 service output

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -928,7 +928,10 @@ func main() {
 					specConversions := map[string]integratedservices.SpecConversion{
 						integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 					}
-					serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions)
+					outputResolvers := map[string]integratedserviceadapter.OutputResolver{
+						integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.OutputResolver{},
+					}
+					serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, outputResolvers)
 					repository := integratedserviceadapter.NewCustomResourceRepository(clusterManager.KubeConfigFunc(), commonLogger, serviceConversion, config.Cluster.Namespace)
 					integratedServicesService = integratedservices.NewISServiceV2(integratedServiceManagerRegistry, integratedServiceOperationDispatcher, repository, commonLogger)
 				} else {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -588,7 +588,10 @@ func main() {
 				specConversions := map[string]integratedservices.SpecConversion{
 					integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 				}
-				serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, make(map[string]integratedserviceadapter.OutputResolver))
+				outputResolvers := map[string]integratedserviceadapter.OutputResolver{
+					integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.OutputResolver{},
+				}
+				serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, outputResolvers)
 				featureRepository = integratedserviceadapter.NewCustomResourceRepository(clusterManager.KubeConfigFunc(), commonLogger, serviceConversion, config.Cluster.Namespace)
 			} else {
 				featureRepository = integratedserviceadapter.NewGormIntegratedServiceRepository(db, logger)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -588,7 +588,7 @@ func main() {
 				specConversions := map[string]integratedservices.SpecConversion{
 					integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 				}
-				serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions)
+				serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, make(map[string]integratedserviceadapter.OutputResolver))
 				featureRepository = integratedserviceadapter.NewCustomResourceRepository(clusterManager.KubeConfigFunc(), commonLogger, serviceConversion, config.Cluster.Namespace)
 			} else {
 				featureRepository = integratedserviceadapter.NewGormIntegratedServiceRepository(db, logger)

--- a/internal/integratedservices/functional_suite_test.go
+++ b/internal/integratedservices/functional_suite_test.go
@@ -130,7 +130,10 @@ func (s *Suite) SetupSuite() {
 		specConversions := map[string]integratedservices.SpecConversion{
 			integratedServiceDNS.IntegratedServiceName: integratedServiceDNS.NewSecretMapper(commonSecretStore),
 		}
-		serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions)
+		outputResolvers := map[string]integratedserviceadapter.OutputResolver{
+			integratedServiceDNS.IntegratedServiceName: &integratedServiceDNS.OutputResolver{},
+		}
+		serviceConversion := integratedserviceadapter.NewServiceConversion(services.NewServiceStatusMapper(), specConversions, outputResolvers)
 		clusterRepository := integratedserviceadapter.NewCustomResourceRepository(kubeConfigFunc, commonLogger, serviceConversion, s.config.Cluster.Namespace)
 		serviceFacade := integratedservices.NewISServiceV2(registry, dispatcher, clusterRepository, commonLogger)
 		return serviceFacade, nil

--- a/internal/integratedservices/service_v2.go
+++ b/internal/integratedservices/service_v2.go
@@ -101,13 +101,6 @@ func (i ISServiceV2) Details(ctx context.Context, clusterID uint, serviceName st
 		return integratedService, errors.WrapIf(err, "failed to retrieve integrated service")
 	}
 
-	output, err := manager.GetOutput(ctx, clusterID, integratedService.Spec)
-	if err != nil {
-		return integratedService, errors.WrapIfWithDetails(err, "failed to retrieve integrated service output", "clusterID", clusterID, "integrated service", serviceName)
-	}
-
-	integratedService.Output = merge(integratedService.Output, output)
-
 	return integratedService, nil
 }
 

--- a/internal/integratedservices/service_v2.go
+++ b/internal/integratedservices/service_v2.go
@@ -84,11 +84,6 @@ func (i ISServiceV2) List(ctx context.Context, clusterID uint) ([]IntegratedServ
 }
 
 func (i ISServiceV2) Details(ctx context.Context, clusterID uint, serviceName string) (IntegratedService, error) {
-	manager, err := i.managerRegistry.GetIntegratedServiceManager(serviceName)
-	if err != nil {
-		return IntegratedService{}, errors.WrapIf(err, "failed to get integrated service manager")
-	}
-
 	integratedService, err := i.repository.GetIntegratedService(ctx, clusterID, serviceName)
 	if err != nil {
 		if IsIntegratedServiceNotFoundError(err) {

--- a/internal/integratedservices/services/dns/outputresolver.go
+++ b/internal/integratedservices/services/dns/outputresolver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/banzaicloud/integrated-service-sdk/api/v1alpha1"
+
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
 )
 

--- a/internal/integratedservices/services/dns/outputresolver.go
+++ b/internal/integratedservices/services/dns/outputresolver.go
@@ -1,0 +1,32 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"context"
+
+	"github.com/banzaicloud/integrated-service-sdk/api/v1alpha1"
+	"github.com/banzaicloud/pipeline/internal/integratedservices"
+)
+
+type OutputResolver struct{}
+
+func (o OutputResolver) Resolve(ctx context.Context, instance v1alpha1.ServiceInstance) (integratedservices.IntegratedServiceOutput, error) {
+	return integratedservices.IntegratedServiceOutput{
+		"externalDns": map[string]string{
+			"version": instance.Status.Version,
+		},
+	}, nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Adds a new abstraction `OutputResolver` to the `ServiceConversion` component to allow filling the service output field as appropriate with values based on the current `ServiceInstance` for v2 services.

### Why?
The current form of service output resolution is not suitable for v2 integrated services.
