### PR TITLE
Updated Cadence env to chart 0.22.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
             - ./etc/config/dex.yml:/dex.yml
 
     cadence:
-        image: ubercadence/server:0.21.3-auto-setup
+        image: ubercadence/server:0.22.1-auto-setup
         environment:
             LOG_LEVEL: debug,info
             DB: mysql
@@ -87,7 +87,7 @@ services:
             - mysql
 
     cadence-web:
-        image: ubercadence/web:v3.28.4
+        image: ubercadence/web:v3.28.7
         environment:
             CADENCE_TCHANNEL_PEERS: cadence:7933
         depends_on:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated local env Cadence to "chart 0.22.1" (server 0.22.1, web 3.28.7).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Converging towards latest supported version.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~