### PR TITLE
Fixed CI integrity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.3 # Note: required until local (Homebrew) 1.16.4 is available.
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed CI integrity check.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

On Go v1.16.4 the `go.sum` lines are treated differently than on v1.16.3 by `go mod tidy`.
Currently the widespread development environment is still v1.16.3, because Homebrew doesn't have a v1.16.4 formulae yet.
As long as v1.16.4 is not available from Homebrew it is safer to leave the CI check on v1.16.3 for local vs CI development environment compatibility.

An alternative would be turning off the Go module dependencies integrity check.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

1.16.4 (newer than local)
![Screenshot 2021-05-18 at 14 06 58](https://user-images.githubusercontent.com/8093632/118648083-9291ab00-b7d1-11eb-98f1-0ac68d962735.png)
vs
1.16.3 (same as local)
![Screenshot 2021-05-18 at 14 08 14](https://user-images.githubusercontent.com/8093632/118648308-ca005780-b7d1-11eb-80ec-408d247c169e.png)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
