### PR TITLE
Velero provider secret

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -22200,6 +22200,13 @@ components:
             NodeInstance role or cluster secret deployment.
           example: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
           type: string
+        useProviderSecret:
+          description: relevant only in case of Amazon clusters. This a fourth option
+            to give permissions for volume snapshots to Velero. Should you set to
+            true Pipeline will configure your provider secret (specified in secretId)
+            for volume snapshot.
+          example: false
+          type: boolean
         storageAccount:
           description: required only case of Azure
           example: my-storage-account

--- a/.gen/pipeline/pipeline/model_enable_ark_request.go
+++ b/.gen/pipeline/pipeline/model_enable_ark_request.go
@@ -30,6 +30,9 @@ type EnableArkRequest struct {
 	// relevant only in case of Amazon clusters. This a third option to give permissions for volume snapshots to Velero, besides the default NodeInstance role or cluster secret deployment.
 	ServiceAccountRoleARN string `json:"serviceAccountRoleARN,omitempty"`
 
+	// relevant only in case of Amazon clusters. This a fourth option to give permissions for volume snapshots to Velero. Should you set to true Pipeline will configure your provider secret (specified in secretId) for volume snapshot.
+	UseProviderSecret bool `json:"useProviderSecret,omitempty"`
+
 	// required only case of Azure
 	StorageAccount string `json:"storageAccount,omitempty"`
 

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -7762,6 +7762,10 @@ components:
                     type: string
                     example: "arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME"
                     description: "relevant only in case of Amazon clusters. This a third option to give permissions for volume snapshots to Velero, besides the default NodeInstance role or cluster secret deployment."
+                useProviderSecret:
+                    type: boolean
+                    example: false
+                    description: "relevant only in case of Amazon clusters. This a fourth option to give permissions for volume snapshots to Velero. Should you set to true Pipeline will configure your provider secret (specified in secretId) for volume snapshot."
                 storageAccount:
                     type: string
                     example: "my-storage-account"

--- a/internal/ark/api/deployments.go
+++ b/internal/ark/api/deployments.go
@@ -32,6 +32,7 @@ type EnableBackupServiceRequest struct {
 	Options               BackupOptions     `json:"options,omitempty"`
 	UseClusterSecret      bool              `json:"useClusterSecret,omitempty"`
 	ServiceAccountRoleARN string            `json:"serviceAccountRoleARN,omitempty"`
+	UseProviderSecret     bool              `json:"useProviderSecret,omitempty"`
 }
 
 // EnableBackupServiceResponse describes Pipeline's EnableBackupServiceRequest API response

--- a/internal/ark/config.go
+++ b/internal/ark/config.go
@@ -104,6 +104,7 @@ type volumeSnapshotLocation struct {
 
 type volumeSnapshotLocationConfig struct {
 	Region        string `json:"region,omitempty"`
+	Profile       string `json:"profile,omitempty"`
 	ApiTimeout    string `json:"apiTimeout,omitempty"`
 	ResourceGroup string `json:"resourceGroup,omitempty"`
 }
@@ -136,6 +137,7 @@ type ConfigRequest struct {
 
 	UseClusterSecret      bool
 	ServiceAccountRoleARN string
+	UseProviderSecret     bool
 	RestoreMode           bool
 }
 
@@ -344,6 +346,9 @@ func (req ConfigRequest) getVolumeSnapshotLocation() (volumeSnapshotLocation, er
 	case providers.Amazon:
 		pvcProvider = amazon.PersistentVolumeProvider
 		vslconfig.Region = req.Cluster.Location
+		if req.UseProviderSecret {
+			vslconfig.Profile = "bucket"
+		}
 	case providers.Azure:
 		pvcProvider = azure.PersistentVolumeProvider
 		vslconfig.ApiTimeout = "3m0s"

--- a/internal/ark/deployments_svc.go
+++ b/internal/ark/deployments_svc.go
@@ -100,7 +100,7 @@ func (s *DeploymentsService) GetActiveDeployment() (*ClusterBackupDeploymentsMod
 
 // Deploy deploys ARK with helm configured to use the given bucket and mode
 func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBackupBucketsModel,
-	restoreMode bool, useClusterSecret bool, serviceAccountRoleARN string) error {
+	restoreMode bool, useClusterSecret bool, serviceAccountRoleARN string, useProviderSecret bool) error {
 	var deployment *ClusterBackupDeploymentsModel
 	if !restoreMode {
 		_, err := s.GetActiveDeployment()
@@ -151,6 +151,7 @@ func (s *DeploymentsService) Deploy(helmService HelmService, bucket *ClusterBack
 		BucketSecret:          bucketSecret,
 		UseClusterSecret:      useClusterSecret,
 		ServiceAccountRoleARN: serviceAccountRoleARN,
+		UseProviderSecret:     useProviderSecret,
 		RestoreMode:           restoreMode,
 	}
 	config, err := req.getChartConfig()

--- a/internal/cluster/clustersetup/velero/restore_backup_activity.go
+++ b/internal/cluster/clustersetup/velero/restore_backup_activity.go
@@ -121,7 +121,7 @@ func (a RestoreBackupActivity) Execute(ctx context.Context, input RestoreBackupA
 
 	err = svc.GetDeploymentsService().Deploy(a.helmService, &backup.Bucket, true,
 		input.RestoreBackupParams.UseClusterSecret, input.RestoreBackupParams.ServiceAccountRoleARN,
-		input.RestoreBackupParams.UseBackupSecret)
+		input.RestoreBackupParams.UseProviderSecret)
 	if err != nil {
 		return err
 	}

--- a/internal/cluster/clustersetup/velero/restore_backup_activity.go
+++ b/internal/cluster/clustersetup/velero/restore_backup_activity.go
@@ -120,7 +120,8 @@ func (a RestoreBackupActivity) Execute(ctx context.Context, input RestoreBackupA
 	}
 
 	err = svc.GetDeploymentsService().Deploy(a.helmService, &backup.Bucket, true,
-		input.RestoreBackupParams.UseClusterSecret, input.RestoreBackupParams.ServiceAccountRoleARN)
+		input.RestoreBackupParams.UseClusterSecret, input.RestoreBackupParams.ServiceAccountRoleARN,
+		input.RestoreBackupParams.UseBackupSecret)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -140,7 +140,7 @@ type RestoreFromBackupParams struct {
 	Options               RestoreOptions `json:"options,omitempty"`
 	UseClusterSecret      bool           `json:"useClusterSecret,omitempty"`
 	ServiceAccountRoleARN string         `json:"serviceAccountRoleARN,omitempty"`
-	UseBackupSecret       bool           `json:"useBackupSecret,omitempty"`
+	UseProviderSecret     bool           `json:"useProviderSecret,omitempty"`
 }
 
 // RestoreOptions defines options specification for an Ark restore

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -140,6 +140,7 @@ type RestoreFromBackupParams struct {
 	Options               RestoreOptions `json:"options,omitempty"`
 	UseClusterSecret      bool           `json:"useClusterSecret,omitempty"`
 	ServiceAccountRoleARN string         `json:"serviceAccountRoleARN,omitempty"`
+	UseBackupSecret       bool           `json:"useBackupSecret,omitempty"`
 }
 
 // RestoreOptions defines options specification for an Ark restore

--- a/src/api/ark/backupservice/enable.go
+++ b/src/api/ark/backupservice/enable.go
@@ -108,7 +108,8 @@ func Enable(helmService helm.UnifiedReleaser) func(c *gin.Context) {
 			return
 		}
 
-		err = svc.GetDeploymentsService().Deploy(helmService, bucket, false, request.UseClusterSecret, request.ServiceAccountRoleARN)
+		err = svc.GetDeploymentsService().Deploy(helmService, bucket, false,
+			request.UseClusterSecret, request.ServiceAccountRoleARN, request.UseProviderSecret)
 		if err != nil {
 			err = errors.WrapIf(err, "could not deploy backup service")
 			common.ErrorHandler.Handle(err)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3456 
| License         | Apache 2.0


### What's in this PR?
- add useProviderSecret option to enable backup request
- if useProviderSecret = true configure the same provider secret used for bucket access by setting the same profile = bucket in volumeSnapshot config as in backupLocation config.

### Why?
When enabling backup we have different options like useClusterSecret, or specify service account role to use for taking
volume snapshots. There should be a third option to configure the same secret used for bucket access.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
