### PR TITLE
chore: update anchore-image-validator chart

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -732,7 +732,7 @@ rbac:
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::anchore::insecure", false)
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.6.1")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.6.2")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	// v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related: https://github.com/banzaicloud/anchore-image-validator/pull/63
| License         | Apache 2.0


### What's in this PR?
The updated chart is using `anchore-image-validator` image version `0.4.5`, which was built on to of alpine:3.12.3

### Why?
Some vulnerabilities were found in the previous version of the alpine image.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Related Helm chart(s) updated (if needed)
