### PR TITLE
set restore failures as non retriable errors

### DIFF
--- a/internal/cluster/clustersetup/velero/BUILD.plz
+++ b/internal/cluster/clustersetup/velero/BUILD.plz
@@ -14,6 +14,7 @@ go_library(
         "//third_party/go:emperror.dev__errors",
         "//third_party/go:github.com__jinzhu__gorm",
         "//third_party/go:github.com__sirupsen__logrus",
+        "//third_party/go:go.uber.org__cadence",
         "//third_party/go:go.uber.org__cadence__activity",
         "//third_party/go:k8s.io__apimachinery__pkg__labels",
     ],

--- a/internal/cluster/clustersetup/workflow.go
+++ b/internal/cluster/clustersetup/workflow.go
@@ -31,6 +31,7 @@ const WorkflowName = "cluster-setup"
 const (
 	DeployClusterAutoscalerActivityName = "deploy-cluster-autoscaler"
 	RestoreBackupActivityName           = "restore-backup"
+	ErrReasonRestoreFailed              = "BACKUP_RESTORE_FAILED"
 )
 
 // Workflow orchestrates the post-creation cluster setup flow.
@@ -87,10 +88,11 @@ func (w Workflow) Execute(ctx workflow.Context, input WorkflowInput) error {
 		StartToCloseTimeout:    30 * time.Minute,
 		WaitForCancellation:    true,
 		RetryPolicy: &cadence.RetryPolicy{
-			InitialInterval:    2 * time.Second,
-			BackoffCoefficient: 1.5,
-			MaximumInterval:    30 * time.Second,
-			MaximumAttempts:    30,
+			InitialInterval:          2 * time.Second,
+			BackoffCoefficient:       1.5,
+			MaximumInterval:          30 * time.Second,
+			MaximumAttempts:          30,
+			NonRetriableErrorReasons: []string{"cadenceInternal:Panic", ErrReasonRestoreFailed},
 		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, activityOptions)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3495 
| License         | Apache 2.0


### What's in this PR?
Throw a non retriable error from RestoreBackupActivity when restore status is 'PartiallyFailed' or 'Failed'.  


### Why?
If restore has a status of 'Failed' or 'PartiallyFailed' there no reason to retry RestoreBackupActivity 30 times since it fail constantly.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
