### PR TITLE
Updated node pool labelset operator chart to version 0.1.1

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -161,9 +161,9 @@ dex:
 #        charts:
 #            nodepoolLabelOperator:
 #                chart: "banzaicloud-stable/nodepool-labels-operator"
-#                version: "0.0.5"
+#                version: "0.1.1"
 #
-#                # See https://github.com/banzaicloud/banzai-charts/tree/master/nodepool-labels-operator for details
+#                # See https://github.com/banzaicloud/nodepool-labels-operator/tree/master/charts/nodepool-labels-operator for details
 #                values: {}
 #
 #    vault:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -559,7 +559,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 		"storagetier",
 	})
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::chart", "banzaicloud-stable/nodepool-labels-operator")
-	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.0.5")
+	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.1.1")
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::vault::enabled", true)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updating node pool labelset operator chart.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To use the latest, most secure alpine base image with the operator.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Notable [changes](https://github.com/banzaicloud/nodepool-labels-operator/compare/v0.0.5...v0.1.1):
1. Alpine base image version update (3.7.x->3.13.0)
2. Builder Golang version update (1.11.y->1.13.z)
3. Dropping pinned builder image tool versions.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
