### PR TITLE
add scan-docker-images target to Makefile

### DIFF
--- a/docker.images.list
+++ b/docker.images.list
@@ -1,0 +1,14 @@
+ghcr.io/banzaicloud/anchore-image-validator
+ghcr.io/banzaicloud/instance-termination-handler:0.1.1
+ghcr.io/banzaicloud/integrated-service-operator
+ghcr.io/banzaicloud/nodepool-labels-operator:v0.1.0
+gcr.io/google-containers/cluster-autoscaler:v1.15.4
+k8s.gcr.io/autoscaling/cluster-autoscaler:v1.16.7
+k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.4
+k8s.gcr.io/autoscaling/cluster-autoscaler:v1.18.3
+k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1
+k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0
+velero/velero:v1.6.0
+velero/velero-plugin-for-aws:v1.2.0
+velero/velero-plugin-for-microsoft-azure:v1.2.0
+velero/velero-plugin-for-gcp:v1.2.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3505
| License         | Apache 2.0


### What's in this PR?
Add scan-docker-images target to Makefile which runs a security scan on a list of container images deployed by Pipeline.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
