### PR TITLE
PKE K8s version validation

### DIFF
--- a/internal/pke/BUILD.plz
+++ b/internal/pke/BUILD.plz
@@ -7,6 +7,9 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//internal/global",
+        "//pkg/errors",
+        "//third_party/go:emperror.dev__errors",
+        "//third_party/go:github.com__Masterminds__semver__v3",
         "//third_party/go:github.com__sirupsen__logrus",
     ],
 )

--- a/internal/providers/azure/pke/driver/cluster_creator.go
+++ b/internal/providers/azure/pke/driver/cluster_creator.go
@@ -164,6 +164,10 @@ func (cc ClusterCreator) Create(ctx context.Context, params ClusterCreationParam
 		return
 	}
 
+	if err = intPKE.ValidatePKEKubernetesVersion(params.Kubernetes.Version); err != nil {
+		return
+	}
+
 	sir, err := cc.secrets.Get(params.OrganizationID, params.SecretID)
 	if err = errors.WrapIf(err, "failed to get secret"); err != nil {
 		return

--- a/internal/providers/vsphere/pke/driver/cluster_creator.go
+++ b/internal/providers/vsphere/pke/driver/cluster_creator.go
@@ -149,6 +149,10 @@ type VspherePKEClusterCreationParams struct {
 
 // Create
 func (cc VspherePKEClusterCreator) Create(ctx context.Context, params VspherePKEClusterCreationParams) (cl pke.PKEOnVsphereCluster, err error) {
+	if err = intPKE.ValidatePKEKubernetesVersion(params.Kubernetes.Version); err != nil {
+		return
+	}
+
 	var vsphereSecret *secret.SecretItemResponse
 	vsphereSecret, err = cc.secrets.Get(params.OrganizationID, params.SecretID)
 	if err = errors.WrapIf(err, "failed to get secret"); err != nil {

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -332,11 +332,11 @@ func (r *CreateClusterRequest) Validate() error {
 
 	switch r.Cloud {
 	case Amazon:
-		// eks validate
+		// pke validate
 		if r.Properties.CreateClusterPKE != nil {
-			// r.Properties.CreateClusterPKE.Validate()
-			return nil
+			return r.Properties.CreateClusterPKE.Validate()
 		}
+		// eks validate
 		return r.Properties.CreateClusterEKS.Validate()
 	case Azure:
 		// aks validate

--- a/pkg/cluster/pke/BUILD.plz
+++ b/pkg/cluster/pke/BUILD.plz
@@ -7,6 +7,7 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//internal/global",
+        "//internal/pke",
         "//pkg/common",
         "//third_party/go:github.com__pkg__errors",
     ],

--- a/pkg/cluster/pke/types.go
+++ b/pkg/cluster/pke/types.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/banzaicloud/pipeline/internal/global"
+	intPKE "github.com/banzaicloud/pipeline/internal/pke"
 	"github.com/banzaicloud/pipeline/pkg/common"
 )
 
@@ -30,6 +31,14 @@ type CreateClusterPKE struct {
 	Kubernetes Kubernetes `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty" binding:"required"`
 	KubeADM    KubeADM    `json:"kubeadm,omitempty" yaml:"kubeadm,omitempty"`
 	CRI        CRI        `json:"cri,omitempty" yaml:"cri,omitempty" binding:"required"`
+}
+
+func (pke *CreateClusterPKE) Validate() error {
+	if err := intPKE.ValidatePKEKubernetesVersion(pke.Kubernetes.Version); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // UpdateClusterPKE describes Pipeline's EC2/BanzaiCloud fields of a UpdateCluster request

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrorNotDifferentInterfaces        = errors.New("There is no change in data")
 	ErrorNilCluster                    = errors.New("<nil> cluster")
 	ErrorWrongKubernetesVersion        = errors.New("Wrong kubernetes version for master/nodes. The required minimum kubernetes version is 1.8.x ")
+	ErrorNotSupportedKubernetesVersion = errors.New("Not supported Kubernetes version")
 	ErrorDifferentKubernetesVersion    = errors.New("Different kubernetes version for master and nodes")
 	ErrorLocationEmpty                 = errors.New("Location field is empty")
 	ErrorNodePoolNotProvided           = errors.New("At least one 'nodepool' is required for creating or updating a cluster")

--- a/src/api/error.go
+++ b/src/api/error.go
@@ -37,6 +37,8 @@ func isInvalid(err error) bool {
 		return true
 	case pkgErrors.ErrorNotSupportedDistributionType:
 		return true
+	case pkgErrors.ErrorNotSupportedKubernetesVersion:
+		return true
 	}
 
 	switch err.(type) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added PKE Kubernetes version validation with hard-coded minimum and maximum version numbers. Starting a PKE cluster with higher or lower Kubernetes version than supported now results in a 400 Bad Request error response from the Pipeline API in the case of the following cloud providers:
- Amazon
- Azure
- vSphere

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Previously if someone started a PKE cluster with higher K8s version than available, there were no feedback from the API that this is not allowed, although the cluster creation failed later on.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~