### PR TITLE
Revert "Save K8s config right after EKSCluster create has completed (…

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra.go
@@ -317,23 +317,6 @@ func (w CreateInfrastructureWorkflow) Execute(ctx workflow.Context, input Create
 		}
 	}
 
-	var configSecretID string
-	{
-		activityInput := SaveK8sConfigActivityInput{
-			ClusterID:        input.ClusterID,
-			ClusterUID:       input.ClusterUID,
-			ClusterName:      input.ClusterName,
-			OrganizationID:   input.OrganizationID,
-			ProviderSecretID: input.SecretID,
-			UserSecretID:     userAccessKeyActivityOutput.SecretID,
-			Region:           input.Region,
-		}
-		future := workflow.ExecuteActivity(ctx, SaveK8sConfigActivityName, activityInput)
-		if err := future.Get(ctx, &configSecretID); err != nil {
-			return nil, err
-		}
-	}
-
 	// initial setup of K8s cluster
 	var bootstrapActivityFeature workflow.Future
 	{
@@ -417,6 +400,23 @@ func (w CreateInfrastructureWorkflow) Execute(ctx workflow.Context, input Create
 	bootstrapActivityOutput := &BootstrapActivityOutput{}
 	if err := bootstrapActivityFeature.Get(ctx, &bootstrapActivityOutput); err != nil {
 		return nil, err
+	}
+
+	var configSecretID string
+	{
+		activityInput := SaveK8sConfigActivityInput{
+			ClusterID:        input.ClusterID,
+			ClusterUID:       input.ClusterUID,
+			ClusterName:      input.ClusterName,
+			OrganizationID:   input.OrganizationID,
+			ProviderSecretID: input.SecretID,
+			UserSecretID:     userAccessKeyActivityOutput.SecretID,
+			Region:           input.Region,
+		}
+		future := workflow.ExecuteActivity(ctx, SaveK8sConfigActivityName, activityInput)
+		if err := future.Get(ctx, &configSecretID); err != nil {
+			return nil, err
+		}
 	}
 
 	output := CreateInfrastructureWorkflowOutput{


### PR DESCRIPTION
…#3526)"

This reverts commit a99fdfa54e9e850cdb55606f20445a4b75206b55.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3528 
| License         | Apache 2.0


### What's in this PR?
Revert https://github.com/banzaicloud/pipeline/pull/3526

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

