### PR TITLE
Refactor/instance termination posthook

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -372,13 +372,13 @@ func main() {
 				deployIngressControllerActivity.Execute,
 				activity.RegisterOptions{Name: clustersetup.DeployIngressControllerActivityName})
 
-			instanceTerminationHandlerActivity := clustersetup.NewInstanceTerminationHandlerActivity(
+			deployInstanceTerminationHandlerActivity := clustersetup.NewDeployInstanceTerminationHandlerActivity(
 				config.Cluster.Labels,
 				unifiedHelmReleaser,
 			)
 			worker.RegisterActivityWithOptions(
-				instanceTerminationHandlerActivity.Execute,
-				activity.RegisterOptions{Name: clustersetup.InstanceTerminationHandlerActivityName})
+				deployInstanceTerminationHandlerActivity.Execute,
+				activity.RegisterOptions{Name: clustersetup.DeployInstanceTerminationHandlerActivityName})
 		}
 
 		worker.RegisterWorkflowWithOptions(cluster.CreateClusterWorkflow, workflow.RegisterOptions{Name: cluster.CreateClusterWorkflowName})

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -371,6 +371,14 @@ func main() {
 			worker.RegisterActivityWithOptions(
 				deployIngressControllerActivity.Execute,
 				activity.RegisterOptions{Name: clustersetup.DeployIngressControllerActivityName})
+
+			instanceTerminationHandlerActivity := clustersetup.NewInstanceTerminationHandlerActivity(
+				config.Cluster.Labels,
+				unifiedHelmReleaser,
+			)
+			worker.RegisterActivityWithOptions(
+				instanceTerminationHandlerActivity.Execute,
+				activity.RegisterOptions{Name: clustersetup.InstanceTerminationHandlerActivityName})
 		}
 
 		worker.RegisterWorkflowWithOptions(cluster.CreateClusterWorkflow, workflow.RegisterOptions{Name: cluster.CreateClusterWorkflowName})

--- a/internal/cluster/clustersetup/BUILD.plz
+++ b/internal/cluster/clustersetup/BUILD.plz
@@ -9,6 +9,7 @@ go_library(
         "//internal/cluster/clusterconfig",
         "//internal/global",
         "//internal/integratedservices/operator",
+        "//internal/hollowtrees",
         "//internal/providers/amazon",
         "//pkg/any",
         "//pkg/cluster",
@@ -38,6 +39,7 @@ go_test(
     deps = [
         "//internal/cluster/clusterconfig",
         "//internal/global",
+        "//internal/hollowtrees",
         "//internal/integratedservices/operator",
         "//internal/providers/amazon",
         "//pkg/any",
@@ -78,6 +80,7 @@ go_test(
     deps = [
         "//internal/cluster/clusterconfig",
         "//internal/global",
+        "//internal/hollowtrees",
         "//internal/integratedservices/operator",
         "//internal/providers/amazon",
         "//pkg/any",

--- a/internal/cluster/clustersetup/activity_deploy_instance_termination_handler.go
+++ b/internal/cluster/clustersetup/activity_deploy_instance_termination_handler.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Banzai Cloud
+// Copyright © 2021 Banzai Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,14 +27,14 @@ import (
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
-const InstanceTerminationHandlerActivityName = "instance-termination-handler"
+const DeployInstanceTerminationHandlerActivityName = "deploy-instance-termination-handler"
 
-type InstanceTerminationHandlerActivity struct {
+type DeployInstanceTerminationHandlerActivity struct {
 	config      clusterconfig.LabelConfig
 	helmService HelmService
 }
 
-type InstanceTerminationHandlerActivityInput struct {
+type DeployInstanceTerminationHandlerActivityInput struct {
 	ClusterID    uint
 	OrgID        uint
 	ClusterName  string
@@ -42,18 +42,18 @@ type InstanceTerminationHandlerActivityInput struct {
 	ScaleOptions *pkgCluster.ScaleOptions
 }
 
-// NewInstanceTerminationHandlerActivity returns a new InstanceTerminationHandlerActivity.
-func NewInstanceTerminationHandlerActivity(
+// NewDeployInstanceTerminationHandlerActivity returns a new DeployInstanceTerminationHandlerActivity.
+func NewDeployInstanceTerminationHandlerActivity(
 	config clusterconfig.LabelConfig,
 	helmService HelmService,
-) InstanceTerminationHandlerActivity {
-	return InstanceTerminationHandlerActivity{
+) DeployInstanceTerminationHandlerActivity {
+	return DeployInstanceTerminationHandlerActivity{
 		config:      config,
 		helmService: helmService,
 	}
 }
 
-func (a InstanceTerminationHandlerActivity) Execute(ctx context.Context, input InstanceTerminationHandlerActivityInput) error {
+func (a DeployInstanceTerminationHandlerActivity) Execute(ctx context.Context, input DeployInstanceTerminationHandlerActivityInput) error {
 	config := global.Config.Cluster.PostHook.ITH
 	if !global.Config.Pipeline.Enterprise || !config.Enabled {
 		return nil

--- a/internal/cluster/clustersetup/activity_instance_termination_handler.go
+++ b/internal/cluster/clustersetup/activity_instance_termination_handler.go
@@ -1,0 +1,114 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustersetup
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/ghodss/yaml"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/clusterconfig"
+	"github.com/banzaicloud/pipeline/internal/global"
+	"github.com/banzaicloud/pipeline/internal/hollowtrees"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
+)
+
+const InstanceTerminationHandlerActivityName = "instance-termination-handler"
+
+type InstanceTerminationHandlerActivity struct {
+	config      clusterconfig.LabelConfig
+	helmService HelmService
+}
+
+type InstanceTerminationHandlerActivityInput struct {
+	ClusterID    uint
+	OrgID        uint
+	ClusterName  string
+	Cloud        string
+	ScaleOptions *pkgCluster.ScaleOptions
+}
+
+// NewInstanceTerminationHandlerActivity returns a new InstanceTerminationHandlerActivity.
+func NewInstanceTerminationHandlerActivity(
+	config clusterconfig.LabelConfig,
+	helmService HelmService,
+) InstanceTerminationHandlerActivity {
+	return InstanceTerminationHandlerActivity{
+		config:      config,
+		helmService: helmService,
+	}
+}
+
+func (a InstanceTerminationHandlerActivity) Execute(ctx context.Context, input InstanceTerminationHandlerActivityInput) error {
+	config := global.Config.Cluster.PostHook.ITH
+	if !global.Config.Pipeline.Enterprise || !config.Enabled {
+		return nil
+	}
+
+	if input.Cloud != pkgCluster.Amazon && input.Cloud != pkgCluster.Google {
+		return nil
+	}
+
+	pipelineSystemNamespace := global.Config.Cluster.Namespace
+
+	values := map[string]interface{}{
+		"tolerations": []v1.Toleration{
+			{
+				Operator: v1.TolerationOpExists,
+			},
+		},
+		"hollowtreesNotifier": map[string]interface{}{
+			"enabled": false,
+		},
+	}
+
+	scaleOptions := input.ScaleOptions
+	if scaleOptions != nil && scaleOptions.Enabled == true {
+		tokenSigningKey := global.Config.Hollowtrees.TokenSigningKey
+		if tokenSigningKey == "" {
+			err := errors.New("no Hollowtrees token signkey specified")
+			return err
+		}
+
+		generator := hollowtrees.NewTokenGenerator(
+			global.Config.Auth.Token.Issuer,
+			global.Config.Auth.Token.Audience,
+			global.Config.Hollowtrees.TokenSigningKey,
+		)
+		_, token, err := generator.Generate(input.ClusterID, input.OrgID, nil)
+		if err != nil {
+			err = errors.WrapIf(err, "could not generate JWT token for instance termination handler")
+			return err
+		}
+
+		values["hollowtreesNotifier"] = map[string]interface{}{
+			"enabled":        true,
+			"URL":            global.Config.Hollowtrees.Endpoint + "/alerts",
+			"organizationID": input.OrgID,
+			"clusterID":      input.ClusterID,
+			"clusterName":    input.ClusterName,
+			"jwtToken":       token,
+		}
+	}
+
+	marshalledValues, err := yaml.Marshal(values)
+	if err != nil {
+		return errors.WrapIf(err, "failed to marshal yaml values")
+	}
+
+	return a.helmService.ApplyDeployment(context.Background(), input.ClusterID, pipelineSystemNamespace, config.Chart, "ith", marshalledValues, config.Version)
+}

--- a/internal/cluster/clustersetup/workflow.go
+++ b/internal/cluster/clustersetup/workflow.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/cadence/workflow"
 
 	"github.com/banzaicloud/pipeline/internal/integratedservices/operator"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 )
 
 // WorkflowName can be used to reference the cluster setup workflow.
@@ -61,6 +62,7 @@ type Cluster struct {
 	Name         string
 	Distribution string
 	Cloud        string
+	ScaleOptions *pkgCluster.ScaleOptions
 }
 
 // Organization contains information about the organization a cluster belongs to.
@@ -163,6 +165,20 @@ func (w Workflow) Execute(ctx workflow.Context, input WorkflowInput) error {
 		}
 
 		err := workflow.ExecuteActivity(ctx, DeployIngressControllerActivityName, activityInput).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		activityInput := InstanceTerminationHandlerActivityInput{
+			ClusterID:    input.Cluster.ID,
+			OrgID:        input.Organization.ID,
+			Cloud:        input.Cluster.Cloud,
+			ClusterName:  input.Cluster.Name,
+			ScaleOptions: input.Cluster.ScaleOptions,
+		}
+
+		err := workflow.ExecuteActivity(ctx, InstanceTerminationHandlerActivityName, activityInput).Get(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cluster/clustersetup/workflow.go
+++ b/internal/cluster/clustersetup/workflow.go
@@ -170,7 +170,7 @@ func (w Workflow) Execute(ctx workflow.Context, input WorkflowInput) error {
 		}
 	}
 	{
-		activityInput := InstanceTerminationHandlerActivityInput{
+		activityInput := DeployInstanceTerminationHandlerActivityInput{
 			ClusterID:    input.Cluster.ID,
 			OrgID:        input.Organization.ID,
 			Cloud:        input.Cluster.Cloud,
@@ -178,7 +178,7 @@ func (w Workflow) Execute(ctx workflow.Context, input WorkflowInput) error {
 			ScaleOptions: input.Cluster.ScaleOptions,
 		}
 
-		err := workflow.ExecuteActivity(ctx, InstanceTerminationHandlerActivityName, activityInput).Get(ctx, nil)
+		err := workflow.ExecuteActivity(ctx, DeployInstanceTerminationHandlerActivityName, activityInput).Get(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cluster/clustersetup/workflow_test.go
+++ b/internal/cluster/clustersetup/workflow_test.go
@@ -74,7 +74,7 @@ func (s *WorkflowTestSuite) SetupTest() {
 	s.env.RegisterActivityWithOptions(LabelKubeSystemNamespaceActivity{}.Execute, activity.RegisterOptions{Name: LabelKubeSystemNamespaceActivityName})
 	s.env.RegisterActivityWithOptions(DeployClusterAutoscalerActivity{}.Execute, activity.RegisterOptions{Name: DeployClusterAutoscalerActivityName})
 	s.env.RegisterActivityWithOptions(DeployIngressControllerActivity{}.Execute, activity.RegisterOptions{Name: DeployIngressControllerActivityName})
-	s.env.RegisterActivityWithOptions(InstanceTerminationHandlerActivity{}.Execute, activity.RegisterOptions{Name: InstanceTerminationHandlerActivityName})
+	s.env.RegisterActivityWithOptions(DeployInstanceTerminationHandlerActivity{}.Execute, activity.RegisterOptions{Name: DeployInstanceTerminationHandlerActivityName})
 }
 
 func (s *WorkflowTestSuite) AfterTest(suiteName, testName string) {
@@ -138,9 +138,9 @@ func (s *WorkflowTestSuite) Test_Success() {
 	).Return(nil)
 
 	s.env.OnActivity(
-		InstanceTerminationHandlerActivityName,
+		DeployInstanceTerminationHandlerActivityName,
 		mock.Anything,
-		InstanceTerminationHandlerActivityInput{
+		DeployInstanceTerminationHandlerActivityInput{
 			ClusterID:    1,
 			OrgID:        1,
 			Cloud:        "",
@@ -218,9 +218,9 @@ func (s *WorkflowTestSuite) Test_Success_InstallInitManifest() {
 	).Return(nil)
 
 	s.env.OnActivity(
-		InstanceTerminationHandlerActivityName,
+		DeployInstanceTerminationHandlerActivityName,
 		mock.Anything,
-		InstanceTerminationHandlerActivityInput{
+		DeployInstanceTerminationHandlerActivityInput{
 			ClusterID:    1,
 			OrgID:        1,
 			Cloud:        "",

--- a/internal/cluster/clustersetup/workflow_test.go
+++ b/internal/cluster/clustersetup/workflow_test.go
@@ -74,6 +74,7 @@ func (s *WorkflowTestSuite) SetupTest() {
 	s.env.RegisterActivityWithOptions(LabelKubeSystemNamespaceActivity{}.Execute, activity.RegisterOptions{Name: LabelKubeSystemNamespaceActivityName})
 	s.env.RegisterActivityWithOptions(DeployClusterAutoscalerActivity{}.Execute, activity.RegisterOptions{Name: DeployClusterAutoscalerActivityName})
 	s.env.RegisterActivityWithOptions(DeployIngressControllerActivity{}.Execute, activity.RegisterOptions{Name: DeployIngressControllerActivityName})
+	s.env.RegisterActivityWithOptions(InstanceTerminationHandlerActivity{}.Execute, activity.RegisterOptions{Name: InstanceTerminationHandlerActivityName})
 }
 
 func (s *WorkflowTestSuite) AfterTest(suiteName, testName string) {
@@ -133,6 +134,18 @@ func (s *WorkflowTestSuite) Test_Success() {
 			ClusterID: 1,
 			OrgID:     1,
 			Cloud:     "",
+		},
+	).Return(nil)
+
+	s.env.OnActivity(
+		InstanceTerminationHandlerActivityName,
+		mock.Anything,
+		InstanceTerminationHandlerActivityInput{
+			ClusterID:    1,
+			OrgID:        1,
+			Cloud:        "",
+			ClusterName:  "example-cluster",
+			ScaleOptions: nil,
 		},
 	).Return(nil)
 
@@ -201,6 +214,18 @@ func (s *WorkflowTestSuite) Test_Success_InstallInitManifest() {
 			ClusterID: 1,
 			OrgID:     1,
 			Cloud:     "",
+		},
+	).Return(nil)
+
+	s.env.OnActivity(
+		InstanceTerminationHandlerActivityName,
+		mock.Anything,
+		InstanceTerminationHandlerActivityInput{
+			ClusterID:    1,
+			OrgID:        1,
+			Cloud:        "",
+			ClusterName:  "example-cluster",
+			ScaleOptions: nil,
 		},
 	).Return(nil)
 

--- a/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
+++ b/internal/cluster/distribution/eks/eksprovider/driver/cluster_creator.go
@@ -166,6 +166,7 @@ func (c *EksClusterCreator) create(ctx context.Context, logger logrus.FieldLogge
 		},
 		PostHooks:        createRequest.PostHooks,
 		OrganizationName: org.Name,
+		ScaleOptions:     commonCluster.GetScaleOptions(),
 	}
 
 	encryptionConfig := make([]workflow.EncryptionConfig, 0, len(eksCluster.EncryptionConfig))

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -433,6 +433,7 @@ func (cc ClusterCreator) Create(ctx context.Context, params ClusterCreationParam
 		HTTPProxy:                       cl.HTTPProxy,
 		AccessPoints:                    params.AccessPoints,
 		APIServerAccessPoints:           params.APIServerAccessPoints,
+		ScaleOptions:                    &cl.ScaleOptions,
 	}
 	workflowOptions := client.StartWorkflowOptions{
 		TaskList:                     "pipeline",

--- a/internal/providers/azure/pke/workflow/create_cluster.go
+++ b/internal/providers/azure/pke/workflow/create_cluster.go
@@ -59,6 +59,7 @@ type CreateClusterWorkflowInput struct {
 	HTTPProxy                       intPKE.HTTPProxy
 	AccessPoints                    pke.AccessPoints
 	APIServerAccessPoints           pke.APIServerAccessPoints
+	ScaleOptions                    *pkgCluster.ScaleOptions
 }
 
 func NewCreateClusterWorkflow() CreateClusterWorkflow {
@@ -159,6 +160,7 @@ func (w CreateClusterWorkflow) Execute(ctx workflow.Context, input CreateCluster
 				Name:         input.ClusterName,
 				Distribution: input.Distribution,
 				Cloud:        pkgCluster.Azure,
+				ScaleOptions: input.ScaleOptions,
 			},
 			Organization: clustersetup.Organization{
 				ID:   input.OrganizationID,

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -280,6 +280,7 @@ func (cc VspherePKEClusterCreator) Create(ctx context.Context, params VspherePKE
 		ResourcePoolName: cl.ResourcePool,
 		DatastoreName:    cl.Datastore,
 		FolderName:       cl.Folder,
+		ScaleOptions:     &cl.ScaleOptions,
 	}
 	workflowOptions := client.StartWorkflowOptions{
 		TaskList:                     "pipeline",

--- a/internal/providers/vsphere/pke/workflow/create_cluster.go
+++ b/internal/providers/vsphere/pke/workflow/create_cluster.go
@@ -58,6 +58,7 @@ type CreateClusterWorkflowInput struct {
 	Nodes            []Node
 	HTTPProxy        intPKE.HTTPProxy
 	NodePoolLabels   map[string]map[string]string
+	ScaleOptions     *pkgCluster.ScaleOptions
 }
 
 func NewCreateClusterWorkflow() CreateClusterWorkflow {
@@ -247,10 +248,11 @@ func (w CreateClusterWorkflow) Execute(ctx workflow.Context, input CreateCluster
 		workflowInput := clustersetup.WorkflowInput{
 			ConfigSecretID: brn.New(input.OrganizationID, brn.SecretResourceType, configSecretID).String(),
 			Cluster: clustersetup.Cluster{
-				ID:    input.ClusterID,
-				UID:   input.ClusterUID,
-				Name:  input.ClusterName,
-				Cloud: pkgCluster.Vsphere,
+				ID:           input.ClusterID,
+				UID:          input.ClusterUID,
+				Name:         input.ClusterName,
+				Cloud:        pkgCluster.Vsphere,
+				ScaleOptions: input.ScaleOptions,
 			},
 			Organization: clustersetup.Organization{
 				ID:   input.OrganizationID,

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -68,7 +68,6 @@ const (
 	InstallKubernetesDashboardPostHook = "InstallKubernetesDashboardPostHook"
 	RestoreFromBackup                  = "RestoreFromBackup"
 	InitSpotConfig                     = "InitSpotConfig"
-	DeployInstanceTerminationHandler   = "DeployInstanceTerminationHandler"
 )
 
 // CreateClusterRequest describes a create cluster request

--- a/src/cluster/create_workflow.go
+++ b/src/cluster/create_workflow.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/banzaicloud/pipeline/internal/cluster/clustersetup"
 	pkgCadence "github.com/banzaicloud/pipeline/pkg/cadence"
+	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
 	"github.com/banzaicloud/pipeline/pkg/sdk/brn"
 )
@@ -50,6 +51,7 @@ type CreateClusterWorkflowInput struct {
 	Distribution     string
 	NodePoolLabels   map[string]map[string]string
 	Cloud            string
+	ScaleOptions     *pkgCluster.ScaleOptions
 }
 
 func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInput) error {
@@ -88,6 +90,7 @@ func CreateClusterWorkflow(ctx workflow.Context, input CreateClusterWorkflowInpu
 				Name:         input.ClusterName,
 				Distribution: input.Distribution,
 				Cloud:        input.Cloud,
+				ScaleOptions: input.ScaleOptions,
 			},
 			Organization: clustersetup.Organization{
 				ID:   input.OrganizationID,

--- a/src/cluster/eks_create_cluster.go
+++ b/src/cluster/eks_create_cluster.go
@@ -34,6 +34,8 @@ type EKSCreateClusterWorkflowInput struct {
 	OrganizationName string
 	PostHooks        pkgCluster.PostHooks
 	NodePoolLabels   map[string]map[string]string
+
+	ScaleOptions *pkgCluster.ScaleOptions
 }
 
 // CreateClusterWorkflow executes the Cadence workflow responsible for creating and configuring an EKS cluster
@@ -79,10 +81,11 @@ func EKSCreateClusterWorkflow(ctx workflow.Context, input EKSCreateClusterWorkfl
 		workflowInput := clustersetup.WorkflowInput{
 			ConfigSecretID: brn.New(input.OrganizationID, brn.SecretResourceType, infraOutput.ConfigSecretID).String(),
 			Cluster: clustersetup.Cluster{
-				ID:    input.ClusterID,
-				UID:   input.ClusterUID,
-				Name:  input.ClusterName,
-				Cloud: pkgCluster.Amazon,
+				ID:           input.ClusterID,
+				UID:          input.ClusterUID,
+				Name:         input.ClusterName,
+				Cloud:        pkgCluster.Amazon,
+				ScaleOptions: input.ScaleOptions,
 			},
 			Organization: clustersetup.Organization{
 				ID:   input.OrganizationID,

--- a/src/cluster/hookfunctions.go
+++ b/src/cluster/hookfunctions.go
@@ -30,9 +30,6 @@ var HookMap = map[string]PostFunctioner{
 	pkgCluster.InitSpotConfig: &InitSpotConfigPostHook{
 		ErrorHandler: ErrorHandler{},
 	},
-	pkgCluster.DeployInstanceTerminationHandler: &InstanceTerminationHandlerPostHook{
-		ErrorHandler: ErrorHandler{},
-	},
 }
 
 // BasePostHookFunctions default posthook functions after cluster create
@@ -40,7 +37,6 @@ var HookMap = map[string]PostFunctioner{
 var BasePostHookFunctions = []string{
 	pkgCluster.InstallKubernetesDashboardPostHook,
 	pkgCluster.InitSpotConfig,
-	pkgCluster.DeployInstanceTerminationHandler,
 }
 
 // PostFunctioner manages posthook functions


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #3444 
| License         | Apache 2.0


### What's in this PR?
- Removed InstanceTerminationHandlerPostHook
- Added InstanceTerminationHandlerActivity to cluster setup workflow
- Workflow inputs update to propagate new ScaleOptions workflow input field value

### Why?
To be able to deprecate post hook functionality.

### Checklist

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
