### PR TITLE
Fixed Please, Make build test kube-apiserver, etcd binary acquisition

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -19,6 +19,8 @@ migrate-version = 4.9.1
 kubectl-version = 1.20.5
 helm-version = 3.5.3
 wollemi-version = 0.7.0
+etcd-version = 3.4.16
+kube-apiserver-version = 1.19.11
 
 [alias "tidy"]
 desc = Tidy generates build targets for dependencies and makes sure that BUILD files are up-to-date.

--- a/BUILD.plz
+++ b/BUILD.plz
@@ -44,23 +44,51 @@ sh_cmd(
     cmd = "docker-compose stop",
 )
 
-_os = {
-    "darwin": "Darwin",
-    "linux": "Linux",
+remote_file(
+    name = "kube-apiserver",
+    out = "bin/test/kube-apiserver",
+    binary = True,
+    hashes = [
+        "9e5800c171e55973d33cbc751226b0b9bc27cfbe16fa039c98572ad50ef6c1dc",  # Note: v1.19.11, linux, amd64.
+        "c80fbbccc726b0f2ad5fcd52e1395b3354705513326b83f45213f5ddd33a338f",  # Note: v1.19.11, linux, arm64.
+    ],
+    test_only = True,
+    url = [
+        f"https://dl.k8s.io/v{CONFIG.KUBE_APISERVER_VERSION}/bin/{CONFIG.HOSTOS}/{CONFIG.HOSTARCH}/kube-apiserver",
+        f"https://dl.k8s.io/v{CONFIG.KUBE_APISERVER_VERSION}/bin/linux/{CONFIG.HOSTARCH}/kube-apiserver",  # Note: fallback until other OSes become available to not break `plz build` on macOS.
+    ],
+)
+
+_etcd_archive_extension = {
+    "darwin": "zip",
+    "linux": "tar.gz",
+    "windows": "zip",
 }
 
 remote_file(
-    name = "kube-apiserver",
-    out = "bin/kube-apiserver",
-    binary = True,
-    url = "https://storage.googleapis.com/k8s-c10s-test-binaries/kube-apiserver-%s-x86_64" % (_os[CONFIG.HOSTOS]),
-)
-
-remote_file(
     name = "etcd",
-    out = "bin/etcd",
+    out = "bin/test/etcd",
     binary = True,
-    url = "https://storage.googleapis.com/k8s-c10s-test-binaries/etcd-%s-x86_64" % (_os[CONFIG.HOSTOS]),
+    exported_files = [
+        f"etcd-v{CONFIG.ETCD_VERSION}-{CONFIG.HOSTOS}-{CONFIG.HOSTARCH}/etcd",
+    ],
+    extract = True,
+    hashes = [
+        "27245adea2e0951913276d8c321d79b91caaf904ae3fdaab65194ab41c01db08",  # Note: v3.4.16, darwin, amd64, zip.
+        "2e2d5b3572e077e7641193ed07b4929b0eaf0dc2f9463e9b677765528acafb89",  # Note: v3.4.16, linux, amd64, tar.gz.
+        "6712ff22aeec39ed19688b1edf6747194193b074548fc62163e4804ca0264512",  # Note: v3.4.16, linux, arm64, tar.gz.
+        "b862c38da3788b15d76a447ec845a2fee79ca702f67e9acd064cd939303bf9f6",  # Note: v3.4.16, windows, amd64, zip.
+    ],
+    test_only = True,
+    url = [
+        "https://github.com/etcd-io/etcd/releases/download/v%s/etcd-v%s-%s-%s.%s" % (
+            CONFIG.ETCD_VERSION,
+            CONFIG.ETCD_VERSION,
+            CONFIG.HOSTOS,
+            CONFIG.HOSTARCH,
+            _etcd_archive_extension[CONFIG.HOSTOS],
+        ),
+    ],
 )
 
 http_archive(

--- a/Makefile.plz
+++ b/Makefile.plz
@@ -162,14 +162,36 @@ test-integration: bin/test/kube-apiserver bin/test/etcd ## Run integration tests
 	@${MAKE} TEST_ASSET_KUBE_APISERVER=$(abspath bin/test/kube-apiserver) TEST_ASSET_ETCD=$(abspath bin/test/etcd) GOARGS="${GOARGS} -run ^TestIntegration\$$\$$" TEST_REPORT=integration test
 
 bin/test/kube-apiserver:
+	if ! echo "amd64 arm64" | grep -q -w "$(ARCH)"; then \
+		printf >&2 "unsupported kube-apiserver architecture %s\n" "$(ARCH)" ; \
+		exit 1 ; \
+	fi
+	if ! echo "linux" | grep -q -w "$(OS)"; then \
+		printf >&2 "unsupported kube-apiserver operating system %s\n" "$(OS)" ; \
+		exit 1 ; \
+	fi
 	@mkdir -p bin/test
-	curl -L https://storage.googleapis.com/k8s-c10s-test-binaries/kube-apiserver-$(shell uname)-x86_64 > bin/test/kube-apiserver
+	curl -L -o bin/test/kube-apiserver https://dl.k8s.io/v$(KUBE_APISERVER_VERSION)/bin/$(OS)/$(ARCH)/kube-apiserver
 	chmod +x bin/test/kube-apiserver
 
 bin/test/etcd:
+	if ! echo "amd64 arm64" | grep -q -w "$(ARCH)"; then \
+		printf >&2 "unsupported etcd architecture %s\n" "$(ARCH)" ; \
+		exit 1 ; \
+	fi
+	if ! echo "darwin linux" | grep -q -w "$(OS)"; then \
+		printf >&2 "unsupported etcd operating system %s\n" "$(OS)" ; \
+		exit 1 ; \
+	fi
 	@mkdir -p bin/test
-	curl -L https://storage.googleapis.com/k8s-c10s-test-binaries/etcd-$(shell uname)-x86_64 > bin/test/etcd
+	if [ "$(OS)" == "darwin" ] ; then \
+		curl -L https://github.com/etcd-io/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-$(OS)-$(ARCH).zip | tar -xv -C bin/test ; \
+	elif [ "$(OS)" == "linux" ] ; then \
+		curl -L https://github.com/etcd-io/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-$(OS)-$(ARCH).tar.gz | tar -xvz -C bin/test ; \
+	fi
+	mv bin/test/etcd-v$(ETCD_VERSION)-$(OS)-$(ARCH)/etcd bin/test/etcd
 	chmod +x bin/test/etcd
+	rm -fr bin/test/etcd-v$(ETCD_VERSION)-$(OS)-$(ARCH)
 
 bin/migrate:
 	./pleasew build ///pleasings2//tools/misc:migrate


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. Fixed the plz config, Makefile, build target.
2. Updated Makefile's corresponding targets.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

1. To use working up to date URLs to fix the plz build command on new machines.
2. To improve the binary acquisition process a bit.

Without these, `plz build` failed with an error on those targets due to the old download URLs responding 404s.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested on my new machine and they worked like a charm.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
