### PR TITLE
install helm-s3 plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ ARG BUILD_DATE
 COPY . /build
 RUN make build-release
 
-FROM alpine:3.12 AS iamauth
+
+FROM alpine:3.13 AS iamauth
 
 WORKDIR /tmp
 
@@ -39,21 +40,24 @@ RUN set -xe \
     && chmod +x aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64 \
     && mv aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64 aws-iam-authenticator
 
-FROM alpine:3.12 AS helms3
+FROM alpine:3.13 AS helms3
 
 WORKDIR /tmp
 
-ENV HELM_S3_PLUGIN_VERSION 0.10.0
+ENV HELM_S3_PLUGIN_VERSION=0.11.0
 
-ENV HELM_S3_PLUGIN_URL "https://github.com/hypnoglow/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+ENV HELM_S3_ARCHIVE_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" \
+    HELM_S3_CHECKSUMS_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_sha512_checksums.txt" \
+    HELM_S3_PLUGIN_URL="https://github.com/banzaicloud/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+
 RUN set -xe \
     && mkdir -p helm-plugins/helm-s3 \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt \
-    && cat helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt | grep "_linux_amd64.tar.gz" | sha256sum -c - \
-    && tar xzf "helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" -C "helm-plugins/helm-s3"
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_ARCHIVE_FILE_NAME}" \
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_CHECKSUMS_FILE_NAME}" \
+    && cat "${HELM_S3_CHECKSUMS_FILE_NAME}" | grep -E "^[0-9a-z]+  ${HELM_S3_ARCHIVE_FILE_NAME}$" | sha512sum -c - \
+    && tar xzf "${HELM_S3_ARCHIVE_FILE_NAME}" -C "helm-plugins/helm-s3"
 
-FROM alpine:3.12 AS migrate
+FROM alpine:3.13 AS migrate
 
 ENV MIGRATE_VERSION v4.9.1
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.16
-ARG FROM_IMAGE=alpine:3.12
+ARG FROM_IMAGE=alpine:3.13
 
 FROM golang:${GO_VERSION}-alpine3.12 AS builder
 
@@ -28,7 +28,7 @@ COPY . /build
 RUN make build-release
 
 
-FROM alpine:3.12 AS iamauth
+FROM alpine:3.13 AS iamauth
 
 WORKDIR /tmp
 
@@ -40,20 +40,24 @@ RUN set -xe \
     && cat authenticator_${IAM_AUTH_VERSION}_checksums.txt | grep "_linux_amd64" | sha256sum -c - \
     && mv aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64 aws-iam-authenticator
 
-FROM alpine:3.12 AS helms3
+FROM alpine:3.13 AS helms3
 
 WORKDIR /tmp
 
-ENV HELM_S3_PLUGIN_VERSION 0.10.0
-ENV HELM_S3_PLUGIN_URL "https://github.com/hypnoglow/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+ENV HELM_S3_PLUGIN_VERSION=0.11.0
+
+ENV HELM_S3_ARCHIVE_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" \
+    HELM_S3_CHECKSUMS_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_sha512_checksums.txt" \
+    HELM_S3_PLUGIN_URL="https://github.com/banzaicloud/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+
 RUN set -xe \
     && mkdir -p helm-plugins/helm-s3 \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt \
-    && cat helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt | grep "_linux_amd64.tar.gz" | sha256sum -c - \
-    && tar xzf "helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" -C "helm-plugins/helm-s3"
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_ARCHIVE_FILE_NAME}" \
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_CHECKSUMS_FILE_NAME}" \
+    && cat "${HELM_S3_CHECKSUMS_FILE_NAME}" | grep -E "^[0-9a-z]+  ${HELM_S3_ARCHIVE_FILE_NAME}$" | sha512sum -c - \
+    && tar xzf "${HELM_S3_ARCHIVE_FILE_NAME}" -C "helm-plugins/helm-s3"
 
-FROM alpine:3.12 AS migrate
+FROM alpine:3.13 AS migrate
 
 ENV MIGRATE_VERSION v4.9.1
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,6 +40,18 @@ RUN set -xe \
     && cat authenticator_${IAM_AUTH_VERSION}_checksums.txt | grep "_linux_amd64" | sha256sum -c - \
     && mv aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64 aws-iam-authenticator
 
+FROM alpine:3.12 AS helms3
+
+WORKDIR /tmp
+
+ENV HELM_S3_PLUGIN_VERSION 0.10.0
+ENV HELM_S3_PLUGIN_URL "https://github.com/hypnoglow/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+RUN set -xe \
+    && mkdir -p helm-plugins/helm-s3 \
+    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz \
+    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt \
+    && cat helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt | grep "_linux_amd64.tar.gz" | sha256sum -c - \
+    && tar xzf "helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" -C "helm-plugins/helm-s3"
 
 FROM alpine:3.12 AS migrate
 
@@ -53,10 +65,13 @@ RUN set -xe && \
 
 FROM ${FROM_IMAGE}
 
+ENV HELM_PLUGINS=/usr/share/helm/plugins
+
 COPY --from=builder /etc/nsswitch.conf.build /etc/nsswitch.conf
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=iamauth /tmp/aws-iam-authenticator /usr/bin/
+COPY --from=helms3 /tmp/helm-plugins /usr/share/helm/plugins
 COPY --from=builder /build/templates /templates/
 COPY --from=builder /build/build/release/pipeline /
 COPY --from=builder /build/build/release/worker /

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -15,7 +15,7 @@ RUN cd $GOPATH/src/github.com/kubernetes-sigs/aws-iam-authenticator && \
 
 RUN go get github.com/derekparker/delve/cmd/dlv
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --update --no-cache bash curl libc6-compat
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -14,16 +14,20 @@ RUN cd $GOPATH/src/github.com/kubernetes-sigs/aws-iam-authenticator && \
     go install ./cmd/aws-iam-authenticator
 
 
-ENV HELM_S3_PLUGIN_VERSION 0.10.0
-ENV HELM_S3_PLUGIN_URL "https://github.com/hypnoglow/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
-RUN set -xe \
-    && mkdir -p /tmp/helm-plugins/helm-s3 \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz \
-    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt \
-    && cat helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt | grep "_linux_amd64.tar.gz" | sha256sum -c - \
-    && tar xzf "helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" -C "/tmp/helm-plugins/helm-s3"
+ENV HELM_S3_PLUGIN_VERSION=0.11.0
 
-FROM alpine:3.12
+ENV HELM_S3_ARCHIVE_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" \
+    HELM_S3_CHECKSUMS_FILE_NAME="helm-s3_${HELM_S3_PLUGIN_VERSION}_sha512_checksums.txt" \
+    HELM_S3_PLUGIN_URL="https://github.com/banzaicloud/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+
+RUN set -xe \
+    && mkdir -p helm-plugins/helm-s3 \
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_ARCHIVE_FILE_NAME}" \
+    && wget "${HELM_S3_PLUGIN_URL}/${HELM_S3_CHECKSUMS_FILE_NAME}" \
+    && cat "${HELM_S3_CHECKSUMS_FILE_NAME}" | grep -E "^[0-9a-z]+  ${HELM_S3_ARCHIVE_FILE_NAME}$" | sha512sum -c - \
+    && tar xzf "${HELM_S3_ARCHIVE_FILE_NAME}" -C "helm-plugins/helm-s3"
+
+FROM alpine:3.13
 
 RUN apk add --update --no-cache bash curl
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -13,14 +13,27 @@ RUN cd $GOPATH/src/github.com/kubernetes-sigs/aws-iam-authenticator && \
     git checkout 981ecbe && \
     go install ./cmd/aws-iam-authenticator
 
+
+ENV HELM_S3_PLUGIN_VERSION 0.10.0
+ENV HELM_S3_PLUGIN_URL "https://github.com/hypnoglow/helm-s3/releases/download/v${HELM_S3_PLUGIN_VERSION}"
+RUN set -xe \
+    && mkdir -p /tmp/helm-plugins/helm-s3 \
+    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz \
+    && wget ${HELM_S3_PLUGIN_URL}/helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt \
+    && cat helm-s3_${HELM_S3_PLUGIN_VERSION}_checksums.txt | grep "_linux_amd64.tar.gz" | sha256sum -c - \
+    && tar xzf "helm-s3_${HELM_S3_PLUGIN_VERSION}_linux_amd64.tar.gz" -C "/tmp/helm-plugins/helm-s3"
+
 FROM alpine:3.12
 
 RUN apk add --update --no-cache bash curl
+
+ENV HELM_PLUGINS=/usr/share/helm/plugins
 
 COPY --from=builder /etc/nsswitch.conf.build /etc/nsswitch.conf
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/aws-iam-authenticator /usr/bin/
+COPY --from=builder /tmp/helm-plugins /usr/share/helm/plugins
 
 COPY build/release/pipeline /
 COPY build/release/worker /

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -213,3 +213,13 @@ pipeline:
         # Base URL where the end users can reach this pipeline instance
         url: "http://<YOUR_NGROK_NUMBER>.ngrok.io/pipeline"
 ```
+
+#### Helm S3 repositories
+
+To be able to handle S3 repositories with Pipeline helm-s3 need to be installed in case you have helm installed on your machine:
+
+```bash
+helm plugin install https://github.com/hypnoglow/helm-s3.git
+```
+
+In case you don't have helm installed you can download helm-s3 plugin from [here](), extract it to a `helm-plugins` folder and set `HELM_PLUGINS=helm-plugins` when starting Pipeline. 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -219,7 +219,7 @@ pipeline:
 To be able to handle S3 repositories with Pipeline helm-s3 need to be installed in case you have helm installed on your machine:
 
 ```bash
-helm plugin install https://github.com/hypnoglow/helm-s3.git
+helm plugin install https://github.com/banzaicloud/helm-s3.git
 ```
 
-In case you don't have helm installed you can download helm-s3 plugin from [here](https://github.com/hypnoglow/helm-s3/releases), extract it to a `helm-plugins` folder and set `HELM_PLUGINS=helm-plugins` when starting Pipeline. 
+In case you don't have helm installed you can download helm-s3 plugin from [here](https://github.com/banzaicloud/helm-s3/releases), extract it to a `helm-plugins` folder and set `HELM_PLUGINS=helm-plugins` when starting Pipeline.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -222,4 +222,4 @@ To be able to handle S3 repositories with Pipeline helm-s3 need to be installed 
 helm plugin install https://github.com/hypnoglow/helm-s3.git
 ```
 
-In case you don't have helm installed you can download helm-s3 plugin from [here](), extract it to a `helm-plugins` folder and set `HELM_PLUGINS=helm-plugins` when starting Pipeline. 
+In case you don't have helm installed you can download helm-s3 plugin from [here](https://github.com/hypnoglow/helm-s3/releases), extract it to a `helm-plugins` folder and set `HELM_PLUGINS=helm-plugins` when starting Pipeline. 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3489 
| License         | Apache 2.0


### What's in this PR?
Add helm-s3 plugin to Pipeline image and set HELM_PLUGINS environment variable to point to that location.
Fix Helm3EnvService.getDetailedCharts to support different download protocols.

### Why?
To be able to add s3 helm chart repositories to Pipeline and install helm charts from such repositories.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
