### PR TITLE
Updated EKS node pool CloudFormation template

### DIFF
--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -504,6 +504,7 @@ Parameters:
       - t4g.nano
       - t4g.small
       - t4g.xlarge
+      - u-12tb1.112xlarge
       - u-12tb1.metal
       - u-6tb1.metal
       - u-9tb1.metal

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -446,6 +446,7 @@ Parameters:
       - r5dn.4xlarge
       - r5dn.8xlarge
       - r5dn.large
+      - r5dn.metal
       - r5dn.xlarge
       - r5n.12xlarge
       - r5n.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -1,3 +1,4 @@
+# Last reference: https://github.com/awslabs/amazon-eks-ami/blob/3616f1da5dab0cc6256ee60df4a0e5f2d8a42684/amazon-eks-nodegroup.yaml.
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -340,6 +340,7 @@ Parameters:
       - m5dn.4xlarge
       - m5dn.8xlarge
       - m5dn.large
+      - m5dn.metal
       - m5dn.xlarge
       - m5n.12xlarge
       - m5n.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -317,9 +317,11 @@ Parameters:
       - m5a.large
       - m5a.xlarge
       - m5ad.12xlarge
+      - m5ad.16xlarge
       - m5ad.24xlarge
       - m5ad.2xlarge
       - m5ad.4xlarge
+      - m5ad.8xlarge
       - m5ad.large
       - m5ad.xlarge
       - m5d.12xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -225,6 +225,16 @@ Parameters:
       - d2.4xlarge
       - d2.8xlarge
       - d2.xlarge
+      - d3.2xlarge
+      - d3.4xlarge
+      - d3.8xlarge
+      - d3.xlarge
+      - d3en.12xlarge
+      - d3en.2xlarge
+      - d3en.4xlarge
+      - d3en.6xlarge
+      - d3en.8xlarge
+      - d3en.xlarge
       - f1.16xlarge
       - f1.2xlarge
       - f1.4xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -244,6 +244,9 @@ Parameters:
       - g3.4xlarge
       - g3.8xlarge
       - g3s.xlarge
+      - g4ad.16xlarge
+      - g4ad.4xlarge
+      - g4ad.8xlarge
       - g4dn.12xlarge
       - g4dn.16xlarge
       - g4dn.2xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -159,6 +159,24 @@ Parameters:
       - c5.large
       - c5.metal
       - c5.xlarge
+      - c5a.12xlarge
+      - c5a.16xlarge
+      - c5a.24xlarge
+      - c5a.2xlarge
+      - c5a.4xlarge
+      - c5a.8xlarge
+      - c5a.large
+      - c5a.metal
+      - c5a.xlarge
+      - c5ad.12xlarge
+      - c5ad.16xlarge
+      - c5ad.24xlarge
+      - c5ad.2xlarge
+      - c5ad.4xlarge
+      - c5ad.8xlarge
+      - c5ad.large
+      - c5ad.metal
+      - c5ad.xlarge
       - c5d.12xlarge
       - c5d.18xlarge
       - c5d.24xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -506,6 +506,7 @@ Parameters:
       - t4g.xlarge
       - u-12tb1.112xlarge
       - u-12tb1.metal
+      - u-18tb1.metal
       - u-6tb1.metal
       - u-9tb1.metal
       - x1.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -191,6 +191,7 @@ Parameters:
       - c5n.4xlarge
       - c5n.9xlarge
       - c5n.large
+      - c5n.metal
       - c5n.xlarge
       - c6g.12xlarge
       - c6g.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -507,6 +507,7 @@ Parameters:
       - u-12tb1.112xlarge
       - u-12tb1.metal
       - u-18tb1.metal
+      - u-24tb1.metal
       - u-6tb1.metal
       - u-9tb1.metal
       - x1.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -351,6 +351,13 @@ Parameters:
       - m5n.large
       - m5n.metal
       - m5n.xlarge
+      - m5zn.12xlarge
+      - m5zn.2xlarge
+      - m5zn.3xlarge
+      - m5zn.6xlarge
+      - m5zn.large
+      - m5zn.metal
+      - m5zn.xlarge
       - m6g.12xlarge
       - m6g.16xlarge
       - m6g.2xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -349,6 +349,7 @@ Parameters:
       - m5n.4xlarge
       - m5n.8xlarge
       - m5n.large
+      - m5n.metal
       - m5n.xlarge
       - m6g.12xlarge
       - m6g.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -132,321 +132,321 @@ Parameters:
     Type: String
     Default: t2.medium
     AllowedValues:
-      - a1.medium
-      - a1.large
-      - a1.xlarge
       - a1.2xlarge
       - a1.4xlarge
+      - a1.large
+      - a1.medium
+      - a1.xlarge
       - c1.medium
       - c1.xlarge
-      - c3.large
-      - c3.xlarge
       - c3.2xlarge
       - c3.4xlarge
       - c3.8xlarge
-      - c4.large
-      - c4.xlarge
+      - c3.large
+      - c3.xlarge
       - c4.2xlarge
       - c4.4xlarge
       - c4.8xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
+      - c4.large
+      - c4.xlarge
       - c5.12xlarge
       - c5.18xlarge
       - c5.24xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.large
       - c5.metal
-      - c5d.large
-      - c5d.xlarge
-      - c5d.2xlarge
-      - c5d.4xlarge
-      - c5d.9xlarge
+      - c5.xlarge
       - c5d.12xlarge
       - c5d.18xlarge
       - c5d.24xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.large
       - c5d.metal
-      - c5n.large
-      - c5n.xlarge
+      - c5d.xlarge
+      - c5n.18xlarge
       - c5n.2xlarge
       - c5n.4xlarge
       - c5n.9xlarge
-      - c5n.18xlarge
-      - c6g.medium
-      - c6g.large
-      - c6g.xlarge
+      - c5n.large
+      - c5n.xlarge
+      - c6g.12xlarge
+      - c6g.16xlarge
       - c6g.2xlarge
       - c6g.4xlarge
       - c6g.8xlarge
-      - c6g.12xlarge
-      - c6g.16xlarge
+      - c6g.large
+      - c6g.medium
       - c6g.metal
-      - c6gd.medium
-      - c6gd.large
-      - c6gd.xlarge
+      - c6g.xlarge
+      - c6gd.12xlarge
+      - c6gd.16xlarge
       - c6gd.2xlarge
       - c6gd.4xlarge
       - c6gd.8xlarge
-      - c6gd.12xlarge
-      - c6gd.16xlarge
+      - c6gd.large
+      - c6gd.medium
       - c6gd.metal
+      - c6gd.xlarge
       - cc2.8xlarge
       - cr1.8xlarge
-      - d2.xlarge
       - d2.2xlarge
       - d2.4xlarge
       - d2.8xlarge
+      - d2.xlarge
+      - f1.16xlarge
       - f1.2xlarge
       - f1.4xlarge
-      - f1.16xlarge
       - g2.2xlarge
       - g2.8xlarge
-      - g3s.xlarge
+      - g3.16xlarge
       - g3.4xlarge
       - g3.8xlarge
-      - g3.16xlarge
-      - h1.2xlarge
-      - h1.4xlarge
-      - h1.8xlarge
-      - h1.16xlarge
-      - hs1.8xlarge
-      - i2.xlarge
-      - i2.2xlarge
-      - i2.4xlarge
-      - i2.8xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - i3.metal
-      - i3en.large
-      - i3en.xlarge
-      - i3en.2xlarge
-      - i3en.3xlarge
-      - i3en.6xlarge
-      - i3en.12xlarge
-      - i3en.24xlarge
-      - inf1.xlarge
-      - inf1.2xlarge
-      - inf1.6xlarge
-      - inf1.24xlarge
-      - m1.small
-      - m1.medium
-      - m1.large
-      - m1.xlarge
-      - m2.xlarge
-      - m2.2xlarge
-      - m2.4xlarge
-      - m3.medium
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m4.10xlarge
-      - m4.16xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.8xlarge
-      - m5.12xlarge
-      - m5.16xlarge
-      - m5.24xlarge
-      - m5.metal
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.8xlarge
-      - m5a.12xlarge
-      - m5a.16xlarge
-      - m5a.24xlarge
-      - m5ad.large
-      - m5ad.xlarge
-      - m5ad.2xlarge
-      - m5ad.4xlarge
-      - m5ad.12xlarge
-      - m5ad.24xlarge
-      - m5d.large
-      - m5d.xlarge
-      - m5d.2xlarge
-      - m5d.4xlarge
-      - m5d.8xlarge
-      - m5d.12xlarge
-      - m5d.16xlarge
-      - m5d.24xlarge
-      - m5d.metal
-      - m5dn.large
-      - m5dn.xlarge
-      - m5dn.2xlarge
-      - m5dn.4xlarge
-      - m5dn.8xlarge
-      - m5dn.12xlarge
-      - m5dn.16xlarge
-      - m5dn.24xlarge
-      - m5n.large
-      - m5n.xlarge
-      - m5n.2xlarge
-      - m5n.4xlarge
-      - m5n.8xlarge
-      - m5n.12xlarge
-      - m5n.16xlarge
-      - m5n.24xlarge
-      - m6g.medium
-      - m6g.large
-      - m6g.xlarge
-      - m6g.2xlarge
-      - m6g.4xlarge
-      - m6g.8xlarge
-      - m6g.12xlarge
-      - m6g.16xlarge
-      - m6g.metal
-      - m6gd.medium
-      - m6gd.large
-      - m6gd.xlarge
-      - m6gd.2xlarge
-      - m6gd.4xlarge
-      - m6gd.8xlarge
-      - m6gd.12xlarge
-      - m6gd.16xlarge
-      - m6gd.metal
-      - p2.xlarge
-      - p2.8xlarge
-      - p2.16xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - p3dn.24xlarge
-      - g4dn.xlarge
+      - g3s.xlarge
+      - g4dn.12xlarge
+      - g4dn.16xlarge
       - g4dn.2xlarge
       - g4dn.4xlarge
       - g4dn.8xlarge
-      - g4dn.12xlarge
-      - g4dn.16xlarge
       - g4dn.metal
-      - r3.large
-      - r3.xlarge
+      - g4dn.xlarge
+      - h1.16xlarge
+      - h1.2xlarge
+      - h1.4xlarge
+      - h1.8xlarge
+      - hs1.8xlarge
+      - i2.2xlarge
+      - i2.4xlarge
+      - i2.8xlarge
+      - i2.xlarge
+      - i3.16xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.large
+      - i3.metal
+      - i3.xlarge
+      - i3en.12xlarge
+      - i3en.24xlarge
+      - i3en.2xlarge
+      - i3en.3xlarge
+      - i3en.6xlarge
+      - i3en.large
+      - i3en.xlarge
+      - inf1.24xlarge
+      - inf1.2xlarge
+      - inf1.6xlarge
+      - inf1.xlarge
+      - m1.large
+      - m1.medium
+      - m1.small
+      - m1.xlarge
+      - m2.2xlarge
+      - m2.4xlarge
+      - m2.xlarge
+      - m3.2xlarge
+      - m3.large
+      - m3.medium
+      - m3.xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.large
+      - m4.xlarge
+      - m5.12xlarge
+      - m5.16xlarge
+      - m5.24xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.8xlarge
+      - m5.large
+      - m5.metal
+      - m5.xlarge
+      - m5a.12xlarge
+      - m5a.16xlarge
+      - m5a.24xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.8xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5d.12xlarge
+      - m5d.16xlarge
+      - m5d.24xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.8xlarge
+      - m5d.large
+      - m5d.metal
+      - m5d.xlarge
+      - m5dn.12xlarge
+      - m5dn.16xlarge
+      - m5dn.24xlarge
+      - m5dn.2xlarge
+      - m5dn.4xlarge
+      - m5dn.8xlarge
+      - m5dn.large
+      - m5dn.xlarge
+      - m5n.12xlarge
+      - m5n.16xlarge
+      - m5n.24xlarge
+      - m5n.2xlarge
+      - m5n.4xlarge
+      - m5n.8xlarge
+      - m5n.large
+      - m5n.xlarge
+      - m6g.12xlarge
+      - m6g.16xlarge
+      - m6g.2xlarge
+      - m6g.4xlarge
+      - m6g.8xlarge
+      - m6g.large
+      - m6g.medium
+      - m6g.metal
+      - m6g.xlarge
+      - m6gd.12xlarge
+      - m6gd.16xlarge
+      - m6gd.2xlarge
+      - m6gd.4xlarge
+      - m6gd.8xlarge
+      - m6gd.large
+      - m6gd.medium
+      - m6gd.metal
+      - m6gd.xlarge
+      - p2.16xlarge
+      - p2.8xlarge
+      - p2.xlarge
+      - p3.16xlarge
+      - p3.2xlarge
+      - p3.8xlarge
+      - p3dn.24xlarge
       - r3.2xlarge
       - r3.4xlarge
       - r3.8xlarge
-      - r4.large
-      - r4.xlarge
+      - r3.large
+      - r3.xlarge
+      - r4.16xlarge
       - r4.2xlarge
       - r4.4xlarge
       - r4.8xlarge
-      - r4.16xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.8xlarge
+      - r4.large
+      - r4.xlarge
       - r5.12xlarge
       - r5.16xlarge
       - r5.24xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r5.large
       - r5.metal
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5a.8xlarge
+      - r5.xlarge
       - r5a.12xlarge
       - r5a.16xlarge
       - r5a.24xlarge
-      - r5ad.large
-      - r5ad.xlarge
-      - r5ad.2xlarge
-      - r5ad.4xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5a.large
+      - r5a.xlarge
       - r5ad.12xlarge
       - r5ad.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.8xlarge
+      - r5ad.2xlarge
+      - r5ad.4xlarge
+      - r5ad.large
+      - r5ad.xlarge
       - r5d.12xlarge
       - r5d.16xlarge
       - r5d.24xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.8xlarge
+      - r5d.large
       - r5d.metal
-      - r5dn.large
-      - r5dn.xlarge
-      - r5dn.2xlarge
-      - r5dn.4xlarge
-      - r5dn.8xlarge
+      - r5d.xlarge
       - r5dn.12xlarge
       - r5dn.16xlarge
       - r5dn.24xlarge
-      - r5n.large
-      - r5n.xlarge
-      - r5n.2xlarge
-      - r5n.4xlarge
-      - r5n.8xlarge
+      - r5dn.2xlarge
+      - r5dn.4xlarge
+      - r5dn.8xlarge
+      - r5dn.large
+      - r5dn.xlarge
       - r5n.12xlarge
       - r5n.16xlarge
       - r5n.24xlarge
-      - r6g.medium
-      - r6g.large
-      - r6g.xlarge
+      - r5n.2xlarge
+      - r5n.4xlarge
+      - r5n.8xlarge
+      - r5n.large
+      - r5n.xlarge
+      - r6g.12xlarge
+      - r6g.16xlarge
       - r6g.2xlarge
       - r6g.4xlarge
       - r6g.8xlarge
-      - r6g.12xlarge
-      - r6g.16xlarge
+      - r6g.large
+      - r6g.medium
       - r6g.metal
-      - r6gd.medium
-      - r6gd.large
-      - r6gd.xlarge
+      - r6g.xlarge
+      - r6gd.12xlarge
+      - r6gd.16xlarge
       - r6gd.2xlarge
       - r6gd.4xlarge
       - r6gd.8xlarge
-      - r6gd.12xlarge
-      - r6gd.16xlarge
+      - r6gd.large
+      - r6gd.medium
       - r6gd.metal
+      - r6gd.xlarge
       - t1.micro
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - t2.xlarge
       - t2.2xlarge
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
+      - t2.large
+      - t2.medium
+      - t2.micro
+      - t2.nano
+      - t2.small
+      - t2.xlarge
       - t3.2xlarge
-      - t3a.nano
-      - t3a.micro
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
+      - t3.large
+      - t3.medium
+      - t3.micro
+      - t3.nano
+      - t3.small
+      - t3.xlarge
       - t3a.2xlarge
+      - t3a.large
+      - t3a.medium
+      - t3a.micro
+      - t3a.nano
+      - t3a.small
+      - t3a.xlarge
+      - u-12tb1.metal
       - u-6tb1.metal
       - u-9tb1.metal
-      - u-12tb1.metal
       - x1.16xlarge
       - x1.32xlarge
-      - x1e.xlarge
+      - x1e.16xlarge
       - x1e.2xlarge
+      - x1e.32xlarge
       - x1e.4xlarge
       - x1e.8xlarge
-      - x1e.16xlarge
-      - x1e.32xlarge
-      - z1d.large
-      - z1d.xlarge
+      - x1e.xlarge
+      - z1d.12xlarge
       - z1d.2xlarge
       - z1d.3xlarge
       - z1d.6xlarge
-      - z1d.12xlarge
+      - z1d.large
       - z1d.metal
+      - z1d.xlarge
     ConstraintDescription: Must be a valid EC2 instance type
     Description: EC2 instance type for the node instances
 

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -421,6 +421,15 @@ Parameters:
       - r5ad.8xlarge
       - r5ad.large
       - r5ad.xlarge
+      - r5b.12xlarge
+      - r5b.16xlarge
+      - r5b.24xlarge
+      - r5b.2xlarge
+      - r5b.4xlarge
+      - r5b.8xlarge
+      - r5b.large
+      - r5b.metal
+      - r5b.xlarge
       - r5d.12xlarge
       - r5d.16xlarge
       - r5d.24xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -276,6 +276,7 @@ Parameters:
       - i3en.3xlarge
       - i3en.6xlarge
       - i3en.large
+      - i3en.metal
       - i3en.xlarge
       - inf1.24xlarge
       - inf1.2xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -564,7 +564,7 @@ Parameters:
 
   NodeVolumeSize:
     Type: Number
-    Default: 0
+    Default: 0 # Note: defaulted to no value when 0.
     Description: Node volume size
 
   StackTags:
@@ -597,7 +597,6 @@ Parameters:
     Type: "AWS::EC2::VPC::Id"
     Description: The VPC of the worker instances
 
-
 Mappings:
   PartitionMap:
     aws:
@@ -617,8 +616,8 @@ Conditions:
 
   HasNodeImageId: !Not
     - "Fn::Equals":
-        - !Ref NodeImageId
-        - ""
+      - !Ref NodeImageId
+      - ""
 
   IMDSv1Disabled:
     "Fn::Equals":
@@ -634,8 +633,7 @@ Conditions:
   NodeVolumeSizeAuto: !Equals [ !Ref NodeVolumeSize, 0 ]
 
 Resources:
-  # Note: we are using preinitialized node instance roles, possibly specified by
-  # the end user.
+  # Note: using preinitialized, possibly user defined node instance roles.
   #
   # NodeInstanceRole:
   #   Type: "AWS::IAM::Role"
@@ -646,11 +644,7 @@ Resources:
   #         - Effect: Allow
   #           Principal:
   #             Service:
-  #               - !FindInMap [
-  #                   PartitionMap,
-  #                   !Ref "AWS::Partition",
-  #                   EC2ServicePrincipal,
-  #                 ]
+  #               - !FindInMap [PartitionMap, !Ref "AWS::Partition", EC2ServicePrincipal]
   #           Action:
   #             - "sts:AssumeRole"
   #     ManagedPolicyArns:
@@ -666,8 +660,7 @@ Resources:
       Roles:
         - !Ref NodeInstanceRoleId # Note: deliberately custom parameter.
 
-  # Note: we are using a preinitialized node security group parameter, possibly
-  # specified by the end user.
+  # Note: using a preinitialized, possibly user defined  node security groups.
   #
   # NodeSecurityGroup:
   #   Type: "AWS::EC2::SecurityGroup"
@@ -711,12 +704,11 @@ Resources:
       IpProtocol: "-1" # Note: deliberately using all protocols and all ports.
       ToPort: 65535
 
-  # Note: unused because ControlPlaneEgressToNodeSecurityGroup allows all
-  # protocols and ports.
+  # Note: unused because all protocols and ports are allowed in ControlPlaneEgressToNodeSecurityGroup.
   #
   # ControlPlaneEgressToNodeSecurityGroupOn443:
   #   Type: "AWS::EC2::SecurityGroupEgress"
-  # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
+  #   DependsOn: NodeSecurityGroup
   #   Properties:
   #     Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
   #     DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -736,12 +728,11 @@ Resources:
       SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
       ToPort: 65535
 
-  # Note: unused because NodeSecurityGroupFromControlPlaneIngress allows all
-  # protocols and ports.
+  # Note: unused because all protocols and ports are allowed in NodeSecurityGroupFromControlPlaneIngress.
   #
   # NodeSecurityGroupFromControlPlaneOn443Ingress:
   #   Type: "AWS::EC2::SecurityGroupIngress"
-  # DependsOn: NodeSecurityGroup # Note: NodeSecurityGroup is preinitialized.
+  #   DependsOn: NodeSecurityGroup
   #   Properties:
   #     Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
   #     FromPort: 443
@@ -915,6 +906,7 @@ Outputs:
   #   Value: !GetAtt NodeInstanceRole.Arn
 
   # Note: node security group is preinitialized.
+  #
   # NodeSecurityGroup:
   #   Description: The security group for the node group
   #   Value: !Ref NodeSecurityGroup

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -414,9 +414,11 @@ Parameters:
       - r5a.large
       - r5a.xlarge
       - r5ad.12xlarge
+      - r5ad.16xlarge
       - r5ad.24xlarge
       - r5ad.2xlarge
       - r5ad.4xlarge
+      - r5ad.8xlarge
       - r5ad.large
       - r5ad.xlarge
       - r5d.12xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -455,6 +455,7 @@ Parameters:
       - r5n.4xlarge
       - r5n.8xlarge
       - r5n.large
+      - r5n.metal
       - r5n.xlarge
       - r6g.12xlarge
       - r6g.16xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -497,6 +497,13 @@ Parameters:
       - t3a.nano
       - t3a.small
       - t3a.xlarge
+      - t4g.2xlarge
+      - t4g.large
+      - t4g.medium
+      - t4g.micro
+      - t4g.nano
+      - t4g.small
+      - t4g.xlarge
       - u-12tb1.metal
       - u-6tb1.metal
       - u-9tb1.metal

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -211,6 +211,14 @@ Parameters:
       - c6gd.medium
       - c6gd.metal
       - c6gd.xlarge
+      - c6gn.12xlarge
+      - c6gn.16xlarge
+      - c6gn.2xlarge
+      - c6gn.4xlarge
+      - c6gn.8xlarge
+      - c6gn.large
+      - c6gn.medium
+      - c6gn.xlarge
       - cc2.8xlarge
       - cr1.8xlarge
       - d2.2xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -511,6 +511,7 @@ Parameters:
       - u-6tb1.112xlarge
       - u-6tb1.56xlarge
       - u-6tb1.metal
+      - u-9tb1.112xlarge
       - u-9tb1.metal
       - x1.16xlarge
       - x1.32xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -384,6 +384,7 @@ Parameters:
       - p3.2xlarge
       - p3.8xlarge
       - p3dn.24xlarge
+      - p4d.24xlarge
       - r3.2xlarge
       - r3.4xlarge
       - r3.8xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -130,7 +130,7 @@ Parameters:
 
   NodeInstanceType:
     Type: String
-    Default: t2.medium
+    Default: t3.medium
     AllowedValues:
       - a1.2xlarge
       - a1.4xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -376,6 +376,7 @@ Parameters:
       - m6gd.medium
       - m6gd.metal
       - m6gd.xlarge
+      - mac1.metal
       - p2.16xlarge
       - p2.8xlarge
       - p2.xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -65,13 +65,6 @@ Parameters:
     Default: ""
     Description: Comma separated list of security groups for all nodes in the pool.
 
-  DisableIMDSv1:
-    Type: String
-    Default: "false"
-    AllowedValues:
-      - "false"
-      - "true"
-
   KeyName:
     Type: String # Note: not using "AWS::EC2::KeyPair::KeyName", because it implicitly validates the value to existing keys and we want to allow using the empty value as well, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html .
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -127,6 +120,13 @@ Parameters:
   NodeInstanceRoleId:
     Type: String
     Description: The role for node IAM profile
+
+  DisableIMDSv1:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "false"
+      - "true"
 
   NodeInstanceType:
     Type: String

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -136,6 +136,7 @@ Parameters:
       - a1.4xlarge
       - a1.large
       - a1.medium
+      - a1.metal
       - a1.xlarge
       - c1.medium
       - c1.xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -521,6 +521,15 @@ Parameters:
       - x1e.4xlarge
       - x1e.8xlarge
       - x1e.xlarge
+      - x2gd.12xlarge
+      - x2gd.16xlarge
+      - x2gd.2xlarge
+      - x2gd.4xlarge
+      - x2gd.8xlarge
+      - x2gd.large
+      - x2gd.medium
+      - x2gd.metal
+      - x2gd.xlarge
       - z1d.12xlarge
       - z1d.2xlarge
       - z1d.3xlarge

--- a/templates/eks/amazon-eks-nodepool-cf.yaml
+++ b/templates/eks/amazon-eks-nodepool-cf.yaml
@@ -508,6 +508,8 @@ Parameters:
       - u-12tb1.metal
       - u-18tb1.metal
       - u-24tb1.metal
+      - u-6tb1.112xlarge
+      - u-6tb1.56xlarge
       - u-6tb1.metal
       - u-9tb1.metal
       - x1.16xlarge


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated EKS node pool CloudFormation template.
1. Added last used upstream reference link.
2. Fixed ordering of upstream parameters to upstream order.
3. Fixed node instance type ordering to upstream order (now alphabetical, previously it was custom based on instance family and size).
4. **Updated the template default node instance type t2.medium->t3.medium. This value is currently not used, because instance type is a required argument of node pool creation configuration.**
5. Added new instance types according to upstream.
6. Fixed formatting (including comment explanations) to upstream.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To be up to date with the latest upstream AWS EKS node pool CloudFormation template, currently located [here](https://github.com/awslabs/amazon-eks-ami/blob/master/amazon-eks-nodegroup.yaml).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
