### PR TITLE
feat: add node pool name validation

### DIFF
--- a/internal/cluster/distribution/eks/ekscluster/eks.go
+++ b/internal/cluster/distribution/eks/ekscluster/eks.go
@@ -182,6 +182,11 @@ const (
 
 // Validate checks Amazon's node fields
 func (a *NodePool) Validate(npName string) error {
+	// ---- [ Node pool name validation ] ---- //
+	if err := pkgCommon.ValidateNodePoolName(npName); err != nil {
+		return err
+	}
+
 	// ---- [ Node instanceType check ] ---- //
 	if len(a.InstanceType) == 0 {
 		return pkgErrors.ErrorInstancetypeFieldIsEmpty


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related issues | fixes https://github.com/banzaicloud/pipeline/issues/2622
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adding validation for node pool names (only accept lowercase characters and numbers) for clusters created on AWS.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The `eks-create-asg` Cadence workflow errors if there are special characters because the node pool name gets attached to the stack name; also the `configure-nodepool-labels` workflow errors if there are uppercase characters in the nood pool name resulting in unsuccessful cluster creation, so it is useful if a validator catches these cases even before the cluster creation begins.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Example config.yaml:

```
{
  "cloud": "amazon",
  "location": "eu-west-1",
  "name": "test-validation",
  "properties": {
    "eks": {
      "nodePools": {
        "pool1X": {
          "autoscaling": true,
          "count": 5,
          "instanceType": "t3a.small",
          "maxCount": 10,
          "minCount": 2
        }
      },
      "version": "1.20"
    }
  },
  "secretName": "secret_name"
}
```

Response (banzai CLI):

```
ERRO[0013] failed to create cluster: 400 Bad Request (err pipeline.GenericOpenAPIError, request=map[cloud:amazon location:eu-west-1 name:test-validation properties:map[eks:map[nodePools:map[pool1X:map[autoscaling:true count:5 instanceType:t3a.small maxCount:10 minCount:2]] version:1.20]] secretName:secret_name], response={"code":400,"message":"node pool name 'pool1X' invalid: a DNS-1123 subdomain must consist of lower case alphanumeric characters","error":"node pool name 'pool1X' invalid: a DNS-1123 subdomain must consist of lower case alphanumeric characters"}
)
Error: failed to create cluster: 400 Bad Request
failed to create cluster: 400 Bad Request
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] OpenAPI and Postman files updated (if needed)~
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~
