### PR TITLE
Create and update core-dns as an EKS addon

### DIFF
--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -193,5 +193,8 @@ func registerEKSWorkflows(
 	eksworkflow2.NewUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)
 	eksworkflow2.NewWaitUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)
 
+	eksworkflow2.NewUpdateAddonActivity(awsSessionFactory, eksFactory).Register(worker)
+	eksworkflow2.NewWaitUpdateAddonActivity(awsSessionFactory, eksFactory).Register(worker)
+
 	return nil
 }

--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -121,7 +121,7 @@ func registerEKSWorkflows(
 	createUserAccessKeyActivity := eksworkflow.NewCreateClusterUserAccessKeyActivity(awsSessionFactory)
 	worker.RegisterActivityWithOptions(createUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: eksworkflow.CreateClusterUserAccessKeyActivityName})
 
-	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory)
+	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory, config.Distribution.EKS.EnableAddons)
 	worker.RegisterActivityWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: eksworkflow.BootstrapActivityName})
 
 	saveK8sConfigActivity := eksworkflow.NewSaveK8sConfigActivity(awsSessionFactory, clusterManager)

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -395,6 +395,8 @@ dex:
 #        exposeAdminKubeconfig: true
 #        ssh:
 #            generate: true
+#        # Enable create & update of EKS addons like coredns
+#        enableAddons: true
 #
 #    pke:
 #        amazon:

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -396,7 +396,7 @@ dex:
 #        ssh:
 #            generate: true
 #        # Enable create & update of EKS addons like coredns
-#        enableAddons: true
+#        enableAddons: false
 #
 #    pke:
 #        amazon:

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -184,6 +184,7 @@ func (a *BootstrapActivity) Execute(ctx context.Context, input BootstrapActivity
 		return nil, errors.Wrap(err, "failed to update CNI driver daemonset")
 	}
 
+	// TODO: check feature flag and K8s version
 	logger.Info("create add-on for cluster : " + (input.ClusterName))
 
 	coreDnsAddOnInput := &eks.CreateAddonInput{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"time"
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver/v3"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/ghodss/yaml"
@@ -187,8 +187,8 @@ func (a *BootstrapActivity) Execute(ctx context.Context, input BootstrapActivity
 	logger.Info("create add-on for cluster : " + (input.ClusterName))
 
 	coreDnsAddOnInput := &eks.CreateAddonInput{
-		AddonName:   aws.String("coredns"),
-		ClusterName: aws.String(input.ClusterName),
+		AddonName:        aws.String("coredns"),
+		ClusterName:      aws.String(input.ClusterName),
 		ResolveConflicts: aws.String(eks.ResolveConflictsOverwrite),
 	}
 	addOnOutput, err := eksSvc.CreateAddon(coreDnsAddOnInput)

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -187,7 +187,7 @@ func (a *BootstrapActivity) Execute(ctx context.Context, input BootstrapActivity
 	}
 
 	// check add-on are enabled and K8s version is >= 1.18
-	constraint, err = semver.NewConstraint("~1.18")
+	constraint, err = semver.NewConstraint(">=1.18")
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not set 1.18 constraint for semver")
 	}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver/v3"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/ghodss/yaml"
 	"go.uber.org/cadence/activity"
@@ -181,6 +184,37 @@ func (a *BootstrapActivity) Execute(ctx context.Context, input BootstrapActivity
 		return nil, errors.Wrap(err, "failed to update CNI driver daemonset")
 	}
 
+	logger.Info("create add-on for cluster : " + (input.ClusterName))
+
+	coreDnsAddOnInput := &eks.CreateAddonInput{
+		AddonName:   aws.String("coredns"),
+		ClusterName: aws.String(input.ClusterName),
+		ResolveConflicts: aws.String(eks.ResolveConflictsOverwrite),
+	}
+	addOnOutput, err := eksSvc.CreateAddon(coreDnsAddOnInput)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceInUseException" {
+			logger.Info("addon created but: " + awsErr.Message())
+		} else {
+			return nil, errors.Wrap(err, "failed to create coredns add-on")
+		}
+	} else {
+		logger.Info("addon created with status: " + addOnOutput.Addon.String())
+	}
+
+	logger.Info("waiting for add-on creation")
+
+	describeAddonInput := &eks.DescribeAddonInput{
+		AddonName:   aws.String("coredns"),
+		ClusterName: aws.String(input.ClusterName),
+	}
+	err = waitUntilAddOnCreateCompleteWithContext(eksSvc, ctx, describeAddonInput)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("add-on created successfully")
+
 	outParams := BootstrapActivityOutput{}
 	return &outParams, nil
 }
@@ -258,4 +292,59 @@ func createDefaultStorageClass(ctx context.Context, kubernetesClient *kubernetes
 	}
 
 	return nil
+}
+
+func waitUntilAddOnCreateCompleteWithContext(eksSvc *eks.EKS, ctx aws.Context, input *eks.DescribeAddonInput, opts ...request.WaiterOption) error {
+	// wait for 15 mins
+	count := 0
+	w := request.Waiter{
+		Name:        "WaitUntilAddOnCreateCompleteWithContext",
+		MaxAttempts: 30,
+		Delay:       request.ConstantWaiterDelay(30 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusActive,
+			},
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusDegraded,
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusDeleting,
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusCreateFailed,
+			},
+			{
+				State:    request.FailureWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+		},
+		Logger: eksSvc.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
+			var inCpy *eks.DescribeAddonInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := eksSvc.DescribeAddonRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
 }

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
@@ -71,7 +71,7 @@ func (s *CreateInfraWorkflowTestSuite) SetupTest() {
 	createUserAccessKeyActivity := NewCreateClusterUserAccessKeyActivity(nil)
 	s.env.RegisterActivityWithOptions(createUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: CreateClusterUserAccessKeyActivityName})
 
-	bootstrapActivity := NewBootstrapActivity(nil)
+	bootstrapActivity := NewBootstrapActivity(nil, true)
 	s.env.RegisterActivityWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: BootstrapActivityName})
 
 	saveClusterActivity := NewSaveNetworkDetailsActivity(nil)

--- a/internal/cluster/distribution/eks/eksworkflow/BUILD.plz
+++ b/internal/cluster/distribution/eks/eksworkflow/BUILD.plz
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sdk/providers/amazon/cloudformation",
         "//pkg/sdk/semver",
         "//third_party/go:emperror.dev__errors",
+        "//third_party/go:github.com__Masterminds__semver__v3",
         "//third_party/go:github.com__aws__aws-sdk-go__aws",
         "//third_party/go:github.com__aws__aws-sdk-go__aws__awserr",
         "//third_party/go:github.com__aws__aws-sdk-go__aws__request",
@@ -31,5 +32,17 @@ go_library(
         "//third_party/go:go.uber.org__cadence",
         "//third_party/go:go.uber.org__cadence__activity",
         "//third_party/go:go.uber.org__cadence__workflow",
+    ],
+)
+
+go_test(
+    name = "test",
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":eksworkflow",
+        "//third_party/go:github.com__aws__aws-sdk-go__aws",
+        "//third_party/go:github.com__aws__aws-sdk-go__service__eks",
+        "//third_party/go:github.com__stretchr__testify__assert",
+        "//third_party/go:github.com__stretchr__testify__require",
     ],
 )

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
@@ -92,7 +92,7 @@ func (a *UpdateAddonActivity) Execute(ctx context.Context, input UpdateAddonActi
 		ClusterName: aws.String(input.ClusterName),
 	}
 	addonOutput, err := eksSvc.DescribeAddon(describeAddonInput)
-	addonNotFoundErrMsg := fmt.Sprintf("No addon: %s found in cluster: %s", input.AddonName, input.ClusterName)
+	addonNotFoundErrMsg := fmt.Sprintf("No %s addon found in cluster: %s", input.AddonName, input.ClusterName)
 	if err != nil {
 		var awsErr awserr.Error
 		if errors.As(err, &awsErr) {

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
@@ -179,7 +179,7 @@ func versionIsCompatible(compatibilities []*eks.Compatibility, kubernetesVersion
 		if c.ClusterVersion == nil {
 			continue
 		}
-		if kubernetesVersion == *c.ClusterVersion {
+		if *c.ClusterVersion == kubernetesVersion {
 			return true
 		}
 	}

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
@@ -1,0 +1,172 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eksworkflow
+
+import (
+	"context"
+	"fmt"
+
+	"emperror.dev/errors"
+	"github.com/Masterminds/semver/v3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
+	"github.com/banzaicloud/pipeline/pkg/cadence/worker"
+)
+
+const UpdateAddonActivityName = "eks-update-addon"
+
+// UpdateAddonActivity responsible for updating an EKS addon
+// Addon is updated only in case it's already enable on cluster and there's a newer version available
+// for given Kubernetes version.
+type UpdateAddonActivity struct {
+	awsSessionFactory awsworkflow.AWSFactory
+	eksFactory        workflow.EKSAPIFactory
+}
+
+// UpdateAddonActivityInput holds data needed for updating an EKS addon
+type UpdateAddonActivityInput struct {
+	OrganizationID    uint
+	ProviderSecretID  string
+	Region            string
+	ClusterID         uint
+	ClusterName       string
+	KubernetesVersion string
+
+	AddonName string
+}
+
+// UpdateAddonActivityOutput holds the output data of the UpdateAddonActivityOutput
+type UpdateAddonActivityOutput struct {
+	UpdateID string
+}
+
+// NewUpdateAddonActivity instantiates a new EKS addon version update
+func NewUpdateAddonActivity(
+	awsSessionFactory awsworkflow.AWSFactory, eksFactory workflow.EKSAPIFactory,
+) *UpdateAddonActivity {
+	return &UpdateAddonActivity{
+		awsSessionFactory: awsSessionFactory,
+		eksFactory:        eksFactory,
+	}
+}
+
+// Register registers the activity in the worker.
+func (a UpdateAddonActivity) Register(worker worker.Registry) {
+	worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: UpdateAddonActivityName})
+}
+
+func (a *UpdateAddonActivity) Execute(ctx context.Context, input UpdateAddonActivityInput) (*UpdateAddonActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+		"region", input.Region,
+		"addonName", input.AddonName,
+	)
+
+	session, err := a.awsSessionFactory.New(input.OrganizationID, input.ProviderSecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+
+	eksSvc := a.eksFactory.New(session)
+
+	describeAddonInput := &eks.DescribeAddonInput{
+		AddonName:   aws.String(input.AddonName),
+		ClusterName: aws.String(input.ClusterName),
+	}
+	addonOutput, err := eksSvc.DescribeAddon(describeAddonInput)
+	addonNotFoundErrMsg := fmt.Sprintf("No addon: %s found in cluster: %s", input.AddonName, input.ClusterName)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			err = errors.New(awsErr.Message())
+		}
+		if err.Error() == addonNotFoundErrMsg {
+			logger.Infof(addonNotFoundErrMsg)
+			return &UpdateAddonActivityOutput{UpdateID: ""}, nil
+		}
+		return nil, errors.WrapIfWithDetails(err, "failed to retrieve addon", "cluster", input.ClusterName, "addon", input.AddonName)
+	}
+
+	currentVersion := *addonOutput.Addon.AddonVersion
+	logger.Infof("addon current version: %v", currentVersion)
+
+	describeAddonVersionInput := &eks.DescribeAddonVersionsInput{
+		AddonName:         aws.String(input.AddonName),
+		KubernetesVersion: aws.String(input.KubernetesVersion),
+	}
+	addonVersionsOutput, err := eksSvc.DescribeAddonVersions(describeAddonVersionInput)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			err = errors.New(awsErr.Message())
+		}
+		return nil, errors.WrapIfWithDetails(err, "failed to retrieve addon versions", "cluster", input.ClusterName, "addon", input.AddonName)
+	}
+
+	selectedVersion, err := selectLatestVersion(addonVersionsOutput, currentVersion)
+	if err != nil {
+		return nil, errors.WrapIfWithDetails(err, "error selecting new version", "cluster", input.ClusterName, "addon", input.AddonName)
+	}
+	if selectedVersion == currentVersion {
+		logger.Infof("no newer version available then current version: %s", currentVersion)
+		return &UpdateAddonActivityOutput{UpdateID: ""}, nil
+	}
+
+	logger.Infof("update addon to selected version: %v", selectedVersion)
+	updateAddonInput := &eks.UpdateAddonInput{
+		AddonName:        aws.String(input.AddonName),
+		ClusterName:      aws.String(input.ClusterName),
+		ResolveConflicts: aws.String(eks.ResolveConflictsOverwrite),
+		AddonVersion:     aws.String(selectedVersion),
+	}
+	updateAddonOutput, err := eksSvc.UpdateAddon(updateAddonInput)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			err = errors.New(awsErr.Message())
+		}
+		return nil, errors.WrapIfWithDetails(err, "failed to update addon", "cluster", input.ClusterName, "addon", input.AddonName)
+	}
+	output := UpdateAddonActivityOutput{UpdateID: aws.StringValue(updateAddonOutput.Update.Id)}
+
+	return &output, nil
+}
+
+func selectLatestVersion(addonVersions *eks.DescribeAddonVersionsOutput, currentVersion string) (string, error) {
+	currentVersionSemver, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return "", err
+	}
+	latestVersion := currentVersionSemver
+
+	for _, addon := range addonVersions.Addons {
+		for _, version := range addon.AddonVersions {
+			newVersion, err := semver.NewVersion(*version.AddonVersion)
+			if err != nil {
+				return "", err
+			}
+			if newVersion.GreaterThan(latestVersion) {
+				latestVersion = newVersion
+			}
+		}
+	}
+	return latestVersion.Original(), nil
+}

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon_test.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eksworkflow
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectLatestVersion(t *testing.T) {
+	addonVersions := &eks.DescribeAddonVersionsOutput{
+		Addons: []*eks.AddonInfo{
+			{
+				AddonName: aws.String("coredns"),
+				AddonVersions: []*eks.AddonVersionInfo{
+					{
+						AddonVersion: aws.String("v1.7.0-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.18"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.8.0-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.18"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.8.3-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.18"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.8.5-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.19"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("latest version is selected for 1.18", func(t *testing.T) {
+		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.18")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.8.3-eksbuild.1", version)
+	})
+
+	t.Run("latest version is selected for 1.19", func(t *testing.T) {
+		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.19")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.8.5-eksbuild.1", version)
+	})
+
+	t.Run("no available new version", func(t *testing.T) {
+		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.20")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.7.0-eksbuild.1", version)
+	})
+}

--- a/internal/cluster/distribution/eks/eksworkflow/activity_wait_update_addon.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_wait_update_addon.go
@@ -1,0 +1,107 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eksworkflow
+
+import (
+	"context"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/workflow"
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
+	"github.com/banzaicloud/pipeline/pkg/cadence/worker"
+)
+
+const WaitUpdateAddonActivityName = "eks-wait-update-addon"
+
+// WaitUpdateAddonActivity responsible for updating an EKS addon
+type WaitUpdateAddonActivity struct {
+	awsSessionFactory awsworkflow.AWSFactory
+	eksFactory        workflow.EKSAPIFactory
+}
+
+// WaitUpdateAddonActivityInput holds data needed for waiting for an EKS addon update
+type WaitUpdateAddonActivityInput struct {
+	Region           string
+	OrganizationID   uint
+	ProviderSecretID string
+	ClusterName      string
+	AddonName        string
+
+	UpdateID string
+}
+
+// NewWaitUpdateAddonActivity instantiates a new EKS addon update waiting activity
+func NewWaitUpdateAddonActivity(
+	awsSessionFactory awsworkflow.AWSFactory, eksFactory workflow.EKSAPIFactory,
+) *WaitUpdateAddonActivity {
+	return &WaitUpdateAddonActivity{
+		awsSessionFactory: awsSessionFactory,
+		eksFactory:        eksFactory,
+	}
+}
+
+// Register registers the activity in the worker.
+func (a WaitUpdateAddonActivity) Register(worker worker.Registry) {
+	worker.RegisterActivityWithOptions(a.Execute, activity.RegisterOptions{Name: WaitUpdateAddonActivityName})
+}
+
+func (a *WaitUpdateAddonActivity) Execute(ctx context.Context, input WaitUpdateAddonActivityInput) error {
+	session, err := a.awsSessionFactory.New(input.OrganizationID, input.ProviderSecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return err
+	}
+
+	eksSvc := a.eksFactory.New(session)
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			describeUpdateInput := &eks.DescribeUpdateInput{
+				Name:      aws.String(input.ClusterName),
+				UpdateId:  aws.String(input.UpdateID),
+				AddonName: aws.String(input.AddonName),
+			}
+			describeUpdateOutput, err := eksSvc.DescribeUpdate(describeUpdateInput)
+			if err != nil {
+				return errors.WrapIfWithDetails(err, "failed to execute describe eks addon update", "cluster", input.ClusterName, "addon", input.AddonName)
+			}
+
+			switch aws.StringValue(describeUpdateOutput.Update.Status) {
+			case eks.UpdateStatusCancelled:
+				return errors.NewWithDetails("eks addon update cancelled", "cluster", input.ClusterName)
+			case eks.UpdateStatusFailed:
+				var err error
+				for _, e := range describeUpdateOutput.Update.Errors {
+					err = errors.Combine(err, errors.New(aws.StringValue(e.ErrorMessage)))
+				}
+
+				return errors.WrapIfWithDetails(err, "eks addon update failed", "cluster", input.ClusterName)
+			case eks.UpdateStatusSuccessful:
+				return nil
+			}
+
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -72,6 +72,7 @@ type Config struct {
 			SSH                   struct {
 				Generate bool
 			}
+			EnableAddons bool
 		}
 
 		PKE struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3529 
| License         | Apache 2.0


### What's in this PR?
- EKS bootstrap activity: create `coredns` addon  if configuration property `distribution.eks.enableAddons` is set true and kubernetes version is >= 1.18.
- add eks-update-addon activity to update addon to the latest available version
- add eks-wait-update-addon acitvity to wait for update to finish
- cluster update: upgrade coredns to the latest available version in case it's already present on cluster

### Why?
Add possibility of creating and updating core-dns as an EKS addon.

### Additional information

To manage EKS addons the following privileges has to added to minimum privileges required to provision an EKS cluster with Banzai Cloud Pipeline:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "eks:CreateAddon",
                "eks:UpdateAddon",
                "eks:DescribeAddon",
                "eks:DescribeAddonVersions"
              ],
              "Resource": [
                  "*"
              ]
          }
      ]
  }
```
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
