### PR TITLE
Fixed the EKS addons, UpdateAddon not existing addon handling, UpdateCluster respecting addon feature flag & k8s version.

### DIFF
--- a/cmd/worker/eks.go
+++ b/cmd/worker/eks.go
@@ -189,7 +189,7 @@ func registerEKSWorkflows(
 	eksworkflow2.NewWaitCloudFormationStackUpdateActivity(awsSessionFactory).Register(worker)
 
 	// New cluster update
-	eksworkflow2.NewUpdateClusterWorkflow().Register(worker)
+	eksworkflow2.NewUpdateClusterWorkflow(config.Distribution.EKS.EnableAddons).Register(worker)
 
 	eksworkflow2.NewUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)
 	eksworkflow2.NewWaitUpdateClusterVersionActivity(awsSessionFactory, eksFactory).Register(worker)

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
@@ -17,6 +17,8 @@ package eksworkflow
 import (
 	"time"
 
+	"emperror.dev/errors"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/workflow"
 
@@ -42,10 +44,13 @@ type UpdateClusterWorkflowInput struct {
 }
 
 type UpdateClusterWorkflow struct {
+	enableAddons bool
 }
 
-func NewUpdateClusterWorkflow() UpdateClusterWorkflow {
-	return UpdateClusterWorkflow{}
+func NewUpdateClusterWorkflow(enableAddons bool) UpdateClusterWorkflow {
+	return UpdateClusterWorkflow{
+		enableAddons: enableAddons,
+	}
 }
 
 // Register registers the activity in the worker.
@@ -106,9 +111,23 @@ func (w UpdateClusterWorkflow) Execute(ctx workflow.Context, input UpdateCluster
 		}
 	}
 
+	// check add-on are enabled and K8s version is >= 1.18
+	clusterKubernetesVersion, err := semver.NewVersion(input.Version)
+	if err != nil {
+		_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
+
+		return errors.WrapIf(err, "parsing cluster version as semantic version failed")
+	}
+
+	kubernetesVersionIsAtLeast1_18, err := semver.NewConstraint(">=1.18")
+	if err != nil {
+		_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
+
+		return errors.WrapIf(err, "could not set 1.18 constraint for semver")
+	}
+
 	// update core-dns addon if there's a new version available for given KubernetesVersion
-	var coreDnsUpdateOutput UpdateAddonActivityOutput
-	{
+	if w.enableAddons && kubernetesVersionIsAtLeast1_18.Check(clusterKubernetesVersion) {
 		activityInput := UpdateAddonActivityInput{
 			OrganizationID:    input.OrganizationID,
 			ProviderSecretID:  input.ProviderSecretID,
@@ -117,30 +136,31 @@ func (w UpdateClusterWorkflow) Execute(ctx workflow.Context, input UpdateCluster
 			KubernetesVersion: input.Version,
 			AddonName:         "coredns",
 		}
+		var coreDnsUpdateOutput UpdateAddonActivityOutput
 		err := workflow.ExecuteActivity(ctx, UpdateAddonActivityName, activityInput).Get(ctx, &coreDnsUpdateOutput)
 		if err != nil {
 			_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
 			return err
 		}
-	}
 
-	// wait for addon update to finish
-	if coreDnsUpdateOutput.UpdateID != "" {
-		activityInput := &WaitUpdateAddonActivityInput{
-			OrganizationID:   input.OrganizationID,
-			ProviderSecretID: input.ProviderSecretID,
-			Region:           input.Region,
-			ClusterName:      input.ClusterName,
-			AddonName:        "coredns",
-			UpdateID:         coreDnsUpdateOutput.UpdateID,
-		}
+		// wait for addon update to finish
+		if coreDnsUpdateOutput.UpdateID != "" {
+			activityInput := &WaitUpdateAddonActivityInput{
+				OrganizationID:   input.OrganizationID,
+				ProviderSecretID: input.ProviderSecretID,
+				Region:           input.Region,
+				ClusterName:      input.ClusterName,
+				AddonName:        "coredns",
+				UpdateID:         coreDnsUpdateOutput.UpdateID,
+			}
 
-		ctx := workflow.WithStartToCloseTimeout(ctx, 2*time.Hour)
+			ctx := workflow.WithStartToCloseTimeout(ctx, 2*time.Hour)
 
-		err := workflow.ExecuteActivity(ctx, WaitUpdateAddonActivityName, activityInput).Get(ctx, nil)
-		if err != nil {
-			_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
-			return err
+			err := workflow.ExecuteActivity(ctx, WaitUpdateAddonActivityName, activityInput).Get(ctx, nil)
+			if err != nil {
+				_ = eksWorkflow.SetClusterStatus(ctx, input.ClusterID, pkgCluster.Warning, pkgCadence.UnwrapError(err).Error())
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the EKS addons, UpdateAddon not existing addon handling, UpdateCluster respecting addon feature flag & k8s version.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

These 2 issues together cause a cluster update to fail on clusters with no addons.

The UpdateAddon not existing addon case handling fix would probably be enough to handle the <1.18 and no addon cluster cases, but we shouldn't even try to describe the addons in these cases, so I introduced the feature flag and k8s version checking to the UpdateCluster's relevant parts to prevent unnecessary addon operations (as it should be IMO when it is feature flagged).
Also the feature flag check is required because of extra permissions being required for Describing addons (where we check non-existing ones).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Testing is in progress.
Feature flag false tested and cluster update works now (failed before).
Feature flag true tested and works with no addon, but requires more tests to see if it works perfectly with/without addons.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
