### PR TITLE
Add amd64 architecture node selector to velero (#3411)

### DIFF
--- a/internal/ark/config_test.go
+++ b/internal/ark/config_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigRequest(t *testing.T) {
+	configRequest := ConfigRequest{
+		Cluster: clusterConfig{
+			Name:         "test",
+			Provider:     "amazon",
+			Distribution: "eks",
+			Location:     "us-east-1",
+			RBACEnabled:  false,
+		},
+		ClusterSecret: nil,
+		Bucket: bucketConfig{
+			Provider: "amazon",
+			Name:     "testBucket",
+			Prefix:   "test",
+			Location: "us-east-1",
+		},
+		BucketSecret:     nil,
+		UseClusterSecret: false,
+
+		RestoreMode: false,
+	}
+	_, err := configRequest.getChartConfig()
+	require.NoError(t, err)
+}

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -16,7 +16,6 @@ package ark
 
 import (
 	"context"
-	"encoding/json"
 
 	"emperror.dev/errors"
 	"github.com/jinzhu/gorm"
@@ -127,7 +126,7 @@ func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBack
 		}
 	}
 
-	config, err := s.getChartConfig(ConfigRequest{
+	req := ConfigRequest{
 		Cluster: clusterConfig{
 			Name:         s.cluster.GetName(),
 			Provider:     s.cluster.GetCloud(),
@@ -153,7 +152,8 @@ func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBack
 		UseClusterSecret:      useClusterSecret,
 		ServiceAccountRoleARN: serviceAccountRoleARN,
 		RestoreMode:           restoreMode,
-	})
+	}
+	config, err := req.getChartConfig()
 	if err != nil {
 		return errors.Wrap(err, "error service getting config")
 	}
@@ -204,24 +204,4 @@ func (s *DeploymentsService) Remove(helmService HelmService) error {
 	}
 
 	return s.repository.Delete(deployment)
-}
-
-func (s *DeploymentsService) getChartConfig(req ConfigRequest) (config ChartConfig, err error) {
-	config = GetChartConfig()
-
-	arkConfig, err := req.Get()
-	if err != nil {
-		err = errors.Wrap(err, "error getting config")
-		return
-	}
-
-	arkJSON, err := json.Marshal(arkConfig)
-	if err != nil {
-		err = errors.Wrap(err, "json convert failed")
-		return
-	}
-
-	config.ValueOverrides = arkJSON
-
-	return
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3411 
| License         | Apache 2.0


### What's in this PR?
Set node affinity for Velero operator pod to schedule only on amd64 nodes.

### Why?
In order to be able to use mixed architecture clusters while only single architecture Velero and Velero-pluging-for-aws images are available, we want to add a node selector/affinity to Velero operator pod which forces the containers onto amd64 nodes.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
