### PR TITLE
Updated PKE image Cloudinfo request params

### DIFF
--- a/.gen/cloudinfo/api/openapi.yaml
+++ b/.gen/cloudinfo/api/openapi.yaml
@@ -252,6 +252,14 @@ paths:
         x-go-name: Gpu
       - explode: true
         in: query
+        name: cr
+        required: false
+        schema:
+          type: string
+        style: form
+        x-go-name: Cr
+      - explode: true
+        in: query
         name: version
         required: false
         schema:

--- a/.gen/cloudinfo/api_images.go
+++ b/.gen/cloudinfo/api_images.go
@@ -31,6 +31,7 @@ type ImagesApiService service
 // GetImagesOpts Optional parameters for the method 'GetImages'
 type GetImagesOpts struct {
     Gpu optional.String
+    Cr optional.String
     Version optional.String
     Os optional.String
     PkeVersion optional.String
@@ -45,6 +46,7 @@ GetImages Provides a list of available images on a given provider in a specific 
  * @param region
  * @param optional nil or *GetImagesOpts - Optional Parameters:
  * @param "Gpu" (optional.String) - 
+ * @param "Cr" (optional.String) - 
  * @param "Version" (optional.String) - 
  * @param "Os" (optional.String) - 
  * @param "PkeVersion" (optional.String) - 
@@ -75,6 +77,9 @@ func (a *ImagesApiService) GetImages(ctx _context.Context, provider string, serv
 
 	if localVarOptionals != nil && localVarOptionals.Gpu.IsSet() {
 		localVarQueryParams.Add("gpu", parameterToString(localVarOptionals.Gpu.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Cr.IsSet() {
+		localVarQueryParams.Add("cr", parameterToString(localVarOptionals.Cr.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.Version.IsSet() {
 		localVarQueryParams.Add("version", parameterToString(localVarOptionals.Version.Value(), ""))

--- a/apis/cloudinfo/openapi.yaml
+++ b/apis/cloudinfo/openapi.yaml
@@ -222,6 +222,11 @@ paths:
           in: query
           schema:
             type: string
+        - x-go-name: Cr
+          name: cr
+          in: query
+          schema:
+            type: string
         - x-go-name: Version
           name: version
           in: query

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -436,8 +436,8 @@ func main() {
 
 		imageSelector := pkeaws.NewImageSelectorChain(commonLogger, errorHandler)
 
-		imageSelector.AddSelector("gpu", pkeaws.NewGPUImageSelector(pkeaws.GPUImages()))
 		imageSelector.AddSelector("cloudinfo", pkeawsadapter.NewCloudinfoImageSelector(cloudinfoClient))
+		imageSelector.AddSelector("gpu", pkeaws.NewGPUImageSelector(pkeaws.GPUImages()))
 		if len(config.Distribution.PKE.Amazon.DefaultImages) > 0 {
 			imageSelector.AddSelector("defaults", pkeaws.RegionMapImageSelector(config.Distribution.PKE.Amazon.DefaultImages))
 		} else {

--- a/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/image_selector.go
+++ b/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/image_selector.go
@@ -65,6 +65,7 @@ func (s CloudinfoImageSelector) SelectImage(ctx context.Context, criteria pkeaws
 		PkeVersion: optional.NewString(criteria.PKEVersion),
 		LatestOnly: optional.NewString("true"),
 		Gpu:        optional.NewString(strconv.FormatBool(isGPUInstance(criteria.InstanceType))),
+		Cr:         optional.NewString(criteria.ContainerRuntime),
 	}
 
 	const (

--- a/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/image_selector.go
+++ b/internal/cluster/distribution/pke/pkeaws/pkeawsadapter/image_selector.go
@@ -16,6 +16,8 @@ package pkeawsadapter
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver/v3"
@@ -52,11 +54,17 @@ func (s CloudinfoImageSelector) SelectImage(ctx context.Context, criteria pkeaws
 		)
 	}
 
+	isGPUInstance := func(instanceType string) bool {
+		return strings.HasPrefix(instanceType, "p2.") || strings.HasPrefix(instanceType, "p3.") ||
+			strings.HasPrefix(instanceType, "g3.") || strings.HasPrefix(instanceType, "g4.")
+	}
+
 	opts := &cloudinfo.GetImagesOpts{
 		Version:    optional.NewString(kubeVersion.String()),
 		Os:         optional.NewString(criteria.OperatingSystem),
 		PkeVersion: optional.NewString(criteria.PKEVersion),
 		LatestOnly: optional.NewString("true"),
+		Gpu:        optional.NewString(strconv.FormatBool(isGPUInstance(criteria.InstanceType))),
 	}
 
 	const (


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added `gpu` and `cr` params to Cloudinfo request listing the available PKE images.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In order to correctly filter the latest, default PKE 0.9.3 images.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~