### PR TITLE
Update dependent charts to support k8s version 1.22

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -578,7 +578,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 		"storagetier",
 	})
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::chart", "banzaicloud-stable/nodepool-labels-operator")
-	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.1.1")
+	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.2.4")
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::vault::enabled", true)
@@ -750,7 +750,7 @@ rbac:
 	v.SetDefault("cluster::securityScan::anchore::password", "")
 	v.SetDefault("cluster::securityScan::anchore::insecure", false)
 	v.SetDefault("cluster::securityScan::webhook::chart", "banzaicloud-stable/anchore-policy-validator")
-	v.SetDefault("cluster::securityScan::webhook::version", "0.7.4")
+	v.SetDefault("cluster::securityScan::webhook::version", "0.8.1")
 	v.SetDefault("cluster::securityScan::webhook::release", "anchore")
 	v.SetDefault("cluster::securityScan::webhook::namespace", "pipeline-system")
 	// v.SetDefault("cluster::securityScan::webhook::values", map[string]interface{}{

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -578,7 +578,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 		"storagetier",
 	})
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::chart", "banzaicloud-stable/nodepool-labels-operator")
-	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.2.4")
+	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::version", "0.2.5")
 	v.SetDefault("cluster::labels::charts::nodepoolLabelOperator::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::vault::enabled", true)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #3573 
| License         | Apache 2.0


### What's in this PR?
Update nodepoolLabelOperator and security scan webhook helm chart version to their latest version update to support deprecated Kubernetes API changes. (https://github.com/banzaicloud/anchore-image-validator/pull/96, https://github.com/banzaicloud/nodepool-labels-operator/pull/24)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] OpenAPI and Postman files updated (if needed)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
