### PR TITLE
Updated default Anchore image validator chart 0.7.1->0.7.4

### DIFF
--- a/docker.images.list
+++ b/docker.images.list
@@ -1,5 +1,5 @@
 docker.io/traefik:1.7.20
-ghcr.io/banzaicloud/anchore-image-validator:0.5.1
+ghcr.io/banzaicloud/anchore-image-validator:0.5.4
 ghcr.io/banzaicloud/instance-termination-handler:0.1.1
 ghcr.io/banzaicloud/integrated-service-operator:v0.5.0
 ghcr.io/banzaicloud/nodepool-labels-operator:v0.1.1

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -750,7 +750,7 @@ rbac:
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::anchore::insecure", false)
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.7.1")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.7.4")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	// v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated default Anchore image validator chart 0.7.1->0.7.4.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To fix a leakage on K8s 1.20+.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
