### PR TITLE
Fixed EKS new aws-iam-authn apiVersion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM alpine:3.13 AS iamauth
 
 WORKDIR /tmp
 
-ENV IAM_AUTH_VERSION 0.4.0
+ENV IAM_AUTH_VERSION 0.5.9
 ENV IAM_AUTH_URL "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_AUTH_VERSION}"
 RUN set -xe \
     && wget ${IAM_AUTH_URL}/aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64 \

--- a/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
+++ b/internal/cluster/distribution/eks/eksprovider/workflow/amazon.go
@@ -125,7 +125,7 @@ func generateK8sConfig(clusterName string, apiEndpoint string, certificateAuthor
 				Name: "eks",
 				AuthInfo: clientcmdapi.AuthInfo{
 					Exec: &clientcmdapi.ExecConfig{
-						APIVersion: "client.authentication.k8s.io/v1alpha1",
+						APIVersion: "client.authentication.k8s.io/v1beta1",
 						Command:    "aws-iam-authenticator",
 						Args:       []string{"token", "-i", clusterName},
 						Env: []clientcmdapi.ExecEnvVar{

--- a/src/cluster/eks.go
+++ b/src/cluster/eks.go
@@ -728,7 +728,7 @@ func (c *EKSCluster) GetK8sUserConfig() ([]byte, error) {
 		k8sutil.CreateAuthInfoFunc(func(clusterName string) *clientcmdapi.AuthInfo {
 			return &clientcmdapi.AuthInfo{
 				Exec: &clientcmdapi.ExecConfig{
-					APIVersion: "client.authentication.k8s.io/v1alpha1",
+					APIVersion: parsedAdminConfig.AuthInfos["eks"].Exec.APIVersion,
 					Command:    "aws-iam-authenticator",
 					Args:       []string{"token", "-i", clusterName},
 				},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Properly generating EKS KUBECONFIG client.authentication.k8s.io APIVersion for aws-iam-authenticator tokens.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because it was not working well for UI/API downloaded KUBECONFIGs even though banzai CLI solves some of these problems.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
