### PR TITLE
Fix logging asg failures

### DIFF
--- a/internal/cluster/distribution/eks/ekscluster/nodepools/BUILD.plz
+++ b/internal/cluster/distribution/eks/ekscluster/nodepools/BUILD.plz
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/providers/amazon/autoscaling",
         "//third_party/go:emperror.dev__errors",
+        "//third_party/go:github.com__aws__aws-sdk-go__aws",
         "//third_party/go:github.com__aws__aws-sdk-go__aws__awserr",
         "//third_party/go:github.com__aws__aws-sdk-go__aws__session",
         "//third_party/go:github.com__sirupsen__logrus",

--- a/pkg/providers/amazon/autoscaling/errors.go
+++ b/pkg/providers/amazon/autoscaling/errors.go
@@ -50,3 +50,22 @@ func (e errAutoscalingGroupNotHealthy) IsFinal() bool { return false }
 func (e errAutoscalingGroupNotHealthy) Context() []interface{} {
 	return []interface{}{"desired", e.Desired, "actual", e.Actual}
 }
+
+type errLaunchConfigurationNotFound struct {
+	asgName string
+}
+
+// newLaunchConfigurationNotFoundError creates a new errLaunchConfigurationNotFound
+func newLaunchConfigurationNotFoundError(asgName string) error {
+	return errLaunchConfigurationNotFound{
+		asgName: asgName,
+	}
+}
+
+func (e errLaunchConfigurationNotFound) Error() string {
+	return "could not find launch configuration for ASG"
+}
+func (e errLaunchConfigurationNotFound) IsFinal() bool { return false }
+func (e errLaunchConfigurationNotFound) Context() []interface{} {
+	return []interface{}{"asgName", e.asgName}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related issues | https://github.com/banzaicloud/pipeline/issues/1684
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add meaningful worker log message when the AWS autoscaling group creation fails during cluster creation and node pool update.

- ASGs can be determined either by launch configuration or launch template. If the former is not found, handle the existence of the latter before returning a "could not find launch configuration for ASG" error message.
- Include info (status, cause, description) of the last ASG activity in the error response when the ASG creation times out.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

When instances in the ASG cannot be created, e.g. because of low spot price in the config, cluster creation time is going to get really long and eventually time out without providing any feedback on the cause.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This is the first step to make an easy to follow cluster creation process.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] OpenAPI and Postman files updated (if needed)~
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~
