### PR TITLE
Upgrade Velero images

### DIFF
--- a/internal/ark/config.go
+++ b/internal/ark/config.go
@@ -201,23 +201,6 @@ func (req ConfigRequest) Get() (values backup.ValueOverrides, err error) {
 		},
 		// cleanup crd's only in restore mode
 		CleanUpCRDs: req.RestoreMode,
-		Affinity: v1.Affinity{
-			NodeAffinity: &v1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-					NodeSelectorTerms: []v1.NodeSelectorTerm{
-						{
-							MatchExpressions: []v1.NodeSelectorRequirement{
-								{
-									Key:      "kubernetes.io/arch",
-									Operator: "In",
-									Values:   []string{"amd64"},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 		ServiceAccount: backup.ServiceAccount{
 			Server: backup.Server{
 				Create: true,

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -763,22 +763,22 @@ traefik:
 	v.SetDefault("cluster::disasterRecovery::charts::ark::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": "velero/velero",
-			"tag":        "v1.5.1",
+			"tag":        "v1.6.0",
 			"pullPolicy": "IfNotPresent",
 		},
 		"awsPluginImage": map[string]interface{}{
 			"repository": "velero/velero-plugin-for-aws",
-			"tag":        "v1.1.0",
+			"tag":        "v1.2.0",
 			"pullPolicy": "IfNotPresent",
 		},
 		"azurePluginImage": map[string]interface{}{
 			"repository": "velero/velero-plugin-for-microsoft-azure",
-			"tag":        "v1.1.0",
+			"tag":        "v1.2.0",
 			"pullPolicy": "IfNotPresent",
 		},
 		"gcpPluginImage": map[string]interface{}{
 			"repository": "velero/velero-plugin-for-gcp",
-			"tag":        "v1.1.0",
+			"tag":        "v1.2.0",
 			"pullPolicy": "IfNotPresent",
 		},
 	})


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3496 
| License         | Apache 2.0


### What's in this PR?
- upgrade Velero image to 1.6.0
- upgrade Velero plugin images to 1.2.0
- remove amd64 node restriction affinity for Velero pod as these images already have multi arch support.

### Why?
To be able to run Velero pod on arm nodes as well.

### Additional context
Azure and GCP plugins have no multi arch support yet, so in case someone wants to store backups on Azure or GCP in a cluster contaning nodes other than amd64 he has to add the following affinity to Velero deployment:

```
affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: ubernetes.io/arch
            operator: In
            values:
            - amd64
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
