### PR TITLE
Reconcile user-added helm repositories during helm environment resolution on each helm operation

### DIFF
--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -294,13 +294,17 @@ func (o orgEnvReconciler) Reconcile(ctx context.Context, helmEnv HelmEnv) error 
 
 	missingRepos := make([]Repository, 0, len(persistedRepos))
 	for _, persistedRepo := range persistedRepos {
+		var found bool = false
 		for _, envRepo := range envRepos {
 			if persistedRepo == envRepo {
 				o.logger.Debug("repo already added")
+				found = true
 				continue
 			}
 		}
-		missingRepos = append(missingRepos, persistedRepo)
+		if !found {
+			missingRepos = append(missingRepos, persistedRepo)
+		}
 	}
 
 	if len(missingRepos) == 0 {

--- a/internal/helm/envresolver.go
+++ b/internal/helm/envresolver.go
@@ -299,7 +299,7 @@ func (o orgEnvReconciler) Reconcile(ctx context.Context, helmEnv HelmEnv) error 
 			if persistedRepo == envRepo {
 				o.logger.Debug("repo already added")
 				found = true
-				continue
+				break
 			}
 		}
 		if !found {

--- a/internal/integratedservices/functional_suite_test.go
+++ b/internal/integratedservices/functional_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/common"
 	"github.com/banzaicloud/pipeline/internal/common/commonadapter"
 	"github.com/banzaicloud/pipeline/internal/global"
+	"github.com/banzaicloud/pipeline/internal/helm/helmadapter"
 	"github.com/banzaicloud/pipeline/internal/integratedservices"
 	"github.com/banzaicloud/pipeline/internal/integratedservices/integratedserviceadapter"
 	"github.com/banzaicloud/pipeline/internal/integratedservices/services"
@@ -93,6 +94,9 @@ func (s *Suite) SetupSuite() {
 	s.Require().NoError(err)
 
 	err = integratedserviceadapter.Migrate(db, logger)
+	s.Require().NoError(err)
+
+	err = helmadapter.Migrate(db, common.NoopLogger{})
 	s.Require().NoError(err)
 
 	vaultClient, err := vault.NewClientWithOptions()

--- a/internal/integratedservices/functional_test.go
+++ b/internal/integratedservices/functional_test.go
@@ -225,7 +225,7 @@ func (s *Suite) TestActivateGoogleDNSWithFakeSecret() {
 				}
 			}
 			return false
-		}, time.Second*30, time.Second*2)
+		}, time.Second*60, time.Second*2)
 
 		details, err := integratedServicesService.Details(ctx, cluster.GetID(), integratedServiceDNS.IntegratedServiceName)
 		s.Require().NoError(err)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3368
| License         | Apache 2.0


### What's in this PR?
Persisted Helm repositories added by users are reconciled during helm operations


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

