### PR TITLE
Check Integrated services before activation; activation only performed once

### DIFF
--- a/internal/integratedservices/registry.go
+++ b/internal/integratedservices/registry.go
@@ -88,12 +88,6 @@ func (e UnknownIntegratedServiceError) Details() []interface{} {
 	return []interface{}{"integratedService", e.IntegratedServiceName}
 }
 
-// NotFound tells a client that this error is related to a resource being not found.
-// Can be used to translate the error to eg. status code.
-func (UnknownIntegratedServiceError) NotFound() bool {
-	return true
-}
-
 // ServiceError tells the transport layer whether this error should be translated into the transport format
 // or an internal error should be returned instead.
 func (UnknownIntegratedServiceError) ServiceError() bool {

--- a/internal/integratedservices/servicerouter_test.go
+++ b/internal/integratedservices/servicerouter_test.go
@@ -355,6 +355,7 @@ func (suite *ServiceRouterSuite) TestActivate_RouteToV2() {
 	// Then
 	require.Nil(suite.T(), err, "router must not return with error")
 }
+
 func (suite *ServiceRouterSuite) TestActivate_RouteToV1() {
 	// Given
 	ctx := context.Background()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
Integrated service activation is only executed once


### Why?
Activation returns early if it has already been called (modification is possible through the update operation)

