### PR TITLE
Fix integrated service tests

### DIFF
--- a/.github/workflows/is-test-v2.yml
+++ b/.github/workflows/is-test-v2.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go', '**/go.mod', '**/go.sum') }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('*.go', 'go.mod', 'go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-build-
 

--- a/.github/workflows/is-test.yml
+++ b/.github/workflows/is-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go', '**/go.mod', '**/go.sum') }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('*.go', 'go.mod', 'go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-build-
 

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ test-integration: bin/test/kube-apiserver bin/test/etcd ## Run integration tests
 test-integrated-service-up: ## Run integrated service functional tests
 	@echo "Stopping pipeline development stack if it's already running"
 	docker-compose stop
-	if ! kind get kubeconfig --name pipeline-is-test 1>/dev/null; then kind create cluster --name pipeline-is-test --kubeconfig $(HOME)/.kube/kind-pipeline-is-test; fi
+	if ! kind get kubeconfig --name pipeline-is-test 1>/dev/null; then kind create cluster --image kindest/node:v1.21.1 --name pipeline-is-test --kubeconfig $(HOME)/.kube/kind-pipeline-is-test; fi
 	mkdir -p .docker/volumes/{mysql,vault/file,vault/keys}
 	uid=$(shell id -u) gid=$(shell id -g) docker-compose -p pipeline-is-test --project-directory $(PWD) -f $(PWD)/internal/integratedservices/testconfig/docker-compose.yml up -d
 	@while ! test -f $(HOME)/.vault-token; do echo "waiting for vault root token"; docker ps; docker-compose logs --tail 10; sleep 3; done

--- a/internal/integratedservices/testconfig/docker-compose.yml
+++ b/internal/integratedservices/testconfig/docker-compose.yml
@@ -18,7 +18,7 @@ services:
             - 127.0.0.1:3306:3306
 
     vault:
-        image: vault:1.4.2
+        image: vault:1.6.1
         command: server
         cap_add:
             - IPC_LOCK
@@ -31,7 +31,7 @@ services:
 
     vault-unsealer:
         user: "${uid}:${gid}"
-        image: banzaicloud/bank-vaults:1.7.0
+        image: banzaicloud/bank-vaults:1.10.0
         depends_on:
             - vault
         restart: on-failure
@@ -44,7 +44,7 @@ services:
 
     vault-configurer:
         user: "${uid}:${gid}"
-        image: banzaicloud/bank-vaults:1.7.0
+        image: banzaicloud/bank-vaults:1.10.0
         depends_on:
             - vault
             - vault-unsealer
@@ -69,7 +69,7 @@ services:
             - ./.docker/volumes/vault/keys:/vault/keys
 
     cadence:
-        image: ubercadence/server:0.13.0-auto-setup
+        image: ubercadence/server:0.22.1-auto-setup
         environment:
             LOG_LEVEL: debug,info
             DB: mysql


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Fixed `hashFiles` function in is-test workflows.
- Updated versions of services in test environment to be in sync with what is being used in the dev env.
- Kubernetes version 1.21.1 has been specified in the Makefile to be used by kind when creating a cluster to run tests against.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In a recent change hashfiles function throws an error instead of failing silently causing these is-test workflows to fail.
Also the latest Ubuntu images that are used in the Github actions use the latest Kind version which starts kubernetes v1.23.4 version clusters by default, causing the integrated services v2 test to fail. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~