### PR TITLE
Added CI integrity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,57 @@ on:
   pull_request:
 
 jobs:
+  check-integrity:
+    name: Check integrity
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Please
+        uses: sagikazarmark/setup-please-action@v0
+        with:
+          profile: ci
+
+      - name: Check Go modules dependency file integrity
+        if: ${{ always() }}
+        run: |
+          go mod tidy
+          test "$(git status --porcelain)" == "" || \
+            ( \
+              printf >&2 "\n`go mod tidy` results in a dirty state, Go mod files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
+              git reset --hard ;
+              exit 1 ; \
+            )
+
+      - name: Check Please Go dependency file integrity
+        if: ${{ always() }}
+        run: |
+          plz tidy
+          test "$(git status --porcelain)" == "" || \
+            ( \
+              printf >&2 "\n`plz tidy` results in a dirty state, Please build files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
+              git reset --hard ;
+              exit 1 ; \
+            )
+
+      - name: Check generated file integrity
+        if: ${{ always() }}
+        run: |
+          make generate-all
+          test "$(git status --porcelain)" == "" || \
+            ( \
+              printf >&2 "\n`go mod tidy` results in a dirty state, generated files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
+              git reset --hard ;
+              exit 1 ; \
+            )
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added CI integrity checks for Go modules, Please Go dependencies and generated files.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Time and time again we run into issues where these manual steps are not done and occasionally the occurring error messages are not clear about the origin of the issue caused by this.

Thought this could be made easier if we checked them before doing anything else in the CI as they are build requirements.

A further step would be a checked in Git commit/push hook, but a lot of people despise mandatory client side Git hooks, so I don't want to push it further for now.

I was itching to do this for a while and I just want to get it out of my system, can be debated, I'm not attached to it.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
