### PR TITLE
update pke version

### DIFF
--- a/internal/cluster/distribution/pke/pkeaws/pkeaws.go
+++ b/internal/cluster/distribution/pke/pkeaws/pkeaws.go
@@ -15,4 +15,4 @@
 package pkeaws
 
 // Version is the currently supported PKE version.
-const Version = "0.7.3"
+const Version = "0.8.0"

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	pkeVersion      = "0.7.3"
+	pkeVersion      = "0.8.0"
 	MasterNodeTaint = pkgPKE.TaintKeyMaster + ":" + string(corev1.TaintEffectNoSchedule)
 )
 

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	pkeVersion      = "0.7.3"
+	pkeVersion      = "0.8.0"
 	MasterNodeTaint = pkgPKE.TaintKeyMaster + ":" + string(corev1.TaintEffectNoSchedule)
 )
 


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related: https://github.com/banzaicloud/pke/pull/142, https://github.com/banzaicloud/pke-image/pull/25
| License         | Apache 2.0


### What's in this PR?
Update PKE version to 0.8.0 (supports k8s 1.20, 1.21)
- PKE has been released
- AWS pre-built images have been created