### PR TITLE
chore(is-v2):  only allow update and deactivation of integrated services managed by pipeline

### DIFF
--- a/internal/integratedservices/integratedserviceadapter/serviceconversion.go
+++ b/internal/integratedservices/integratedserviceadapter/serviceconversion.go
@@ -63,6 +63,12 @@ func (c ServiceConversion) Convert(ctx context.Context, instance v1alpha1.Servic
 				return integratedservices.IntegratedService{}, errors.WrapIfWithDetails(err, "output resolution failed for service",
 					"name", instance.Name, "service", instance.Spec.Service)
 			}
+
+			// signal whether the resource is managed by pipeline in the output
+			if services.IsManagedByPipeline(instance.ObjectMeta) {
+				output["managed-by"] = "pipeline"
+			}
+
 			convertedService.Output = output
 		}
 		return convertedService, nil

--- a/internal/integratedservices/interface.go
+++ b/internal/integratedservices/interface.go
@@ -16,6 +16,7 @@ package integratedservices
 
 import (
 	"context"
+	"fmt"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/integrated-service-sdk/api/v1alpha1"
@@ -234,4 +235,16 @@ func (e ClusterIsNotReadyError) ShouldRetry() bool {
 type SpecConversion interface {
 	// ConvertSpec converts in integrated service spec while keeping it's original structure
 	ConvertSpec(ctx context.Context, instance v1alpha1.ServiceInstance) (IntegratedServiceSpec, error)
+}
+
+type NotManagedIntegratedServiceError struct {
+	IntegratedServiceName string
+}
+
+func (NotManagedIntegratedServiceError) ServiceError() bool {
+	return true
+}
+
+func (n NotManagedIntegratedServiceError) Error() string {
+	return fmt.Sprintf("the integrated service [%s] is not managed by pipeline", n.IntegratedServiceName)
 }

--- a/internal/integratedservices/interface.go
+++ b/internal/integratedservices/interface.go
@@ -246,5 +246,5 @@ func (NotManagedIntegratedServiceError) ServiceError() bool {
 }
 
 func (n NotManagedIntegratedServiceError) Error() string {
-	return fmt.Sprintf("the integrated service [%s] is not managed by pipeline", n.IntegratedServiceName)
+	return fmt.Sprintf("the %s integrated service is not managed by pipeline", n.IntegratedServiceName)
 }

--- a/internal/integratedservices/service_v2.go
+++ b/internal/integratedservices/service_v2.go
@@ -183,6 +183,9 @@ func (i ISServiceV2) Update(ctx context.Context, clusterID uint, serviceName str
 func (i ISServiceV2) isManagedByPipeline(ctx context.Context, clusterID uint, serviceName string) error {
 	integratedService, err := i.repository.GetIntegratedService(ctx, clusterID, serviceName)
 	if err != nil {
+		if IsIntegratedServiceNotFoundError(err) {
+			return nil
+		}
 		return errors.WrapIf(err, "failed to retrieve the integrated service")
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3427
| License         | Apache 2.0


### What's in this PR?
Only Integrated service instances that are managed by [pipeline are allowed to be updated and deactivated


### Why?
In a cluster there might exist integrated service custom resources that are not added and managed by pipline.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
