### PR TITLE
Instance storage api

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -23718,6 +23718,7 @@ components:
             root if available. As a result emptyDir volumes will be provisioned on
             local instance storage disks. You can check out available instance storages
             here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+          nullable: true
           type: boolean
         options:
           $ref: '#/components/schemas/BaseUpdateNodePoolOptions'

--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19370,6 +19370,12 @@ components:
           items:
             type: string
           type: array
+        useInstanceStore:
+          description: Setup available instance stores (NVMe disks) to use for Kubelet
+            root if available. As a result emptyDir volumes will be provisioned on
+            local instance storage disks. You can check out available instance storages
+            here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+          type: boolean
       required:
       - instanceType
       - maxCount
@@ -23662,6 +23668,12 @@ components:
           items:
             type: string
           type: array
+        useInstanceStore:
+          description: Setup available instance stores (NVMe disks) to use for Kubelet
+            root if available. As a result emptyDir volumes will be provisioned on
+            local instance storage disks. You can check out available instance storages
+            here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+          type: boolean
       required:
       - instanceType
     EksUpdateNodePoolRequest_allOf:
@@ -23701,6 +23713,12 @@ components:
             type: string
           nullable: true
           type: array
+        useInstanceStore:
+          description: Setup available instance stores (NVMe disks) to use for Kubelet
+            root if available. As a result emptyDir volumes will be provisioned on
+            local instance storage disks. You can check out available instance storages
+            here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+          type: boolean
         options:
           $ref: '#/components/schemas/BaseUpdateNodePoolOptions'
     PkeAwsUpdateNodePoolRequest_allOf:

--- a/.gen/pipeline/pipeline/model_eks_node_pool.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool.go
@@ -37,4 +37,7 @@ type EksNodePool struct {
 
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups []string `json:"securityGroups,omitempty"`
+
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
@@ -32,4 +32,7 @@ type EksNodePoolAllOf struct {
 
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups []string `json:"securityGroups,omitempty"`
+
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
@@ -41,5 +41,8 @@ type EksUpdateNodePoolRequest struct {
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
@@ -42,7 +42,7 @@ type EksUpdateNodePoolRequest struct {
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
 	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
-	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+	UseInstanceStore *bool `json:"useInstanceStore,omitempty"`
 
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
@@ -34,5 +34,8 @@ type EksUpdateNodePoolRequestAllOf struct {
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
@@ -35,7 +35,7 @@ type EksUpdateNodePoolRequestAllOf struct {
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
 	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
-	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+	UseInstanceStore *bool `json:"useInstanceStore,omitempty"`
 
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_node_pool.go
+++ b/.gen/pipeline/pipeline/model_node_pool.go
@@ -41,4 +41,7 @@ type NodePool struct {
 
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups []string `json:"securityGroups,omitempty"`
+
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_node_pool_summary.go
+++ b/.gen/pipeline/pipeline/model_node_pool_summary.go
@@ -43,6 +43,9 @@ type NodePoolSummary struct {
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups []string `json:"securityGroups,omitempty"`
 
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+
 	// Current status of the node pool.
 	Status string `json:"status,omitempty"`
 

--- a/.gen/pipeline/pipeline/model_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_update_node_pool_request.go
@@ -40,5 +40,8 @@ type UpdateNodePoolRequest struct {
 	// List of additional custom security groups for all nodes in the pool.
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
+	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/.gen/pipeline/pipeline/model_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_update_node_pool_request.go
@@ -41,7 +41,7 @@ type UpdateNodePoolRequest struct {
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 
 	// Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
-	UseInstanceStore bool `json:"useInstanceStore,omitempty"`
+	UseInstanceStore *bool `json:"useInstanceStore,omitempty"`
 
 	Options BaseUpdateNodePoolOptions `json:"options,omitempty"`
 }

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4693,6 +4693,9 @@ components:
                             items:
                                 type: string
                             example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
+                        useInstanceStore:
+                            description: Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+                            type: boolean
 
         EKSNodePoolVolumeEncryption:
             description: Encryption details of the node volumes in an EKS node pool.
@@ -4816,6 +4819,9 @@ components:
                             items:
                                 type: string
                             example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
+                        useInstanceStore:
+                            description: Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+                            type: boolean
                         options:
                             $ref: '#/components/schemas/BaseUpdateNodePoolOptions'
 
@@ -4933,6 +4939,10 @@ components:
                     items:
                         type: string
                     example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
+                useInstanceStore:
+                    description: Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
+                    type: boolean
+
 
         CreateEKSProperties:
             type: object

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4820,6 +4820,7 @@ components:
                                 type: string
                             example: ["sg-00000xxxx0000xxx1", "sg-00000xxxx0000xxx2"]
                         useInstanceStore:
+                            nullable: true
                             description: Setup available instance stores (NVMe disks) to use for Kubelet root if available. As a result emptyDir volumes will be provisioned on local instance storage disks. You can check out available instance storages here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes.
                             type: boolean
                         options:

--- a/internal/cluster/distribution/eks/eksadapter/node_pool_manager.go
+++ b/internal/cluster/distribution/eks/eksadapter/node_pool_manager.go
@@ -246,6 +246,7 @@ func (n nodePoolManager) UpdateNodePool(
 		NodeVolumeSize:       nodePoolUpdate.VolumeSize,
 		NodeImage:            nodePoolUpdate.Image,
 		SecurityGroups:       nodePoolUpdate.SecurityGroups,
+		UseInstanceStore:     nodePoolUpdate.UseInstanceStore,
 
 		Options: eks.NodePoolUpdateOptions{
 			MaxSurge:       nodePoolUpdate.Options.MaxSurge,

--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -126,7 +126,8 @@ type NodePool struct {
 
 	// SecurityGroups collects the user provided node security group IDs for the
 	// node pool.
-	SecurityGroups []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	SecurityGroups   []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	UseInstanceStore *bool    `json:"useInstanceStore,omitempty" yaml:"useInstanceStore,omitempty"`
 
 	// Subnet for worker nodes of this node pool. If not specified than worker nodes
 	// are launched in the same subnet in one of the subnets from the list of subnets of the EKS cluster

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
@@ -226,12 +226,13 @@ func (c *EksClusterCreator) create(ctx context.Context, logger logrus.FieldLogge
 				MinSize: requestedNodePool.MinCount,
 				MaxSize: requestedNodePool.MaxCount,
 			},
-			VolumeSize:     requestedNodePool.VolumeSize,
-			InstanceType:   requestedNodePool.InstanceType,
-			Image:          requestedNodePool.Image,
-			SpotPrice:      requestedNodePool.SpotPrice,
-			SecurityGroups: requestedNodePool.SecurityGroups,
-			SubnetID:       subnetID,
+			VolumeSize:       requestedNodePool.VolumeSize,
+			InstanceType:     requestedNodePool.InstanceType,
+			Image:            requestedNodePool.Image,
+			SpotPrice:        requestedNodePool.SpotPrice,
+			SecurityGroups:   requestedNodePool.SecurityGroups,
+			SubnetID:         subnetID,
+			UseInstanceStore: requestedNodePool.UseInstanceStore,
 		}
 
 		if requestedNodePool.VolumeEncryption != nil {

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_updater.go
@@ -266,6 +266,7 @@ func newASGsFromRequestedUpdatedNodePools(
 			NodeImage:            nodePool.Image,
 			NodeInstanceType:     nodePool.InstanceType,
 			SecurityGroups:       nodePool.SecurityGroups,
+			UseInstanceStore:     nodePool.UseInstanceStore,
 			Labels:               nodePool.Labels,
 			Delete:               false,
 			Create:               false,
@@ -487,6 +488,7 @@ func newNodePoolsFromRequestedNewNodePools(
 			SpotPrice:        nodePool.SpotPrice,
 			SecurityGroups:   nodePool.SecurityGroups,
 			SubnetID:         newNodePoolSubnetIDs[nodePoolName][0],
+			UseInstanceStore: nodePool.UseInstanceStore,
 		})
 	}
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/activity_calculate_node_pool_version.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/activity_calculate_node_pool_version.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"go.uber.org/cadence/activity"
@@ -37,6 +38,7 @@ type CalculateNodePoolVersionActivityInput struct {
 	VolumeEncryption     *eks.NodePoolVolumeEncryption
 	VolumeSize           int
 	CustomSecurityGroups []string
+	UseInstanceStore     *bool
 }
 
 type CalculateNodePoolVersionActivityOutput struct {
@@ -62,12 +64,16 @@ func (a CalculateNodePoolVersionActivity) Execute(
 	if input.VolumeEncryption != nil {
 		volumeEncryption = fmt.Sprintf("%v", *input.VolumeEncryption)
 	}
-
+	useInstanceStore := "<nil>"
+	if input.UseInstanceStore != nil {
+		useInstanceStore = strconv.FormatBool(*input.UseInstanceStore)
+	}
 	calculationParams := []string{
 		input.Image,
 		volumeEncryption,
 		fmt.Sprintf("%d", input.VolumeSize),
 		strings.Join(input.CustomSecurityGroups, ","),
+		useInstanceStore,
 	}
 
 	h := sha1.New() // #nosec

--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -236,7 +236,8 @@ type AutoscaleGroup struct {
 
 	// SecurityGroups collects the user specified custom node security group
 	// IDs.
-	SecurityGroups []string
+	SecurityGroups   []string
+	UseInstanceStore *bool
 
 	Labels    map[string]string
 	Delete    bool

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -264,14 +264,12 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 			ParameterKey:   aws.String("KubeletExtraArguments"),
 			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
+		{
+			ParameterKey:   aws.String("UseInstanceStore"),
+			ParameterValue: aws.String(strconv.FormatBool(aws.BoolValue(input.UseInstanceStore))),
+		},
 	}
 
-	if input.UseInstanceStore != nil {
-		stackParams = append(stackParams, &cloudformation.Parameter{
-			ParameterKey:   aws.String("UseInstanceStore"),
-			ParameterValue: aws.String(strconv.FormatBool(*input.UseInstanceStore)),
-		})
-	}
 	clientRequestToken := sdkAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateAsgActivityName)
 
 	createStackInput := &cloudformation.CreateStackInput{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -263,6 +263,7 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 			ParameterKey:   aws.String("KubeletExtraArguments"),
 			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
+		
 	}
 	clientRequestToken := sdkAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, CreateAsgActivityName)
 

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -306,18 +306,11 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 			ParameterKey:   aws.String("KubeletExtraArguments"),
 			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
-	}
-
-	if input.UseInstanceStore != nil {
-		stackParams = append(stackParams, &cloudformation.Parameter{
-			ParameterKey:   aws.String("UseInstanceStore"),
-			ParameterValue: aws.String(strconv.FormatBool(*input.UseInstanceStore)),
-		})
-	} else if !input.CurrentTemplateVersion.IsLessThan("2.2.0") {
-		stackParams = append(stackParams, &cloudformation.Parameter{
-			ParameterKey:     aws.String("UseInstanceStore"),
-			UsePreviousValue: aws.Bool(true),
-		})
+		sdkCloudformation.NewOptionalStackParameter(
+			"UseInstanceStore",
+			input.UseInstanceStore != nil || input.CurrentTemplateVersion.IsLessThan("2.2.0"),
+			strconv.FormatBool(aws.BoolValue(input.UseInstanceStore)), // Note: false default value for old stacks.
+		),
 	}
 
 	clientRequestToken := sdkAmazon.NewNormalizedClientRequestToken(input.AWSClientRequestTokenBase, UpdateAsgActivityName)

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_node_group.go
@@ -238,18 +238,11 @@ func (a UpdateNodeGroupActivity) Execute(ctx context.Context, input UpdateNodeGr
 			ParameterKey:   aws.String("KubeletExtraArguments"),
 			ParameterValue: aws.String(fmt.Sprintf("--node-labels %v", strings.Join(nodeLabels, ","))),
 		},
-	}
-
-	if input.UseInstanceStore != nil {
-		stackParams = append(stackParams, &cloudformation.Parameter{
-			ParameterKey:   aws.String("UseInstanceStore"),
-			ParameterValue: aws.String(strconv.FormatBool(*input.UseInstanceStore)),
-		})
-	} else if !input.CurrentTemplateVersion.IsLessThan("2.2.0") {
-		stackParams = append(stackParams, &cloudformation.Parameter{
-			ParameterKey:     aws.String("UseInstanceStore"),
-			UsePreviousValue: aws.Bool(true),
-		})
+		sdkCloudFormation.NewOptionalStackParameter(
+			"UseInstanceStore",
+			input.UseInstanceStore != nil || input.CurrentTemplateVersion.IsLessThan("2.2.0"),
+			strconv.FormatBool(aws.BoolValue(input.UseInstanceStore)), // Note: false default value for old stacks.
+		),
 	}
 
 	// we don't reuse the creation time template, since it may have changed

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -161,8 +161,8 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			NodeVolumeEncryptionEnabled string         `mapstructure:"NodeVolumeEncryptionEnabled,omitempty"` // Note: NodeVolumeEncryptionEnabled is only available from template version 2.1.0.
 			NodeVolumeEncryptionKeyARN  string         `mapstructure:"NodeVolumeEncryptionKeyARN,omitempty"`  // Note: NodeVolumeEncryptionKeyARN is only available from template version 2.1.0.
 			NodeVolumeSize              int            `mapstructure:"NodeVolumeSize"`
-			TemplateVersion             semver.Version `mapstructure:"TemplateVersion,omitempty"` // Note: TemplateVersion is only available from template version 2.0.0.
-			UseInstanceStore            string         `mapstructure:"UseInstanceStore"`          // Note: TemplateVersion is only available from template version 2.2.0.
+			TemplateVersion             semver.Version `mapstructure:"TemplateVersion,omitempty"`  // Note: TemplateVersion is only available from template version 2.0.0.
+			UseInstanceStore            string         `mapstructure:"UseInstanceStore,omitempty"` // Note: TemplateVersion is only available from template version 2.2.0.
 
 		}
 		err = sdkCloudFormation.ParseStackParameters(getCFStackOutput.Stack.Parameters, &parameters)

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -75,6 +75,7 @@ type UpdateNodePoolWorkflowInput struct {
 	NodeVolumeSize       int
 	NodeImage            string
 	SecurityGroups       []string
+	UseInstanceStore     *bool
 
 	Options eks.NodePoolUpdateOptions
 
@@ -139,6 +140,8 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 	effectiveVolumeEncryption := input.NodeVolumeEncryption
 	effectiveVolumeSize := input.NodeVolumeSize
 	effectiveSecurityGroups := input.SecurityGroups
+	effectiveUseInstanceStore := input.UseInstanceStore
+
 	{ // Note: needing CF stack for template version and possibly node pool version.
 		getCFStackInput := eksWorkflow.GetCFStackActivityInput{
 			EKSActivityInput: eksActivityInput,
@@ -159,6 +162,8 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			NodeVolumeEncryptionKeyARN  string         `mapstructure:"NodeVolumeEncryptionKeyARN,omitempty"`  // Note: NodeVolumeEncryptionKeyARN is only available from template version 2.1.0.
 			NodeVolumeSize              int            `mapstructure:"NodeVolumeSize"`
 			TemplateVersion             semver.Version `mapstructure:"TemplateVersion,omitempty"` // Note: TemplateVersion is only available from template version 2.0.0.
+			UseInstanceStore            string         `mapstructure:"UseInstanceStore"` // Note: TemplateVersion is only available from template version 2.2.0.
+
 		}
 		err = sdkCloudFormation.ParseStackParameters(getCFStackOutput.Stack.Parameters, &parameters)
 		if err != nil {
@@ -192,6 +197,15 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			parameters.CustomNodeSecurityGroups != "" {
 			effectiveSecurityGroups = strings.Split(parameters.CustomNodeSecurityGroups, ",")
 			sort.Strings(effectiveSecurityGroups)
+		}
+
+		if effectiveUseInstanceStore == nil &&
+			parameters.UseInstanceStore != "" {
+			useInstanceStore, err := strconv.ParseBool(parameters.UseInstanceStore)
+			if err != nil {
+				return errors.WrapIf(err, "invalid UseInstanceStore parameter value")
+			}
+			effectiveUseInstanceStore = &useInstanceStore
 		}
 	}
 
@@ -239,6 +253,7 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			VolumeEncryption:     effectiveVolumeEncryption,
 			VolumeSize:           effectiveVolumeSize,
 			CustomSecurityGroups: effectiveSecurityGroups,
+			UseInstanceStore:     effectiveUseInstanceStore,
 		}
 
 		var output eksWorkflow.CalculateNodePoolVersionActivityOutput
@@ -266,6 +281,7 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			NodeVolumeSize:         volumeSize,
 			NodeImage:              input.NodeImage,
 			SecurityGroups:         input.SecurityGroups,
+			UseInstanceStore:       input.UseInstanceStore,
 			MaxBatchSize:           input.Options.MaxBatchSize,
 			MinInstancesInService:  input.Options.MaxSurge,
 			ClusterTags:            input.ClusterTags,

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_node_pool.go
@@ -162,7 +162,7 @@ func (w UpdateNodePoolWorkflow) Execute(ctx workflow.Context, input UpdateNodePo
 			NodeVolumeEncryptionKeyARN  string         `mapstructure:"NodeVolumeEncryptionKeyARN,omitempty"`  // Note: NodeVolumeEncryptionKeyARN is only available from template version 2.1.0.
 			NodeVolumeSize              int            `mapstructure:"NodeVolumeSize"`
 			TemplateVersion             semver.Version `mapstructure:"TemplateVersion,omitempty"` // Note: TemplateVersion is only available from template version 2.0.0.
-			UseInstanceStore            string         `mapstructure:"UseInstanceStore"` // Note: TemplateVersion is only available from template version 2.2.0.
+			UseInstanceStore            string         `mapstructure:"UseInstanceStore"`          // Note: TemplateVersion is only available from template version 2.2.0.
 
 		}
 		err = sdkCloudFormation.ParseStackParameters(getCFStackOutput.Stack.Parameters, &parameters)

--- a/internal/cluster/distribution/eks/node_pool.go
+++ b/internal/cluster/distribution/eks/node_pool.go
@@ -37,6 +37,7 @@ type NewNodePool struct {
 	SpotPrice        string                    `mapstructure:"spotPrice"`
 	SecurityGroups   []string                  `mapstructure:"securityGroups"`
 	SubnetID         string                    `mapstructure:"subnetId"`
+	UseInstanceStore *bool                     `mapstructure:"useInstanceStore,omitempty"`
 }
 
 // Validate semantically validates the new node pool.

--- a/internal/cluster/distribution/eks/service.go
+++ b/internal/cluster/distribution/eks/service.go
@@ -68,8 +68,9 @@ type NodePoolUpdate struct {
 	VolumeEncryption *NodePoolVolumeEncryption `mapstructure:"volumeEncryption,omitempty"`
 	VolumeSize       int                       `mapstructure:"volumeSize"`
 
-	Image          string   `mapstructure:"image"`
-	SecurityGroups []string `mapstructure:"securityGroups"`
+	Image            string   `mapstructure:"image"`
+	SecurityGroups   []string `mapstructure:"securityGroups"`
+	UseInstanceStore *bool    `mapstructure:"useInstanceStore,omitempty"`
 
 	Options NodePoolUpdateOptions `mapstructure:"options"`
 }

--- a/internal/cluster/distribution/eks/service.go
+++ b/internal/cluster/distribution/eks/service.go
@@ -111,6 +111,7 @@ type NodePool struct {
 	SpotPrice        string                    `mapstructure:"spotPrice"`
 	SecurityGroups   []string                  `mapstructure:"securityGroups,omitempty"`
 	SubnetID         string                    `mapstructure:"subnetId"`
+	UseInstanceStore bool                      `mapstructure:"UseInstanceStore"`
 	Status           NodePoolStatus            `mapstructure:"status"`
 	StatusMessage    string                    `mapstructure:"statusMessage"`
 }
@@ -131,6 +132,7 @@ func NewNodePoolFromCFStack(name string, labels map[string]string, stack *cloudf
 		NodeVolumeSize              int    `mapstructure:"NodeVolumeSize"`
 		CustomNodeSecurityGroups    string `mapstructure:"CustomNodeSecurityGroups,omitempty"` // Note: CustomNodeSecurityGroups is only available from template version 2.0.0.
 		Subnets                     string `mapstructure:"Subnets"`
+		UseInstanceStore            string `mapstructure:"UseInstanceStore,omitempty"`
 	}
 
 	err := sdkCloudFormation.ParseStackParameters(stack.Parameters, &nodePoolParameters)
@@ -170,6 +172,14 @@ func NewNodePoolFromCFStack(name string, labels map[string]string, stack *cloudf
 	nodePool.SubnetID = nodePoolParameters.Subnets // Note: currently we ensure a single value at creation.
 	nodePool.Status = NewNodePoolStatusFromCFStackStatus(aws.StringValue(stack.StackStatus))
 	nodePool.StatusMessage = aws.StringValue(stack.StackStatusReason)
+
+	if nodePoolParameters.UseInstanceStore != "" {
+		useInstanceStore, err := strconv.ParseBool(nodePoolParameters.UseInstanceStore)
+		if err != nil {
+			return NewNodePoolWithNoValues(name, NodePoolStatusError, "invalid useInstanceStore information")
+		}
+		nodePool.UseInstanceStore = useInstanceStore
+	}
 
 	return nodePool
 }

--- a/src/cluster/eks_update_cluster.go
+++ b/src/cluster/eks_update_cluster.go
@@ -349,6 +349,7 @@ func (w EKSUpdateClusterWorkflow) Execute(ctx workflow.Context, input EKSUpdateC
 				Labels:                 updatedNodePool.Labels,
 				Tags:                   input.Tags,
 				CurrentTemplateVersion: currentTemplateVersion,
+				UseInstanceStore:       updatedNodePool.UseInstanceStore,
 			}
 			ctx = workflow.WithActivityOptions(ctx, aoWithHeartBeat)
 			f := workflow.ExecuteActivity(ctx, eksWorkflow.UpdateAsgActivityName, activityInput)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3381 
| License         | Apache 2.0

### What's in this PR?
Add `useInstanceStore` property to EKS node pool in create / update cluster, create / update node pool API.
Setting `useInstanceStore: true` for a node pool means in case there's available storage for a given instance type that will used by Kubelet and EmptyDir volumes will be provisioned on these storages.

Tested scenarios:

- create cluster with old CF template (Pipeline version: 0.64.0) then upgrade node pool to with image, don't set useInstanceStore
- update node pool, set useInstanceStore = true for a c5.large image. CF param UseInstanceStore will be set to true however there will be no instance storage available
- add new node pool i3.large 
- update previously created node pool set useInstanceStore = true
- create cluster setting useInstanceStore = true for each node pool

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
