### PR TITLE
Add vpc-cni and kube-proxy addons in cluster create flow

### DIFF
--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -195,7 +195,7 @@ func registerEKSWorkflows(
 	eksworkflow2.NewWaitCloudFormationStackUpdateActivity(awsSessionFactory).Register(worker)
 
 	// New cluster update
-	eksworkflow2.NewUpdateClusterWorkflow(config.Distribution.EKS.EnableAddons).Register(worker)
+	eksworkflow2.NewUpdateClusterWorkflow().Register(worker)
 
 	eksworkflow2.NewUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)
 	eksworkflow2.NewWaitUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)

--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -122,8 +122,14 @@ func registerEKSWorkflows(
 	createUserAccessKeyActivity := eksworkflow.NewCreateClusterUserAccessKeyActivity(awsSessionFactory)
 	worker.RegisterActivityWithOptions(createUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: eksworkflow.CreateClusterUserAccessKeyActivityName})
 
-	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory, config.Distribution.EKS.EnableAddons)
+	bootstrapWorkflow := eksworkflow.NewBootstrapWorkflow(awsSessionFactory, config.Distribution.EKS.EnableAddons)
+	worker.RegisterWorkflowWithOptions(bootstrapWorkflow.Execute, workflow.RegisterOptions{Name: eksworkflow.BootstrapWorkflowName})
+
+	bootstrapActivity := eksworkflow.NewBootstrapActivity(awsSessionFactory)
 	worker.RegisterActivityWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: eksworkflow.BootstrapActivityName})
+
+	createAddonActivity := eksworkflow.NewCreateAddonActivity(awsSessionFactory)
+	worker.RegisterActivityWithOptions(createAddonActivity.Execute, activity.RegisterOptions{Name: eksworkflow.CreateAddonActivityName})
 
 	saveK8sConfigActivity := eksworkflow.NewSaveK8sConfigActivity(awsSessionFactory, clusterManager)
 	worker.RegisterActivityWithOptions(saveK8sConfigActivity.Execute, activity.RegisterOptions{Name: eksworkflow.SaveK8sConfigActivityName})

--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_workflow.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_workflow.go
@@ -1,0 +1,139 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/Masterminds/semver/v3"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/workflow"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
+	pkgCadence "github.com/banzaicloud/pipeline/pkg/cadence"
+)
+
+const BootstrapWorkflowName = "eks-bootstrap-flow"
+
+// BootstrapWorkflow creates EKS addons and other EKS related configs
+type BootstrapWorkflow struct {
+	awsSessionFactory *awsworkflow.AWSSessionFactory
+	enableAddons      bool
+}
+
+// BootstrapWorkflowInput holds input data
+type BootstrapWorkflowInput struct {
+	EKSActivityInput
+
+	KubernetesVersion   string
+	NodeInstanceRoleArn string
+	ClusterUserArn      string
+	AuthConfigMap       string
+}
+
+// NewBootstrapWorkflow instantiates a new BootstrapWorkflow
+func NewBootstrapWorkflow(awsSessionFactory *awsworkflow.AWSSessionFactory, enableAddons bool) *BootstrapWorkflow {
+	return &BootstrapWorkflow{
+		awsSessionFactory: awsSessionFactory,
+		enableAddons:      enableAddons,
+	}
+}
+
+func (a *BootstrapWorkflow) Execute(ctx workflow.Context, input BootstrapWorkflowInput) error {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: 10 * time.Minute,
+		StartToCloseTimeout:    5 * time.Minute,
+		WaitForCancellation:    true,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:    2 * time.Second,
+			BackoffCoefficient: 1.5,
+			MaximumInterval:    30 * time.Second,
+			MaximumAttempts:    5,
+		},
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	commonActivityInput := EKSActivityInput{
+		OrganizationID: input.OrganizationID,
+		SecretID:       input.SecretID,
+		Region:         input.Region,
+		ClusterName:    input.ClusterName,
+	}
+
+	// install EKS addons
+
+	// check add-on are enabled and K8s version is >= 1.18
+	constraint, err := semver.NewConstraint(">=1.18")
+	if err != nil {
+		return errors.WrapIf(err, "could not set 1.18 constraint for semver")
+	}
+	kubeVersion, err := semver.NewVersion(input.KubernetesVersion)
+	if err != nil {
+		return errors.WrapIf(err, "could not set eks version for semver check")
+	}
+
+	enableAddonFutures := make([]workflow.Future, 0, 3)
+	enableAddonErrors := make([]error, 0, 3)
+	if a.enableAddons && constraint.Check(kubeVersion) {
+		enableAddonFutures = append(enableAddonFutures,
+			workflow.ExecuteActivity(ctx, CreateAddonActivityName,
+				CreateAddonActivityInput{
+					EKSActivityInput:  commonActivityInput,
+					KubernetesVersion: input.KubernetesVersion,
+					AddonName:         "coredns",
+				}),
+			workflow.ExecuteActivity(ctx, CreateAddonActivityName,
+				CreateAddonActivityInput{
+					EKSActivityInput:  commonActivityInput,
+					KubernetesVersion: input.KubernetesVersion,
+					AddonName:         "vpc-cni",
+				}),
+			workflow.ExecuteActivity(ctx, CreateAddonActivityName,
+				CreateAddonActivityInput{
+					EKSActivityInput:  commonActivityInput,
+					KubernetesVersion: input.KubernetesVersion,
+					AddonName:         "kube-proxy",
+				}),
+		)
+	}
+
+	for _, future := range enableAddonFutures {
+		enableAddonErrors = append(enableAddonErrors, pkgCadence.UnwrapError(future.Get(ctx, nil)))
+	}
+	if err := errors.Combine(enableAddonErrors...); err != nil {
+		return err
+	}
+
+	// initial setup of K8s cluster
+	{
+		activityInput := &BootstrapActivityInput{
+			EKSActivityInput:    commonActivityInput,
+			KubernetesVersion:   input.KubernetesVersion,
+			NodeInstanceRoleArn: input.NodeInstanceRoleArn,
+			ClusterUserArn:      input.ClusterUserArn,
+			AuthConfigMap:       input.AuthConfigMap,
+		}
+		bootstrapActivityOutput := &BootstrapActivityOutput{}
+		// wait for initial cluster setup to terminate
+		err = workflow.ExecuteActivity(ctx, BootstrapActivityName, activityInput).Get(ctx, &bootstrapActivityOutput)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
@@ -1,0 +1,170 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"go.uber.org/cadence/activity"
+
+	"github.com/banzaicloud/pipeline/internal/cluster/infrastructure/aws/awsworkflow"
+)
+
+const CreateAddonActivityName = "eks-create-addon"
+
+// CreateAddonActivity creates an EKS addon
+type CreateAddonActivity struct {
+	awsSessionFactory *awsworkflow.AWSSessionFactory
+}
+
+// CreateAddonActivityInput holds input data
+type CreateAddonActivityInput struct {
+	EKSActivityInput
+
+	KubernetesVersion string
+	AddonName         string
+}
+
+// CreateAddonActivityOutput holds the output data
+type CreateAddonActivityOutput struct {
+}
+
+// NewCreateAddonActivity instantiates a new CreateAddonActivity
+func NewCreateAddonActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *CreateAddonActivity {
+	return &CreateAddonActivity{
+		awsSessionFactory: awsSessionFactory,
+	}
+}
+
+func (a *CreateAddonActivity) Execute(ctx context.Context, input CreateAddonActivityInput) (*CreateAddonActivityOutput, error) {
+	logger := activity.GetLogger(ctx).Sugar().With(
+		"organization", input.OrganizationID,
+		"cluster", input.ClusterName,
+		"region", input.Region,
+		"version", input.KubernetesVersion,
+	)
+
+	awsSession, err := a.awsSessionFactory.New(input.OrganizationID, input.SecretID, input.Region)
+	if err = errors.WrapIf(err, "failed to create AWS session"); err != nil {
+		return nil, err
+	}
+	eksSvc := eks.New(
+		awsSession,
+		aws.NewConfig().
+			WithLogger(aws.LoggerFunc(
+				func(args ...interface{}) {
+					logger.Debug(args)
+				})).
+			WithLogLevel(aws.LogDebugWithHTTPBody),
+	)
+
+	logger = logger.With("addonName", input.AddonName)
+	logger.Info("create add-on for cluster : " + (input.ClusterName))
+	t := time.Now().Unix()
+
+	addOnInput := &eks.CreateAddonInput{
+		AddonName:        aws.String(input.AddonName),
+		ClusterName:      aws.String(input.ClusterName),
+		ResolveConflicts: aws.String(eks.ResolveConflictsOverwrite),
+	}
+	addOnOutput, err := eksSvc.CreateAddon(addOnInput)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceInUseException" {
+			logger.Info("addon created but: " + awsErr.Message())
+		} else {
+			return nil, errors.Wrap(err, "failed to create coredns add-on")
+		}
+	} else {
+		logger.Info("addon created with status: " + addOnOutput.Addon.String())
+	}
+
+	logger.Info("waiting for add-on creation")
+
+	describeAddonInput := &eks.DescribeAddonInput{
+		AddonName:   aws.String(input.AddonName),
+		ClusterName: aws.String(input.ClusterName),
+	}
+	err = waitUntilAddOnCreateCompleteWithContext(eksSvc, ctx, describeAddonInput)
+	if err != nil {
+		return nil, err
+	}
+
+	t = time.Now().Unix() - t
+	logger.Infof("add-on created successfully in %v secs", t)
+
+	outParams := CreateAddonActivityOutput{}
+	return &outParams, nil
+}
+
+func waitUntilAddOnCreateCompleteWithContext(eksSvc *eks.EKS, ctx aws.Context, input *eks.DescribeAddonInput, opts ...request.WaiterOption) error {
+	// wait for 15 mins
+	count := 0
+	w := request.Waiter{
+		Name:        "WaitUntilAddOnCreateCompleteWithContext",
+		MaxAttempts: 30,
+		Delay:       request.ConstantWaiterDelay(10 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusActive,
+			},
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusDegraded,
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusDeleting,
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Addon.Status",
+				Expected: eks.AddonStatusCreateFailed,
+			},
+			{
+				State:    request.FailureWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "ValidationError",
+			},
+		},
+		Logger: eksSvc.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			count++
+			activity.RecordHeartbeat(ctx, count)
+
+			var inCpy *eks.DescribeAddonInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := eksSvc.DescribeAddonRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
@@ -77,7 +77,7 @@ func (a *CreateAddonActivity) Execute(ctx context.Context, input CreateAddonActi
 	)
 
 	logger = logger.With("addonName", input.AddonName)
-	logger.Info("create add-on for cluster : " + (input.ClusterName))
+	logger.Info("create add-on for cluster: " + (input.ClusterName))
 	t := time.Now().Unix()
 
 	addOnInput := &eks.CreateAddonInput{

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_infra_test.go
@@ -71,7 +71,10 @@ func (s *CreateInfraWorkflowTestSuite) SetupTest() {
 	createUserAccessKeyActivity := NewCreateClusterUserAccessKeyActivity(nil)
 	s.env.RegisterActivityWithOptions(createUserAccessKeyActivity.Execute, activity.RegisterOptions{Name: CreateClusterUserAccessKeyActivityName})
 
-	bootstrapActivity := NewBootstrapActivity(nil, true)
+	bootstrapWorkflow := NewBootstrapWorkflow(nil, false)
+	s.env.RegisterWorkflowWithOptions(bootstrapWorkflow.Execute, workflow.RegisterOptions{Name: BootstrapWorkflowName})
+
+	bootstrapActivity := NewBootstrapActivity(nil)
 	s.env.RegisterActivityWithOptions(bootstrapActivity.Execute, activity.RegisterOptions{Name: BootstrapActivityName})
 
 	saveClusterActivity := NewSaveNetworkDetailsActivity(nil)

--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon.go
@@ -54,7 +54,8 @@ type UpdateAddonActivityInput struct {
 
 // UpdateAddonActivityOutput holds the output data of the UpdateAddonActivityOutput
 type UpdateAddonActivityOutput struct {
-	UpdateID string
+	UpdateID          string
+	AddonNotInstalled bool
 }
 
 // NewUpdateAddonActivity instantiates a new EKS addon version update
@@ -96,7 +97,7 @@ func (a *UpdateAddonActivity) Execute(ctx context.Context, input UpdateAddonActi
 		if isAWSAddonNotFoundError(err, input.AddonName, input.ClusterName) { // Note: no update for not existing addons.
 			logger.Infof("%s", err.Error())
 
-			return &UpdateAddonActivityOutput{UpdateID: ""}, nil
+			return &UpdateAddonActivityOutput{AddonNotInstalled: true}, nil
 		}
 
 		return nil, errors.WrapIfWithDetails(err, "failed to retrieve addon", "cluster", input.ClusterName, "addon", input.AddonName)

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
@@ -17,8 +17,6 @@ package eksworkflow
 import (
 	"time"
 
-	"emperror.dev/errors"
-	"github.com/Masterminds/semver/v3"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
 
@@ -108,59 +106,6 @@ func (w UpdateClusterWorkflow) Execute(ctx workflow.Context, input UpdateCluster
 		if err != nil {
 			_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
 			return err
-		}
-	}
-
-	// check add-on are enabled and K8s version is >= 1.18
-	clusterKubernetesVersion, err := semver.NewVersion(input.Version)
-	if err != nil {
-		_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
-
-		return errors.WrapIf(err, "parsing cluster version as semantic version failed")
-	}
-
-	kubernetesVersionIsAtLeast1_18, err := semver.NewConstraint(">=1.18")
-	if err != nil {
-		_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
-
-		return errors.WrapIf(err, "could not set 1.18 constraint for semver")
-	}
-
-	// update core-dns addon if there's a new version available for given KubernetesVersion
-	if w.enableAddons && kubernetesVersionIsAtLeast1_18.Check(clusterKubernetesVersion) {
-		activityInput := UpdateAddonActivityInput{
-			OrganizationID:    input.OrganizationID,
-			ProviderSecretID:  input.ProviderSecretID,
-			Region:            input.Region,
-			ClusterName:       input.ClusterName,
-			KubernetesVersion: input.Version,
-			AddonName:         "coredns",
-		}
-		var coreDnsUpdateOutput UpdateAddonActivityOutput
-		err := workflow.ExecuteActivity(ctx, UpdateAddonActivityName, activityInput).Get(ctx, &coreDnsUpdateOutput)
-		if err != nil {
-			_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
-			return err
-		}
-
-		// wait for addon update to finish
-		if coreDnsUpdateOutput.UpdateID != "" {
-			activityInput := &WaitUpdateAddonActivityInput{
-				OrganizationID:   input.OrganizationID,
-				ProviderSecretID: input.ProviderSecretID,
-				Region:           input.Region,
-				ClusterName:      input.ClusterName,
-				AddonName:        "coredns",
-				UpdateID:         coreDnsUpdateOutput.UpdateID,
-			}
-
-			ctx := workflow.WithStartToCloseTimeout(ctx, 2*time.Hour)
-
-			err := workflow.ExecuteActivity(ctx, WaitUpdateAddonActivityName, activityInput).Get(ctx, nil)
-			if err != nil {
-				_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
-				return err
-			}
 		}
 	}
 

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
@@ -42,13 +42,10 @@ type UpdateClusterWorkflowInput struct {
 }
 
 type UpdateClusterWorkflow struct {
-	enableAddons bool
 }
 
-func NewUpdateClusterWorkflow(enableAddons bool) UpdateClusterWorkflow {
-	return UpdateClusterWorkflow{
-		enableAddons: enableAddons,
-	}
+func NewUpdateClusterWorkflow() UpdateClusterWorkflow {
+	return UpdateClusterWorkflow{}
 }
 
 // Register registers the activity in the worker.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3539 
| License         | Apache 2.0


### What's in this PR?
- create new activity `eks-create-addon` to submit a createAddon request to EKS and waits until addon status is active
- create new workflow `eks-bootstrap-flow` which starts  `eks-create-addon` activities in parallel (to install coredns, kube-proxy and vpc-cni addons) and after all of these are finished lauches `eks-bootstrap` activity. Addon install are started only in case of k8s version >= 1.18 and `distribution.eks.enableAddons` is set to true in Pipeline config.
- in `create-infra` workflow launch `eks-bootstrap-flow` instead of `eks-bootstrap` activity.

To be able to create addons in cluster create flow the following privileges has to added to minimum privileges required to provision an EKS cluster with Banzai Cloud Pipeline:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "eks:CreateAddon",
                "eks:UpdateAddon",
                "eks:DescribeAddon",
                "eks:DescribeAddonVersions"
              ],
              "Resource": [
                  "*"
              ]
          }
      ]
  }
```

### Tested use cases:

- set `addonsEnabled = false` create cluster with secret having no permissions for addons then update the cluster:
cluster will be created with no addons  installed.
- set `addonsEnabled = true` create cluster with secret having permissions for addons then update the cluster:
cluster will be created with  `kube-proxy`, `vpc-cni`, `coredns` addons  installed.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)

