### PR TITLE
feat(securityscan): add multiple registries

### DIFF
--- a/.gen/anchore/api/openapi.yaml
+++ b/.gen/anchore/api/openapi.yaml
@@ -1490,7 +1490,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegistryConfiguration'
+                $ref: '#/components/schemas/RegistryConfigurationList'
           description: Registry configuration
       summary: Get a specific registry configuration
       tags:

--- a/.gen/anchore/api_registries.go
+++ b/.gen/anchore/api_registries.go
@@ -228,16 +228,16 @@ Get information on a specific registry
  * @param registry
  * @param optional nil or *GetRegistryOpts - Optional Parameters:
  * @param "XAnchoreAccount" (optional.String) -  An account name to change the resource scope of the request to that account, if permissions allow (admin only)
-@return RegistryConfiguration
+@return []RegistryConfiguration
 */
-func (a *RegistriesApiService) GetRegistry(ctx _context.Context, registry string, localVarOptionals *GetRegistryOpts) (RegistryConfiguration, *_nethttp.Response, error) {
+func (a *RegistriesApiService) GetRegistry(ctx _context.Context, registry string, localVarOptionals *GetRegistryOpts) ([]RegistryConfiguration, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  RegistryConfiguration
+		localVarReturnValue  []RegistryConfiguration
 	)
 
 	// create path and map variables

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ apis/anchore/swagger.yaml:
 	curl https://raw.githubusercontent.com/anchore/anchore-engine/${ANCHORE_VERSION}/anchore_engine/services/apiext/swagger/swagger.yaml | tr '\n' '\r' | sed $$'s/- Images\r      - Vulnerabilities/- Images/g' | tr '\r' '\n' | sed '/- Image Content/d; /- Policy Evaluation/d; /- Queries/d' > apis/anchore/swagger.yaml
 
 .PHONY: generate-anchore-client
-generate-anchore-client: apis/anchore/swagger.yaml ## Generate client from Anchore OpenAPI spec
+generate-anchore-client: ## apis/anchore/swagger.yaml ## https://github.com/anchore/anchore-engine/pull/846 ## Generate client from Anchore OpenAPI spec
 	$(call back_up_file,.gen/anchore/BUILD)
 	$(call generate_openapi_client,apis/anchore/swagger.yaml,anchore,.gen/anchore)
 	@ sed -i~ 's/whitelist_ids,omitempty/whitelist_ids/' .gen/anchore/model_mapping_rule.go && rm .gen/anchore/model_mapping_rule.go~

--- a/apis/anchore/swagger.yaml
+++ b/apis/anchore/swagger.yaml
@@ -1096,7 +1096,7 @@ paths:
         200:
           description: Registry configuration
           schema:
-            $ref: "#/definitions/RegistryConfiguration"
+            $ref: "#/definitions/RegistryConfigurationList"
     put:
       tags:
       - Registries
@@ -3264,7 +3264,7 @@ definitions:
         description: Error code name
       description:
         type: string
-        description: Description of the error code 
+        description: Description of the error code
   GateSpec:
     type: object
     description: A description of the set of gates available in this engine and the triggers and parameters supported

--- a/internal/integratedservices/services/securityscan/operator.go
+++ b/internal/integratedservices/services/securityscan/operator.go
@@ -156,9 +156,17 @@ func (op IntegratedServiceOperator) Apply(ctx context.Context, clusterID uint, s
 				registry.Password = secret[secrettype.Password]
 			}
 
-			err = anchoreClient.AddRegistry(ctx, registry)
+			_, err = anchoreClient.GetRegistry(ctx, registry.Registry)
 			if err != nil {
-				return errors.WrapWithDetails(err, "failed to add anchore registry")
+				err = anchoreClient.AddRegistry(ctx, registry)
+				if err != nil {
+					return errors.WrapWithDetails(err, "failed to add anchore registry")
+				}
+			} else {
+				err = anchoreClient.UpdateRegistry(ctx, registry.Registry, registry)
+				if err != nil {
+					return errors.WrapWithDetails(err, "failed to update anchore registry")
+				}
 			}
 		}
 	}

--- a/internal/integratedservices/services/securityscan/operator.go
+++ b/internal/integratedservices/services/securityscan/operator.go
@@ -160,12 +160,12 @@ func (op IntegratedServiceOperator) Apply(ctx context.Context, clusterID uint, s
 			if err != nil {
 				err = anchoreClient.AddRegistry(ctx, registry)
 				if err != nil {
-					return errors.WrapWithDetails(err, "failed to add anchore registry")
+					return err
 				}
 			} else {
-				err = anchoreClient.UpdateRegistry(ctx, registry.Registry, registry)
+				err = anchoreClient.UpdateRegistry(ctx, registry)
 				if err != nil {
-					return errors.WrapWithDetails(err, "failed to update anchore registry")
+					return err
 				}
 			}
 		}

--- a/internal/integratedservices/services/securityscan/spec.go
+++ b/internal/integratedservices/services/securityscan/spec.go
@@ -27,7 +27,7 @@ type integratedServiceSpec struct {
 	Policy           policySpec        `json:"policy" mapstructure:"policy"`
 	ReleaseWhiteList []releaseSpec     `json:"releaseWhiteList,omitempty" mapstructure:"releaseWhiteList"`
 	WebhookConfig    webHookConfigSpec `json:"webhookConfig" mapstructure:"webhookConfig"`
-	Registry         *registrySpec     `json:"registry" mapstructure:"registry"`
+	Registries       []*registrySpec   `json:"registry" mapstructure:"registries"`
 }
 
 // Validate validates the input security scan specification.
@@ -48,8 +48,10 @@ func (s integratedServiceSpec) Validate(pipelineNamespace string) error {
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate(pipelineNamespace))
 
-	if s.Registry != nil {
-		validationErrors = errors.Combine(validationErrors, s.Registry.Validate())
+	if s.Registries != nil {
+		for _, registryItem := range s.Registries {
+			validationErrors = errors.Combine(validationErrors, registryItem.Validate())
+		}
 	}
 
 	return validationErrors

--- a/internal/integratedservices/services/securityscan/spec.go
+++ b/internal/integratedservices/services/securityscan/spec.go
@@ -27,7 +27,8 @@ type integratedServiceSpec struct {
 	Policy           policySpec        `json:"policy" mapstructure:"policy"`
 	ReleaseWhiteList []releaseSpec     `json:"releaseWhiteList,omitempty" mapstructure:"releaseWhiteList"`
 	WebhookConfig    webHookConfigSpec `json:"webhookConfig" mapstructure:"webhookConfig"`
-	Registries       []*registrySpec   `json:"registry" mapstructure:"registries"`
+	Registry         *registrySpec     `json:"registry" mapstructure:"registry"`
+	Registries       []*registrySpec   `json:"registries" mapstructure:"registries"`
 }
 
 // Validate validates the input security scan specification.
@@ -47,6 +48,10 @@ func (s integratedServiceSpec) Validate(pipelineNamespace string) error {
 	}
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate(pipelineNamespace))
+
+	if s.Registry != nil && len(s.Registries) == 0 {
+		validationErrors = errors.Combine(validationErrors, s.Registry.Validate())
+	}
 
 	for _, registryItem := range s.Registries {
 		validationErrors = errors.Combine(validationErrors, registryItem.Validate())

--- a/internal/integratedservices/services/securityscan/spec.go
+++ b/internal/integratedservices/services/securityscan/spec.go
@@ -48,10 +48,8 @@ func (s integratedServiceSpec) Validate(pipelineNamespace string) error {
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate(pipelineNamespace))
 
-	if s.Registries != nil {
-		for _, registryItem := range s.Registries {
-			validationErrors = errors.Combine(validationErrors, registryItem.Validate())
-		}
+	for _, registryItem := range s.Registries {
+		validationErrors = errors.Combine(validationErrors, registryItem.Validate())
 	}
 
 	return validationErrors

--- a/internal/security/anchore_client.go
+++ b/internal/security/anchore_client.go
@@ -309,7 +309,7 @@ func (a anchoreClient) AddRegistry(ctx context.Context, registry Registry) error
 
 	_, resp, err := a.getRestClient().RegistriesApi.CreateRegistry(a.authorizedContext(ctx), request, opts)
 
-	if err != nil || (resp.StatusCode != http.StatusOK) {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		a.logger.Debug("failed to add anchore registry", fnCtx)
 
 		return errors.WrapIfWithDetails(err, "failed to add anchore registry", fnCtx)
@@ -327,11 +327,6 @@ func (a anchoreClient) GetRegistry(ctx context.Context, registryName string) ([]
 	opts := &anchore.GetRegistryOpts{}
 	registry, resp, err := a.getRestClient().RegistriesApi.GetRegistry(a.authorizedContext(ctx), registryName, opts)
 
-	a.logger.Debug("registry", map[string]interface{}{
-		"response":   resp.Status,
-		"registriey": registry,
-	})
-
 	if err != nil || (resp.StatusCode != http.StatusOK) {
 		return nil, errors.WrapIfWithDetails(err, "failed to get registry", registryName)
 	}
@@ -343,36 +338,11 @@ func (a anchoreClient) UpdateRegistry(ctx context.Context, registry Registry) er
 	fnCtx := map[string]interface{}{"registry": registry.Registry}
 	a.logger.Info("updating anchore registry", fnCtx)
 
-	// registryType := registry.Type
-	// if registryType == "" {
-	// 	if IsEcrRegistry(registry.Registry) {
-	// 		registryType = "awsecr"
-	// 	} else {
-	// 		registryType = "docker_v2"
-	// 	}
-	// }
-
-	// request := anchore.RegistryConfigurationRequest{
-	// 	Registry:       registry.Registry,
-	// 	RegistryName:   registry.Registry,
-	// 	RegistryUser:   registry.Username,
-	// 	RegistryPass:   registry.Password,
-	// 	RegistryType:   registryType,
-	// 	RegistryVerify: registry.Verify,
-	// }
-
-	// opts := &anchore.UpdateRegistryOpts{Validate: optional.NewBool(true)}
-	// _, resp, err := a.getRestClient().RegistriesApi.UpdateRegistry(a.authorizedContext(ctx), registry.Registry, request, opts)
-
-	// if err != nil || (resp.StatusCode != http.StatusOK) {
-	// 	return errors.WrapIfWithDetails(err, "failed to update anchore registry", fnCtx)
-	// }
-
 	// https://github.com/anchore/anchore-engine/issues/847
 	// using DeleteRegistry and AddRegistry instead of updateRegistry because UpdateRegistry doesn't work in anchore-engine
 	opts := &anchore.DeleteRegistryOpts{}
 	resp, err := a.getRestClient().RegistriesApi.DeleteRegistry(a.authorizedContext(ctx), registry.Registry, opts)
-	if err != nil || (resp.StatusCode != http.StatusOK) {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		return errors.WrapIfWithDetails(err, "failed to delete anchore registry", fnCtx)
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     |yes
| Deprecations?   | no
| Related tickets | related: https://github.com/banzaicloud/banzai-cli/pull/338
| License         | Apache 2.0

### What's in this PR?
In the case of `securityscan` integrated service, multiple image registries can be set.


### Additional context
- The swagger file is fixed within the `pipeline` repo and downloading the upstream one is disabled, until the [pull-request](https://github.com/anchore/anchore-engine/pull/846) in the `anchore-engine` will merge.

- Using DeleteRegistry and AddRegistry instead of UpdateRegistry as workaround because of the [anchore-engine issue](https://github.com/anchore/anchore-engine/issues/847).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
