### PR TITLE
chore: update vault-secrets-webhook chart version

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -179,7 +179,7 @@ dex:
 #        charts:
 #            webhook:
 #                chart: "banzaicloud-stable/vault-secrets-webhook"
-#                version: "1.10.0"
+#                version: "1.10.1"
 #
 #                # See https://github.com/banzaicloud/bank-vaults/tree/master/charts/vault-secrets-webhook for details
 #                values: {}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -567,7 +567,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::vault::managed::enabled", false)
 	v.SetDefault("cluster::vault::managed::endpoint", "")
 	v.SetDefault("cluster::vault::charts::webhook::chart", "banzaicloud-stable/vault-secrets-webhook")
-	v.SetDefault("cluster::vault::charts::webhook::version", "1.10.0")
+	v.SetDefault("cluster::vault::charts::webhook::version", "1.10.1")
 	v.SetDefault("cluster::vault::charts::webhook::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::monitoring::enabled", true)


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related: banzaicloud/bank-vaults#1231, related: banzaicloud/bank-vaults#1227
| License         | Apache 2.0

### What's in this PR?
Update `vault-secrets-webhook` chart version

### Why
The base image was updated in the webhook image tag 1.10.1

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
