### PR TITLE
Handle container images over 2GB size returned from `ListNodes`

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -23510,6 +23510,7 @@ components:
           type: array
         sizeBytes:
           example: 286572743
+          format: int64
           type: integer
     NodeItem_status:
       example:

--- a/.gen/pipeline/pipeline/model_node_item_status_images.go
+++ b/.gen/pipeline/pipeline/model_node_item_status_images.go
@@ -14,5 +14,5 @@ type NodeItemStatusImages struct {
 
 	Name []string `json:"name,omitempty"`
 
-	SizeBytes int32 `json:"sizeBytes,omitempty"`
+	SizeBytes int64 `json:"sizeBytes,omitempty"`
 }

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -5675,6 +5675,7 @@ components:
                                             type: string
                                         example: ["asia.gcr.io/google_containers/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e", "eu.gcr.io/google_containers/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe"]
                                     sizeBytes:
+                                        format: int64
                                         type: integer
                                         example: 286572743
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Changed the node's container image's `sizeBytes` property in the API spec from `int32` to `int64` and regenerated the corresponding model in order to handle node images over 2GB size returned from `ListNodes`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

A customer tried to use a 8.3 GB container image and the node listing API returns a parsing error because the byte size cannot fit into the Golang `int32` type during the internal parsing.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Related to https://github.com/banzaicloud/banzai-cli/pull/348.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
