### PR TITLE
updragde to latest Velero helm chart

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -807,11 +807,11 @@ traefik:
 	v.SetDefault("cluster::disasterRecovery::ark::backupSyncInterval", "20s")
 	v.SetDefault("cluster::disasterRecovery::ark::restoreWaitTimeout", "5m")
 	v.SetDefault("cluster::disasterRecovery::charts::ark::chart", "banzaicloud-stable/velero")
-	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.13.3-bc.1")
+	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.23.6-bc.2")
 	v.SetDefault("cluster::disasterRecovery::charts::ark::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": "velero/velero",
-			"tag":        "v1.6.0",
+			"tag":        "v1.6.3",
 			"pullPolicy": "IfNotPresent",
 		},
 		"awsPluginImage": map[string]interface{}{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Backport: [updragde to latest Velero helm chart](https://github.com/banzaicloud/pipeline/pull/3570) to 0.77.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
