### PR TITLE
Add amd64 architecture node selector to cluster autoscaler based on k8s version

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -304,6 +304,9 @@ dex:
 #                    - k8sVersion: ">=1.19"
 #                      tag: "v1.19.1"
 #                      repository: "k8s.gcr.io/autoscaling/cluster-autoscaler"
+#                    - k8sVersion: ">=1.20"
+#                      tag: "v1.20.0"
+#                      repository: "k8s.gcr.io/autoscaling/cluster-autoscaler"
 #
 #                # See https://github.com/banzaicloud/banzai-charts/tree/master/cluster-autoscaler for details
 #                values: {}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -718,6 +718,11 @@ rbac:
 			"tag":        "v1.19.1",
 			"repository": "k8s.gcr.io/autoscaling/cluster-autoscaler",
 		},
+		map[string]interface{}{
+			"k8sVersion": ">=1.20",
+			"tag":        "v1.20.0",
+			"repository": "k8s.gcr.io/autoscaling/cluster-autoscaler",
+		},
 	})
 
 	v.SetDefault("cluster::autoscale::charts::hpaOperator::chart", "banzaicloud-stable/hpa-operator")

--- a/src/cluster/autoscale.go
+++ b/src/cluster/autoscale.go
@@ -40,6 +40,7 @@ const (
 	AzureVirtualMachineScaleSet = "vmss"
 )
 
+// nolint: gochecknoglobals
 // Required for the selectArchNodeSelector func to compare k8s versions
 var comparedK8sSemver *semver.Version
 

--- a/src/cluster/autoscale.go
+++ b/src/cluster/autoscale.go
@@ -42,16 +42,16 @@ const (
 
 const releaseName = "autoscaler"
 
-const (
-	install deploymentAction = "Install"
-	upgrade deploymentAction = "Upgrade"
-)
-
 // nolint: gochecknoglobals
 // Required for the newAMD64ArchNodeSelector func to compare k8s versions
 var comparedK8sSemver *semver.Version = semver.MustParse("1.20.0")
 
 type deploymentAction string
+
+const (
+	install deploymentAction = "Install"
+	upgrade deploymentAction = "Upgrade"
+)
 
 type nodeGroup struct {
 	Name    string `json:"name"`


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #3410 
| License         | Apache 2.0


### What's in this PR?
Extension of  src/cluster/autoscale.go.autoscalingInfo with a nodeSelector map which  populated accordingly in the corresponding createAutoscalingFor...() functions based on k8s version (package local getK8sVersion() is used to obtain a structured k8s version).

### Why?
From the ticket:
"In order to be able to use mixed architecture clusters while using k8s version < 1.20, we want to add a node selector to cluster-autoscaler which forces the container onto amd64 nodes on these versions. (ARM container support is available from CA 1.20, supporting k8s 1.20)."

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
