### PR TITLE
Revert "Updated EKS kubeconfig auth apiversion"

### DIFF
--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -728,7 +728,7 @@ func (c *EKSCluster) GetK8sUserConfig() ([]byte, error) {
 		k8sutil.CreateAuthInfoFunc(func(clusterName string) *clientcmdapi.AuthInfo {
 			return &clientcmdapi.AuthInfo{
 				Exec: &clientcmdapi.ExecConfig{
-					APIVersion: "client.authentication.k8s.io/v1beta1",
+					APIVersion: "client.authentication.k8s.io/v1alpha1",
 					Command:    "aws-iam-authenticator",
 					Args:       []string{"token", "-i", clusterName},
 				},


### PR DESCRIPTION
Reverts banzaicloud/pipeline#3623

It did not deliver the expected behavior on Pipeline instances deployed on AWS EKS.