### PR TITLE
Force delete on cluster in deleting status

### DIFF
--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -289,12 +289,11 @@ func (s service) DeleteCluster(ctx context.Context, clusterIdentifier Identifier
 		return false, err
 	}
 
-	// Already being deleted, return 202 Accepted
-	if c.Status == Deleting {
+	// Already being deleted, return 202 Accepted if not forced
+	if c.Status == Deleting && !options.Force {
 		return false, nil
-	}
-
-	if !clusterIsReady(c.Status) && !options.Force {
+		// Return error when cluster is not ready if not forced
+	} else if !clusterIsReady(c.Status) && !options.Force {
 		return false, NotReadyError{
 			OrganizationID: c.OrganizationID,
 			ID:             c.ID,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Made force delete work on clusters already in deleting status.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

If a cluster stuck in deleting status according to the database (even though its resources were terminated), there was no way to make it disappear from the client side.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally. If a force delete is called on a cluster with a running deletion workflow still unfinished, the second workflow failed but the resources were terminated and the database was updated successfully (tested with PKE on AWS).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~