### PR TITLE
Fixed CI integrity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,38 +28,41 @@ jobs:
       - name: Check Go modules dependency file integrity
         if: ${{ always() }}
         run: |
-          go mod tidy
-          test "$(git status --porcelain)" == "" || \
-            ( \
-              printf >&2 "\n`go mod tidy` results in a dirty state, Go mod files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
-              git reset --hard ;
-              exit 1 ; \
-            )
+          exit_code=0
+          for module_file in $(find . -type d -path "./plz-out**" -prune -a -not -type d -name "./plz-out" -o -type f -name go.mod); do
+            cd "$(dirname ${module_file})"
+            go mod tidy
+            if [ "$(git status --porcelain)" != "" ]; then
+              printf >&2 '\n`go mod tidy` in module `%s` results in a dirty state, Go mod files are not in sync with the source code files, differences:\n\n%s\n\n' "$(go list -m)" "$(git diff)"
+              git reset --hard
+              exit_code=1
+            fi
+          done
+          exit ${exit_code}
 
       - name: Check Please Go dependency file integrity
         if: ${{ always() }}
         run: |
           plz tidy
-          test "$(git status --porcelain)" == "" || \
-            ( \
-              printf >&2 "\n`plz tidy` results in a dirty state, Please build files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
-              git reset --hard ;
-              exit 1 ; \
-            )
+          if [ "$(git status --porcelain)" != "" ]; then
+            printf >&2 '\n`plz tidy` results in a dirty state, Please build files are not in sync with the source code files, differences:\n\n%s\n\n' "$(git diff)"
+            git reset --hard
+            exit 1
+          fi
 
       - name: Check generated file integrity
         if: ${{ always() }}
         run: |
           make generate-all
-          test "$(git status --porcelain)" == "" || \
-            ( \
-              printf >&2 "\n`make generate-all` results in a dirty state, generated files are not in sync with the source code files, differences:\n\n%s\n\n" "$(git diff)" ; \
-              git reset --hard ;
-              exit 1 ; \
-            )
+          if [ "$(git status --porcelain)" != "" ]; then
+            printf >&2 '\n`make generate-all` results in a dirty state, generated files are not in sync with the source code files, differences:\n\n%s\n\n' "$(git diff)"
+            git reset --hard
+            exit 1
+          fi
 
   build:
     name: Build
+    needs: [check-integrity]
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed CI integrity check.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Missed the multiple module monorepository setup, fumbled on the printf formatting with backticks and there was a missed backslash in the original command at a line break, but as run can handle multiline commands it was possible to convert it to a more easily readable and writable state.

Tested for both `go mod tidy` and `please tidy` failure, looks good now.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
