### PR TITLE
Velero sync api fix

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -11932,7 +11932,7 @@ paths:
       summary: Create ARK backup
       tags:
       - ark-backups
-  /api/v1/orgs/{orgId}/backups/{id}/sync:
+  /api/v1/orgs/{orgId}/clusters/{id}/backups/sync:
     put:
       description: Sync ARK backups of a cluster
       operationId: SyncARKBackupsOfACluster
@@ -13430,7 +13430,7 @@ paths:
       summary: Create ARK restore
       tags:
       - ark-restores
-  /api/v1/orgs/{orgId}/restores/{id}/sync:
+  /api/v1/orgs/{orgId}/clusters/{id}/restores/sync:
     put:
       description: Sync ARK restores of a cluster
       operationId: SyncARKRestoresOfACluster

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -2689,7 +2689,7 @@ paths:
                 default:
                     $ref: '#/components/responses/Error'
 
-    /api/v1/orgs/{orgId}/backups/{id}/sync:
+    /api/v1/orgs/{orgId}/clusters/{id}/backups/sync:
         put:
             security:
                 - bearerAuth: []
@@ -2931,7 +2931,7 @@ paths:
                 default:
                     $ref: '#/components/responses/Error'
 
-    /api/v1/orgs/{orgId}/restores/{id}/sync:
+    /api/v1/orgs/{orgId}/clusters/{id}/restores/sync:
         put:
             security:
                 - bearerAuth: []

--- a/internal/ark/backups_repository.go
+++ b/internal/ark/backups_repository.go
@@ -56,13 +56,14 @@ func (r *BackupsRepository) FindByClusterID(clusterID uint) (backups []*ClusterB
 		ClusterID:      clusterID,
 	}
 
-	return r.db.
-	    Where(&query).
-	    Preload("Bucket").
-	    Preload("Bucket.Deployment").
-	    Preload("Organization").
-	    Find(&backups).
-	    Error
+	err = r.db.
+		Where(&query).
+		Preload("Bucket").
+		Preload("Bucket.Deployment").
+		Preload("Organization").
+		Find(&backups).
+		Error
+	return
 }
 
 // FindOneByName returns a ClusterBackupsModel instance by name

--- a/internal/ark/backups_repository.go
+++ b/internal/ark/backups_repository.go
@@ -56,9 +56,13 @@ func (r *BackupsRepository) FindByClusterID(clusterID uint) (backups []*ClusterB
 		ClusterID:      clusterID,
 	}
 
-	err = r.db.Where(&query).Preload("Bucket").Preload("Bucket.Deployment").Preload("Organization").Find(&backups).Error
-
-	return
+	return r.db.
+	    Where(&query).
+	    Preload("Bucket").
+	    Preload("Bucket.Deployment").
+	    Preload("Organization").
+	    Find(&backups).
+	    Error
 }
 
 // FindOneByName returns a ClusterBackupsModel instance by name

--- a/internal/ark/backups_repository.go
+++ b/internal/ark/backups_repository.go
@@ -49,6 +49,18 @@ func (r *BackupsRepository) Find() (backups []*ClusterBackupsModel, err error) {
 	return
 }
 
+// Find returns ClusterBackupsModel instances
+func (r *BackupsRepository) FindByClusterID(clusterID uint) (backups []*ClusterBackupsModel, err error) {
+	query := ClusterBackupsModel{
+		OrganizationID: r.org.ID,
+		ClusterID:      clusterID,
+	}
+
+	err = r.db.Where(&query).Preload("Bucket").Preload("Bucket.Deployment").Preload("Organization").Find(&backups).Error
+
+	return
+}
+
 // FindOneByName returns a ClusterBackupsModel instance by name
 func (r *BackupsRepository) FindOneByName(name string) (*ClusterBackupsModel, error) {
 	var backup ClusterBackupsModel

--- a/internal/ark/backups_svc.go
+++ b/internal/ark/backups_svc.go
@@ -105,6 +105,23 @@ func (s *BackupsService) List() ([]*api.Backup, error) {
 	return backups, nil
 }
 
+// List returns Backup instances for a given cluster
+func (s *BackupsService) ListForACluster(clusterID uint) ([]*api.Backup, error) {
+	backups := make([]*api.Backup, 0)
+
+	items, err := s.repository.FindByClusterID(clusterID)
+	if err != nil {
+		return backups, err
+	}
+
+	for _, item := range items {
+		backup := item.ConvertModelToEntity()
+		backups = append(backups, backup)
+	}
+
+	return backups, nil
+}
+
 // FindByPersistRequest returns a ClusterBackupsModel by PersistBackupRequest
 func (s *BackupsService) FindByPersistRequest(req *api.PersistBackupRequest) (*ClusterBackupsModel, error) {
 	backup, err := s.repository.FindByPersistRequest(req)

--- a/internal/ark/backups_svc.go
+++ b/internal/ark/backups_svc.go
@@ -113,6 +113,7 @@ func (s *BackupsService) ListForACluster(clusterID uint) ([]*api.Backup, error) 
 	if err != nil {
 		return backups, err
 	}
+	backups = make([]*api.Backup, 0, len(items))
 
 	for _, item := range items {
 		backup := item.ConvertModelToEntity()

--- a/internal/ark/sync/backups_sync_svc.go
+++ b/internal/ark/sync/backups_sync_svc.go
@@ -117,7 +117,7 @@ func (s *BackupsSyncService) SyncBackupsForCluster(cluster api.Cluster) error {
 	if err != nil {
 		return errors.WrapIf(err, "could not list backups")
 	}
-	backupIDS := make([]int, 0)
+	backupIDs := make([]int, 0, len(backups.Items))
 
 	for _, backup := range backups.Items {
 		log := s.logger.WithField("backup", backup.Name)
@@ -158,14 +158,14 @@ func (s *BackupsSyncService) SyncBackupsForCluster(cluster api.Cluster) error {
 		if err != nil {
 			return errors.WrapIf(err, "could not persist backup")
 		}
-		backupIDS = append(backupIDS, int(syncedBackup.ID))
+		backupIDs = append(backupIDs, int(syncedBackup.ID))
 
 		log.Debug("backup synced")
 	}
 
 	log := s.logger.WithField("bucket", bucket.Name).WithField("clusterId", bucket.ClusterID)
 	log.Debug("removing backups not found on cluster")
-	err = s.backupsSvc.DeleteNonExistingBackupsByBucketAndKeys(bucket.ID, backupIDS)
+	err = s.backupsSvc.DeleteNonExistingBackupsByBucketAndKeys(bucket.ID, backupIDs)
 	if err != nil {
 		return err
 	}

--- a/internal/ark/sync/buckets_sync_svc.go
+++ b/internal/ark/sync/buckets_sync_svc.go
@@ -58,6 +58,11 @@ func (s *BucketsSyncService) SyncBackupsFromBuckets() error {
 
 	for _, bucket := range buckets {
 		log := s.logger.WithField("bucket", bucket.Name)
+
+		if bucket.InUse {
+			log.Debug("bucket is in use not syncing from objectstorage")
+			continue
+		}
 		log.Debug("syncing backups from bucket")
 		backupIDS, err := s.syncBackupsFromBucket(bucket)
 		if err != nil {

--- a/src/api/ark/backups/list.go
+++ b/src/api/ark/backups/list.go
@@ -20,7 +20,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/gin-gonic/gin"
 
-	"github.com/banzaicloud/pipeline/internal/ark/api"
 	"github.com/banzaicloud/pipeline/internal/platform/gin/correlationid"
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	"github.com/banzaicloud/pipeline/src/api/ark/common"
@@ -31,24 +30,17 @@ func List(c *gin.Context) {
 	logger := correlationid.LogrusLogger(common.Log, c)
 	logger.Info("getting backups")
 
-	cluserID, ok := ginutils.UintParam(c, ClusterIDParamName)
+	clusterID, ok := ginutils.UintParam(c, ClusterIDParamName)
 	if !ok {
 		return
 	}
 
-	orgBackups, err := common.GetARKService(c.Request).GetBackupsService().List()
+	backups, err := common.GetARKService(c.Request).GetBackupsService().ListForACluster(clusterID)
 	if err != nil {
 		err = errors.WrapIf(err, "could not get backups")
 		common.ErrorHandler.Handle(err)
 		common.ErrorResponse(c, err)
 		return
-	}
-
-	backups := make([]*api.Backup, 0)
-	for _, backup := range orgBackups {
-		if backup.ClusterID == cluserID {
-			backups = append(backups, backup)
-		}
 	}
 
 	c.JSON(http.StatusOK, backups)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3449 
| License         | Apache 2.0


### What's in this PR?
- fix OpenAPI  path for backup / restore sync per cluster
- BackupsSyncService.SyncBackupsForCluster: delete backups not found on cluster. 
- sync backups from bucket only for inactive deployments (backup service disabled or cluster already  deleted)
- add ListForACluster to BackupService to optimise listing of buckets for a cluster

### Why?
Syncing backups both from cluster (Velero Backup CRD) and from objectstorage might cause different problems in case there are discrepancies between them, like backups hanging in InProgress or Deleting mode, when they are not yet created or already deleted in/from objectstorage. To avoid this it's enough to sync backups / restores from cluster (since if backup is enabled Backup/Restore CR's should be in sync with objectstorage) just that currently we only update backups found on cluster, we don't delete backups found in db but not on the cluster anymore. So we had to modify  backup sync to delete these.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

