### PR TITLE
Updated bitnami/external-dns chart 4.5.0->6.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -244,7 +244,7 @@ dex:
 #        charts:
 #            externalDns:
 #                chart: "bitnami/external-dns"
-#                version: "4.5.0"
+#                version: "6.5.1"
 #
 #                # See https://github.com/bitnami/charts/tree/master/bitnami/external-dns for details
 #                values: {}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -669,7 +669,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::dns::baseDomain", "")
 	v.SetDefault("cluster::dns::providerSecret", "secret/data/banzaicloud/aws")
 	v.SetDefault("cluster::dns::charts::externalDns::chart", "bitnami/external-dns")
-	v.SetDefault("cluster::dns::charts::externalDns::version", "4.5.0")
+	v.SetDefault("cluster::dns::charts::externalDns::version", "6.5.1")
 	v.SetDefault("cluster::dns::charts::externalDns::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"registry":   "k8s.gcr.io",

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -53,7 +53,7 @@ func TestConfigure_DefaultValueBinding(t *testing.T) {
 						ExternalDNS: dns.ExternalDNSChartConfig{
 							ChartConfigBase: dns.ChartConfigBase{
 								Chart:   "bitnami/external-dns",
-								Version: "4.5.0",
+								Version: "6.5.1",
 							},
 							Values: dns.ExternalDNSChartValuesConfig{
 								Image: dns.ExternalDNSChartValuesImageConfig{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated bitnami/external-dns chart 4.5.0->6.5.1.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The the external-dns chart 4.5.0 version we used (for the DNS integrated service) were pulled down from the bitnami chart repository.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Successful activation tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~