### PR TITLE
Updated packages

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [please]
-version = 16.22.0
+version = 16.26.1
 
 [build]
 PassUnsafeEnv = VAULT_ADDR

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -244,7 +244,7 @@ dex:
 #        charts:
 #            externalDns:
 #                chart: "bitnami/external-dns"
-#                version: "6.5.1"
+#                version: "6.12.2"
 #
 #                # See https://github.com/bitnami/charts/tree/master/bitnami/external-dns for details
 #                values: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
             - mysql
 
     cadence-web:
-        image: ubercadence/web:v3.29.5
+        image: ubercadence/web:v3.32.0
         environment:
             CADENCE_TCHANNEL_PEERS: cadence:7933
         depends_on:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -676,7 +676,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("cluster::dns::baseDomain", "")
 	v.SetDefault("cluster::dns::providerSecret", "secret/data/banzaicloud/aws")
 	v.SetDefault("cluster::dns::charts::externalDns::chart", "bitnami/external-dns")
-	v.SetDefault("cluster::dns::charts::externalDns::version", "6.5.1")
+	v.SetDefault("cluster::dns::charts::externalDns::version", "6.12.2")
 	v.SetDefault("cluster::dns::charts::externalDns::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"registry":   "k8s.gcr.io",

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -53,7 +53,7 @@ func TestConfigure_DefaultValueBinding(t *testing.T) {
 						ExternalDNS: dns.ExternalDNSChartConfig{
 							ChartConfigBase: dns.ChartConfigBase{
 								Chart:   "bitnami/external-dns",
-								Version: "6.5.1",
+								Version: "6.12.2",
 							},
 							Values: dns.ExternalDNSChartValuesConfig{
 								Image: dns.ExternalDNSChartValuesImageConfig{

--- a/internal/integratedservices/testconfig/docker-compose.yml
+++ b/internal/integratedservices/testconfig/docker-compose.yml
@@ -18,7 +18,7 @@ services:
             - 127.0.0.1:3306:3306
 
     vault:
-        image: vault:1.6.1
+        image: vault:1.6.2
         command: server
         cap_add:
             - IPC_LOCK
@@ -31,7 +31,7 @@ services:
 
     vault-unsealer:
         user: "${uid}:${gid}"
-        image: banzaicloud/bank-vaults:1.10.0
+        image: banzaicloud/bank-vaults:1.16.0
         depends_on:
             - vault
         restart: on-failure
@@ -44,7 +44,7 @@ services:
 
     vault-configurer:
         user: "${uid}:${gid}"
-        image: banzaicloud/bank-vaults:1.10.0
+        image: banzaicloud/bank-vaults:1.16.0
         depends_on:
             - vault
             - vault-unsealer
@@ -69,7 +69,7 @@ services:
             - ./.docker/volumes/vault/keys:/vault/keys
 
     cadence:
-        image: ubercadence/server:0.22.1-auto-setup
+        image: ubercadence/server:0.23.2-auto-setup
         environment:
             LOG_LEVEL: debug,info
             DB: mysql
@@ -84,7 +84,7 @@ services:
             - 127.0.0.1:7935:7935
 
 #    cadence-web:
-#        image: ubercadence/web:3.18.1
+#        image: ubercadence/web:3.32.0
 #        environment:
 #            CADENCE_TCHANNEL_PEERS: cadence:7933
 #        depends_on:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated packages:

- `external-dns` version 6.5.1->6.12.2 (latest) because the Helm chart for the old one got removed from the bitnami repository (an it also broke automated tests).
- `cadence-web` version 3.29.5->3.32.0 in the docker-compose file used for local development because that is what is used in the installer now
- `please` version 16.22.0->16.26.1
- service versions in the docker-compose file used in integration testing to match the version numbers used for local development and by the installer 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (with at least one cloud provider)
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~OpenAPI and Postman files updated (if needed)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~