### PR TITLE
update instanceTerminationHandler chart version

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -755,7 +755,7 @@ traefik:
 	// Instance Termination Handler
 	v.SetDefault("cluster::posthook::ith::enabled", true)
 	v.SetDefault("cluster::posthook::ith::chart", "banzaicloud-stable/instance-termination-handler")
-	v.SetDefault("cluster::posthook::ith::version", "0.0.9")
+	v.SetDefault("cluster::posthook::ith::version", "0.1.1")
 
 	// Cluster Autoscaler
 	v.SetDefault("cluster::posthook::autoscaler::enabled", true)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Update instanceTerminationHandler chart version


### Why?
To use latest ith image containing: https://github.com/banzaicloud/instance-termination-handler/pull/29

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
