### PR TITLE
Vpc-cni addon should be updated only one minor version at a time

### DIFF
--- a/internal/cluster/distribution/eks/eksworkflow/activity_update_addon_test.go
+++ b/internal/cluster/distribution/eks/eksworkflow/activity_update_addon_test.go
@@ -61,26 +61,82 @@ func TestSelectLatestVersion(t *testing.T) {
 							},
 						},
 					},
+					{
+						AddonVersion: aws.String("v1.8.5-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.20"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.8.8-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.20"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.9.0-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.20"),
+							},
+						},
+					},
+					{
+						AddonVersion: aws.String("v1.9.1-eksbuild.1"),
+						Compatibilities: []*eks.Compatibility{
+							{
+								ClusterVersion: aws.String("1.20"),
+							},
+						},
+					},
 				},
 			},
 		},
 	}
 
 	t.Run("latest version is selected for 1.18", func(t *testing.T) {
-		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.18")
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.7.0-eksbuild.1", "1.18", false)
 		require.NoError(t, err)
 		assert.Equal(t, "v1.8.3-eksbuild.1", version)
+		assert.True(t, isLatestVersion)
 	})
 
 	t.Run("latest version is selected for 1.19", func(t *testing.T) {
-		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.19")
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.7.0-eksbuild.1", "1.19", false)
 		require.NoError(t, err)
 		assert.Equal(t, "v1.8.5-eksbuild.1", version)
+		assert.True(t, isLatestVersion)
+	})
+
+	t.Run("next minor version is selected for 1.18", func(t *testing.T) {
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.7.0-eksbuild.1", "1.18", true)
+		require.NoError(t, err)
+		assert.Equal(t, "v1.8.0-eksbuild.1", version)
+		assert.False(t, isLatestVersion)
+	})
+
+	t.Run("next minor version is selected for 1.20", func(t *testing.T) {
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.8.5-eksbuild.1", "1.20", true)
+		require.NoError(t, err)
+		assert.Equal(t, "v1.9.0-eksbuild.1", version)
+		assert.False(t, isLatestVersion)
+	})
+
+	t.Run("latest version is selected for 1.20", func(t *testing.T) {
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.9.0-eksbuild.1", "1.20", true)
+		require.NoError(t, err)
+		assert.Equal(t, "v1.9.1-eksbuild.1", version)
+		assert.True(t, isLatestVersion)
 	})
 
 	t.Run("no available new version", func(t *testing.T) {
-		version, err := selectLatestVersion(addonVersions, "v1.7.0-eksbuild.1", "1.20")
+		version, isLatestVersion, err := selectNextVersion(addonVersions, "v1.7.0-eksbuild.1", "1.21", false)
 		require.NoError(t, err)
 		assert.Equal(t, "v1.7.0-eksbuild.1", version)
+		assert.True(t, isLatestVersion)
 	})
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3652
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
Cluster update fails when updating vpc-cni plugin.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
