### PR TITLE
Consolidate EBS volume size units to GiB

### DIFF
--- a/.gen/pipeline/api/openapi.yaml
+++ b/.gen/pipeline/api/openapi.yaml
@@ -19035,7 +19035,7 @@ components:
         volumeEncryption:
           $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
         volumeSize:
-          description: Size of the EBS volume in GBs of the nodes in the pool.
+          description: Size of the EBS volume in GiBs of the nodes in the pool.
           example: 50
           type: integer
         image:
@@ -19235,7 +19235,7 @@ components:
           example: ami-dd3c0f36
           type: string
         volumeSize:
-          description: Size of root EBS volume to attach to the nodes in GBs. Zero
+          description: Size of root EBS volume to attach to the nodes in GiBs. Zero
             means that the size is determined automatically.
           type: integer
         zones:
@@ -23005,7 +23005,7 @@ components:
         volumeEncryption:
           $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
         volumeSize:
-          description: Size of the EBS volume in GBs of the nodes in the pool.
+          description: Size of the EBS volume in GiBs of the nodes in the pool.
           example: 50
           type: integer
         volumeType:
@@ -23053,7 +23053,7 @@ components:
         volumeEncryption:
           $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
         volumeSize:
-          description: Size of the EBS volume in GBs of the nodes in the pool.
+          description: Size of the EBS volume in GiBs of the nodes in the pool.
           example: 50
           type: integer
         volumeType:
@@ -23101,7 +23101,7 @@ components:
         autoscaling:
           $ref: '#/components/schemas/NodePoolAutoScaling'
         volumeSize:
-          description: Size of the EBS volume in GBs of the nodes in the pool.
+          description: Size of the EBS volume in GiBs of the nodes in the pool.
           example: 50
           type: integer
         instanceType:

--- a/.gen/pipeline/pipeline/model_amazon_auto_scaling_group.go
+++ b/.gen/pipeline/pipeline/model_amazon_auto_scaling_group.go
@@ -16,7 +16,7 @@ type AmazonAutoScalingGroup struct {
 
 	Image string `json:"image"`
 
-	// Size of root EBS volume to attach to the nodes in GBs. Zero means that the size is determined automatically.
+	// Size of root EBS volume to attach to the nodes in GiBs. Zero means that the size is determined automatically.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	Zones []string `json:"zones"`

--- a/.gen/pipeline/pipeline/model_create_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_create_node_pool_request.go
@@ -25,7 +25,7 @@ type CreateNodePoolRequest struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_eks_node_pool.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool.go
@@ -28,7 +28,7 @@ type EksNodePool struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	Image string `json:"image,omitempty"`

--- a/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_node_pool_all_of.go
@@ -16,7 +16,7 @@ type EksNodePoolAllOf struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request.go
@@ -23,7 +23,7 @@ type EksUpdateNodePoolRequest struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_eks_update_node_pool_request_all_of.go
@@ -16,7 +16,7 @@ type EksUpdateNodePoolRequestAllOf struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_node_pool.go
+++ b/.gen/pipeline/pipeline/model_node_pool.go
@@ -25,7 +25,7 @@ type NodePool struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_node_pool_summary.go
+++ b/.gen/pipeline/pipeline/model_node_pool_summary.go
@@ -26,7 +26,7 @@ type NodePoolSummary struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/.gen/pipeline/pipeline/model_pke_aws_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_pke_aws_update_node_pool_request.go
@@ -21,7 +21,7 @@ type PkeAwsUpdateNodePoolRequest struct {
 
 	Autoscaling NodePoolAutoScaling `json:"autoscaling,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// The instance type to use for your node pool.

--- a/.gen/pipeline/pipeline/model_pke_aws_update_node_pool_request_all_of.go
+++ b/.gen/pipeline/pipeline/model_pke_aws_update_node_pool_request_all_of.go
@@ -14,7 +14,7 @@ type PkeAwsUpdateNodePoolRequestAllOf struct {
 
 	Autoscaling NodePoolAutoScaling `json:"autoscaling,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// The instance type to use for your node pool.

--- a/.gen/pipeline/pipeline/model_update_node_pool_request.go
+++ b/.gen/pipeline/pipeline/model_update_node_pool_request.go
@@ -22,7 +22,7 @@ type UpdateNodePoolRequest struct {
 
 	VolumeEncryption *EksNodePoolVolumeEncryption `json:"volumeEncryption,omitempty"`
 
-	// Size of the EBS volume in GBs of the nodes in the pool.
+	// Size of the EBS volume in GiBs of the nodes in the pool.
 	VolumeSize int32 `json:"volumeSize,omitempty"`
 
 	// Type of the EBS volume of the nodes in the pool (default gp3).

--- a/apis/pipeline/pipeline.yaml
+++ b/apis/pipeline/pipeline.yaml
@@ -4595,7 +4595,7 @@ components:
                         volumeEncryption:
                             $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
                         volumeSize:
-                            description: Size of the EBS volume in GBs of the nodes in the pool.
+                            description: Size of the EBS volume in GiBs of the nodes in the pool.
                             type: integer
                             example: 50
                         volumeType:
@@ -4723,7 +4723,7 @@ components:
                         volumeEncryption:
                             $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
                         volumeSize:
-                            description: Size of the EBS volume in GBs of the nodes in the pool.
+                            description: Size of the EBS volume in GiBs of the nodes in the pool.
                             type: integer
                             example: 50
                         volumeType:
@@ -4771,7 +4771,7 @@ components:
                         autoscaling:
                             $ref: '#/components/schemas/NodePoolAutoScaling'
                         volumeSize:
-                            description: Size of the EBS volume in GBs of the nodes in the pool.
+                            description: Size of the EBS volume in GiBs of the nodes in the pool.
                             type: integer
                             example: 50
                         instanceType:
@@ -4860,7 +4860,7 @@ components:
                 volumeEncryption:
                     $ref: '#/components/schemas/EKSNodePoolVolumeEncryption'
                 volumeSize:
-                    description: Size of the EBS volume in GBs of the nodes in the pool.
+                    description: Size of the EBS volume in GiBs of the nodes in the pool.
                     example: 50
                     type: integer
                 image:
@@ -5215,7 +5215,7 @@ components:
                     example: "ami-dd3c0f36"
                 volumeSize:
                     type: integer
-                    description: Size of root EBS volume to attach to the nodes in GBs. Zero means that the size is determined automatically.
+                    description: Size of root EBS volume to attach to the nodes in GiBs. Zero means that the size is determined automatically.
                 zones:
                     type: array
                     items:

--- a/charts/pipeline/values.yaml
+++ b/charts/pipeline/values.yaml
@@ -180,7 +180,7 @@ configuration:
   #       enabled: false
   #       encryptionKeyARN: ""
 
-  #     defaultNodeVolumeSize: 0 # GB, 0/fallback: max(50, AMISize)
+  #     defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)
 
   #     # Expose admin kubeconfig over the API by default.
   #     # Set this to false to remove credentials from the config and make the user responsible for how they authenticate.

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -398,7 +398,7 @@ dex:
 #            enabled: false
 #            encryptionKeyARN: ""
 #
-#        defaultNodeVolumeSize: 0 # GB, 0/fallback: max(50, AMISize)
+#        defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)
 #
 #        # Expose admin kubeconfig over the API by default.
 #        # Set this to false to remove credentials from the config and make the user responsible for how they authenticate.

--- a/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity.go
@@ -70,7 +70,7 @@ func (a *SelectVolumeSizeActivity) Execute(ctx context.Context, input SelectVolu
 
 	if output.VolumeSize < input.AMISize {
 		return nil, errors.New(fmt.Sprintf(
-			"selected volume size of %d GB (source: %s) is less than the AMI size of %d GB",
+			"selected volume size of %d GiB (source: %s) is less than the AMI size of %d GiB",
 			output.VolumeSize, valueSource, input.AMISize,
 		))
 	}

--- a/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity_test.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/select_volume_size_activity_test.go
@@ -84,7 +84,7 @@ func TestSelectVolumeSizeActivityExecute(t *testing.T) {
 			},
 			output: outputType{
 				expectedError: errors.New(
-					"selected volume size of 1 GB (source: explicitly set) is less than the AMI size of 2 GB",
+					"selected volume size of 1 GiB (source: explicitly set) is less than the AMI size of 2 GiB",
 				),
 				expectedOutput: nil,
 			},
@@ -100,7 +100,7 @@ func TestSelectVolumeSizeActivityExecute(t *testing.T) {
 			},
 			output: outputType{
 				expectedError: errors.New(
-					"selected volume size of 1 GB (source: default configured) is less than the AMI size of 2 GB",
+					"selected volume size of 1 GiB (source: default configured) is less than the AMI size of 2 GiB",
 				),
 				expectedOutput: nil,
 			},
@@ -254,7 +254,7 @@ func TestSelectVolumeSize(t *testing.T) {
 			},
 			output: outputType{
 				expectedError: errors.New(
-					"selected volume size of 1 GB (source: explicitly set) is less than the AMI size of 2 GB",
+					"selected volume size of 1 GiB (source: explicitly set) is less than the AMI size of 2 GiB",
 				),
 				expectedVolumeSize: 0,
 			},
@@ -348,7 +348,7 @@ func TestSelectVolumeSizeAsync(t *testing.T) {
 			},
 			output: outputType{
 				expectedError: errors.New(
-					"selected volume size of 1 GB (source: explicitly set) is less than the AMI size of 2 GB",
+					"selected volume size of 1 GiB (source: explicitly set) is less than the AMI size of 2 GiB",
 				),
 				expectedOutput: nil,
 			},

--- a/templates/pke/master.cf.yaml
+++ b/templates/pke/master.cf.yaml
@@ -40,7 +40,7 @@ Parameters:
     Default: ""
   VolumeSize:
     Type: Number
-    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
+    Description: Size of EBS volume to create in GiB. Zero means to use the the AMI snapshot size.
     Default: 0
 
 Conditions:

--- a/templates/pke/masters.cf.yaml
+++ b/templates/pke/masters.cf.yaml
@@ -58,7 +58,7 @@ Parameters:
     Description: Initial count of nodes in the pool
   VolumeSize:
     Type: Number
-    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
+    Description: Size of EBS volume to create in GiB. Zero means to use the the AMI snapshot size.
     Default: 0
 
 Conditions:

--- a/templates/pke/worker.cf.yaml
+++ b/templates/pke/worker.cf.yaml
@@ -61,7 +61,7 @@ Parameters:
     Type: String
   VolumeSize:
     Type: Number
-    Description: Size of EBS volume to create in GB. Zero means to use the the AMI snapshot size.
+    Description: Size of EBS volume to create in GiB. Zero means to use the the AMI snapshot size.
     Default: 0
 
 Conditions:


### PR DESCRIPTION
GB unit is used throughout the code base for description, while the AWS EC2 instance EBS VolumeSize definition states the unit is GiB instead.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related issues | https://github.com/banzaicloud/pipeline/issues/3162
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Consolidate EBS volume size measurement units to GiB

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

GB unit is used throughout the code base for description, while the AWS EC2 instance EBS VolumeSize definition states the unit is GiB instead.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The values are transferred transparently through integer holders so this does not have an impact on code execution, it is merely for clarifying the documentation of the corresponding variables and meeting the end user expectations and relations between the value put in and the resulting volume size.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] OpenAPI and Postman files updated (if needed)~
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~
