### PR TITLE
[Backport to 0.77] Fixed/improved cluster-charts endpoint, ignored enabled flag, added non-chart values

### DIFF
--- a/internal/helm/chart_config.go
+++ b/internal/helm/chart_config.go
@@ -22,10 +22,11 @@ import (
 
 // ChartConfig describes a Helm chart configuration.
 type ChartConfig struct {
-	Name       string                 `json:"name" mapstructure:"name" yaml:"name"`
-	Version    string                 `json:"version" mapstructure:"version" yaml:"version"`
-	Repository string                 `json:"repository" mapstructure:"repository" yaml:"repository"`
-	Values     map[string]interface{} `json:"values,omitempty" mapstructure:"values,omitempty" yaml:"values,omitempty"`
+	Name           string                 `json:"name" mapstructure:"name" yaml:"name"`
+	Version        string                 `json:"version" mapstructure:"version" yaml:"version"`
+	Repository     string                 `json:"repository" mapstructure:"repository" yaml:"repository"`
+	Values         map[string]interface{} `json:"values,omitempty" mapstructure:"values,omitempty" yaml:"values,omitempty"`
+	NonChartValues map[string]interface{} `json:"nonChartValues,omitempty" mapstructure:"nonChartValues,omitempty" yaml:"nonChartValues,omitempty"`
 }
 
 // IsLessThan determines whether the receiver is ordered less than the specified
@@ -49,5 +50,7 @@ func (config ChartConfig) IsLessThan(otherConfig ChartConfig) bool {
 		return config.Repository < otherConfig.Repository
 	}
 
-	return fmt.Sprint(config.Values) < fmt.Sprint(otherConfig.Values)
+	return fmt.Sprint(config.Values) < fmt.Sprint(otherConfig.Values) ||
+		(fmt.Sprint(config.Values) == fmt.Sprint(otherConfig.Values) &&
+			fmt.Sprint(config.NonChartValues) < fmt.Sprint(otherConfig.NonChartValues))
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. Fixed the `orgs/helm/cluster-charts` endpoint to not use the services' `enabled` flag, because it is unreliable, not all services - which can be enabled on the managed cluster - set it to true, so we should list all charts regardless of their enabled flags.
2. Added functionality to list the non-chart values of the configuration as well (values which are not part of the chart name, version, repository and values fields, but are extra fields in the same structure).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The fix was required because the listing was incomplete (velero and traefik were missing).
The non-chart value addition is to give the most amount of information from the charts, it doesn't add too much garbage.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

<details>
<summary>Before</summary>

```json
[
    {
        "name": "anchore-policy-validator",
        "version": "0.7.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "cluster-autoscaler",
        "version": "7.1.0",
        "repository": "stable"
    },
    {
        "name": "external-dns",
        "version": "4.5.0",
        "repository": "bitnami"
    },
    {
        "name": "instance-termination-handler",
        "version": "0.1.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "kube-prometheus-stack",
        "version": "12.11.3",
        "repository": "prometheus-community",
        "values": {
            "alertmanager": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefix",
                        "traefik.ingress.kubernetes.io/ssl-redirect": "true"
                    }
                }
            },
            "grafana": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefixStrip",
                        "traefik.ingress.kubernetes.io/redirect-permanent": "true",
                        "traefik.ingress.kubernetes.io/redirect-regex": "^http://(.*)",
                        "traefik.ingress.kubernetes.io/redirect-replacement": "https://$1\\"
                    }
                },
                "sidecar": {
                    "datasources": {
                        "enabled": "true"
                    }
                }
            },
            "prometheus": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefix",
                        "traefik.ingress.kubernetes.io/ssl-redirect": "true"
                    }
                }
            }
        }
    },
    {
        "name": "logging-operator",
        "version": "3.2.2",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "loki",
        "version": "0.17.4",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "nodepool-labels-operator",
        "version": "0.1.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "pipeline-cluster-ingress",
        "version": "0.0.10",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "prometheus-pushgateway",
        "version": "1.5.1",
        "repository": "prometheus-community"
    },
    {
        "name": "vault-secrets-webhook",
        "version": "1.10.1",
        "repository": "banzaicloud-stable"
    }
]
```
</details>

<details>
<summary>After</summary>

```json
[
    {
        "name": "anchore-policy-validator",
        "version": "0.7.1",
        "repository": "banzaicloud-stable",
        "nonChartValues": {
            "namespace": "pipeline-system",
            "release": "anchore"
        }
    },
    {
        "name": "cluster-autoscaler",
        "version": "7.1.0",
        "repository": "stable",
        "nonChartValues": {
            "imageVersionConstraints": [
                {
                    "K8sVersion": "<=1.12.x",
                    "Tag": "v1.12.8",
                    "Repository": "gcr.io/google-containers/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.13",
                    "Tag": "v1.13.9",
                    "Repository": "gcr.io/google-containers/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.14",
                    "Tag": "v1.14.7",
                    "Repository": "gcr.io/google-containers/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.15",
                    "Tag": "v1.15.4",
                    "Repository": "gcr.io/google-containers/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.16",
                    "Tag": "v1.16.7",
                    "Repository": "k8s.gcr.io/autoscaling/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.17",
                    "Tag": "v1.17.4",
                    "Repository": "k8s.gcr.io/autoscaling/cluster-autoscaler"
                },
                {
                    "K8sVersion": "~1.18",
                    "Tag": "v1.18.3",
                    "Repository": "k8s.gcr.io/autoscaling/cluster-autoscaler"
                },
                {
                    "K8sVersion": ">=1.19",
                    "Tag": "v1.19.1",
                    "Repository": "k8s.gcr.io/autoscaling/cluster-autoscaler"
                },
                {
                    "K8sVersion": ">=1.20",
                    "Tag": "v1.20.0",
                    "Repository": "k8s.gcr.io/autoscaling/cluster-autoscaler"
                }
            ]
        }
    },
    {
        "name": "external-dns",
        "version": "4.5.0",
        "repository": "bitnami"
    },
    {
        "name": "instance-termination-handler",
        "version": "0.1.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "kube-prometheus-stack",
        "version": "12.11.3",
        "repository": "prometheus-community",
        "values": {
            "alertmanager": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefix",
                        "traefik.ingress.kubernetes.io/ssl-redirect": "true"
                    }
                }
            },
            "grafana": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefixStrip",
                        "traefik.ingress.kubernetes.io/redirect-permanent": "true",
                        "traefik.ingress.kubernetes.io/redirect-regex": "^http://(.*)",
                        "traefik.ingress.kubernetes.io/redirect-replacement": "https://$1\\"
                    }
                },
                "sidecar": {
                    "datasources": {
                        "enabled": "true"
                    }
                }
            },
            "prometheus": {
                "ingress": {
                    "annotations": {
                        "traefik.frontend.rule.type": "PathPrefix",
                        "traefik.ingress.kubernetes.io/ssl-redirect": "true"
                    }
                }
            }
        }
    },
    {
        "name": "kubernetes-dashboard",
        "version": "0.9.2",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "logging-operator",
        "version": "3.2.2",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "loki",
        "version": "0.17.4",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "nodepool-labels-operator",
        "version": "0.1.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "pipeline-cluster-ingress",
        "version": "0.0.10",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "prometheus-pushgateway",
        "version": "1.5.1",
        "repository": "prometheus-community"
    },
    {
        "name": "spot-config-webhook",
        "version": "0.1.6",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "spot-scheduler",
        "version": "0.1.2",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "traefik",
        "version": "1.86.2",
        "repository": "stable",
        "values": {
            "rbac": {
                "enabled": true
            },
            "ssl": {
                "enabled": true,
                "generateTLS": true
            }
        }
    },
    {
        "name": "vault-secrets-webhook",
        "version": "1.10.1",
        "repository": "banzaicloud-stable"
    },
    {
        "name": "velero",
        "version": "2.13.3-bc.1",
        "repository": "banzaicloud-stable",
        "values": {
            "image": {
                "pullpolicy": "IfNotPresent",
                "repository": "velero/velero",
                "tag": "v1.6.0"
            },
            "resources": {
                "limits": {
                    "cpu": 4,
                    "memory": "8192Mi"
                },
                "requests": {
                    "cpu": "1500m",
                    "memory": "3072Mi"
                }
            }
        },
        "nonChartValues": {
            "pluginImages": {
                "aws": {
                    "pullPolicy": "IfNotPresent",
                    "repository": "velero/velero-plugin-for-aws",
                    "tag": "v1.2.0"
                },
                "azure": {
                    "pullPolicy": "IfNotPresent",
                    "repository": "velero/velero-plugin-for-microsoft-azure",
                    "tag": "v1.2.0"
                },
                "gcp": {
                    "pullPolicy": "IfNotPresent",
                    "repository": "velero/velero-plugin-for-gcp",
                    "tag": "v1.2.0"
                }
            }
        }
    }
]
```
</details>

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
