### PR TITLE
Option to disable PKE on Azure and AWS

### DIFF
--- a/charts/pipeline/values.yaml
+++ b/charts/pipeline/values.yaml
@@ -170,7 +170,7 @@ configuration:
     #           default: true
 
   # Distribution settings
-  # distribution:
+  distribution:
 
   #   eks:
   #     # EKS Cloud Formation template location
@@ -190,12 +190,15 @@ configuration:
   #     # Enable create & update of EKS addons like coredns
   #     enableAddons: false
 
-  #   pke:
-  #     amazon:
+    pke:
+      amazon:
+        enabled: true
   #       globalRegion: us-east-1
   #       defaultImages: {}
   #       defaultNetworkProvider: "cilium"
   #       defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)
+      azure:
+        enabled: true
 
   # Database configuration
   database:

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -436,6 +436,7 @@ func main() {
 	clusterCreators := api.ClusterCreators{
 		PKEOnAzure: azurePKEDriver.MakeClusterCreator(
 			azurePKEDriver.ClusterCreatorConfig{
+				Enabled:                     config.Distribution.PKE.Azure.Enabled,
 				OIDCIssuerURL:               config.Auth.OIDC.Issuer,
 				PipelineExternalURL:         externalBaseURL,
 				PipelineExternalURLInsecure: externalURLInsecure,
@@ -672,6 +673,7 @@ func main() {
 		dynamicClientFactory,
 		unifiedHelmReleaser,
 		config.Auth,
+		config.Distribution,
 		clusterAuthService,
 	)
 

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -397,7 +397,7 @@ dex:
 #        # Default Amazon region
 #        defaultRegion: "us-west-1"
 
-#distribution:
+distribution:
 #    eks:
 #
 #        # EKS Cloud Formation template location
@@ -417,12 +417,15 @@ dex:
 #        # Enable create & update of EKS addons like coredns
 #        enableAddons: false
 #
-#    pke:
-#        amazon:
+   pke:
+       amazon:
+           enabled: true
 #            globalRegion: us-east-1
 #            defaultImages: {}
 #            defaultNetworkProvider: "cilium"
 #            defaultNodeVolumeSize: 0 # GiB, 0/fallback: max(50, AMISize)
+       azure:
+           enabled: true
 
 cloudinfo:
     # Format: {baseUrl}/api/v1

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -61,30 +61,7 @@ type Config struct {
 		APICa   string
 	}
 
-	Distribution struct {
-		EKS struct {
-			TemplateLocation            string
-			DefaultNodeVolumeEncryption *struct {
-				Enabled          bool
-				EncryptionKeyARN string
-			}
-			DefaultNodeVolumeSize int
-			ExposeAdminKubeconfig bool
-			SSH                   struct {
-				Generate bool
-			}
-			EnableAddons bool
-		}
-
-		PKE struct {
-			Amazon struct {
-				GlobalRegion           string
-				DefaultImages          map[string]string
-				DefaultNetworkProvider string
-				DefaultNodeVolumeSize  int
-			}
-		}
-	}
+	Distribution DistributionConfig
 
 	Helm helm.Config
 
@@ -521,6 +498,35 @@ func (c TelemetryConfig) Validate() error {
 	return err
 }
 
+type DistributionConfig struct {
+	EKS struct {
+		TemplateLocation            string
+		DefaultNodeVolumeEncryption *struct {
+			Enabled          bool
+			EncryptionKeyARN string
+		}
+		DefaultNodeVolumeSize int
+		ExposeAdminKubeconfig bool
+		SSH                   struct {
+			Generate bool
+		}
+		EnableAddons bool
+	}
+
+	PKE struct {
+		Amazon struct {
+			Enabled                bool
+			GlobalRegion           string
+			DefaultImages          map[string]string
+			DefaultNetworkProvider string
+			DefaultNodeVolumeSize  int
+		}
+		Azure struct {
+			Enabled bool
+		}
+	}
+}
+
 // Configure configures some defaults in the Viper instance.
 func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	// Log configuration
@@ -877,10 +883,13 @@ traefik:
 	v.SetDefault("distribution::eks::ssh::generate", true)
 	v.SetDefault("distribution::eks::enableAddons", false)
 
+	v.SetDefault("distribution::pke::amazon::enabled", true)
 	v.SetDefault("distribution::pke::amazon::globalRegion", "us-east-1")
 	v.SetDefault("distribution::pke::amazon::defaultImages", map[string]string{})
 	v.SetDefault("distribution::pke::amazon::defaultNetworkProvider", "cilium")
 	v.SetDefault("distribution::pke::amazon::defaultNodeVolumeSize", 0)
+
+	v.SetDefault("distribution::pke::azure::enabled", true)
 
 	v.SetDefault("cloudinfo::endpoint", "")
 

--- a/internal/providers/azure/pke/driver/BUILD.plz
+++ b/internal/providers/azure/pke/driver/BUILD.plz
@@ -21,6 +21,7 @@ go_library(
         "//pkg/cluster",
         "//pkg/cluster/pke",
         "//pkg/common",
+        "//pkg/errors",
         "//pkg/k8sclient",
         "//pkg/providers/azure",
         "//src/auth",

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/secret/secrettype"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgPKE "github.com/banzaicloud/pipeline/pkg/cluster/pke"
+	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	pkgAzure "github.com/banzaicloud/pipeline/pkg/providers/azure"
 	"github.com/banzaicloud/pipeline/src/auth"
 	"github.com/banzaicloud/pipeline/src/cluster"
@@ -86,6 +87,7 @@ type ClusterCreatorSecretStore interface {
 }
 
 type ClusterCreatorConfig struct {
+	Enabled                     bool
 	OIDCIssuerURL               string
 	PipelineExternalURL         string
 	PipelineExternalURLInsecure bool
@@ -157,6 +159,11 @@ type ClusterCreationParams struct {
 
 // Create
 func (cc ClusterCreator) Create(ctx context.Context, params ClusterCreationParams) (cl pke.Cluster, err error) {
+	if !cc.config.Enabled {
+		err = pkgErrors.ErrorNotSupportedDistributionType
+		return
+	}
+
 	sir, err := cc.secrets.Get(params.OrganizationID, params.SecretID)
 	if err = errors.WrapIf(err, "failed to get secret"); err != nil {
 		return

--- a/src/api/BUILD.plz
+++ b/src/api/BUILD.plz
@@ -15,6 +15,7 @@ go_library(
         "//internal/cluster/endpoints",
         "//internal/cluster/oidc",
         "//internal/cluster/resourcesummary",
+        "//internal/cmd",
         "//internal/common",
         "//internal/global",
         "//internal/helm",

--- a/src/api/cluster.go
+++ b/src/api/cluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/banzaicloud/pipeline/internal/cluster/clusteradapter"
 	eksdriver "github.com/banzaicloud/pipeline/internal/cluster/distribution/eks/eksprovider/driver"
 	"github.com/banzaicloud/pipeline/internal/cluster/resourcesummary"
+	"github.com/banzaicloud/pipeline/internal/cmd"
 	"github.com/banzaicloud/pipeline/internal/global"
 	azureDriver "github.com/banzaicloud/pipeline/internal/providers/azure/pke/driver"
 	vsphereDriver "github.com/banzaicloud/pipeline/internal/providers/vsphere/pke/driver"
@@ -63,6 +64,7 @@ type ClusterAPI struct {
 
 	helmService        cluster.HelmService
 	authConfig         auth.Config
+	distributionConfig cmd.DistributionConfig
 	clientSecretGetter clusterAuth.ClusterClientSecretGetter
 }
 
@@ -97,6 +99,7 @@ func NewClusterAPI(
 	clientFactory common.DynamicClientFactory,
 	helmService cluster.HelmService,
 	authConfig auth.Config,
+	distributionConfig cmd.DistributionConfig,
 	clientSecretGetter clusterAuth.ClusterClientSecretGetter,
 ) *ClusterAPI {
 	return &ClusterAPI{
@@ -112,6 +115,7 @@ func NewClusterAPI(
 		clientFactory:           clientFactory,
 		helmService:             helmService,
 		authConfig:              authConfig,
+		distributionConfig:      distributionConfig,
 		clientSecretGetter:      clientSecretGetter,
 	}
 }

--- a/src/api/cluster_create.go
+++ b/src/api/cluster_create.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/gin-gonic/gin"
@@ -28,6 +29,7 @@ import (
 	ginutils "github.com/banzaicloud/pipeline/internal/platform/gin/utils"
 	pkgCluster "github.com/banzaicloud/pipeline/pkg/cluster"
 	pkgCommon "github.com/banzaicloud/pipeline/pkg/common"
+	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	clusterAPI "github.com/banzaicloud/pipeline/src/api/cluster"
 	"github.com/banzaicloud/pipeline/src/auth"
 	"github.com/banzaicloud/pipeline/src/cluster"
@@ -259,6 +261,14 @@ func (a *ClusterAPI) createCluster(
 			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 			Error:   err.Error(),
+		}
+	}
+
+	if strings.HasPrefix(commonCluster.GetDistribution(), pkgCluster.PKE) && commonCluster.GetCloud() == pkgCluster.Amazon && !a.distributionConfig.PKE.Amazon.Enabled {
+		return nil, &pkgCommon.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: pkgErrors.ErrorNotSupportedDistributionType.Error(),
+			Error:   pkgErrors.ErrorNotSupportedDistributionType.Error(),
 		}
 	}
 

--- a/src/api/error.go
+++ b/src/api/error.go
@@ -17,6 +17,7 @@ package api
 import (
 	"github.com/pkg/errors"
 
+	pkgErrors "github.com/banzaicloud/pipeline/pkg/errors"
 	"github.com/banzaicloud/pipeline/src/secret"
 )
 
@@ -33,6 +34,8 @@ func isInvalid(err error) bool {
 
 	switch err {
 	case secret.ErrSecretNotExists:
+		return true
+	case pkgErrors.ErrorNotSupportedDistributionType:
 		return true
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added config options to disable starting PKE clusters on Azure or AWS. If PKE is disabled on either of them, the cluster creation request now returns 400 Bad Request with the message `Not supported distribution type`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It is nice to have more configuration options for Pipeline CP, also PKE on Azure is currently misbehaving, and we decided to drop support for now.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

A similar solution is going to be implemented in Cloudinfo to remove the disabled options from the GUI as well.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)