### PR TITLE
Auto-fixed Go structs by linter/formatter

### DIFF
--- a/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/bootstrap_activity.go
@@ -57,8 +57,7 @@ type BootstrapActivityInput struct {
 }
 
 // BootstrapActivityOutput holds the output data
-type BootstrapActivityOutput struct {
-}
+type BootstrapActivityOutput struct{}
 
 // BootstrapActivity instantiates a new BootstrapActivity
 func NewBootstrapActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *BootstrapActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_addon_activity.go
@@ -44,8 +44,7 @@ type CreateAddonActivityInput struct {
 }
 
 // CreateAddonActivityOutput holds the output data
-type CreateAddonActivityOutput struct {
-}
+type CreateAddonActivityOutput struct{}
 
 // NewCreateAddonActivity instantiates a new CreateAddonActivity
 func NewCreateAddonActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *CreateAddonActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_asg_activity.go
@@ -88,8 +88,7 @@ type CreateAsgActivityInput struct {
 }
 
 // CreateAsgActivityOutput holds the output data of the CreateAsgActivityOutput
-type CreateAsgActivityOutput struct {
-}
+type CreateAsgActivityOutput struct{}
 
 // CreateAsgActivity instantiates a new CreateAsgActivity
 func NewCreateAsgActivity(

--- a/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/create_eks_control_plane_activity.go
@@ -55,8 +55,7 @@ type CreateEksControlPlaneActivityInput struct {
 }
 
 // CreateEksControlPlaneActivityOutput holds the output data of the CreateEksControlPlaneActivityOutput
-type CreateEksControlPlaneActivityOutput struct {
-}
+type CreateEksControlPlaneActivityOutput struct{}
 
 // CreateEksControlPlaneActivity instantiates a new CreateEksControlPlaneActivity
 func NewCreateEksClusterActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *CreateEksControlPlaneActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_control_plane_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_control_plane_activity.go
@@ -40,8 +40,7 @@ type DeleteControlPlaneActivityInput struct {
 }
 
 //   DeleteControlPlaneActivityOutput holds the output data of the DeleteControlPlaneActivity
-type DeleteControlPlaneActivityOutput struct {
-}
+type DeleteControlPlaneActivityOutput struct{}
 
 //   DeleteControlPlaneActivity instantiates a new DeleteControlPlaneActivity
 func NewDeleteControlPlaneActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *DeleteControlPlaneActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/delete_orphan_nic_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/delete_orphan_nic_activity.go
@@ -38,8 +38,7 @@ type DeleteOrphanNICActivityInput struct {
 	NicID string
 }
 
-type DeleteOrphanNICActivityOutput struct {
-}
+type DeleteOrphanNICActivityOutput struct{}
 
 //   DeleteOrphanNICActivity instantiates a new DeleteOrphanNICActivity
 func NewDeleteOrphanNICActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *DeleteOrphanNICActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/update_asg_activity.go
@@ -84,8 +84,7 @@ type UpdateAsgActivityInput struct {
 }
 
 // UpdateAsgActivityOutput holds the output data of the UpdateAsgActivityOutput
-type UpdateAsgActivityOutput struct {
-}
+type UpdateAsgActivityOutput struct{}
 
 // UpdateAsgActivity instantiates a new UpdateAsgActivity
 func NewUpdateAsgActivity(

--- a/internal/cluster/distribution/eks/eksprovider/workflow/upload_ssh_key_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/upload_ssh_key_activity.go
@@ -42,8 +42,7 @@ type UploadSSHKeyActivityInput struct {
 }
 
 //  UploadSSHKeyActivityOutput holds the output data of UploadSSHKeyActivity
-type UploadSSHKeyActivityOutput struct {
-}
+type UploadSSHKeyActivityOutput struct{}
 
 //  UploadSSHKeyActivity instantiates a new  UploadSSHKeyActivity
 func NewUploadSSHKeyActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *UploadSSHKeyActivity {

--- a/internal/cluster/distribution/eks/eksprovider/workflow/validate_iam_role.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/validate_iam_role.go
@@ -39,8 +39,7 @@ type ValidateIAMRoleActivityInput struct {
 }
 
 //  ValidateIAMRoleActivityOutput holds the output data of ValidateIAMRoleActivity
-type ValidateIAMRoleActivityOutput struct {
-}
+type ValidateIAMRoleActivityOutput struct{}
 
 //  NewValidateIAMRoleActivity instantiates a new  ValidateIAMRoleActivity
 func NewValidateIAMRoleActivity(awsSessionFactory *awsworkflow.AWSSessionFactory) *ValidateIAMRoleActivity {

--- a/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
+++ b/internal/cluster/distribution/eks/eksworkflow/workflow_update_cluster.go
@@ -41,8 +41,7 @@ type UpdateClusterWorkflowInput struct {
 	Version string
 }
 
-type UpdateClusterWorkflow struct {
-}
+type UpdateClusterWorkflow struct{}
 
 func NewUpdateClusterWorkflow() UpdateClusterWorkflow {
 	return UpdateClusterWorkflow{}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Auto-fixed Go structs by linter/formatter.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

I ran into this for 20 times at least already, always reverted my auto-changes.
See no reason why not to commit the auto-fixed format.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested (with at least one cloud provider)~
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
