### PR TITLE
Added partial ARM support for Monitoring integrated service

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -195,17 +195,17 @@ dex:
 #
 #        charts:
 #            operator:
-#                chart: "stable/prometheus-operator"
-#                version: "8.5.14"
+#                chart: "prometheus-community/kube-prometheus-stack"
+#                version: "12.11.3"
 #
-#                # See https://github.com/helm/charts/tree/master/stable/prometheus-operator for details
+#                # See https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack for details
 #                values: {}
 #
 #            pushgateway:
-#                chart: "stable/prometheus-pushgateway"
-#                version: "1.2.13"
+#                chart: "prometheus-community/prometheus-pushgateway"
+#                version: "1.5.1"
 #
-#                # See https://github.com/helm/charts/tree/master/stable/prometheus-pushgateway for details
+#                # See https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-pushgateway for details
 #                values: {}
 #
 #    logging:
@@ -424,6 +424,7 @@ dex:
 #        bitnami: "https://charts.bitnami.com/bitnami"
 #        loki: "https://grafana.github.io/loki/charts"
 #        kubefed-charts: "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts"
+#        prometheus-community: "https://prometheus-community.github.io/helm-charts"
 
 #cloud:
 #    amazon:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -573,8 +573,8 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::monitoring::enabled", true)
 	v.SetDefault("cluster::monitoring::namespace", "")
 	v.SetDefault("cluster::monitoring::grafana::adminUser", "admin")
-	v.SetDefault("cluster::monitoring::charts::operator::chart", "stable/prometheus-operator")
-	v.SetDefault("cluster::monitoring::charts::operator::version", "8.13.8")
+	v.SetDefault("cluster::monitoring::charts::operator::chart", "prometheus-community/kube-prometheus-stack")
+	v.SetDefault("cluster::monitoring::charts::operator::version", "12.11.3")
 	v.SetDefault("cluster::monitoring::charts::operator::values", map[string]interface{}{
 		"prometheus": map[string]interface{}{
 			"ingress": map[string]interface{}{
@@ -608,21 +608,21 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 			},
 		},
 	})
-	v.SetDefault("cluster::monitoring::images::operator::repository", "quay.io/coreos/prometheus-operator")
-	v.SetDefault("cluster::monitoring::images::operator::tag", "v0.34.0")
+	v.SetDefault("cluster::monitoring::images::operator::repository", "quay.io/prometheus-operator/prometheus-operator")
+	v.SetDefault("cluster::monitoring::images::operator::tag", "v0.44.1")
 	v.SetDefault("cluster::monitoring::images::prometheus::repository", "quay.io/prometheus/prometheus")
-	v.SetDefault("cluster::monitoring::images::prometheus::tag", "v2.13.1")
+	v.SetDefault("cluster::monitoring::images::prometheus::tag", "v2.22.1")
 	v.SetDefault("cluster::monitoring::images::alertmanager::repository", "quay.io/prometheus/alertmanager")
-	v.SetDefault("cluster::monitoring::images::alertmanager::tag", "v0.19.0")
+	v.SetDefault("cluster::monitoring::images::alertmanager::tag", "v0.21.0")
 	v.SetDefault("cluster::monitoring::images::grafana::repository", "grafana/grafana")
-	v.SetDefault("cluster::monitoring::images::grafana::tag", "6.5.2")
+	v.SetDefault("cluster::monitoring::images::grafana::tag", "7.3.5")
 	v.SetDefault("cluster::monitoring::images::kubestatemetrics::repository", "quay.io/coreos/kube-state-metrics")
-	v.SetDefault("cluster::monitoring::images::kubestatemetrics::tag", "v1.9.3")
+	v.SetDefault("cluster::monitoring::images::kubestatemetrics::tag", "v1.9.7")
 	v.SetDefault("cluster::monitoring::images::nodeexporter::repository", "quay.io/prometheus/node-exporter")
-	v.SetDefault("cluster::monitoring::images::nodeexporter::tag", "v0.18.1")
+	v.SetDefault("cluster::monitoring::images::nodeexporter::tag", "v1.0.1")
 
-	v.SetDefault("cluster::monitoring::charts::pushgateway::chart", "stable/prometheus-pushgateway")
-	v.SetDefault("cluster::monitoring::charts::pushgateway::version", "1.2.13")
+	v.SetDefault("cluster::monitoring::charts::pushgateway::chart", "prometheus-community/prometheus-pushgateway")
+	v.SetDefault("cluster::monitoring::charts::pushgateway::version", "1.5.1")
 	v.SetDefault("cluster::monitoring::charts::pushgateway::values", map[string]interface{}{})
 	v.SetDefault("cluster::monitoring::images::pushgateway::repository", "prom/pushgateway")
 	v.SetDefault("cluster::monitoring::images::pushgateway::tag", "v1.0.1")
@@ -877,6 +877,7 @@ traefik:
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
 	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
 	v.SetDefault("helm::repositories::kubefed-charts", "https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts")
+	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration
 	v.SetDefault("cloud::amazon::defaultRegion", "us-west-1")

--- a/internal/helm/integration_test.go
+++ b/internal/helm/integration_test.go
@@ -98,8 +98,9 @@ func testIntegrationInstall(t *testing.T) {
 	config := helm.Config{
 		Home: home,
 		Repositories: map[string]string{
-			"stable":             "https://charts.helm.sh/stable",
-			"banzaicloud-stable": "https://kubernetes-charts.banzaicloud.com",
+			"stable":               "https://charts.helm.sh/stable",
+			"banzaicloud-stable":   "https://kubernetes-charts.banzaicloud.com",
+			"prometheus-community": "https://prometheus-community.github.io/helm-charts",
 		},
 	}
 

--- a/internal/helm/service_test.go
+++ b/internal/helm/service_test.go
@@ -236,6 +236,10 @@ func Test_service_ListRepositories(t *testing.T) {
 					Name: "loki",
 					URL:  "https://grafana.github.io/loki/charts",
 				},
+				{
+					Name: "prometheus-community",
+					URL:  "https://prometheus-community.github.io/helm-charts",
+				},
 			},
 			setupMocks: func(store *Store, secretStore *SecretStore, envResolver *EnvResolver, envService *EnvService, arguments args) {
 				storeMock := (*store).(*MockStore)
@@ -262,6 +266,10 @@ func Test_service_ListRepositories(t *testing.T) {
 						{
 							Name: "loki",
 							URL:  "https://grafana.github.io/loki/charts",
+						},
+						{
+							Name: "prometheus-community",
+							URL:  "https://prometheus-community.github.io/helm-charts",
 						},
 					},
 					nil,

--- a/internal/integratedservices/services/monitoring/operator.go
+++ b/internal/integratedservices/services/monitoring/operator.go
@@ -800,8 +800,10 @@ func (op IntegratedServiceOperator) getDefaultStorageClassName(ctx context.Conte
 func (op IntegratedServiceOperator) cleanupCRDs(ctx context.Context, clusterID uint) error {
 	// list with the monitoring related CRDs
 	crdNames := []string{
+		"alertmanagerconfigs.monitoring.coreos.com",
 		"alertmanagers.monitoring.coreos.com",
 		"podmonitors.monitoring.coreos.com",
+		"probes.monitoring.coreos.com",
 		"prometheuses.monitoring.coreos.com",
 		"prometheusrules.monitoring.coreos.com",
 		"servicemonitors.monitoring.coreos.com",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added partial ARM support for Monitoring integrated service

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

We would like to support pure ARM and mixed managed clusters in the future, this is a step towards that direction.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The reason behind partial support is that we decided to wait for the kube-state-metrics 2.0.0 verion (for ARM support) and official chart.

#### Major version change release notes:

Prometheus alertmanager:
[v0.20.0](https://github.com/prometheus/alertmanager/releases/tag/v0.20.0)
[v0.21.0](https://github.com/prometheus/alertmanager/releases/tag/v0.21.0)

Prometheus node exporter:
[v1.0.0](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0)

Prometheus operator:
[v0.35.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.35.0)
[v0.36.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.36.0)
[v0.37.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.37.0)
[v0.38.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.38.0)
[v0.39.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.39.0)
[v0.40.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.40.0)
[v0.41.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.41.0)
[v0.42.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.42.0)
[v0.43.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.43.0)
[v0.44.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.44.0)

Prometheus operator chart:
https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#upgrading-an-existing-release-to-a-new-major-version

Grafana:
[v7.0](https://grafana.com/docs/grafana/latest/installation/upgrading/#upgrading-to-v70)

Nothing stood out as Pipeline functionality breaking change (neither by the notes, nor empirically), but **there are some possibly user experience breaking changes such as Prometheus default metrics being renamed or removed**.

**It's up to us to consider whether this is worth it or it's better to wait for a OneEye replacement in Pipeline.**

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
