### PR TITLE
fix: create postgres directory during plz up

### DIFF
--- a/BUILD.plz
+++ b/BUILD.plz
@@ -34,7 +34,7 @@ sh_cmd(
     name = "start",
     cmd = [
         "if [ ! -f docker-compose.override.yml ]; then plz make :docker-compose.override.yml; fi",
-        "mkdir -p .docker/volumes/{mysql,vault/file,vault/keys}",
+        "mkdir -p .docker/volumes/{mysql,postgres,vault/file,vault/keys}",
         "docker-compose up -d",
     ],
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Amending the `start` command (which is a dependency of the `up` command) in BUILD.plz with the creation of a `postgres` directory.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Running `plz up` resulted in an error complaining about the lack of this directory:

``` shell
$ plz up

[+] Running 11/12
 ⠿ Network pipeline_default                 Created                                                                                                                                                                                                                                 0.1s
 ⠿ Container pipeline_ui_1                  Created                                                                                                                                                                                                                                 0.2s
 ⠇ Container pipeline_postgres_1            Creating                                                                                                                                                                                                                                0.8s
 ⠿ Container pipeline_vault_1               Created                                                                                                                                                                                                                                 0.3s
 ⠿ Container pipeline_mysql_1               Created                                                                                                                                                                                                                                 0.3s
 ⠿ Container pipeline_uiproxy_1             Created                                                                                                                                                                                                                                 0.3s
 ⠿ Container pipeline_dex_1                 Created                                                                                                                                                                                                                                 0.2s
 ⠿ Container pipeline_cadence_1             Created                                                                                                                                                                                                                                 0.2s
 ⠿ Container pipeline_vault-unsealer_1      Created                                                                                                                                                                                                                                 0.2s
 ⠿ Container pipeline_cadence-web_1         Created                                                                                                                                                                                                                                 0.2s
 ⠿ Container pipeline_vault-configurer_1    Created                                                                                                                                                                                                                                 0.2s
 ⠿ Container pipeline_vault-token-helper_1  Created                                                                                                                                                                                                                                 0.1s
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: .../pipeline/.docker/volumes/postgres
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
