### PR TITLE
feat: add secret not created yet error response

### DIFF
--- a/src/api/BUILD.plz
+++ b/src/api/BUILD.plz
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//.gen/pipeline/pipeline",
         "//internal/anchore",
+        "//internal/cluster",
         "//internal/cluster/auth",
         "//internal/cluster/clusteradapter",
         "//internal/cluster/distribution/eks/eksprovider/driver",


### PR DESCRIPTION
In case of a PKE cluster on AWS during creation time.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The API now responds with a 409 status code getting a PKE cluster on AWS if there was an error getting the cluster secret during creation time.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

For PKE (AWS) clusters the cluster creation immediately starts but the secret creation happens later and until the cluster secret is created, the cluster GET response was always going to run into error, resulting in a not too telling 500 Internal server error response a couple of times if the cluster creation was initiated from the banzai cli with the `-w` flag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] OpenAPI and Postman files updated (if needed)~
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~