### PR TITLE
Update configuration for external dns

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -636,7 +636,8 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::dns::charts::externalDns::version", "4.5.0")
 	v.SetDefault("cluster::dns::charts::externalDns::values", map[string]interface{}{
 		"image": map[string]interface{}{
-			"repository": "k8s.gcr.io/external-dns/external-dns",
+			"registry":   "k8s.gcr.io",
+			"repository": "external-dns/external-dns",
 			"tag":        "v0.7.5",
 		},
 	})

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -57,7 +57,8 @@ func TestConfigure_DefaultValueBinding(t *testing.T) {
 							},
 							Values: dns.ExternalDNSChartValuesConfig{
 								Image: dns.ExternalDNSChartValuesImageConfig{
-									Repository: "k8s.gcr.io/external-dns/external-dns",
+									Registry:   "k8s.gcr.io",
+									Repository: "external-dns/external-dns",
 									Tag:        "v0.7.5",
 								},
 							},

--- a/internal/integratedservices/services/dns/config.go
+++ b/internal/integratedservices/services/dns/config.go
@@ -63,6 +63,7 @@ type ExternalDNSChartValuesConfig struct {
 }
 
 type ExternalDNSChartValuesImageConfig struct {
+	Registry   string
 	Repository string
 	Tag        string
 }

--- a/internal/integratedservices/services/dns/operator.go
+++ b/internal/integratedservices/services/dns/operator.go
@@ -163,6 +163,7 @@ func (op IntegratedServiceOperator) getChartValues(ctx context.Context, clusterI
 			Create: cl.RbacEnabled(),
 		},
 		Image: &externaldns.ImageSettings{
+			Registry:   op.config.Charts.ExternalDNS.Values.Image.Registry,
 			Repository: op.config.Charts.ExternalDNS.Values.Image.Repository,
 			Tag:        op.config.Charts.ExternalDNS.Values.Image.Tag,
 		},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fixes the external-dns chart configuration to allow specifying a registry independently from the repository.

### Why?
The current config with the latest chart renders an invalid configuration where the registry is not properly recognized and added as part of the repo with the default registry docker.io.
