### PR TITLE
Helm chart with component level logging flow configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,4 +323,4 @@ workflows:
                         branches:
                             ignore: /.*/
                         tags:
-                            only: /chart\/pipeline\/\d+.\d+.\d+/
+                            only: /chart\/[0-9a-z-_]+\/\d+.\d+.\d+/

--- a/charts/pipeline-logs/.helmignore
+++ b/charts/pipeline-logs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/pipeline-logs/Chart.yaml
+++ b/charts/pipeline-logs/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: pipeline-logs
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/pipeline-logs/templates/_helpers.tpl
+++ b/charts/pipeline-logs/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pipeline-logs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pipeline-logs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pipeline-logs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pipeline-logs.labels" -}}
+helm.sh/chart: {{ include "pipeline-logs.chart" . }}
+{{ include "pipeline-logs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pipeline-logs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pipeline-logs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pipeline-logs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pipeline-logs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/pipeline-logs/templates/fileoutput.yaml
+++ b/charts/pipeline-logs/templates/fileoutput.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.fileOutput.enabled -}}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Output
+metadata:
+  name: file
+  labels:
+    {{- include "pipeline-logs.labels" . | nindent 4 }}
+spec:
+  file:
+    {{- toYaml .Values.fileOutput.config | nindent 4 -}}
+{{- end -}}

--- a/charts/pipeline-logs/templates/flows.yaml
+++ b/charts/pipeline-logs/templates/flows.yaml
@@ -1,0 +1,35 @@
+{{- $root := . -}}
+{{- range $name, $flow := .Values.flows }}
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Flow
+metadata:
+  name: {{ include "pipeline-logs.fullname" $root }}-{{ $name }}
+  labels:
+    {{- include "pipeline-logs.labels" $root | nindent 4 }}
+spec:
+  match:
+    {{- toYaml $flow.match | nindent 4 }}
+  {{- if $flow.filters }}
+  filters:
+    {{- toYaml $flow.filters | nindent 4 }}
+  {{- end }}
+  {{- if or $flow.localOutputRefs $root.Values.localOutputRefs }}
+  localOutputRefs:
+    {{- if $flow.localOutputRefs }}
+    {{- toYaml $flow.localOutputRefs | nindent 4 }}
+    {{- end }}
+    {{- if $root.Values.localOutputRefs }}
+    {{- toYaml $root.Values.localOutputRefs | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or $flow.globalOutputRefs $root.Values.globalOutputRefs }}
+  globalOutputRefs:
+    {{- if $flow.globalOutputRefs }}
+    {{- toYaml $flow.globalOutputRefs | nindent 4 }}
+    {{- end }}
+    {{- if $root.Values.globalOutputRefs }}
+    {{- toYaml $root.Values.globalOutputRefs | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/pipeline-logs/templates/flows.yaml
+++ b/charts/pipeline-logs/templates/flows.yaml
@@ -12,7 +12,13 @@ spec:
     {{- toYaml $flow.match | nindent 4 }}
   {{- if $flow.filters }}
   filters:
+    {{- if $root.Values.flowPreFilters }}
+    {{- toYaml $root.Values.flowPreFilters | nindent 4 }}
+    {{- end }}
     {{- toYaml $flow.filters | nindent 4 }}
+    {{- if $root.Values.flowPostFilters }}
+    {{- toYaml $root.Values.flowPostFilters | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- if or $flow.localOutputRefs $root.Values.localOutputRefs }}
   localOutputRefs:

--- a/charts/pipeline-logs/templates/logging.yaml
+++ b/charts/pipeline-logs/templates/logging.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.logging.enabled -}}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: default
+spec:
+  {{- if .Values.logging.fluentd }}
+  fluentd:
+    {{- toYaml .Values.logging.fluentd | nindent 4 }}
+  {{- else }}
+  fluentd: {}
+  {{- end }}
+  {{- if .Values.logging.fluentbit }}
+  fluentbit:
+    {{- toYaml .Values.logging.fluentbit | nindent 4 }}
+  {{- else }}
+  fluentbit: {}
+  {{- end }}
+  controlNamespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/pipeline-logs/values.yaml
+++ b/charts/pipeline-logs/values.yaml
@@ -1,0 +1,120 @@
+# Default values for pipeline-logs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# outputs added to all the flows
+#localOutputRefs:
+#  - example
+#globalOutputRefs:
+#  - example
+
+flows:
+  pipeline:
+    match:
+      - select:
+          labels:
+            app.kubernetes.io/instance: pipeline
+    filters:
+      - parser:
+          reserve_time: true
+          reserve_data: true
+          remove_key_name_field: true
+          parse:
+            type: json
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  ui:
+    match:
+      - select:
+          labels:
+            app.kubernetes.io/instance: pipeline-ui
+    filters:
+      - parser:
+          reserve_time: true
+          reserve_data: true
+          remove_key_name_field: true
+          parse:
+            type: nginx
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  cadence:
+    match:
+      - select:
+          labels:
+            app.kubernetes.io/instance: cadence
+    filters:
+      - parser:
+          reserve_time: true
+          reserve_data: true
+          remove_key_name_field: true
+          parse:
+            type: json
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  dex:
+    match:
+      - select:
+          labels:
+            app: dex
+    filters:
+      - parser:
+          reserve_time: true
+          reserve_data: true
+          remove_key_name_field: true
+          parse:
+            type: logfmt
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  vault:
+    match:
+      - select:
+          labels:
+            app.kubernetes.io/instance: vault
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  traefik:
+    match:
+      - select:
+          labels:
+            app: traefik
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+  mysql:
+    match:
+      - select:
+          labels:
+            app: mysql
+    #localOutputRefs:
+    #  - example
+    #globalOutputRefs:
+    #  - example
+
+# for testing purposes
+fileOutput:
+  enabled: false
+  config:
+    path: /tmp/pipeline-sink-${tag}
+    append: true
+    buffer:
+      tags: tag,time
+      timekey: 1m
+
+
+# default logging setup for development purposes
+logging:
+  enabled: false

--- a/charts/pipeline-logs/values.yaml
+++ b/charts/pipeline-logs/values.yaml
@@ -11,6 +11,13 @@ fullnameOverride: ""
 #globalOutputRefs:
 #  - example
 
+flowPreFilters:
+  - sumologic:
+      source_name: kubernetes
+      log_format: fields
+      tracing_namespace: namespace_name
+      tracing_pod: pod_name
+
 flows:
   pipeline:
     match:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR contains a chart that can be used as the Flow configuration interpreted by the [Logging operator](https://github.com/banzaicloud/logging-operator) (from version v3.6.0).

It contains all the Pipeline components' log sources identified by label selectors when installed using the [official Pipeline installer](https://banzaicloud.com/docs/pipeline/quickstart/install-pipeline/prod/)

Parse configuration is added where appropriate.

### Why?
To make logging configuration simpler for Pipeline components.

### Additional context
This chart is supposed to be used in an environment where the base logging system and the outputs are already configured separately.

Optional base logging system setup and a file output is also included but for testing purposes only.

### Test instructions


```
$WORKSPACE=workspace

# Install Pipeline on kind
banzai pipeline init --auto-approve --provider kind --workspace $WORKSPACE
banzai pipeline up --workspace $WORKSPACE

# Kubeconfig will be available under the workspace
export KUBECONFIG=$WORKSPACE/.kube/config

helm upgrade --install lo banzaicloud-stable/logging-operator --version 3.9.0

helm upgrade --install pipeline-logs charts/pipeline-logs --set 'localOutputRefs={file},fileOutput.enabled=true,logging.enabled=true' -n banzaicloud
```

After that collected logs can be seen under `/tmp/pipeline-sink-*` in the `default-fluentd-0` pod's `fluentd` container.