### PR TITLE
Updated vault, bank-vaults and pipeline-web versions

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -18,6 +18,7 @@ ignored = [
   "github.com/samuel/go-thrift", # BSD-3
   "github.com/uber-go/tally", # MIT
   "github.com/leodido/go-urn", # MIT
+	"github.com/form3tech-oss/jwt-go", # MIT
 
   "github.com/davecgh/go-spew", # ISC license
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
             - $HOME:/root
 
     ui:
-        image: banzaicloud/pipeline-web:0.27.0
+        image: banzaicloud/pipeline-web:0.42.1
         environment:
             TAG: local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             - ${PWD}/database/docker-init-mysql.sql:/docker-entrypoint-initdb.d/docker-init.sql
 
     vault:
-        image: vault:1.6.1
+        image: vault:1.6.2
         command: server
         cap_add:
             - IPC_LOCK
@@ -23,7 +23,7 @@ services:
             - ./etc/config/vault.hcl:/vault/config/vault.hcl
 
     vault-unsealer:
-        image: banzaicloud/bank-vaults:1.10.0
+        image: banzaicloud/bank-vaults:1.16.0
         depends_on:
             - vault
         restart: on-failure
@@ -34,7 +34,7 @@ services:
             - ./etc/config/vault-config.yml:/vault-config.yml
 
     vault-configurer:
-        image: banzaicloud/bank-vaults:1.10.0
+        image: banzaicloud/bank-vaults:1.16.0
         depends_on:
             - vault
             - vault-unsealer

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -594,7 +594,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::vault::managed::enabled", false)
 	v.SetDefault("cluster::vault::managed::endpoint", "")
 	v.SetDefault("cluster::vault::charts::webhook::chart", "banzaicloud-stable/vault-secrets-webhook")
-	v.SetDefault("cluster::vault::charts::webhook::version", "1.10.1")
+	v.SetDefault("cluster::vault::charts::webhook::version", "1.16.0")
 	v.SetDefault("cluster::vault::charts::webhook::values", map[string]interface{}{})
 
 	v.SetDefault("cluster::monitoring::enabled", true)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Updated the Bank-Vaults webhook version (1.10.1->1.16.0) to the latest default in Pipeline config that is also used in the latest community installer (0.36.2).
- Updated Vault (1.6.1->1.6.2), Bank-Vaults (1.10.0->1.16.0) and pipeline-web (0.27.0->0.42.1) to the latest default versions also used in the latest community installer (0.36.2) in the docker-compose file used for local development.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So versions are consolidated across the Pipeline-related repos.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~