### PR TITLE
Propagated EKS NP CF stack tags to volumes

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -171,6 +171,15 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 		nodeVolumeEncryptionKeyARN = a.defaultNodeVolumeEncryption.EncryptionKeyARN
 	}
 
+	var stackTagsBuilder strings.Builder
+	for tagIndex, tag := range tags {
+		if tagIndex != 0 {
+			_, _ = stackTagsBuilder.WriteString(",")
+		}
+
+		_, _ = stackTagsBuilder.WriteString(aws.StringValue(tag.Key) + "=" + aws.StringValue(tag.Value))
+	}
+
 	var subnetIDs []string
 
 	for _, subnet := range input.Subnets {
@@ -219,6 +228,10 @@ func (a *CreateAsgActivity) Execute(ctx context.Context, input CreateAsgActivity
 		{
 			ParameterKey:   aws.String("NodeVolumeSize"),
 			ParameterValue: aws.String(fmt.Sprintf("%d", input.NodeVolumeSize)),
+		},
+		{
+			ParameterKey:   aws.String("StackTags"),
+			ParameterValue: aws.String(stackTagsBuilder.String()),
 		},
 		{
 			ParameterKey:   aws.String("ClusterName"),

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -216,6 +216,15 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 		nodeVolumeEncryptionKeyARN = a.defaultNodeVolumeEncryption.EncryptionKeyARN
 	}
 
+	var stackTagsBuilder strings.Builder
+	for tagIndex, tag := range tags {
+		if tagIndex != 0 {
+			_, _ = stackTagsBuilder.WriteString(",")
+		}
+
+		_, _ = stackTagsBuilder.WriteString(aws.StringValue(tag.Key) + "=" + aws.StringValue(tag.Value))
+	}
+
 	if input.Version != "" {
 		nodeLabels = append(nodeLabels, fmt.Sprintf("%v=%v", cluster.NodePoolVersionLabelKey, input.Version))
 	}
@@ -262,6 +271,10 @@ func (a *UpdateAsgActivity) Execute(ctx context.Context, input UpdateAsgActivity
 			input.NodeVolumeSize > 0,
 			fmt.Sprintf("%d", input.NodeVolumeSize),
 		),
+		{
+			ParameterKey:   aws.String("StackTags"),
+			ParameterValue: aws.String(stackTagsBuilder.String()),
+		},
 		{
 			ParameterKey:     aws.String("ClusterName"),
 			UsePreviousValue: aws.Bool(true),

--- a/templates/eks/amazon-eks-iam-cf.yaml
+++ b/templates/eks/amazon-eks-iam-cf.yaml
@@ -107,6 +107,7 @@ Resources:
             -
               Effect: "Allow"
               Action:
+              - ec2:CreateTags # Note: required for node pool custom and stack tag propagation to volumes.
               - ec2:Describe*
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -33,6 +33,7 @@ Metadata:
           - KubeletExtraArguments
           - UseInstanceStore
           - DisableIMDSv1
+          - StackTags
           - TemplateVersion
       - Label:
           default: Worker Network Configuration
@@ -475,13 +476,18 @@ Parameters:
     Default: 0
     Description: Node volume size
 
+  StackTags:
+    Type: "String"
+    Default: ""
+    Description: The tags of the stack.
+
   Subnets:
     Type: "List<AWS::EC2::Subnet::Id>"
     Description: The subnets where workers can be created.
 
   TemplateVersion:
     Type: String
-    Default: "2.2.0"
+    Default: "2.3.0"
     Description: Current version of the template structure as metainformation for created stacks.
 
   TerminationDetachEnabled:
@@ -691,6 +697,13 @@ Resources:
         KeyName: !If [ HasKeyName, !Ref KeyName, !Ref "AWS::NoValue" ]
         SecurityGroupIds:
           !If [NoCustomNodeSecurityGroups, [!Ref NodeSecurityGroup], !Split [ ",",  !Join [ ",", [ !Ref NodeSecurityGroup, !Ref CustomNodeSecurityGroups ] ]  ] ]
+        TagSpecifications:
+          - ResourceType: volume
+            Tags:
+              - Key: Name
+                Value: !Sub ${ClusterName}-${NodeGroupName}-Volume
+              - Key: !Sub kubernetes.io/cluster/${ClusterName}
+                Value: owned
         UserData:
             Fn::Base64:
                 Fn::Sub: |
@@ -735,6 +748,33 @@ Resources:
                         fi
                       else
                         /etc/eks/bootstrap.sh ${ClusterName} --kubelet-extra-args '${KubeletExtraArguments}' ${BootstrapArguments}
+                      fi
+
+                      # Note: manually applying stack tags onto root EBS
+                      # volumes, because automatic tag propagation for Amazon
+                      # EBS volumes created from block device mappings is not
+                      # supported as of 2021-03-11, source:
+                      # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
+                      # > All stack-level tags, including automatically created
+                      # > tags, are propagated to resources that CloudFormation
+                      # > supports. Currently, tags aren't propagated to Amazon
+                      # > EBS volumes that are created from block device
+                      # > mappings.
+                      if [ "${StackTags}" != "" ]; then
+                        STACK_TAG_ARGUMENTS=""
+                        for TAG in $(echo -n "${StackTags}" | tr "," "\n"); do
+                          TAG_KEY=$(echo -n "$TAG" | cut -d "=" -f 1)
+                          TAG_VALUE=$(echo -n "$TAG" | cut -d "=" -f 2)
+
+                          STACK_TAG_ARGUMENTS="$STACK_TAG_ARGUMENTS Key=$TAG_KEY,Value=$TAG_VALUE"
+                        done
+
+                        AWS_AVAIL_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+                        AWS_REGION="$(echo "$AWS_AVAIL_ZONE" | sed 's/[a-z]$//')"
+                        AWS_INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+                        ROOT_VOLUME_IDS=$(aws ec2 describe-instances --region $AWS_REGION --instance-id $AWS_INSTANCE_ID --output text --query Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId)
+                        # Note: the lack of quotes around the tag arguments is intentional.
+                        aws ec2 create-tags --resources $ROOT_VOLUME_IDS --region $AWS_REGION --tags $STACK_TAG_ARGUMENTS
                       fi
         MetadataOptions:
           HttpPutResponseHopLimit: 2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Propagated EKS NP CF stack tags to volumes.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Customer feature request.

Note: manually applying stack tags onto root EBS volumes, because automatic tag propagation for Amazon EBS volumes created from block device mappings is not supported as of 2021-03-11, [source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)
> All stack-level tags, including automatically created tags, are propagated to resources that CloudFormation supports. Currently, tags aren't propagated to Amazon EBS volumes that are created from block device mappings.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Requires an additional `ec2:CreateTags` permission for the node instance role in order for the instance to be able to create the tags from the node pool stack template values.
Requires documentation update on minimal privileges for the node instance role.

Tested using cluster create (node pool create), node pool update and cluster update (node pool update 2).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- [x] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Document additional node instance role permission requirement (`ec2:CreateTags`), see `Additional context` for details.
