### PR TITLE
Added EBS CSI driver policy to EKS NodeInstanceRole and PKE AWS WorkerRole

### DIFF
--- a/templates/eks/amazon-eks-iam-cf.yaml
+++ b/templates/eks/amazon-eks-iam-cf.yaml
@@ -98,6 +98,7 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
       Policies:
         -
           PolicyName: NodePolicy

--- a/templates/pke/global.cf.yaml
+++ b/templates/pke/global.cf.yaml
@@ -16,6 +16,8 @@ Resources:
           Action:
           - "sts:AssumeRole"
       RoleName: !Join ["", [ !Ref "AWS::StackName" , "-worker" ]]
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
       Policies:
       - PolicyName: PkeKubernetesWorkerPolicy
         PolicyDocument:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added EBS CSI driver policy to EKS NodeInstanceRole and PKE AWS WorkerRole.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To make K8s 1.23+ clusters work out of the box with PVCs when the new EBS CSI driver is installed and set to use the role inherited from the nodes (easiest default setup without the additional OIDC burden).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The installation of the new driver is going to be added in another PR.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
