### PR TITLE
Updated image scan images list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,12 @@ bin/grype-${GRYPE_VERSION}:
 	@mv bin/grype $@
 scan-docker-images: bin/grype
 	@echo "- Start vulnerablity scan for images: $$(cat docker.images.list)"
+	@if [ -z "$${GITHUB_TOKEN}" ]; then \
+		echo "missing required GITHUB_TOKEN environment variable for ghcr.io authentication" ; \
+		exit 1 ; \
+	else \
+		echo $${GITHUB_TOKEN} | docker login ghcr.io --username "dummy" --password-stdin ; \
+	fi
 	@for image in $$(cat docker.images.list); do echo "Scanning image: " $$image; grype $$image; done;
 	@echo "- Scan completed."
 

--- a/docker.images.list
+++ b/docker.images.list
@@ -1,7 +1,9 @@
+docker.io/traefik:1.7.20
 ghcr.io/banzaicloud/anchore-image-validator:0.5.1
 ghcr.io/banzaicloud/instance-termination-handler:0.1.1
-ghcr.io/banzaicloud/integrated-service-operator
-ghcr.io/banzaicloud/nodepool-labels-operator:v0.1.0
+ghcr.io/banzaicloud/integrated-service-operator:v0.5.0
+ghcr.io/banzaicloud/nodepool-labels-operator:v0.1.1
+ghcr.io/banzaicloud/vault-secrets-webhook:1.10.1
 gcr.io/google-containers/cluster-autoscaler:v1.15.4
 k8s.gcr.io/autoscaling/cluster-autoscaler:v1.16.7
 k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.4


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated image scan images list:
1. Added GHCR auth.
2. Added traefik (core image).
3. Added vault-secrets-webhook (core image).
4. Updated IS operator version to what Pipeline uses.
5. Updated NPLS version to what Pipeline uses.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

1. Required by some images.
2. Traefik image is currently used by default in managed clusters.
3. Vault-secrets-webhook is a commonly used image (unless explicitly configured not to).
4. To make sure the correct version tag is analyzed.
5. To make sure the correct version tag is analyzed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
